### PR TITLE
skip loading readme files if it won't fit in the DB

### DIFF
--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -232,7 +232,14 @@ fn get_readme(pkg: &Package) -> Result<Option<String>> {
     let mut reader = try!(fs::File::open(readme_path).map(|f| BufReader::new(f)));
     let mut readme = String::new();
     try!(reader.read_to_string(&mut readme));
-    Ok(Some(readme))
+
+    if readme.is_empty() {
+        Ok(None)
+    } else if readme.len() > 51200 {
+        Ok(Some(format!("(Readme ignored due to being too long. ({} > 51200))", readme.len())))
+    } else {
+        Ok(Some(readme))
+    }
 }
 
 


### PR DESCRIPTION
Some crates have excessively long README files, that are too big for the database column. This PR changes the README loading function to discard a README if it wouldn't fit in the database, using a similar check that the `read_rust_doc` function uses.