### PR TITLE
Add queue-related prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,11 +435,13 @@ dependencies = [
  "handlebars-iron 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.22.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "magic 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "params 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2_postgres 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1756,6 +1758,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,6 +2444,11 @@ dependencies = [
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "stable_deref_trait"
@@ -3340,6 +3359,7 @@ dependencies = [
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 "checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
+"checksum prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5567486d5778e2c6455b1b90ff1c558f29e751fc018130fa182e15828e728af1"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
@@ -3416,6 +3436,7 @@ dependencies = [
 "checksum slug 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39af1ce888a1253c8b9fcfa36626557650fb487c013620a743262d2769a3e9f3"
 "checksum smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "153ffa32fd170e9944f7e0838edf824a754ec4c1fc64746fcc9fe1f8fa602e5d"
 "checksum socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7"
+"checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum staticfile 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31493480e073d52522a94cdf56269dd8eb05f99549effd1826b0271690608878"
 "checksum stb_truetype 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "48fa7d3136d8645909de1f7c7eb5416cc43057a75ace08fc39ae736bc9da8af1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ rusoto_credential = "0.40"
 futures = "0.1"
 tokio = "0.1"
 systemstat = "0.1.4"
+prometheus = { version = "0.7.0", default-features = false }
+lazy_static = "1.0.0"
 
 # iron dependencies
 iron = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,10 @@
 extern crate log;
 #[macro_use]
 extern crate failure;
+#[macro_use]
+extern crate prometheus;
+#[macro_use]
+extern crate lazy_static;
 extern crate cargo;
 extern crate regex;
 extern crate rustc_serialize;

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -1,0 +1,41 @@
+use super::pool::Pool;
+use iron::headers::ContentType;
+use iron::prelude::*;
+use prometheus::{Encoder, IntGauge, TextEncoder};
+
+lazy_static! {
+    static ref QUEUED_CRATES_COUNT: IntGauge = register_int_gauge!(
+        "docsrs_queued_crates_count",
+        "Number of crates in the build queue"
+    )
+    .unwrap();
+    static ref FAILED_CRATES_COUNT: IntGauge = register_int_gauge!(
+        "docsrs_failed_crates_count",
+        "Number of crates that failed to build"
+    )
+    .unwrap();
+}
+
+pub fn metrics_handler(req: &mut Request) -> IronResult<Response> {
+    let conn = extension!(req, Pool);
+
+    QUEUED_CRATES_COUNT.set(
+        ctry!(conn.query("SELECT COUNT(*) FROM queue WHERE attempt < 5;", &[]))
+            .get(0)
+            .get(0),
+    );
+    FAILED_CRATES_COUNT.set(
+        ctry!(conn.query("SELECT COUNT(*) FROM queue WHERE attempt >= 5;", &[]))
+            .get(0)
+            .get(0),
+    );
+
+    let mut buffer = Vec::new();
+    let families = prometheus::gather();
+    ctry!(TextEncoder::new().encode(&families, &mut buffer));
+
+    let mut resp = Response::with(buffer);
+    resp.headers
+        .set(ContentType("text/plain; version=0.0.4".parse().unwrap()));
+    Ok(resp)
+}

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -44,6 +44,7 @@ mod file;
 mod builds;
 mod error;
 mod sitemap;
+mod metrics;
 
 use std::{env, fmt};
 use std::error::Error;
@@ -98,6 +99,7 @@ impl CratesfyiHandler {
         router.get("/", releases::home_page, "index");
         router.get("/style.css", style_css_handler, "style_css");
         router.get("/about", sitemap::about_handler, "about");
+        router.get("/about/metrics", metrics::metrics_handler, "metrics");
         router.get("/robots.txt", sitemap::robots_txt_handler, "robots_txt");
         router.get("/sitemap.xml", sitemap::sitemap_handler, "sitemap_xml");
         router.get("/opensearch.xml", opensearch_xml_handler, "opensearch_xml");


### PR DESCRIPTION
This adds the `docsrs_queued_crates_count` and `docsrs_failed_crates_count` prometheus metrics to docs.rs, exposed in the `/about/metrics` page. Those metrics will be helpful to setup alerting based on the state of the queue.

I chose `/about/metrics` for the URL as it doesn't clash with any current of future crate (`/about` is reserved anyway), but other suggestions are welcome.

r? @Mark-Simulacrum 