### PR TITLE
Update github links from rust-lang-nursery to rust-lang

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.0"
 authors = ["Onur Aslan <onuraslan@gmail.com>"]
 readme = "README.md"
 license = "MIT"
-repository = "https://github.com/rust-lang-nursery/docs.rs"
+repository = "https://github.com/rust-lang/docs.rs"
 build = "build.rs"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Docs.rs
 
 [![Build Status](https://dev.azure.com/docsrs/docs.rs/_apis/build/status/docs.rs?branchName=master)](https://dev.azure.com/docsrs/docs.rs/_build/latest?definitionId=1)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/rust-lang-nursery/docs.rs/master/LICENSE)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/rust-lang/docs.rs/master/LICENSE)
 
 Docs.rs (formerly cratesfyi) is an open source project to host documentation
 of crates for the Rust Programming Language.
@@ -59,7 +59,7 @@ to able to download ~800MB data on the first run.
 
 
 ```sh
-git clone https://github.com/rust-lang-nursery/docs.rs.git docs.rs
+git clone https://github.com/rust-lang/docs.rs.git docs.rs
 cd docs.rs
 vagrant up  # This may take a little while on the first run
 ```

--- a/src/web/badge/Cargo.toml
+++ b/src/web/badge/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 description = "Simple badge generator"
 authors = ["Onur Aslan <onur@onur.im>"]
 license-file = "LICENSE"
-repository = "https://github.com/rust-lang-nursery/docs.rs"
+repository = "https://github.com/rust-lang/docs.rs"
 documentation = "https://docs.rs/badge"
 
 [lib]

--- a/src/web/badge/LICENSE
+++ b/src/web/badge/LICENSE
@@ -1,6 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: badge
-Source: https://github.com/rust-lang-nursery/docs.rs
+Source: https://github.com/rust-lang/docs.rs
 
 Files: *
 Copyright: Copyright (c) 2016  Onur Aslan  <onur@onur.im>

--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -14,7 +14,7 @@
 
   <p>
   The source code of Docs.rs is available on
-    <a href="https://github.com/rust-lang-nursery/docs.rs" target="_blank">GitHub</a>. If
+    <a href="https://github.com/rust-lang/docs.rs" target="_blank">GitHub</a>. If
   you ever encounter an issue, don't hesitate to report it! (And
   thanks in advance!)
   </p>

--- a/templates/crate_details.hbs
+++ b/templates/crate_details.hbs
@@ -56,7 +56,7 @@
       <div class="warning">{{name}}-{{version}} is not a library.</div>
       {{else}}
       {{#unless build_status}}
-      <div class="warning">docs.rs failed to build {{name}}-{{version}}<br>Please check <a href="/crate/{{name}}/{{version}}/builds">build logs</a> and if you believe this is docs.rs' fault, report into <a href="https://github.com/rust-lang-nursery/docs.rs/issues/23">this issue report</a>.</div>
+      <div class="warning">docs.rs failed to build {{name}}-{{version}}<br>Please check <a href="/crate/{{name}}/{{version}}/builds">build logs</a> and if you believe this is docs.rs' fault, report into <a href="https://github.com/rust-lang/docs.rs/issues/23">this issue report</a>.</div>
       {{else}}
       {{#unless rustdoc_status}}
       <div class="warning">{{name}}-{{version}} doesn't have any documentation.</div>


### PR DESCRIPTION
cc @QuietMisdreavus

I think GitHub should be managing redirects for these links, but I did a global search for `rust-lang-nursery`. Hopefully I haven't missed anything :)