### PR TITLE
Fix http redirects

### DIFF
--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -2,7 +2,7 @@
 
 
 use super::pool::Pool;
-use super::{MetaData, duration_to_str, match_version, render_markdown, MatchVersion};
+use super::{MetaData, duration_to_str, match_version, render_markdown, MatchVersion, redirect_base};
 use super::error::Nope;
 use super::page::Page;
 use iron::prelude::*;
@@ -240,10 +240,8 @@ pub fn crate_details_handler(req: &mut Request) -> IronResult<Response> {
                 .to_resp("crate_details")
         }
         MatchVersion::Semver(version) => {
-            let url = ctry!(Url::parse(&format!("{}://{}:{}/crate/{}/{}",
-                                                req.url.scheme(),
-                                                req.url.host(),
-                                                req.url.port(),
+            let url = ctry!(Url::parse(&format!("{}/crate/{}/{}",
+                                                redirect_base(req),
                                                 name,
                                                 version)[..]));
 

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -1,7 +1,7 @@
 //! Releases web handlers
 
 
-use super::{duration_to_str, match_version};
+use super::{duration_to_str, match_version, redirect_base};
 use super::error::Nope;
 use super::page::Page;
 use super::pool::Pool;
@@ -468,10 +468,8 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
                 let name: String = rows.get(0).get(0);
                 let version: String = rows.get(0).get(1);
                 let target_name: String = rows.get(0).get(2);
-                let url = ctry!(Url::parse(&format!("{}://{}:{}/{}/{}/{}",
-                                                    req.url.scheme(),
-                                                    req.url.host(),
-                                                    req.url.port(),
+                let url = ctry!(Url::parse(&format!("{}/{}/{}/{}",
+                                                    redirect_base(req),
                                                     name,
                                                     version,
                                                     target_name)));
@@ -504,17 +502,13 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
                     }
                 };
                 let url = if rustdoc_status {
-                    ctry!(Url::parse(&format!("{}://{}:{}/{}/{}",
-                                              req.url.scheme(),
-                                              req.url.host(),
-                                              req.url.port(),
+                    ctry!(Url::parse(&format!("{}/{}/{}",
+                                              redirect_base(req),
                                               query,
                                               version)[..]))
                 } else {
-                    ctry!(Url::parse(&format!("{}://{}:{}/crate/{}/{}",
-                                              req.url.scheme(),
-                                              req.url.host(),
-                                              req.url.port(),
+                    ctry!(Url::parse(&format!("{}/crate/{}/{}",
+                                              redirect_base(req),
                                               query,
                                               version)[..]))
                 };

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -3,7 +3,7 @@
 
 use super::pool::Pool;
 use super::file::File;
-use super::latest_version;
+use super::{latest_version, redirect_base};
 use super::crate_details::CrateDetails;
 use iron::prelude::*;
 use iron::{status, Url};
@@ -75,10 +75,8 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
                        vers: &str,
                        target_name: &str)
                        -> IronResult<Response> {
-        let url = ctry!(Url::parse(&format!("{}://{}:{}/{}/{}/{}/",
-                                            req.url.scheme(),
-                                            req.url.host(),
-                                            req.url.port(),
+        let url = ctry!(Url::parse(&format!("{}/{}/{}/{}/",
+                                            redirect_base(req),
                                             name,
                                             vers,
                                             target_name)[..]));
@@ -92,10 +90,8 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
                          name: &str,
                          vers: &str)
                          -> IronResult<Response> {
-        let url = ctry!(Url::parse(&format!("{}://{}:{}/crate/{}/{}",
-                                            req.url.scheme(),
-                                            req.url.host(),
-                                            req.url.port(),
+        let url = ctry!(Url::parse(&format!("{}/crate/{}/{}",
+                                            redirect_base(req),
                                             name,
                                             vers)[..]));
 
@@ -188,10 +184,8 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
             // to prevent cloudfront caching the wrong artifacts on URLs with loose semver
             // versions, redirect the browser to the returned version instead of loading it
             // immediately
-            let url = ctry!(Url::parse(&format!("{}://{}:{}/{}/{}/{}",
-                                                req.url.scheme(),
-                                                req.url.host(),
-                                                req.url.port(),
+            let url = ctry!(Url::parse(&format!("{}/{}/{}/{}",
+                                                redirect_base(req),
                                                 name,
                                                 v,
                                                 req_path.join("/"))[..]));
@@ -297,10 +291,8 @@ pub fn badge_handler(req: &mut Request) -> IronResult<Response> {
             }
         }
         MatchVersion::Semver(version) => {
-            let url = ctry!(Url::parse(&format!("{}://{}:{}/{}/badge.svg?version={}",
-                                                req.url.scheme(),
-                                                req.url.host(),
-                                                req.url.port(),
+            let url = ctry!(Url::parse(&format!("{}/{}/badge.svg?version={}",
+                                                redirect_base(req),
                                                 name,
                                                 version)[..]));
 


### PR DESCRIPTION
All the docs.rs redirects are absolute, including the protocol and the host name. This is fine if docs.rs is exposed directly on the Internet, but the production instance sits behind CloudFront which terminates TLS connections. This means the application thinks it's serving HTTP requests instead of HTTPS ones, and it issues wrong redirects.

This PR fixes the issue by taking the Cloudfront-Forwarded-Proto header into account when building the redirect URL. This also adds `dotenv` to the project. It's not *necessary* but it's handy when you want to set environment variables and you aren't in the vagrant VM.

Fixes #363, and thanks @HeroicKatora for investigating this!