### PR TITLE
Migrate files database to S3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,7 @@ dependencies = [
  "crates-index-diff 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars-iron 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.22.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -451,6 +452,7 @@ dependencies = [
  "staticfile 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ schemamama_postgres = "0.2"
 rusoto_s3 = "0.40"
 rusoto_core = "0.40"
 rusoto_credential = "0.40"
-
+futures = "0.1"
+tokio = "0.1"
 
 # iron dependencies
 iron = "0.5"

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -109,6 +109,7 @@ pub fn main() {
         .subcommand(SubCommand::with_name("daemon").about("Starts cratesfyi daemon"))
         .subcommand(SubCommand::with_name("database")
             .about("Database operations")
+            .subcommand(SubCommand::with_name("move-to-s3"))
             .subcommand(SubCommand::with_name("migrate")
                 .about("Run database migrations")
                 .arg(Arg::with_name("VERSION")))
@@ -239,6 +240,9 @@ pub fn main() {
         } else if let Some(_) = matches.subcommand_matches("update-search-index") {
             let conn = db::connect_db().unwrap();
             db::update_search_index(&conn).expect("Failed to update search index");
+        } else if let Some(_) = matches.subcommand_matches("move-to-s3") {
+            let conn = db::connect_db().unwrap();
+            db::file::move_to_s3(&conn, 5_000).expect("Failed to update search index");
         }
     } else if let Some(matches) = matches.subcommand_matches("start-web-server") {
         start_web_server(Some(matches.value_of("SOCKET_ADDR").unwrap_or("0.0.0.0:3000")));

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -242,7 +242,16 @@ pub fn main() {
             db::update_search_index(&conn).expect("Failed to update search index");
         } else if let Some(_) = matches.subcommand_matches("move-to-s3") {
             let conn = db::connect_db().unwrap();
-            db::file::move_to_s3(&conn, 5_000).expect("Failed to update search index");
+            let mut count = 1;
+            let mut total = 0;
+            while count != 0 {
+                count = db::file::move_to_s3(&conn, 5_000).expect("Failed to upload batch to S3");
+                total += count;
+                eprintln!(
+                    "moved {} rows to s3 in this batch, total moved so far: {}",
+                    count, total
+                );
+            }
         }
     } else if let Some(matches) = matches.subcommand_matches("start-web-server") {
         start_web_server(Some(matches.value_of("SOCKET_ADDR").unwrap_or("0.0.0.0:3000")));

--- a/src/db/file.rs
+++ b/src/db/file.rs
@@ -160,7 +160,6 @@ pub fn add_path_into_database<P: AsRef<Path>>(conn: &Connection,
 
             let content: Option<Vec<u8>> = if let Some(client) = &client {
                 let s3_res = client.put_object(PutObjectRequest {
-                    acl: Some("public-read".into()),
                     bucket: "rust-docs-rs".into(),
                     key: bucket_path.clone(),
                     body: Some(content.clone().into()),

--- a/src/db/file.rs
+++ b/src/db/file.rs
@@ -224,7 +224,52 @@ fn file_list_to_json(file_list: Vec<(String, PathBuf)>) -> Result<Json> {
     Ok(file_list_json.to_json())
 }
 
+pub fn move_to_s3(conn: &Connection, n: usize) -> Result<()> {
+    let trans = try!(conn.transaction());
+    let client = s3_client().expect("configured s3");
 
+    let rows = try!(trans.query(
+            &format!("SELECT path, mime, content FROM files WHERE content != E'in-s3' LIMIT {}", n),
+            &[]));
+
+    let mut rt = ::tokio::runtime::current_thread::Runtime::new().unwrap();
+    let mut futures = Vec::new();
+    for row in &rows {
+        let path: String = row.get(0);
+        let mime: String = row.get(1);
+        let content: Vec<u8> = row.get(2);
+        let path_1 = path.clone();
+        futures.push(client.put_object(PutObjectRequest {
+            bucket: "rust-docs-rs".into(),
+            key: path.clone(),
+            body: Some(content.into()),
+            content_type: Some(mime),
+            ..Default::default()
+        }).map(move |_| {
+            path_1
+        }).map_err(move |e| {
+            panic!("failed to upload to {}: {:?}", path, e)
+        }));
+    }
+
+    use ::futures::future::Future;
+    match rt.block_on(::futures::future::join_all(futures)) {
+        Ok(paths) => {
+            let statement = trans.prepare("UPDATE files SET content = E'in-s3' WHERE path = $1")
+                .unwrap();
+            for path in paths {
+                statement.execute(&[&path]).unwrap();
+            }
+        }
+        Err(e) => {
+            panic!("results err: {:?}", e);
+        }
+    }
+
+    try!(trans.commit());
+
+    Ok(())
+}
 
 #[cfg(test)]
 mod test {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ extern crate schemamama_postgres;
 extern crate rusoto_s3;
 extern crate rusoto_core;
 extern crate rusoto_credential;
+extern crate futures;
+extern crate tokio;
 
 pub use self::docbuilder::DocBuilder;
 pub use self::docbuilder::ChrootBuilderResult;


### PR DESCRIPTION
This adds the migrate command to start moving files out of the DB and into S3.

The Cargo.lock update is unfortunate, but I ran into trouble with `rand` when adding tokio, and this fixed it -- I can try to reduce it down but I suspect that'll be rather painful, so I'd rather not (this is just the effects of `cargo update` after the changes in Cargo.toml).

This PR can be reverted once we're done with the migration if desired.

Based on local testing, albeit with minio and not real S3, this should take around 80 hours. It might take longer -- we are talking over network and not to a local server -- or maybe S3 is faster to upload to than minio; I'm not sure.

r? @QuietMisdreavus 