### PR TITLE
Utilize multi-threaded tokio runtime for move-to-s3

### DIFF
--- a/src/db/file.rs
+++ b/src/db/file.rs
@@ -233,7 +233,7 @@ pub fn move_to_s3(conn: &Connection, n: usize) -> Result<usize> {
             &[]));
     let count = rows.len();
 
-    let mut rt = ::tokio::runtime::current_thread::Runtime::new().unwrap();
+    let mut rt = ::tokio::runtime::Runtime::new().unwrap();
     let mut futures = Vec::new();
     for row in &rows {
         let path: String = row.get(0);


### PR DESCRIPTION
The current thread runtime was previously used but there was no reason
to do so. This utilizes the default runtime.