### PR TITLE
Add a test: latest_version() should ignore yanked

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -592,4 +592,16 @@ mod test {
         assert_eq!(latest_version(&versions, "0.9.0"), Some("1.1.0".to_owned()));
         assert_eq!(latest_version(&versions, "invalidversion"), None);
     }
+    
+    #[test]
+    fn test_latest_version_yanked() {
+        let versions = vec!["0.3.0-docs-yank.2".to_string(),
+                            "0.3.0-docs-yank".to_string(),
+                            "0.2.0".to_string(),
+                            "0.1.0".to_string()];
+        assert_eq!(latest_version(&versions, "0.3.0-docs-yank.2"), Some("0.2.0".to_owned()));
+        assert_eq!(latest_version(&versions, "0.3.0-docs-yank"), Some("0.2.0".to_owned()));
+        assert_eq!(latest_version(&versions, "0.2.0"), None);
+        assert_eq!(latest_version(&versions, "0.1.0"), Some("0.2.0".to_owned()));
+    }
 }


### PR DESCRIPTION
This is a test for https://github.com/rust-lang/docs.rs/issues/396

"Go to latest version" should be displayed for yanked versions and point to the latest non-yanked version.

See also: https://github.com/rust-lang/docs.rs/blob/3bebf1c79bcda76cf8536bb536135f633b6b2ff2/templates/navigation_rustdoc.hbs#L89