### PR TITLE
fix navigation_rustdoc template

### DIFF
--- a/templates/navigation_rustdoc.hbs
+++ b/templates/navigation_rustdoc.hbs
@@ -58,7 +58,7 @@
                                 <a href="/{{this.[0]}}/{{this.[1]}}"
                                    class="pure-menu-link">
                                   {{this.[0]}} {{this.[1]}}
-                                  <i class="dependencies this.[2]">{{this.[2]}}</i>
+                                  <i class="dependencies {{this.[2]}}">{{this.[2]}}</i>
                                 </a>
                               </li>
                             {{/each}}


### PR DESCRIPTION
In https://github.com/rust-lang/docs.rs/pull/282, there was an error in the `navigation_rustdoc` template that i missed in the review. This fixes that so that normal dependencies don't have the "*normal*" tag next to them.