### PR TITLE
always redirect version-catchall URLs to their latest version

### DIFF
--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -484,7 +484,7 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
             }
 
 
-            if let Some(version) = match_version(&conn, &query, None) {
+            if let Some(version) = match_version(&conn, &query, None).into_option() {
                 // FIXME: This is a super dirty way to check if crate have rustdocs generated.
                 //        match_version should handle this instead of this code block.
                 //        This block is introduced to fix #163

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -483,7 +483,9 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
                 return Ok(resp);
             }
 
-
+            // since we never pass a version into `match_version` here, we'll never get
+            // `MatchVersion::Exact`, so the distinction between `Exact` and `Semver` doesn't
+            // matter
             if let Some(version) = match_version(&conn, &query, None).into_option() {
                 // FIXME: This is a super dirty way to check if crate have rustdocs generated.
                 //        match_version should handle this instead of this code block.

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -66,7 +66,8 @@ impl ToJson for RustdocPage {
 }
 
 
-
+/// Handler called for `/:crate` and `/:crate/:version` URLs. Automatically redirects to the docs
+/// or crate details page based on whether the given crate version was successfully built.
 pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
 
     fn redirect_to_doc(req: &Request,
@@ -120,6 +121,8 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
 
     let conn = extension!(req, Pool);
 
+    // it doesn't matter if the version that was given was exact or not, since we're redirecting
+    // anyway
     let version = match match_version(&conn, &crate_name, req_version).into_option() {
         Some(v) => v,
         None => return Err(IronError::new(Nope::CrateNotFound, status::NotFound)),

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -9,7 +9,7 @@ use iron::prelude::*;
 use iron::{status, Url};
 use iron::modifiers::Redirect;
 use router::Router;
-use super::match_version;
+use super::{match_version, MatchVersion};
 use super::error::Nope;
 use super::page::Page;
 use rustc_serialize::json::{Json, ToJson};
@@ -120,7 +120,7 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
 
     let conn = extension!(req, Pool);
 
-    let version = match match_version(&conn, &crate_name, req_version) {
+    let version = match match_version(&conn, &crate_name, req_version).into_option() {
         Some(v) => v,
         None => return Err(IronError::new(Nope::CrateNotFound, status::NotFound)),
     };
@@ -153,16 +153,34 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
 
     let router = extension!(req, Router);
     let name = router.find("crate").unwrap_or("").to_string();
-    let version = router.find("version");
+    let url_version = router.find("version");
+    let version; // pre-declaring it to enforce drop order relative to `req_path`
     let conn = extension!(req, Pool);
-    let version = try!(match_version(&conn, &name, version)
-        .ok_or(IronError::new(Nope::ResourceNotFound, status::NotFound)));
+
     let mut req_path = req.url.path();
 
     // remove name and version from path
     for _ in 0..2 {
         req_path.remove(0);
     }
+
+    version = match match_version(&conn, &name, url_version) {
+        MatchVersion::Exact(v) => v,
+        MatchVersion::Semver(v) => {
+            // to prevent cloudfront caching the wrong artifacts on URLs with loose semver
+            // versions, redirect the browser to the returned version instead of loading it
+            // immediately
+            let url = ctry!(Url::parse(&format!("{}://{}:{}/{}/{}/{}",
+                                                req.url.scheme(),
+                                                req.url.host(),
+                                                req.url.port(),
+                                                name,
+                                                v,
+                                                req_path.join("/"))[..]));
+            return Ok(super::redirect(url));
+        }
+        MatchVersion::None => return Err(IronError::new(Nope::ResourceNotFound, status::NotFound)),
+    };
 
     // docs have "rustdoc" prefix in database
     req_path.insert(0, "rustdoc");
@@ -240,7 +258,7 @@ pub fn badge_handler(req: &mut Request) -> IronResult<Response> {
     let conn = extension!(req, Pool);
 
     let options = match match_version(&conn, &name, Some(&version)) {
-        Some(version) => {
+        MatchVersion::Exact(version) => {
             let rows = ctry!(conn.query("SELECT rustdoc_status
                                          FROM releases
                                          INNER JOIN crates ON crates.id = releases.crate_id
@@ -260,7 +278,17 @@ pub fn badge_handler(req: &mut Request) -> IronResult<Response> {
                 }
             }
         }
-        None => {
+        MatchVersion::Semver(version) => {
+            let url = ctry!(Url::parse(&format!("{}://{}:{}/{}/badge.svg?version={}",
+                                                req.url.scheme(),
+                                                req.url.host(),
+                                                req.url.port(),
+                                                name,
+                                                version)[..]));
+
+            return Ok(super::redirect(url));
+        }
+        MatchVersion::None => {
             BadgeOptions {
                 subject: "docs".to_owned(),
                 status: "no builds".to_owned(),


### PR DESCRIPTION
Fixes https://github.com/rust-lang/docs.rs/issues/316 (the iteration where semver-catchall URLs were getting updated after they were cached the first time)

One of docs.rs's powerful features is the ability to provide semver requirements in lieu of actual version numbers in many places. However, when combined with a CDN that likes to cache content at certain URLs, that can cause problems when not all URLs for a certain crate are cached at the same time. For example, if you load `docs.rs/tokio/0.1/tokio/index.html`, it's not certain whether you'll load the `index.html` from `0.1.0` or `0.1.19` (the current latest version in that series), since the CDN could have cached the page from an earlier version and hasn't updated the cache since then. (Or perhaps more confusing, it has updated the cache, but only in certain regions, and not everywhere has the right version yet, which happened on a different issue.)

This PR aims to solve the problem by never serving a URL where the "version" doesn't match the actual version number of the docs it's serving. Instead it aims to issue redirects to the URL with the exact version information. This way, the URL that actually serves the content is the one that's not expected to change over time.