### PR TITLE
handle docs that don't use spaces in doc comments

### DIFF
--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -260,8 +260,10 @@ fn read_rust_doc(file_path: &Path) -> Result<Option<String>> {
     for line in reader.lines() {
         let line = try!(line);
         if line.starts_with("//!") {
-            if line.len() > 3 {
-                rustdoc.push_str(line.split_at(4).1);
+            // some lines may or may not have a space between the `//!` and the start of the text
+            let line = line.trim_start_matches("//!").trim_start();
+            if !line.is_empty() {
+                rustdoc.push_str(line);
             }
             rustdoc.push('\n');
         }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/docs.rs/issues/291

The `learn_rust` crate had a line in its crate docs which had no space between the `//!` and the first character - and the first character was a multibyte character. Combined with the code this PR is changing, docs.rs started slicing a string in an improper location, causing the build to panic and fail.

I ran the code on my test server and built `learn_rust-0.1.2`, and it worked just fine.