### PR TITLE
don't check new crates if lock file exists

### DIFF
--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -53,10 +53,14 @@ pub fn start_daemon() {
             let opts = opts();
             let mut doc_builder = DocBuilder::new(opts);
 
-            debug!("Checking new crates");
-            match doc_builder.get_new_crates() {
-                Ok(n) => debug!("{} crates added to queue", n),
-                Err(e) => error!("Failed to get new crates: {}", e),
+            if doc_builder.is_locked() {
+                debug!("Lock file exists, skipping checking new crates");
+            } else {
+                debug!("Checking new crates");
+                match doc_builder.get_new_crates() {
+                    Ok(n) => debug!("{} crates added to queue", n),
+                    Err(e) => error!("Failed to get new crates: {}", e),
+                }
             }
 
             thread::sleep(Duration::from_secs(60));


### PR DESCRIPTION
When i wrote https://github.com/rust-lang/docs.rs/pull/344 i didn't think i would need to lock the "check for new crates" thread, but after running a couple deployments since then, i've realized that it's helpful to know that the local crates.io clone won't be messed with if a new build takes longer than expected.