### PR TITLE
don't render raw html or data/javascript URLs in crate readmes

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -359,6 +359,7 @@ fn render_markdown(text: &str) -> String {
 
     let options = {
         let mut options = ComrakOptions::default();
+        options.safe = true;
         options.ext_superscript = true;
         options.ext_table = true;
         options.ext_autolink = true;


### PR DESCRIPTION
Currently, when we render README files for viewing, we leave the output HTML untouched. However, this can lead to some malicious (or at least obstructive) files including `javascript:` or `data:` URLs which can create security risks.

There's an option in `comrak`'s Markdown renderer to strip out all raw HTML elements and `javascript:`/`data:` URLs when it renders Markdown, so this PR sets that option when rendering README files.