### PR TITLE
Show dev/build dependencies info on menu and detail

### DIFF
--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use std::fs;
 
 use cargo::core::{Package, TargetKind};
+use cargo::core::dependency::Kind;
 use rustc_serialize::json::{Json, ToJson};
 use slug::slugify;
 use reqwest::Client;
@@ -208,13 +209,18 @@ fn initialize_package_in_database(conn: &Connection, pkg: &Package) -> Result<i3
 
 
 
-/// Convert dependencies into Vec<(String, String)>
-fn convert_dependencies(pkg: &Package) -> Vec<(String, String)> {
-    let mut dependencies: Vec<(String, String)> = Vec::new();
+/// Convert dependencies into Vec<(String, String, String)>
+fn convert_dependencies(pkg: &Package) -> Vec<(String, String, String)> {
+    let mut dependencies: Vec<(String, String, String)> = Vec::new();
     for dependency in pkg.manifest().dependencies() {
         let name = dependency.package_name().to_string();
         let version = format!("{}", dependency.version_req());
-        dependencies.push((name, version));
+        let kind = match dependency.kind() {
+            Kind::Normal => "normal",
+            Kind::Development => "dev",
+            Kind::Build => "build",
+        };
+        dependencies.push((name, version, kind.to_string()));
     }
     dependencies
 }

--- a/templates/crate_details.hbs
+++ b/templates/crate_details.hbs
@@ -27,7 +27,13 @@
             <div class="pure-menu pure-menu-scrollable sub-menu">
               <ul class="pure-menu-list">
                 {{#each dependencies}}
-                <li class="pure-menu-item"><a href="/crate/{{this.[0]}}/{{this.[1]}}" class="pure-menu-link">{{this.[0]}} {{this.[1]}}</a></li>
+                  <li class="pure-menu-item">
+                    <a href="/crate/{{this.[0]}}/{{this.[1]}}"
+                       class="pure-menu-link">
+                      {{this.[0]}} {{this.[1]}}
+                      <i class="dependencies {{this.[2]}}">{{this.[2]}}</i>
+                    </a>
+                  </li>
                 {{/each}}
               </ul>
             </div>

--- a/templates/navigation_rustdoc.hbs
+++ b/templates/navigation_rustdoc.hbs
@@ -54,7 +54,13 @@
                         <div class="pure-menu pure-menu-scrollable sub-menu">
                           <ul class="pure-menu-list">
                             {{#each dependencies}}
-                            <li class="pure-menu-item"><a href="/{{this.[0]}}/{{this.[1]}}" class="pure-menu-link">{{this.[0]}} {{this.[1]}}</a></li>
+                              <li class="pure-menu-item">
+                                <a href="/{{this.[0]}}/{{this.[1]}}"
+                                   class="pure-menu-link">
+                                  {{this.[0]}} {{this.[1]}}
+                                  <i class="dependencies this.[2]">{{this.[2]}}</i>
+                                </a>
+                              </li>
                             {{/each}}
                           </ul>
                         </div>

--- a/templates/style.scss
+++ b/templates/style.scss
@@ -721,3 +721,8 @@ footer {
         background-color: inherit;
     }
 }
+
+i.dependencies.normal {
+  visibility: hidden;
+  display: none;
+}


### PR DESCRIPTION
I decided to go with the simple fix without JS; `nomal` kind is hidden `dev` and `build` is shown (only for new crate)

![1545853922](https://user-images.githubusercontent.com/98590/50455854-9b575d00-0948-11e9-8de0-50d55e97f1de.png)

ref #175