### PR TITLE
Remove sources path and fix Vagrant vm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,18 +539,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "env_logger"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2821,7 +2809,6 @@ dependencies = [
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum encoding_rs 0.8.10 (registry+https://github.com/rust-lang/crates.io-index)" = "065f4d0c826fdaef059ac45487169d918558e3cf86c9d89f6e81cf52369126e5"
 "checksum entities 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
-"checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afb070faf94c85d17d50ca44f6ad076bce18ae92f0037d350947240a36e9d42e"
 "checksum error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e606f14042bb87cc02ef6a14db6c90ab92ed6f62d87e69377bc759fd7987cc"
 "checksum failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,7 +47,7 @@ Vagrant.configure("2") do |config|
     ############################################################
     lxc-attach -n cratesfyi-container -- apt-get update
     lxc-attach -n cratesfyi-container -- apt-get install -y --no-install-recommends curl ca-certificates binutils gcc libc6-dev libmagic1
-    lxc-attach -n cratesfyi-container -- su - cratesfyi -c 'curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-12-19'
+    lxc-attach -n cratesfyi-container -- su - cratesfyi -c 'curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly'
 
     ############################################################
     # Installing extra targets into cratesfyi-container        #

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,7 +47,7 @@ Vagrant.configure("2") do |config|
     ############################################################
     lxc-attach -n cratesfyi-container -- apt-get update
     lxc-attach -n cratesfyi-container -- apt-get install -y --no-install-recommends curl ca-certificates binutils gcc libc6-dev libmagic1
-    lxc-attach -n cratesfyi-container -- su - cratesfyi -c 'curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-10-20'
+    lxc-attach -n cratesfyi-container -- su - cratesfyi -c 'curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-12-19'
 
     ############################################################
     # Installing extra targets into cratesfyi-container        #

--- a/src/docbuilder/chroot_builder.rs
+++ b/src/docbuilder/chroot_builder.rs
@@ -2,7 +2,7 @@
 use super::DocBuilder;
 use super::crates::crates_from_path;
 use super::metadata::Metadata;
-use utils::{get_package, source_path, copy_dir, copy_doc_dir,
+use utils::{get_package, source_path, copy_doc_dir,
             update_sources, parse_rustc_version, command_result};
 use db::{connect_db, add_package_into_database, add_build_into_database, add_path_into_database};
 use cargo::core::Package;
@@ -178,19 +178,6 @@ impl DocBuilder {
             }
         }
         successfuly_targets
-    }
-
-
-    /// Copies source files of a package into source_path
-    #[allow(dead_code)]  // I've been using this function before storing files in database
-    fn copy_sources(&self, package: &Package) -> Result<()> {
-        debug!("Copying sources");
-        let destination =
-            PathBuf::from(&self.options.sources_path).join(format!("{}/{}",
-                                                                   package.manifest().name(),
-                                                                   package.manifest().version()));
-        // unwrap is safe here, this function will be always called after get_package
-        copy_dir(source_path(&package).unwrap(), &destination)
     }
 
 

--- a/src/docbuilder/options.rs
+++ b/src/docbuilder/options.rs
@@ -13,7 +13,6 @@ pub struct DocBuilderOptions {
     pub chroot_user: String,
     pub container_name: String,
     pub crates_io_index_path: PathBuf,
-    pub sources_path: PathBuf,
     pub skip_if_exists: bool,
     pub skip_if_log_exists: bool,
     pub skip_oldest_versions: bool,
@@ -28,7 +27,7 @@ impl Default for DocBuilderOptions {
 
         let cwd = env::current_dir().unwrap();
 
-        let (prefix, destination, chroot_path, crates_io_index_path, sources_path) =
+        let (prefix, destination, chroot_path, crates_io_index_path) =
             generate_paths(cwd);
 
         DocBuilderOptions {
@@ -36,7 +35,6 @@ impl Default for DocBuilderOptions {
             destination: destination,
             chroot_path: chroot_path,
             crates_io_index_path: crates_io_index_path,
-            sources_path: sources_path,
 
             chroot_user: "cratesfyi".to_string(),
             container_name: "cratesfyi-container".to_string(),
@@ -57,13 +55,12 @@ impl fmt::Debug for DocBuilderOptions {
         write!(f,
                "DocBuilderOptions {{ destination: {:?}, chroot_path: {:?}, \
                 crates_io_index_path: {:?}, \
-                sources_path: {:?}, container_name: {:?}, chroot_user: {:?}, \
+                container_name: {:?}, chroot_user: {:?}, \
                 keep_build_directory: {:?}, skip_if_exists: {:?}, \
                 skip_if_log_exists: {:?}, debug: {:?} }}",
                self.destination,
                self.chroot_path,
                self.crates_io_index_path,
-               self.sources_path,
                self.container_name,
                self.chroot_user,
                self.keep_build_directory,
@@ -77,14 +74,13 @@ impl fmt::Debug for DocBuilderOptions {
 impl DocBuilderOptions {
     /// Creates new DocBuilderOptions from prefix
     pub fn from_prefix(prefix: PathBuf) -> DocBuilderOptions {
-        let (prefix, destination, chroot_path, crates_io_index_path, sources_path) =
+        let (prefix, destination, chroot_path, crates_io_index_path) =
             generate_paths(prefix);
         DocBuilderOptions {
             prefix: prefix,
             destination: destination,
             chroot_path: chroot_path,
             crates_io_index_path: crates_io_index_path,
-            sources_path: sources_path,
 
             ..Default::default()
         }
@@ -101,21 +97,17 @@ impl DocBuilderOptions {
         if !self.crates_io_index_path.exists() {
             bail!("crates.io-index path '{}' does not exist", self.crates_io_index_path.display());
         }
-        if !self.sources_path.exists() {
-            bail!("sources path '{}' does not exist", self.sources_path.display());
-        }
         Ok(())
     }
 }
 
 
 
-fn generate_paths(prefix: PathBuf) -> (PathBuf, PathBuf, PathBuf, PathBuf, PathBuf) {
+fn generate_paths(prefix: PathBuf) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
 
     let destination = PathBuf::from(&prefix).join("documentations");
     let chroot_path = PathBuf::from(&prefix).join("cratesfyi-container/rootfs");
     let crates_io_index_path = PathBuf::from(&prefix).join("crates.io-index");
-    let sources_path = PathBuf::from(&prefix).join("sources");
 
-    (prefix, destination, chroot_path, crates_io_index_path, sources_path)
+    (prefix, destination, chroot_path, crates_io_index_path)
 }

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -5,7 +5,6 @@ use rustc_serialize::json::Json;
 use super::page::Page;
 use super::pool::Pool;
 use time;
-use db::connect_db;
 
 pub fn sitemap_handler(req: &mut Request) -> IronResult<Response> {
     let conn = extension!(req, Pool);


### PR DESCRIPTION
docs.rs is been using `~/.cargo/registy/src` instead of `sources_path` for a while. This patch removes `sources_path`, updates nightly compiler used in Vagrant, removes some unused dependency from Cargo.lock and removes unused dependency from sitemap.rs.

Closes: #278