### PR TITLE
use rustdoc's body classes on the rustdoc-container

### DIFF
--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -24,6 +24,7 @@ use utils;
 struct RustdocPage {
     pub head: String,
     pub body: String,
+    pub body_class: String,
     pub name: String,
     pub full: String,
     pub version: String,
@@ -37,6 +38,7 @@ impl Default for RustdocPage {
         RustdocPage {
             head: String::new(),
             body: String::new(),
+            body_class: String::new(),
             name: String::new(),
             full: String::new(),
             version: String::new(),
@@ -52,6 +54,7 @@ impl ToJson for RustdocPage {
         let mut m: BTreeMap<String, Json> = BTreeMap::new();
         m.insert("rustdoc_head".to_string(), self.head.to_json());
         m.insert("rustdoc_body".to_string(), self.body.to_json());
+        m.insert("rustdoc_body_class".to_string(), self.body_class.to_json());
         m.insert("rustdoc_full".to_string(), self.full.to_json());
         m.insert("rustdoc_status".to_string(), true.to_json());
         m.insert("name".to_string(), self.name.to_json());
@@ -160,9 +163,17 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
 
     let file_content = ctry!(String::from_utf8(file.content));
 
-    let (head, body) = ctry!(utils::extract_head_and_body(&file_content));
+    let (head, body, mut body_class) = ctry!(utils::extract_head_and_body(&file_content));
     content.head = head;
     content.body = body;
+
+    if body_class.is_empty() {
+        body_class = "rustdoc container-rustdoc".to_string();
+    } else {
+        // rustdoc adds its own "rustdoc" class to the body
+        body_class.push_str(" container-rustdoc");
+    }
+    content.body_class = body_class;
 
     content.full = file_content;
     let crate_details = cexpect!(CrateDetails::new(&conn, &name, &version));

--- a/templates/rustdoc.hbs
+++ b/templates/rustdoc.hbs
@@ -10,7 +10,7 @@
 </head>
 <body>
 {{> navigation_rustdoc}}
-<div class="rustdoc container-rustdoc">
+<div class="{{content.rustdoc_body_class}}">
     {{{content.rustdoc_body}}}
 </div>
 </body>


### PR DESCRIPTION
Fixes https://github.com/rust-lang/docs.rs/issues/264 (requires updating prod server to tomorrow's nightly to include https://github.com/rust-lang/rust/pull/56498 - however, *today's* nightly introduces the new source sidebar files mentioned in https://github.com/rust-lang/docs.rs/issues/270 so there will need to be another PR before that's totally ready)

Upstream rustdoc sets some styles on the `<body>` tag that affect some CSS rules. Most notably, on `[src]` pages, it sets the `source` class. Docs.rs doesn't currently carry over all of those styles (it does hardcode the `rustdoc` class, set on all pages, but misses everything else), which has caused some problems getting the new-style line numbers to work. This PR changes the rustdoc page handling to extract any classes being set on the `<body>` tag, so it can save them and apply them to the template when sending the page.