### PR TITLE
start tracking when crates are yanked

### DIFF
--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -44,6 +44,7 @@ pub struct CrateDetails {
     github_issues: Option<i32>,
     metadata: MetaData,
     is_library: bool,
+    yanked: bool,
     doc_targets: Option<Json>,
     license: Option<String>,
     documentation_url: Option<String>,
@@ -82,6 +83,7 @@ impl ToJson for CrateDetails {
         m.insert("github_issues".to_string(), self.github_issues.to_json());
         m.insert("metadata".to_string(), self.metadata.to_json());
         m.insert("is_library".to_string(), self.is_library.to_json());
+        m.insert("yanked".to_string(), self.yanked.to_json());
         m.insert("doc_targets".to_string(), self.doc_targets.to_json());
         m.insert("license".to_string(), self.license.to_json());
         m.insert("documentation_url".to_string(), self.documentation_url.to_json());
@@ -116,6 +118,7 @@ impl CrateDetails {
                             crates.github_forks,
                             crates.github_issues,
                             releases.is_library,
+                            releases.yanked,
                             releases.doc_targets,
                             releases.license,
                             releases.documentation_url
@@ -185,9 +188,10 @@ impl CrateDetails {
             github_issues: rows.get(0).get(20),
             metadata: metadata,
             is_library: rows.get(0).get(21),
-            doc_targets: rows.get(0).get(22),
-            license: rows.get(0).get(23),
-            documentation_url: rows.get(0).get(24),
+            yanked: rows.get(0).get(22),
+            doc_targets: rows.get(0).get(23),
+            license: rows.get(0).get(24),
+            documentation_url: rows.get(0).get(25),
         };
 
         if let Some(repository_url) = crate_details.repository_url.clone() {

--- a/templates/crate_details.hbs
+++ b/templates/crate_details.hbs
@@ -61,6 +61,9 @@
       {{#unless is_library}}
       <div class="warning">{{name}}-{{version}} is not a library.</div>
       {{else}}
+      {{#if yanked}}
+      <div class="warning">{{name}}-{{version}} has been yanked.</div>
+      {{else}}
       {{#unless build_status}}
       <div class="warning">docs.rs failed to build {{name}}-{{version}}<br>Please check <a href="/crate/{{name}}/{{version}}/builds">build logs</a> and if you believe this is docs.rs' fault, report into <a href="https://github.com/rust-lang/docs.rs/issues/23">this issue report</a>.</div>
       {{else}}
@@ -68,6 +71,7 @@
       <div class="warning">{{name}}-{{version}} doesn't have any documentation.</div>
       {{/unless}}
       {{/unless}}
+      {{/if}}
       {{/unless}}
       {{#if readme}}
         {{{readme}}}


### PR DESCRIPTION
There's currently a column in our database to see whether a release has been yanked, but we don't set it when tracking updates. This PR changes that by adding:

* A change to the build queue that handles yank events by setting the release as yanked,
* A change to the "crate details" screen that adds a banner when the release is marked as yanked in our database, and
* A change to the version resolution code to look up the list of releases of the crate that are marked as yanked in our database, and avoid resolving to yanked releases unless explicitly asked for.
  * (Side note: if all of a crate's versions have been yanked, this will make it appear to not exist if you go to `docs.rs/crate`. Is this behavior we want? I can make it check whether all versions have been yanked before filtering them out, if desired.)

I also added a test to ensure that the templates are properly formatted, since i messed that up initially. `>_>`

Fixes https://github.com/rust-lang/docs.rs/issues/112, Fixes https://github.com/rust-lang/docs.rs/issues/221