### PR TITLE
add settings.js to essential files

### DIFF
--- a/src/docbuilder/chroot_builder.rs
+++ b/src/docbuilder/chroot_builder.rs
@@ -383,6 +383,7 @@ impl DocBuilder {
                       "normalize.css",
                       "rustdoc.css",
                       "settings.css",
+                      "settings.js",
                       "storage.js",
                       "theme.js",
                       "source-script.js",


### PR DESCRIPTION
Fixes https://github.com/rust-lang/docs.rs/issues/213, though all the existing `settings.js` files need to be loaded in separately. Can be deployed without updating rustdoc at the same time, since this file has been there for a while `>_>`

In https://github.com/rust-lang/rust/pull/49954, rustdoc added a settings menu, which added the separate JavaScript file `settings.js`. This is a static file just like the other JS/CSS files bundled with rustdoc, but docs.rs never picked it up as an essential file.

A separate change will need to be made to rustdoc to use `--static-root-path` for this file, but this can at least let users begin using the settings page.