### PR TITLE
Add aria hints where labels were missing or unclear

### DIFF
--- a/templates/navigation.hbs
+++ b/templates/navigation.hbs
@@ -1,11 +1,11 @@
     <div class="nav-container">
       <div class="container">
-        <div class="pure-menu pure-menu-horizontal">
+        <div class="pure-menu pure-menu-horizontal" role="navigation" aria-label="Main navigation">
           <form action="/releases/search" method="GET" class="landing-search-form-nav">
             {{#unless varsb.show_search_form}}
-            <input class="search-input-nav" name="query" type="text" placeholder="Find crate"{{#if varss.search_query}} value="{{varss.search_query}}"{{/if}}>
+            <input class="search-input-nav" name="query" type="text" aria-label="Find crate by search query" placeholder="Find crate"{{#if varss.search_query}} value="{{varss.search_query}}"{{/if}}>
             {{/unless}}
-          <a href="/" class="pure-menu-heading pure-menu-link"><i class="fa fa-cubes fa-fw"></i> Docs.rs</a>
+          <a href="/" class="pure-menu-heading pure-menu-link" aria-label="Docs.rs"><i class="fa fa-cubes fa-fw"></i> Docs.rs</a>
           <ul class="pure-menu-list">
             <li class="pure-menu-item"><a href="/releases" class="pure-menu-link">Releases</a></li>
             <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">

--- a/templates/navigation_rustdoc.hbs
+++ b/templates/navigation_rustdoc.hbs
@@ -3,7 +3,7 @@
         <div class="pure-menu pure-menu-horizontal">
           <form action="/releases/search" method="GET" class="landing-search-form-nav">
             {{#unless varsb.show_search_form}}
-            <input class="search-input-nav" name="query" tabindex="-1" type="text" placeholder="Find crate"{{#if varss.search_query}} value="{{varss.search_query}}"{{/if}}>
+            <input class="search-input-nav" name="query" aria-label="Find crate by search query" tabindex="-1" type="text" placeholder="Find crate"{{#if varss.search_query}} value="{{varss.search_query}}"{{/if}}>
             {{/unless}}
             <a href="/" class="pure-menu-heading pure-menu-link"><i class="fa fa-cubes fa-fw"></i><span class="title"> Docs.rs</span></a>
           {{#with content.crate_details}}
@@ -93,7 +93,7 @@
               <a href="/crate/{{name}}/{{version}}/source/" title="Browse source of {{name}}-{{version}}" class="pure-menu-link{{#if ../../varsb.package_source_tab}} pure-menu-active{{/if}}"><i class="fa fa-fw fa-folder-open-o"></i><span class="title"> Source</span></a>
             </li>
             <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
-              <a href="#" class="pure-menu-link"><i class="fa fa-fw fa-gears"></i><span class="title"> Platform</span></a>
+              <a href="#" class="pure-menu-link" aria-label="Platform"><i class="fa fa-fw fa-gears"></i><span class="title"> Platform</span></a>
               <ul class="pure-menu-children">
                 {{#each doc_targets}}
                 <li class="pure-menu-item"><a href="/{{../../content.crate_details.name}}/{{../../content.crate_details.version}}/{{this}}/{{../../content.crate_details.target_name}}/" class="pure-menu-link">{{this}}</a></li>

--- a/templates/releases.hbs
+++ b/templates/releases.hbs
@@ -14,7 +14,7 @@
   <h1 class="brand"><i class="fa fa-cubes fa-fw"></i> Docs.rs</h1>
 
   <form action="/releases/search" method="GET" class="landing-search-form">
-    <div><input class="search-input" id="search" name="query" type="text" placeholder="Click or press 'S' to search" autofocus></div>
+    <div><input class="search-input" id="search" name="query" type="text" aria-label="Find crate by search query" placeholder="Click or press 'S' to search" autofocus></div>
     <div class="buttons">
       <button type="submit" class="pure-button pure-button-normal">Search</button>
       <button type="submit" class="pure-button pure-button-normal" id="i-am-feeling-lucky-button">I'm Feeling Lucky</button>


### PR DESCRIPTION
While reading the source, I noticed several links that didn't seem to have descernible text. Running the site though webhint.io [confirmed my hunch](https://webhint.io/scanner/a6f3c31b-7d33-427a-bf93-df4aa0b9d176#category-Accessibility). In those cases, I've added the `aria-label` attribute, which will be used by screen reader software.

I scanned the home, releases, and crate detail pages. These changes are fairly complete, but not exhaustive. In fact, this is the first of what I hope will be several accessibility-related PRs I make to docs.rs!