### PR TITLE
updates to handle new nightlies

### DIFF
--- a/src/docbuilder/chroot_builder.rs
+++ b/src/docbuilder/chroot_builder.rs
@@ -385,7 +385,8 @@ impl DocBuilder {
                       "settings.css",
                       "storage.js",
                       "theme.js",
-                      "source-script.js"],
+                      "source-script.js",
+                      "noscript.css"],
                      // files doesn't require rustc version subfix
                      ["FiraSans-Medium.woff",
                       "FiraSans-Regular.woff",

--- a/src/utils/build_doc.rs
+++ b/src/utils/build_doc.rs
@@ -75,7 +75,9 @@ pub fn build_doc(name: &str, vers: Option<&str>, target: Option<&str>) -> Result
     let mut rustdoc_args: Vec<String> =
         vec!["-Z".to_string(), "unstable-options".to_string(),
              "--resource-suffix".to_string(),
-             format!("-{}", parse_rustc_version(get_current_versions()?.0)?)];
+             format!("-{}", parse_rustc_version(get_current_versions()?.0)?),
+             "--static-root-path".to_string(), "/".to_string(),
+             "--disable-per-crate-search".to_string()];
 
     // since https://github.com/rust-lang/rust/pull/51384, we can pass --extern-html-root-url to
     // force rustdoc to link to other docs.rs docs for dependencies


### PR DESCRIPTION
This PR adds three things:

* Starts copying `noscript.css` with "essential files"
* Sends `--static-root-path /` to rustdoc to make it load CSS/JS/font files from the root of the server and let people cache them better
* Sends `--disable-per-crate-search` to rustdoc to stop creating the crate listing drop-down on search boxes, since we only ever build one crate at a time