### PR TITLE
print current rust version on the about page

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -61,7 +61,6 @@ use semver::{Version, VersionReq};
 use rustc_serialize::json::{Json, ToJson};
 use std::collections::BTreeMap;
 
-
 /// Duration of static files for staticfile and DatabaseFileHandler (in seconds)
 const STATIC_FILE_CACHE_DURATION: u64 = 60 * 60 * 24 * 30 * 12;   // 12 months
 const STYLE_CSS: &'static str = include_str!(concat!(env!("OUT_DIR"), "/style.css"));
@@ -97,9 +96,7 @@ impl CratesfyiHandler {
         let mut router = Router::new();
         router.get("/", releases::home_page, "index");
         router.get("/style.css", style_css_handler, "style_css");
-        router.get("/about",
-                   |_: &mut Request| page::Page::new(false).title("About Docs.rs").to_resp("about"),
-                   "about");
+        router.get("/about", sitemap::about_handler, "about");
         router.get("/robots.txt", sitemap::robots_txt_handler, "robots_txt");
         router.get("/sitemap.xml", sitemap::sitemap_handler, "sitemap_xml");
         router.get("/opensearch.xml", opensearch_xml_handler, "opensearch_xml");
@@ -426,7 +423,6 @@ fn opensearch_xml_handler(_: &mut Request) -> IronResult<Response> {
     response.headers.set(CacheControl(cache));
     Ok(response)
 }
-
 
 /// MetaData used in header
 #[derive(Debug)]

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -1,11 +1,11 @@
-
-
+use std::collections::BTreeMap;
 use iron::prelude::*;
 use iron::headers::ContentType;
+use rustc_serialize::json::Json;
 use super::page::Page;
 use super::pool::Pool;
 use time;
-
+use db::connect_db;
 
 pub fn sitemap_handler(req: &mut Request) -> IronResult<Response> {
     let conn = extension!(req, Pool);
@@ -30,4 +30,21 @@ pub fn robots_txt_handler(_: &mut Request) -> IronResult<Response> {
     let mut resp = Response::with("Sitemap: https://docs.rs/sitemap.xml");
     resp.headers.set(ContentType("text/plain".parse().unwrap()));
     Ok(resp)
+}
+
+pub fn about_handler(req: &mut Request) -> IronResult<Response> {
+    let mut content = BTreeMap::new();
+
+    let conn = extension!(req, Pool);
+    let res = ctry!(conn.query("SELECT value FROM config WHERE name = 'rustc_version'", &[]));
+
+    if let Some(row) = res.iter().next() {
+        if let Some(Ok::<Json, _>(res)) = row.get_opt(0) {
+            if let Some(vers) = res.as_string() {
+                content.insert("rustc_version".to_string(), vers.to_string());
+            }
+        }
+    }
+
+    Page::new(content).title("About Docs.rs").to_resp("about")
 }

--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -10,6 +10,12 @@
   Docs.rs automatically builds crates' documentation released on
   <a href="https://crates.io/">crates.io</a>
   using the nightly release of the Rust compiler.
+  {{#if content.rustc_version}}
+  The current version of the Rust compiler in use is <code>{{content.rustc_version}}</code>.
+  If you need a newer version of this compiler, check the
+  <a href="https://github.com/rust-lang/docs.rs/issues">issues page</a>
+  and file a new issue if you don't see an existing request.
+  {{/if}}
   </p>
 
   <p>


### PR DESCRIPTION
Closes https://github.com/rust-lang/docs.rs/issues/257

Now that we're using a real nightly compiler to build docs, let's show the version somewhere. This PR takes the suggestion from the linked issue and prints the version of the rustc inside the container on the "about" page.

Open question: Would it be better to cache this version string somewhere (say, in the database or in some `lazy_static`) so we don't have to attach to the container and run `rustc --version` every time someone loads the About page?