### PR TITLE
Fix mount detection panic when the prefix is relative

### DIFF
--- a/src/docbuilder/chroot_builder.rs
+++ b/src/docbuilder/chroot_builder.rs
@@ -483,6 +483,7 @@ fn crates<F>(path: PathBuf, mut func: F) -> Result<()>
 }
 
 fn mount_for_path(path: &Path) -> Filesystem {
+    let path = std::fs::canonicalize(path).unwrap_or_else(|_| path.into());
     let system = System::new();
 
     let mut found = None;


### PR DESCRIPTION
I tried to setup docs.rs with a relative prefix and the mount detection panicked because it didn't receive an absolute path. This fixes the issue by canonicalizing the prefix before checking where it's mounted.