### PR TITLE
Show message that doc comment is too long instead of failing

### DIFF
--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -264,6 +264,8 @@ fn read_rust_doc(file_path: &Path) -> Result<Option<String>> {
 
     if rustdoc.is_empty() {
         Ok(None)
+    } else if rustdoc.len() > 51200 {
+        Ok(Some(format!("(Library doc comment ignored due to being too long. ({} > 51200))", rustdoc.len())))
     } else {
         Ok(Some(rustdoc))
     }


### PR DESCRIPTION
Fixes at least <https://github.com/onur/docs.rs/issues/23#issuecomment-414062152>.