### PR TITLE
Mention *|latest|newest redirects to latest

### DIFF
--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -63,6 +63,10 @@
         <td><a href="https://docs.rs/clap/2.9.3">docs.rs/clap/2.9.3</a></td>
         <td>2.9.3 version (you don't need <code>=</code> unlike semver)</td>
       </tr>
+      <tr>
+        <td><a href="https://docs.rs/clap/*/clap/struct.App.html">docs.rs/clap/*/clap/struct.App.html</a></td>
+        <td>Latest version of this page (if it still exists). "latest" or "newest" work as well as <code>*</code>.</td>
+      </tr>
     </tbody>
   </table>
 


### PR DESCRIPTION
Addresses issue #361. I don't know whether in a .hbs file `"` needs to be escaped `&quot;`, or `*` should be encoded `%2A`.