### PR TITLE
fix keyboard nav on releases pages

### DIFF
--- a/templates/releases.hbs
+++ b/templates/releases.hbs
@@ -63,6 +63,7 @@
         return;
       }
       if (ev.which === 40) { // Down arrow
+        ev.preventDefault();
         if (active === null) {
           active = document.getElementsByClassName("recent-releases-container")[0].getElementsByTagName("li")[0];
         } else if (active.nextElementSibling) {
@@ -71,6 +72,7 @@
         }
         active.classList.add("selected");
       } else if (ev.which === 38) { // Up arrow
+        ev.preventDefault();
         if (active === null) {
           active = document.getElementsByClassName("recent-releases-container")[0].getElementsByTagName("li")[0];
         } else if (active.previousElementSibling) {

--- a/templates/releases.hbs
+++ b/templates/releases.hbs
@@ -79,7 +79,7 @@
         }
         active.classList.add("selected");
         active.focus();
-      } else if (e.which === 13) { // Return
+      } else if (ev.which === 13) { // Return
         if (active !== null) {
           document.location.href = active.getElementsByTagName("a")[0].href;
         }

--- a/templates/releases.hbs
+++ b/templates/releases.hbs
@@ -62,7 +62,7 @@
       if (ev.ctrlKey || ev.altKey || ev.metaKey || document.activeElement.tagName === "INPUT") {
         return;
       }
-      if (ev.which === 38) { // Down arrow
+      if (ev.which === 40) { // Down arrow
         if (active === null) {
           active = document.getElementsByClassName("recent-releases-container")[0].getElementsByTagName("li")[0];
         } else if (active.nextElementSibling) {
@@ -70,7 +70,7 @@
           active = active.nextElementSibling;
         }
         active.classList.add("selected");
-      } else if (ev.which === 40) { // Up arrow
+      } else if (ev.which === 38) { // Up arrow
         if (active === null) {
           active = document.getElementsByClassName("recent-releases-container")[0].getElementsByTagName("li")[0];
         } else if (active.previousElementSibling) {


### PR DESCRIPTION
After deploying rust-lang/docs.rs#324 and testing it out, it looks like @GuillaumeGomez got the arrow keys backwards. This switches them around and makes it work properly.