### PR TITLE
[WIP] Adding a configuration option to specify rustc version

### DIFF
--- a/src/docbuilder/metadata.rs
+++ b/src/docbuilder/metadata.rs
@@ -45,6 +45,14 @@ pub struct Metadata {
     /// is always built on this target. You can change default target by setting this.
     pub default_target: Option<String>,
 
+    /// Define the Rust version that will be used to build documentation
+    ///
+    /// You can either provide a specific nightly (such as `2018-08-18`) or
+    /// simply `nightly` to always use the current.
+    ///
+    /// Note: Depending on latest nightly can easily break your documentation!
+    pub rustc_version: Option<String>,
+
     /// List of command line arguments for `rustc`.
     pub rustc_args: Option<Vec<String>>,
 
@@ -90,6 +98,7 @@ impl Metadata {
     fn default() -> Metadata {
         Metadata {
             features: None,
+            rustc_version: None,
             all_features: false,
             no_default_features: false,
             default_target: None,
@@ -120,6 +129,10 @@ impl Metadata {
                         .and_then(|v| v.as_bool()).unwrap_or(metadata.all_features);
                     metadata.default_target = table.get("default-target")
                         .and_then(|v| v.as_str()).map(|v| v.to_owned());
+                    metadata.rustc_version = table.get("rustc-version").and_then(|f| match f {
+                        Value::String(s) => Some(s.clone()),
+                        _ => None,
+                    });
                     metadata.rustc_args = table.get("rustc-args").and_then(|f| f.as_array())
                         .and_then(|f| f.iter().map(|v| v.as_str().map(|v| v.to_owned())).collect());
                     metadata.rustdoc_args = table.get("rustdoc-args").and_then(|f| f.as_array())

--- a/src/utils/build_doc.rs
+++ b/src/utils/build_doc.rs
@@ -15,6 +15,8 @@ use cargo::ops::{self, Packages, DefaultExecutor};
 use utils::{get_current_versions, parse_rustc_version};
 use error::Result;
 
+use super::rustup;
+
 use Metadata;
 
 
@@ -48,6 +50,11 @@ pub fn build_doc(name: &str, vers: Option<&str>, target: Option<&str>) -> Result
     let target_dir = PathBuf::from(current_dir).join("cratesfyi");
 
     let metadata = Metadata::from_package(&pkg).map_err(|e| human(e.description()))?;
+
+    // Change rustc version if requested
+    if metadata.rustc_version.is_some() {
+        rustup::set_version(metadata.rustc_version.unwrap());
+    }
 
     // This is only way to pass rustc_args to cargo.
     // CompileOptions::target_rustc_args is used only for the current crate,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -17,3 +17,4 @@ mod daemon;
 mod pubsubhubbub;
 mod rustc_version;
 mod html;
+mod rustup;

--- a/src/utils/rustup.rs
+++ b/src/utils/rustup.rs
@@ -1,0 +1,14 @@
+//! A wrapper around using rustup
+//!
+
+use std::process::Command;
+
+/// Invoke rustup in a folder to `override set` a rustc version
+pub fn set_version(v: String) {
+    Command::new("rustup")
+        .arg("override")
+        .arg("set")
+        .arg(v)
+        .output()
+        .unwrap();
+}


### PR DESCRIPTION
This code is maybe not as elegant as it could be but should hopefully work. 

I'm not 100% sure how the crates are built (i.e. how the working directories are
built and scoped) so I hope that `rustup` is invoked in the correct directory.

If that's not the case, then this can be changed.

Additionally I am aware that this is a **work in progress** and further changes
are required on docs.rs and the compilers part to make "hot-swapping" versions
easier. See #225 for more details.

This PR addresses #228