### PR TITLE
Redirect docs.rs/std to the official standard library docs.

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -101,6 +101,7 @@ impl CratesfyiHandler {
         router.get("/robots.txt", sitemap::robots_txt_handler, "robots_txt");
         router.get("/sitemap.xml", sitemap::sitemap_handler, "sitemap_xml");
         router.get("/opensearch.xml", opensearch_xml_handler, "opensearch_xml");
+        router.get("/std", rustdoc::std_redirector_handler, "std");
         router.get("/releases", releases::recent_releases_handler, "releases");
         router.get("/releases/feed",
                    releases::releases_feed_handler,

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -66,6 +66,12 @@ impl ToJson for RustdocPage {
 }
 
 
+/// Handler called for the `/std`. Redirects to the official standard library docs.
+pub fn std_redirector_handler(_req: &mut Request) -> IronResult<Response> {
+    let url = Url::parse("https://doc.rust-lang.org/std/").unwrap();
+    Ok(Response::with((status::Found, Redirect(url))))
+}
+
 /// Handler called for `/:crate` and `/:crate/:version` URLs. Automatically redirects to the docs
 /// or crate details page based on whether the given crate version was successfully built.
 pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -68,7 +68,7 @@ impl ToJson for RustdocPage {
 
 /// Handler called for the `/std`. Redirects to the official standard library docs.
 pub fn std_redirector_handler(_req: &mut Request) -> IronResult<Response> {
-    let url = Url::parse("https://doc.rust-lang.org/std/").unwrap();
+    let url = Url::parse("https://doc.rust-lang.org/stable/std/").unwrap();
     Ok(Response::with((status::Found, Redirect(url))))
 }
 


### PR DESCRIPTION
See also #56 and #193.