### PR TITLE
templates/about: mention that "dependencies" key isn't being used yet

### DIFF
--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -117,7 +117,7 @@ no-default-features = true
 default-target = "x86_64-unknown-linux-gnu"
 rustc-args = [ "--example-rustc-arg" ]
 rustdoc-args = [ "--example-rustdoc-arg" ]
-# the dependencies key is not being used for builds yet
+# the dependencies key is currently unused, but is being saved for future support
 dependencies = [ "example-system-dependency" ]</pre></code>
 
   <h4>Version</h4>

--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -116,9 +116,7 @@ all-features = true
 no-default-features = true
 default-target = "x86_64-unknown-linux-gnu"
 rustc-args = [ "--example-rustc-arg" ]
-rustdoc-args = [ "--example-rustdoc-arg" ]
-# the dependencies key is currently unused, but is being saved for future support
-dependencies = [ "example-system-dependency" ]</pre></code>
+rustdoc-args = [ "--example-rustdoc-arg" ]</pre></code>
 
   <h4>Version</h4>
   <p>Currently running Docs.rs version is: <strong>{{cratesfyi_version}}</strong>

--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -117,6 +117,7 @@ no-default-features = true
 default-target = "x86_64-unknown-linux-gnu"
 rustc-args = [ "--example-rustc-arg" ]
 rustdoc-args = [ "--example-rustdoc-arg" ]
+# the dependencies key is not being used for builds yet
 dependencies = [ "example-system-dependency" ]</pre></code>
 
   <h4>Version</h4>


### PR DESCRIPTION
Adding a comment that the `dependencies` key in the `package.metadata.docs.rs` key isn't yet used for builds should clear up some confusion.