### PR TITLE
Make font size consistent for all `pre` elements.

### DIFF
--- a/templates/style.scss
+++ b/templates/style.scss
@@ -129,6 +129,7 @@ body {
 }
 
 pre {
+    font-size: 0.9rem;
     overflow: auto;
     white-space: pre;
 }
@@ -314,7 +315,6 @@ div.recent-releases-container {
     }
 
     pre {
-        font-size: 0.8rem;
         white-space: pre-wrap;
     }
 


### PR DESCRIPTION
The change also has the effect of allowing 100 characters (`rustfmt`'s
default) to be visible on all source views. Resolves #296.