### PR TITLE
Remove jessie-backports repository from Vagrant image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,6 +37,11 @@ Vagrant.configure("2") do |config|
     set -ev
 
     ############################################################
+    # Removing jessie-backports                                #
+    ############################################################
+    sed -i '/jessie-backports/d' /etc/apt/sources.list
+
+    ############################################################
     # Installing docs.rs dependencies                          #
     ############################################################
     apt-get update


### PR DESCRIPTION
jessie-backports have been removed by Debian FTP masters and it's no longer available [[1]](https://www.lucas-nussbaum.net/blog/?p=947). Our Vagrant image is causing an error during provision for this reason. This patch is removing `jessie-backports` from sources.list and fixing our Vagrant image. This change is not affecting anything else, we didn't even use any package from jessie-backports in our image.