### PR TITLE
add "priority" to the build queue, and decouple builds from reading new crates

### DIFF
--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -169,6 +169,16 @@ pub fn migrate(version: Option<Version>) -> CratesfyiResult<()> {
             "DROP TABLE authors, author_rels, keyword_rels, keywords, owner_rels,
                         owners, releases, crates, builds, queue, files, config;"
         ),
+        migration!(
+            // version
+            2,
+            // description
+            "Added priority column to build queue",
+            // upgrade query
+            "ALTER TABLE queue ADD COLUMN priority INT DEFAULT 0;",
+            // downgrade query
+            "ALTER TABLE queue DROP COLUMN priority;"
+        ),
     ];
 
     for migration in migrations {

--- a/src/docbuilder/mod.rs
+++ b/src/docbuilder/mod.rs
@@ -110,6 +110,11 @@ impl DocBuilder {
         Ok(())
     }
 
+    /// Checks for the lock file and returns whether it currently exists.
+    pub fn is_locked(&self) -> bool {
+        self.lock_path().exists()
+    }
+
     /// Returns a reference of options
     pub fn options(&self) -> &DocBuilderOptions {
         &self.options

--- a/src/docbuilder/queue.rs
+++ b/src/docbuilder/queue.rs
@@ -5,6 +5,7 @@ use super::DocBuilder;
 use db::connect_db;
 use error::Result;
 use crates_index_diff::{ChangeKind, Index};
+use utils::add_crate_to_queue;
 
 
 impl DocBuilder {
@@ -20,9 +21,7 @@ impl DocBuilder {
         changes.reverse();
 
         for krate in changes.iter().filter(|k| k.kind != ChangeKind::Yanked) {
-            conn.execute("INSERT INTO queue (name, version, priority) VALUES ($1, $2, 0)",
-                         &[&krate.name, &krate.version])
-                .ok();
+            add_crate_to_queue(&conn, &krate.name, &krate.version, 0).ok();
             debug!("{}-{} added into build queue", krate.name, krate.version);
             add_count += 1;
         }

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -95,7 +95,7 @@ pub fn start_daemon() {
                 continue;
             }
 
-            if status.count() > 10 {
+            if status.count() >= 10 {
                 // periodically, we need to flush our caches and ping the hubs
                 debug!("10 builds in a row; flushing caches");
                 status = BuilderState::QueueInProgress(0);

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -127,7 +127,7 @@ pub fn start_daemon() {
                     continue;
                 }
                 Ok(0) => {
-                    if status.is_in_progress() {
+                    if status.count() > 0 {
                         // ping the hubs before continuing
                         match pubsubhubbub::ping_hubs() {
                             Err(e) => error!("Failed to ping hub: {}", e),

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -4,6 +4,7 @@
 
 
 use std::{env, thread};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::process::exit;
 use std::fs::File;
 use std::io::Write;
@@ -44,78 +45,158 @@ pub fn start_daemon() {
         exit(0);
     }
 
-
     // check new crates every minute
     thread::spawn(move || {
+        // space this out to prevent it from clashing against the queue-builder thread on launch
+        thread::sleep(Duration::from_secs(30));
         loop {
-            thread::sleep(Duration::from_secs(60));
-
-            let mut opts = opts();
-            opts.skip_if_exists = true;
-
-            // check lock file
-            if opts.prefix.join("cratesfyi.lock").exists() {
-                warn!("Lock file exits, skipping building new crates");
-                continue;
-            }
-
+            let opts = opts();
             let mut doc_builder = DocBuilder::new(opts);
 
             debug!("Checking new crates");
-            let queue_count = match doc_builder.get_new_crates() {
-                Ok(size) => size,
-                Err(e) => {
-                    error!("Failed to get new crates: {}", e);
+            match doc_builder.get_new_crates() {
+                Ok(n) => debug!("{} crates added to queue", n),
+                Err(e) => error!("Failed to get new crates: {}", e),
+            }
+
+            thread::sleep(Duration::from_secs(60));
+        }
+    });
+
+    // build new crates every minute
+    thread::spawn(move || {
+        let mut opts = opts();
+        opts.skip_if_exists = true;
+        let mut doc_builder = DocBuilder::new(opts);
+
+        /// Represents the current state of the builder thread.
+        enum BuilderState {
+            /// The builder thread has just started, and hasn't built any crates yet.
+            Fresh,
+            /// The builder has just seen an empty build queue.
+            EmptyQueue,
+            /// The builder has just seen the lock file.
+            Locked,
+            /// The builder has just finished building a crate. The enclosed count is the number of
+            /// crates built since the caches have been refreshed.
+            QueueInProgress(usize),
+        }
+
+        let mut status = BuilderState::Fresh;
+
+        loop {
+            if !status.is_in_progress() {
+                thread::sleep(Duration::from_secs(60));
+            }
+
+            // check lock file
+            if doc_builder.is_locked() {
+                warn!("Lock file exits, skipping building new crates");
+                status = BuilderState::Locked;
+                continue;
+            }
+
+            if status.count() > 10 {
+                // periodically, we need to flush our caches and ping the hubs
+                debug!("10 builds in a row; flushing caches");
+                status = BuilderState::QueueInProgress(0);
+
+                match pubsubhubbub::ping_hubs() {
+                    Err(e) => error!("Failed to ping hub: {}", e),
+                    Ok(n) => debug!("Succesfully pinged {} hubs", n)
+                }
+
+                if let Err(e) = doc_builder.load_cache() {
+                    error!("Failed to load cache: {}", e);
+                }
+
+                if let Err(e) = doc_builder.save_cache() {
+                    error!("Failed to save cache: {}", e);
+                }
+
+                if let Err(e) = update_sources() {
+                    error!("Failed to update sources: {}", e);
                     continue;
                 }
-            };
-
-            // Only build crates if there is any
-            if queue_count == 0 {
-                debug!("Queue is empty, going back to sleep");
-                continue;
             }
 
-            info!("Building {} crates from queue", queue_count);
+            // Only build crates if there are any to build
+            debug!("Checking build queue");
+            match doc_builder.get_queue_count() {
+                Err(e) => {
+                    error!("Failed to read the number of crates in the queue: {}", e);
+                    continue;
+                }
+                Ok(0) => {
+                    if status.is_in_progress() {
+                        // ping the hubs before continuing
+                        match pubsubhubbub::ping_hubs() {
+                            Err(e) => error!("Failed to ping hub: {}", e),
+                            Ok(n) => debug!("Succesfully pinged {} hubs", n)
+                        }
 
-            // update index
-            if let Err(e) = update_sources() {
-                error!("Failed to update sources: {}", e);
-                continue;
-            }
-
-            if let Err(e) = doc_builder.load_cache() {
-                error!("Failed to load cache: {}", e);
-                continue;
-            }
-
-
-            // Run build_packages_queue in it's own thread to catch panics
-            // This only panicked twice in the last 6 months but its just a better
-            // idea to do this.
-            let res = thread::spawn(move || {
-                    match doc_builder.build_packages_queue() {
-                        Err(e) => error!("Failed build new crates: {}", e),
-                        Ok(n) => {
-                            if n > 0 {
-                                match pubsubhubbub::ping_hubs() {
-                                    Err(e) => error!("Failed to ping hub: {}", e),
-                                    Ok(n) => debug!("Succesfully pinged {} hubs", n)
-                                }
-                            }
+                        if let Err(e) = doc_builder.save_cache() {
+                            error!("Failed to save cache: {}", e);
                         }
                     }
+                    debug!("Queue is empty, going back to sleep");
+                    status = BuilderState::EmptyQueue;
+                    continue;
+                }
+                Ok(queue_count) => {
+                    info!("Starting build with {} crates in queue (currently on a {} crate streak)",
+                          queue_count, status.count());
+                }
+            }
 
-                    if let Err(e) = doc_builder.save_cache() {
-                        error!("Failed to save cache: {}", e);
+            // if we're starting a new batch, reload our caches and sources
+            if !status.is_in_progress() {
+                if let Err(e) = doc_builder.load_cache() {
+                    error!("Failed to load cache: {}", e);
+                    continue;
+                }
+
+                if let Err(e) = update_sources() {
+                    error!("Failed to update sources: {}", e);
+                    continue;
+                }
+            }
+
+            // Run build_packages_queue under `catch_unwind` to catch panics
+            // This only panicked twice in the last 6 months but its just a better
+            // idea to do this.
+            let res = catch_unwind(AssertUnwindSafe(|| {
+                match doc_builder.build_next_queue_package() {
+                    Err(e) => error!("Failed to build crate from queue: {}", e),
+                    Ok(crate_built) => if crate_built {
+                        status.increment();
                     }
 
-                    debug!("Finished building new crates, going back to sleep");
-                })
-                .join();
+                }
+            }));
 
             if let Err(e) = res {
                 error!("GRAVE ERROR Building new crates panicked: {:?}", e);
+            }
+        }
+
+        impl BuilderState {
+            fn count(&self) -> usize {
+                match *self {
+                    BuilderState::QueueInProgress(n) => n,
+                    _ => 0,
+                }
+            }
+
+            fn is_in_progress(&self) -> bool {
+                match *self {
+                    BuilderState::QueueInProgress(_) => true,
+                    _ => false,
+                }
+            }
+
+            fn increment(&mut self) {
+                *self = BuilderState::QueueInProgress(self.count() + 1);
             }
         }
     });

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -65,8 +65,7 @@ pub fn start_daemon() {
 
     // build new crates every minute
     thread::spawn(move || {
-        let mut opts = opts();
-        opts.skip_if_exists = true;
+        let opts = opts();
         let mut doc_builder = DocBuilder::new(opts);
 
         /// Represents the current state of the builder thread.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,6 +8,7 @@ pub use self::release_activity_updater::update_release_activity;
 pub use self::daemon::start_daemon;
 pub use self::rustc_version::{parse_rustc_version, get_current_versions, command_result};
 pub use self::html::extract_head_and_body;
+pub use self::queue::add_crate_to_queue;
 
 mod github_updater;
 mod build_doc;
@@ -17,3 +18,4 @@ mod daemon;
 mod pubsubhubbub;
 mod rustc_version;
 mod html;
+mod queue;

--- a/src/utils/queue.rs
+++ b/src/utils/queue.rs
@@ -1,0 +1,10 @@
+//! Utilities for interacting with the build queue
+
+use postgres::Connection;
+use error::Result;
+
+pub fn add_crate_to_queue(conn: &Connection, name: &str, version: &str, priority: i32) -> Result<()> {
+    try!(conn.execute("INSERT INTO queue (name, version, priority) VALUES ($1, $2, $3)",
+                      &[&name, &version, &priority]));
+    Ok(())
+}

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -565,7 +565,7 @@ pub fn build_queue_handler(req: &mut Request) -> IronResult<Response> {
     for krate in &conn.query("SELECT name, version
                               FROM queue
                               WHERE attempt < 5
-                              ORDER BY id ASC",
+                              ORDER BY priority ASC, attempt ASC, id ASC",
                &[])
         .unwrap() {
         crates.push((krate.get(0), krate.get(1)));


### PR DESCRIPTION
This PR implements the first couple steps of https://github.com/rust-lang/docs.rs/issues/301, paving the way for manually batching builds while still allowing for new crate releases to be posted in a timely manner.

The largest change is the first commit, which breaks up the queue thread in the daemon into two: one which loads new crates from crates.io once a minute, and one which checks the build queue once a minute to start builds. This turned out to be a little more complicated than i initially imagined, because of the way the `DocBuilder` caches what has been built already. Juggling the caches made it a little more awkward than it otherwise would have been, but i think it turned out alright.

This alone allows docs.rs to avoid the confusing scenario where a long-running build job jams up the queue and makes it appear like the builder died (whereas now the queue will start accumulating entries and the builder will merely appear stuck, which is more reflective of reality). cc https://github.com/rust-lang/docs.rs/issues/335

The later commits are a logically-distinct change which is the core of https://github.com/rust-lang/docs.rs/issues/301 - the notion of a "priority" in the build queue, and a change in how builds are sorted. This allows us to queue up a batch of rebuilds without blocking new crate releases from being built.

Finally, for ease of maintenance, i added a `cratesfyi queue add` command, which allows administrators to add a crate to the build queue without having to manually enter a row into the database for it. (This means we can easily wire up a script for it, a la the current `build-from-psql-select`.) By default, crates entered through this command get priority 5 (which means they'll be sorted below the priority 0 that new crates get), though there is an available `--priority` flag you can use to override that. Since the column (and the types used in the code) are signed, it's *technically* possible to add queue entries above new crates, so some care is necessary. However, this is a much easier scheme than the current "lock the world so we can run builds outside the main log" system.