### PR TITLE
add new static files from recent rustdoc changes

### DIFF
--- a/src/docbuilder/chroot_builder.rs
+++ b/src/docbuilder/chroot_builder.rs
@@ -396,7 +396,8 @@ impl DocBuilder {
                       "rustdoc.css",
                       "settings.css",
                       "storage.js",
-                      "theme.js"],
+                      "theme.js",
+                      "source-script.js"],
                      // files doesn't require rustc version subfix
                      ["FiraSans-Medium.woff",
                       "FiraSans-Regular.woff",

--- a/src/docbuilder/chroot_builder.rs
+++ b/src/docbuilder/chroot_builder.rs
@@ -389,6 +389,7 @@ impl DocBuilder {
         let files = (// files require rustc version subfix
                      ["brush.svg",
                       "wheel.svg",
+                      "down-arrow.svg",
                       "dark.css",
                       "light.css",
                       "main.js",

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -177,6 +177,9 @@ impl CratesfyiHandler {
         router.get("/:crate/:version/aliases.js",
                    rustdoc::rustdoc_html_server_handler,
                    "crate_version_aliases_js");
+        router.get("/:crate/:version/source-files.js",
+                   rustdoc::rustdoc_html_server_handler,
+                   "crate_version_source_files_js");
         router.get("/:crate/:version/:target",
                    rustdoc::rustdoc_redirector_handler,
                    "crate_version_target");


### PR DESCRIPTION
Fixes https://github.com/rust-lang/docs.rs/issues/270

The two upstream-rustdoc PRs referenced in the linked issue added some new files that come with a doc bundle, so this is the update to make docs.rs work with these files. Note that this won't be totally effective until a nightly for 2018-12-07 is released, and the server is updated to use it.