### PR TITLE
Don't override the user's fonts

### DIFF
--- a/templates/style.scss
+++ b/templates/style.scss
@@ -1,10 +1,4 @@
 
-// FONTS
-$font-family-sans: "Fira Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-$font-family-serif: "Source Serif Pro",Georgia,Times,"Times New Roman",serif;
-$font-family-mono: "Source Code Pro", Menlo, Monaco, Consolas, "DejaVu Sans Mono", Inconsolata, monospace;
-
-
 // COLORS - Guess what?
 $color-standard: #000;             // pure black
 $color-url: #4d76ae;               // blue
@@ -33,7 +27,7 @@ $media-xl: "screen and (min-width: 80em)";
 
 html, button, input, select, textarea,
 .pure-g [class *= "pure-u"] {
-    font-family: $font-family-sans;
+    font-family: sans-serif;
     color: $color-standard;
 }
 
@@ -44,12 +38,12 @@ html, button, input, select, textarea,
 }
 
 .description {
-    font-family: $font-family-serif;
+    font-family: serif;
 }
 
 // rustdoc overrides
 div.rustdoc {
-    font-family: $font-family-serif;
+    font-family: serif;
     padding: 10px 15px 20px 15px;
 
     .sidebar {
@@ -94,7 +88,7 @@ body.blur > div.rustdoc > :not(#help) {
 
 body {
     text-align: center;
-    font: 16px/1.4 $font-family-sans;
+    font: 16px/1.4 sans-serif;
 }
 
 pre {
@@ -186,7 +180,7 @@ div.nav-container {
             width: 350px;
 
             p.description {
-                font-family: $font-family-sans;
+                font-family: sans-serif;
                 font-size: 0.8em;
                 color: #777;  // color from pure
                 padding: .5em 1em;
@@ -322,7 +316,7 @@ div.recent-releases-container {
     }
 
     .description {
-        font-family: $font-family-serif;
+        font-family: serif;
         font-weight: normal;
         @media #{$media-sm} {
             font-size: 1em;
@@ -475,7 +469,7 @@ div.package-page-container {
     div.package-details {
         padding: 0 1em;
 
-        font-family: $font-family-serif;
+        font-family: serif;
 
         a {
             color: $color-url;
@@ -486,7 +480,7 @@ div.package-page-container {
         }
 
         h1, h2, h3, h4, h5, h6 {
-            font-family: $font-family-sans;
+            font-family: sans-serif;
         }
 
         h1:first-child,
@@ -516,7 +510,7 @@ div.package-page-container {
             }
 
             th {
-                font-family: $font-family-sans;
+                font-family: sans-serif;
                 font-weight: 500;
             }
 
@@ -561,7 +555,7 @@ div.cratesfyi-package-container {
         padding: 15px 0 0 14px;
     }
     div.description {
-        font-family: $font-family-serif;
+        font-family: serif;
         margin: 0;
         padding: 0 0 15px 14px;
 
@@ -640,7 +634,7 @@ div.cratesfyi-package-container-rustdoc {
 
 
 div.warning {
-    font-family: $font-family-sans;
+    font-family: sans-serif;
     border-radius: 4px;
     background-color: lighten($color-type, 45%);
     padding: .4em 1em;
@@ -699,7 +693,7 @@ footer {
 
 
 .about {
-    font-family: $font-family-serif;
+    font-family: serif;
     padding: .4em 1em;
     a {
         color: $color-url;
@@ -711,7 +705,7 @@ footer {
         margin-bottom: 10px;
     }
     thead tr th {
-        font-family: $font-family-sans;
+        font-family: sans-serif;
         font-weight: 500;
     }
     strong {


### PR DESCRIPTION
This patch is similar in spirit to rust-lang/blog.rust-lang.org#263, though it's also less invasive; it removes the specific font overrides in style.css so that the browser will use the user's configured fonts.

The net result of the change is that the page will look less "uniform" across different browsers, OSes, and devices, but the overall aesthetic should be preserved. It also means that user preferences are respected, and that legibility is improved for users with particular font needs, or on platforms that sometimes gets confused about how to render fonts nicely (ehrm, Linux).