### PR TITLE
Get build_package_in_chroot target from metadata.default_target.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,38 +1,3 @@
-[root]
-name = "cratesfyi"
-version = "0.4.2"
-dependencies = [
- "badge 0.1.1",
- "cargo 0.20.0 (git+https://github.com/onur/cargo.git?branch=docs.rs)",
- "clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "comrak 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crates-index-diff 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "git2 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "handlebars-iron 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "magic 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "params 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "postgres 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2_postgres 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "router 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "sass-rs 0.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slug 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "staticfile 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "advapi32-sys"
 version = "0.2.0"
@@ -287,6 +252,41 @@ dependencies = [
  "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cratesfyi"
+version = "0.4.2"
+dependencies = [
+ "badge 0.1.1",
+ "cargo 0.20.0 (git+https://github.com/onur/cargo.git?branch=docs.rs)",
+ "clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "comrak 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crates-index-diff 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "handlebars-iron 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "magic 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "params 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "postgres 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2_postgres 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "router 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sass-rs 0.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slug 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "staticfile 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/src/docbuilder/chroot_builder.rs
+++ b/src/docbuilder/chroot_builder.rs
@@ -122,15 +122,18 @@ impl DocBuilder {
 
         let meta = Metadata::from_package(package).ok();
         let target = meta.as_ref().and_then(|meta| meta.default_target.as_ref());
-        let cmd = if let Some(target) = target {
-            format!("cratesfyi doc {} ={} {}",
-                package.manifest().name(),
-                package.manifest().version(),
-                target)
-        } else {
-            format!("cratesfyi doc {} ={}",
-                package.manifest().name(),
-                package.manifest().version())
+        let cmd = match target {
+            Some(target) if TARGETS.contains(&target.as_str()) => {
+                format!("cratesfyi doc {} ={} {}",
+                    package.manifest().name(),
+                    package.manifest().version(),
+                    target)
+            }
+            _ => {
+                format!("cratesfyi doc {} ={}",
+                    package.manifest().name(),
+                    package.manifest().version())
+            }
         };
 
         match self.chroot_command(cmd) {


### PR DESCRIPTION
- The only test I did was to make sure it built.
- It silently reverts to the platform native target if...
  - there was an error getting the metadata.
  - the user gave a target that was unsupported.

Again, sorry if this is an incredibly stupid PR and I'm just missing something.