### PR TITLE
only build crates for default target unless asked

### DIFF
--- a/src/docbuilder/chroot_builder.rs
+++ b/src/docbuilder/chroot_builder.rs
@@ -25,7 +25,7 @@ const TARGETS: [&'static str; 6] = [
     "x86_64-unknown-linux-gnu"
 ];
 
-
+const DEFAULT_TARGET: &'static str = "x86_64-unknown-linux-gnu";
 
 #[derive(Debug)]
 pub struct ChrootBuilderResult {
@@ -88,7 +88,10 @@ impl DocBuilder {
         let successfully_targets = if res.have_doc {
             let default_target = metadata.default_target.as_ref().map(String::as_str);
             let mut build_targets = metadata.extra_targets.clone().unwrap_or_default();
-            if let Some(default_target) = default_target {
+            {
+                // FIXME: skip the second build for `default_target` by copying its documentation
+                // in twice
+                let default_target = default_target.unwrap_or(DEFAULT_TARGET);
                 if !build_targets.iter().any(|t| t == default_target) {
                     build_targets.push(default_target.to_owned());
                 }

--- a/src/docbuilder/metadata.rs
+++ b/src/docbuilder/metadata.rs
@@ -21,6 +21,7 @@ use failure::err_msg;
 /// all-features = true
 /// no-default-features = true
 /// default-target = "x86_64-unknown-linux-gnu"
+/// extra-targets = [ "x86_64-apple-darwin", "x86_64-pc-windows-msvc" ]
 /// rustc-args = [ "--example-rustc-arg" ]
 /// rustdoc-args = [ "--example-rustdoc-arg" ]
 /// dependencies = [ "example-system-dependency" ]
@@ -44,6 +45,11 @@ pub struct Metadata {
     /// Docs.rs is running on `x86_64-unknown-linux-gnu` target system and default documentation
     /// is always built on this target. You can change default target by setting this.
     pub default_target: Option<String>,
+
+    /// Docs.rs doesn't automatically build extra targets for crates. If you want a crate to build
+    /// for multiple targets, set `extra-targets` to the list of targets to build, in addition to
+    /// `default-target`.
+    pub extra_targets: Option<Vec<String>>,
 
     /// List of command line arguments for `rustc`.
     pub rustc_args: Option<Vec<String>>,
@@ -93,6 +99,7 @@ impl Metadata {
             all_features: false,
             no_default_features: false,
             default_target: None,
+            extra_targets: None,
             rustc_args: None,
             rustdoc_args: None,
             dependencies: None,
@@ -120,6 +127,8 @@ impl Metadata {
                         .and_then(|v| v.as_bool()).unwrap_or(metadata.all_features);
                     metadata.default_target = table.get("default-target")
                         .and_then(|v| v.as_str()).map(|v| v.to_owned());
+                    metadata.extra_targets = table.get("extra-targets").and_then(|f| f.as_array())
+                        .and_then(|f| f.iter().map(|v| v.as_str().map(|v| v.to_owned())).collect());
                     metadata.rustc_args = table.get("rustc-args").and_then(|f| f.as_array())
                         .and_then(|f| f.iter().map(|v| v.as_str().map(|v| v.to_owned())).collect());
                     metadata.rustdoc_args = table.get("rustdoc-args").and_then(|f| f.as_array())
@@ -151,6 +160,7 @@ mod test {
             all-features = true
             no-default-features = true
             default-target = "x86_64-unknown-linux-gnu"
+            extra-targets = [ "x86_64-apple-darwin", "x86_64-pc-windows-msvc" ]
             rustc-args = [ "--example-rustc-arg" ]
             rustdoc-args = [ "--example-rustdoc-arg" ]
             dependencies = [ "example-system-dependency" ]
@@ -170,6 +180,11 @@ mod test {
         assert_eq!(features[1], "feature2".to_owned());
 
         assert_eq!(metadata.default_target.unwrap(), "x86_64-unknown-linux-gnu".to_owned());
+
+        let extra_targets = metadata.extra_targets.unwrap();
+        assert_eq!(extra_targets.len(), 2);
+        assert_eq!(extra_targets[0], "x86_64-apple-darwin".to_owned());
+        assert_eq!(extra_targets[1], "x86_64-pc-windows-msvc".to_owned());
 
         let rustc_args = metadata.rustc_args.unwrap();
         assert_eq!(rustc_args.len(), 1);

--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -101,22 +101,44 @@
     </tbody>
   </table>
 
-  <h4>Metadata for custom builds</h4>
+  <h4 id="metadata"><a href="#metadata">Metadata for custom builds</a></h4>
 
   <p>You can customize docs.rs builds by defining <code>[package.metadata.docs.rs]</code> table in your crates' `Cargo.toml`.</p>
 
-  <p>An example metadata:</p>
+  <p>The available configuration flags you can customize are:</p>
 
   <pre><code>[package]
 name = "test"
 
 [package.metadata.docs.rs]
+
+# Features to pass to Cargo (default: none)
 features = [ "feature1", "feature2" ]
+
+# Whether to pass `--all-features` to Cargo (default: false)
 all-features = true
+
+# Whether to pass `--no-default-features` to Cargo (default: false)
 no-default-features = true
+
+# Target to test build on, used as the default landing page (default: "x86_64-unknown-linux-gnu")
+#
+# Available targets:
+# - x86_64-unknown-linux-gnu
+# - x86_64-apple-darwin
+# - x86_64-pc-windows-msvc
+# - i686-unknown-linux-gnu
+# - i686-apple-darwin
+# - i686-pc-windows-msvc
 default-target = "x86_64-unknown-linux-gnu"
+
+# Extra targets to build, same available targets as `default-target` (default: none)
 extra-targets = [ "x86_64-apple-darwin", "x86_64-pc-windows-msvc" ]
+
+# Additional `RUSTFLAGS` to set (default: none)
 rustc-args = [ "--example-rustc-arg" ]
+
+# Additional `RUSTDOCFLAGS` to set (default: none)
 rustdoc-args = [ "--example-rustdoc-arg" ]</pre></code>
 
   <h4>Version</h4>

--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -115,6 +115,7 @@ features = [ "feature1", "feature2" ]
 all-features = true
 no-default-features = true
 default-target = "x86_64-unknown-linux-gnu"
+extra-targets = [ "x86_64-apple-darwin", "x86_64-pc-windows-msvc" ]
 rustc-args = [ "--example-rustc-arg" ]
 rustdoc-args = [ "--example-rustdoc-arg" ]</pre></code>
 


### PR DESCRIPTION
fixes https://github.com/rust-lang/docs.rs/issues/343

This PR makes it so that we don't automatically build crates for every target in our build container. See discussion in the linked issue for rationale.

I've also included an expansion of the documentation of the package metadata, since it wasn't very well explained before.