### PR TITLE
add new essential files from new nightly

### DIFF
--- a/src/docbuilder/chroot_builder.rs
+++ b/src/docbuilder/chroot_builder.rs
@@ -386,15 +386,17 @@ impl DocBuilder {
                       "storage.js",
                       "theme.js",
                       "source-script.js",
-                      "noscript.css"],
+                      "noscript.css",
+                      "rust-logo.png"],
+                      // favicon.ico is not needed because we set our own
                      // files doesn't require rustc version subfix
                      ["FiraSans-Medium.woff",
                       "FiraSans-Regular.woff",
-                      "Heuristica-Italic.woff",
                       "SourceCodePro-Regular.woff",
                       "SourceCodePro-Semibold.woff",
-                      "SourceSerifPro-Bold.woff",
-                      "SourceSerifPro-Regular.woff"]);
+                      "SourceSerifPro-Bold.ttf.woff",
+                      "SourceSerifPro-Regular.ttf.woff",
+                      "SourceSerifPro-It.ttf.woff"]);
 
         let source = PathBuf::from(&self.options.chroot_path)
             .join("home")


### PR DESCRIPTION
Adds in the files from the last couple comments in https://github.com/rust-lang/docs.rs/issues/270.

The font updates are weird, but since it's not *changing* any of the existing font files, just *adding/removing* them, we can just switch to this new list of essential files, leave the old font files in place for existing documentation, and make it load in the new font files when the new rustc is used.