### PR TITLE
Use git command instead of git2 in build script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,6 @@ dependencies = [
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "git2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars-iron 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.22.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ tempdir = "0.3"
 
 [build-dependencies]
 time = "0.1"
-git2 = "0.9"
 sass-rs = "0.2"
 
 [[bin]]

--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,12 @@
 
 extern crate time;
 extern crate sass_rs;
-extern crate git2;
 
 use std::env;
 use std::path::Path;
 use std::fs::File;
 use std::io::Write;
-use git2::Repository;
-
+use std::process::Command;
 
 fn main() {
     write_git_version();
@@ -26,16 +24,13 @@ fn write_git_version() {
 
 
 fn get_git_hash() -> Option<String> {
-    let repo = match Repository::open(env::current_dir().unwrap()) {
-        Ok(repo) => repo,
-        Err(_) => return None,
-    };
-    let head = repo.head().unwrap();
-    head.target().map(|h| {
-        let mut h = format!("{}", h);
-        h.truncate(7);
-        h
-    })
+    let output = Command::new("git")
+        .arg("rev-parse")
+        .arg("--short=7")
+        .arg("HEAD")
+        .output()
+        .ok()?;
+    Some(String::from_utf8(output.stdout).ok()?)
 }
 
 


### PR DESCRIPTION
This doesn't remove git2 from our dependencies (cargo and
crates-index-diff both use it), but it does simplify the build script.

r? @QuietMisdreavus 