### PR TITLE
Add json version of search route; #145

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -125,6 +125,9 @@ impl CratesfyiHandler {
         router.get("/releases/search",
                    releases::search_handler,
                    "releases_search");
+        router.get("/releases/search.json",
+                   releases::search_handler,
+                   "releases_search_json");
         router.get("/releases/queue",
                    releases::build_queue_handler,
                    "releases_queue");


### PR DESCRIPTION
First step towards #145.

I based the implementation of the .json route of the existing`/crate/:name/:version/builds.json` route.