### PR TITLE
serve all in-crate js files

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -170,9 +170,6 @@ impl CratesfyiHandler {
         router.get("/:crate/:version/",
                    rustdoc::rustdoc_redirector_handler,
                    "crate_version_");
-        router.get("/:crate/:version/*.js",
-                   rustdoc::rustdoc_redirector_handler,
-                   "crate_version_js");
         router.get("/:crate/:version/settings.html",
                    rustdoc::rustdoc_html_server_handler,
                    "crate_version_settings_html");

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -170,21 +170,15 @@ impl CratesfyiHandler {
         router.get("/:crate/:version/",
                    rustdoc::rustdoc_redirector_handler,
                    "crate_version_");
-        router.get("/:crate/:version/search-index.js",
-                   rustdoc::rustdoc_html_server_handler,
-                   "crate_version_search_index_js");
+        router.get("/:crate/:version/*.js",
+                   rustdoc::rustdoc_redirector_handler,
+                   "crate_version_js");
         router.get("/:crate/:version/settings.html",
                    rustdoc::rustdoc_html_server_handler,
                    "crate_version_settings_html");
         router.get("/:crate/:version/all.html",
                    rustdoc::rustdoc_html_server_handler,
                    "crate_version_all_html");
-        router.get("/:crate/:version/aliases.js",
-                   rustdoc::rustdoc_html_server_handler,
-                   "crate_version_aliases_js");
-        router.get("/:crate/:version/source-files.js",
-                   rustdoc::rustdoc_html_server_handler,
-                   "crate_version_source_files_js");
         router.get("/:crate/:version/:target",
                    rustdoc::rustdoc_redirector_handler,
                    "crate_version_target");


### PR DESCRIPTION
Starting with rust-lang/rust#59776, the search index, aliases, and source file list are getting the resource suffix added to their file names. This means we can't route them from a static path any more.

Since we always check the static file router first, this will still allow serving `main.js` for rustdoc versions prior to the addition of `--static-root-path`, and also allows rustdoc to add per-crate javascript files without requiring docs.rs to update to handle it.

(It also allows us to start hosting things *other* than rustdoc output as docs - e.g. mdbook output - in the future without changing the routing table massively.)

**WARNING**: Do not merge/deploy until rust-lang/rust#59776 is in nightly rustdoc. Deploy with `update-both-rustc-docsrs` script to ensure that docs.rs doesn't use the wrong rustdoc to build/serve docs!