### PR TITLE
clean up debug logging around "not found" errors

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -237,32 +237,30 @@ impl Handler for CratesfyiHandler {
                     panic!("all cratesfyi errors should be of type Nope");
                 };
 
-                match err {
-                    error::Nope::ResourceNotFound => {
-                        // print the path of the URL that triggered a 404 error
-                        struct DebugPath<'a>(&'a iron::Url);
-                        impl<'a> fmt::Display for DebugPath<'a> {
-                            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                                for path_elem in self.0.path() {
-                                    write!(f, "/{}", path_elem)?;
-                                }
-
-                                if let Some(query) = self.0.query() {
-                                    write!(f, "?{}", query)?;
-                                }
-
-                                if let Some(hash) = self.0.fragment() {
-                                    write!(f, "#{}", hash)?;
-                                }
-
-                                Ok(())
+                if let error::Nope::ResourceNotFound = err {
+                    // print the path of the URL that triggered a 404 error
+                    struct DebugPath<'a>(&'a iron::Url);
+                    impl<'a> fmt::Display for DebugPath<'a> {
+                        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                            for path_elem in self.0.path() {
+                                write!(f, "/{}", path_elem)?;
                             }
-                        }
 
-                        debug!("Path not found: {}", DebugPath(&req.url));
+                            if let Some(query) = self.0.query() {
+                                write!(f, "?{}", query)?;
+                            }
+
+                            if let Some(hash) = self.0.fragment() {
+                                write!(f, "#{}", hash)?;
+                            }
+
+                            Ok(())
+                        }
                     }
-                    _ => {}
+
+                    debug!("Path not found: {}", DebugPath(&req.url));
                 }
+
 
                 Self::chain(err).handle(req)
             })

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -229,7 +229,6 @@ impl Handler for CratesfyiHandler {
                 self.static_handler.handle(req).or(Err(e))
             })
             .or_else(|e| {
-                debug!("{}", e.description());
                 let err = if let Some(err) = e.error.downcast::<error::Nope>() {
                     *err
                 } else if e.error.downcast::<NoRoute>().is_some() {
@@ -260,7 +259,7 @@ impl Handler for CratesfyiHandler {
                             }
                         }
 
-                        debug!("Path: {}", DebugPath(&req.url));
+                        debug!("Path not found: {}", DebugPath(&req.url));
                     }
                     _ => {}
                 }


### PR DESCRIPTION
We currently emit two `debug!()` statements on 404 errors: a static "Requested resource not found" and a newer one that prints the path that 404'd. (The former also prints a different one for searches with no results, but "Requested resource not found" is enormously more common in the log.) This PR will strip out the less useful log line in favor of the one that displays what was actually not found.

(It also includes a separate code formatting commit that reduces one level of indentation around that block, as a personal style preference - even though i was the one who wrote that block in the first place `>_>`)