### PR TITLE
update vagrant to use 2048MB ram on Windows

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure("2") do |config|
       mem = `grep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'`.to_i / 1024 / 4
     else
       cpus = 2
-      mem = 1024
+      mem = 2048
     end
 
     vb.memory = mem


### PR DESCRIPTION
`cargo build` ran out of memory when it was set to 1024