### PR TITLE
attempt to look up crates with -/_ replaced before 404ing

### DIFF
--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -483,7 +483,9 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
             // since we never pass a version into `match_version` here, we'll never get
             // `MatchVersion::Exact`, so the distinction between `Exact` and `Semver` doesn't
             // matter
-            if let Some(version) = match_version(&conn, &query, None).into_option() {
+            if let Some(matchver) = match_version(&conn, &query, None) {
+                let version = matchver.version.into_string();
+                let query = matchver.corrected_name.unwrap_or_else(|| query.to_string());
                 // FIXME: This is a super dirty way to check if crate have rustdocs generated.
                 //        match_version should handle this instead of this code block.
                 //        This block is introduced to fix #163
@@ -493,7 +495,7 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
                                                  INNER JOIN crates
                                                  ON crates.id = releases.crate_id
                                                  WHERE crates.name = $1 AND releases.version = $2",
-                                                &[query, &version]));
+                                                &[&query, &version]));
                     if rows.is_empty() {
                         false
                     } else {


### PR DESCRIPTION
While reading the logs today, i noticed a few 404s where people had tried to go to the URL `docs.rs/crate_name` when the real crate is called `crate-name` with a hyphen instead of an underscore. This PR adds an extra lookup in the `/:crate` route that replaces hyphens with underscores (and vice-versa) before returning the 404. So in this case, attempting to go to `/crate_name` will redirect to `/crate-name/version/target` instead.