### PR TITLE
remove duplicate imports

### DIFF
--- a/src/docbuilder/chroot_builder.rs
+++ b/src/docbuilder/chroot_builder.rs
@@ -244,7 +244,6 @@ impl DocBuilder {
     /// Remove documentation, build directory and sources directory of a package
     fn clean(&self, package: &Package) -> Result<()> {
         debug!("Cleaning package");
-        use std::fs::remove_dir_all;
         let documentation_path = PathBuf::from(&self.options.destination)
             .join(package.manifest().name().as_str());
         let source_path = source_path(&package).unwrap();

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -504,8 +504,6 @@ fn opensearch_xml_handler(_: &mut Request) -> IronResult<Response> {
 }
 
 fn ico_handler(req: &mut Request) -> IronResult<Response> {
-    use iron::Url;
-
     if let Some(&"favicon.ico") = req.url.path().last() {
         // if we're looking for exactly "favicon.ico", we need to defer to the handler that loads
         // from `public_html`, so return a 404 here to make the main handler carry on

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -476,7 +476,6 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
 
                 let mut resp = Response::with((status::Found, Redirect(url)));
                 use iron::headers::{Expires, HttpDate};
-                use time;
                 resp.headers.set(Expires(HttpDate(time::now())));
                 return Ok(resp);
             }
@@ -515,7 +514,6 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
                 let mut resp = Response::with((status::Found, Redirect(url)));
 
                 use iron::headers::{Expires, HttpDate};
-                use time;
                 resp.headers.set(Expires(HttpDate(time::now())));
                 return Ok(resp);
             }


### PR DESCRIPTION
Newer versions of Rust have introduced a new warning that tells you when you import something that was already imported in a higher scope. This started triggering on some code in docs.rs, so this PR is here to clean those warnings up.