### PR TITLE
add option to wait for build queue to see lock file

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -94,8 +94,11 @@ pub fn main() {
                     .help("Version of crate")))
             .subcommand(SubCommand::with_name("add-essential-files")
                 .about("Adds essential files for rustc"))
-            .subcommand(SubCommand::with_name("lock").about("Locks cratesfyi daemon to stop \
-                                                              building new crates"))
+            .subcommand(SubCommand::with_name("lock")
+                .about("Locks cratesfyi daemon to stop building new crates")
+                .arg(Arg::with_name("WAIT")
+                     .long("wait")
+                     .help("wait until the build queue finishes building a crate before exiting")))
             .subcommand(SubCommand::with_name("unlock")
                 .about("Unlocks cratesfyi daemon to continue \
                                                               building new crates"))
@@ -213,8 +216,12 @@ pub fn main() {
             docbuilder.save_cache().expect("Failed to save cache");
         } else if let Some(_) = matches.subcommand_matches("add-essential-files") {
             docbuilder.add_essential_files().expect("Failed to add essential files");
-        } else if let Some(_) = matches.subcommand_matches("lock") {
+        } else if let Some(matches) = matches.subcommand_matches("lock") {
             docbuilder.lock().expect("Failed to lock");
+            if matches.is_present("WAIT") {
+                println!("Waiting for build queue to lock...");
+                docbuilder.wait_for_signal().expect("Failed to set signal file");
+            }
         } else if let Some(_) = matches.subcommand_matches("unlock") {
             docbuilder.unlock().expect("Failed to unlock");
         } else if let Some(_) = matches.subcommand_matches("print-options") {

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -96,6 +96,9 @@ pub fn start_daemon() {
             if doc_builder.is_locked() {
                 warn!("Lock file exits, skipping building new crates");
                 status = BuilderState::Locked;
+                if let Err(e) = doc_builder.signal() {
+                    error!("Could not signal waiting locker: {}", e);
+                }
                 continue;
             }
 


### PR DESCRIPTION
When performing maintenance on the server, it can be useful to know that the build queue has stopped without manually inspecting the logs to wait for the "lock file exists" message. This PR introduces a `cratesfyi build lock --wait` command, which adds a second lock file to the prefix directory and blocks until it is deleted. The builder thread in the daemon will then see this file and delete it whenever it finishes an iteration and sees the main lock file.

This is admittedly very crude, but in lieu of spinning up a whole new message queue service or a unix socket or some other means of communicating between processes, this should suffice. Mainly i want a way to change our "update rustc" scripts so i don't have to `tail -f` the log file every time.