### PR TITLE
Silence debug logging for failed S3 queries

### DIFF
--- a/src/db/file.rs
+++ b/src/db/file.rs
@@ -73,7 +73,6 @@ pub fn get_path(conn: &Connection, path: &str) -> Option<Blob> {
         let res = match res {
             Ok(r) => r,
             Err(err) => {
-                debug!("error fetching {}: {:?}", path, err);
                 return None;
             }
         };


### PR DESCRIPTION
The database/S3 handler is not the last one, so we'll often end up
successfully returning a response. There's separate handling for logging
actual 404s.