### PR TITLE
Add global alert to notify users about upcoming breaking changes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,15 @@ pub mod utils;
 mod docbuilder;
 mod web;
 
+use web::page::GlobalAlert;
+
+
+// Warning message shown in the navigation bar of every page. Set to `None` to hide it.
+pub(crate) static GLOBAL_ALERT: Option<GlobalAlert> = Some(GlobalAlert {
+    url: "https://blog.rust-lang.org/2019/09/18/upcoming-docsrs-changes.html",
+    text: "Upcoming docs.rs breaking changes!",
+});
+
 
 /// Version string generated at build time contains last git
 /// commit hash and build date

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,8 @@ use web::page::GlobalAlert;
 pub(crate) static GLOBAL_ALERT: Option<GlobalAlert> = Some(GlobalAlert {
     url: "https://blog.rust-lang.org/2019/09/18/upcoming-docsrs-changes.html",
     text: "Upcoming docs.rs breaking changes!",
+    css_class: "error",
+    fa_icon: "warning",
 });
 
 

--- a/src/web/page.rs
+++ b/src/web/page.rs
@@ -7,6 +7,21 @@ use iron::response::Response;
 use handlebars_iron::Template;
 
 
+pub(crate) struct GlobalAlert {
+    pub(crate) url: &'static str,
+    pub(crate) text: &'static str,
+}
+
+impl ToJson for GlobalAlert {
+    fn to_json(&self) -> Json {
+        let mut map = BTreeMap::new();
+        map.insert("url".to_string(), self.url.to_json());
+        map.insert("text".to_string(), self.text.to_json());
+        Json::Object(map)
+    }
+}
+
+
 pub struct Page<T: ToJson> {
     title: Option<String>,
     content: T,
@@ -87,6 +102,11 @@ impl<T: ToJson> ToJson for Page<T> {
 
         if let Some(ref title) = self.title {
             tree.insert("title".to_owned(), title.to_json());
+        }
+
+        tree.insert("has_global_alert".to_owned(), ::GLOBAL_ALERT.is_some().to_json());
+        if let Some(ref global_alert) = ::GLOBAL_ALERT {
+            tree.insert("global_alert".to_owned(), global_alert.to_json());
         }
 
         tree.insert("content".to_owned(), self.content.to_json());

--- a/src/web/page.rs
+++ b/src/web/page.rs
@@ -10,6 +10,8 @@ use handlebars_iron::Template;
 pub(crate) struct GlobalAlert {
     pub(crate) url: &'static str,
     pub(crate) text: &'static str,
+    pub(crate) css_class: &'static str,
+    pub(crate) fa_icon: &'static str,
 }
 
 impl ToJson for GlobalAlert {
@@ -17,6 +19,8 @@ impl ToJson for GlobalAlert {
         let mut map = BTreeMap::new();
         map.insert("url".to_string(), self.url.to_json());
         map.insert("text".to_string(), self.text.to_json());
+        map.insert("css_class".to_string(), self.css_class.to_json());
+        map.insert("fa_icon".to_string(), self.fa_icon.to_json());
         Json::Object(map)
     }
 }

--- a/templates/navigation.hbs
+++ b/templates/navigation.hbs
@@ -21,6 +21,7 @@
                 <li class="pure-menu-item"><a href="/about" class="pure-menu-link">About Docs.rs</a></li>
               </ul>
             </li>
+            {{> navigation_global_alert}}
           </ul>
           </form>
         </div>

--- a/templates/navigation_global_alert.hbs
+++ b/templates/navigation_global_alert.hbs
@@ -1,0 +1,10 @@
+{{#if ../has_global_alert}}
+<li class="pure-menu-item">
+  <a href="{{../global_alert.url}}" class="pure-menu-link warn">
+    <i class="fa fa-fw fa-warning"></i>
+    {{../global_alert.text}}
+    <i class="fa fa-fw fa-warning"></i>
+  </a>
+</li>
+{{/if}}
+

--- a/templates/navigation_global_alert.hbs
+++ b/templates/navigation_global_alert.hbs
@@ -1,9 +1,8 @@
 {{#if ../has_global_alert}}
 <li class="pure-menu-item">
-  <a href="{{../global_alert.url}}" class="pure-menu-link warn">
-    <i class="fa fa-fw fa-warning"></i>
+  <a href="{{../global_alert.url}}" class="pure-menu-link {{../global_alert.css_class}}">
+    <i class="fa fa-fw fa-{{../global_alert.fa_icon}}"></i>
     {{../global_alert.text}}
-    <i class="fa fa-fw fa-warning"></i>
   </a>
 </li>
 {{/if}}

--- a/templates/navigation_rustdoc.hbs
+++ b/templates/navigation_rustdoc.hbs
@@ -101,6 +101,7 @@
               </ul>
             </li>
           {{/with}}
+          {{> navigation_global_alert}}
           </ul>
           </form>
         </div>

--- a/templates/style.scss
+++ b/templates/style.scss
@@ -19,6 +19,7 @@ $color-lifetime-incode: #B76514;   // orangish
 $color-comment-in-code: #8E908C;   // light gray
 $color-background-code: #F5F5F5;   // lighter gray
 $color-border: #ddd;               // gray
+$color-red: #d93d3d;               // red
 $top-navbar-height: 32px;          // height of the floating top navbar
 
 
@@ -212,6 +213,15 @@ div.nav-container {
 
     .warn:hover {
         color: darken($color-type, 10%);
+    }
+
+    // used for global alerts
+    .error {
+        color: $color-red;
+
+        &:hover {
+            color: darken($color-red, 10%);
+        }
     }
 
     div.rustdoc-navigation {


### PR DESCRIPTION
This PR adds an alert in the navigation bar of each page to alert everyone of the changes in #407. It links to the blog post prepared in https://github.com/rust-lang/blog.rust-lang.org/pull/403, so it should be merged only after the post is published (and ideally shortly after).

The alert can be easily disabled or customized in the source code, so it's safe to keep the code even when it's not used anymore.

| Crate page | Docs page | Index |
| --- | --- | --- |
| ![2019-09-16--15-47-24](https://user-images.githubusercontent.com/2299951/64963356-681f7a00-d899-11e9-9115-a5796298d93f.png) | ![2019-09-16--15-47-44](https://user-images.githubusercontent.com/2299951/64963355-681f7a00-d899-11e9-8b7e-b7e7c2bc356f.png) | ![2019-09-16--15-47-54](https://user-images.githubusercontent.com/2299951/64963354-681f7a00-d899-11e9-854c-4e091f06e1f7.png) |

r? @Mark-Simulacrum @QuietMisdreavus 
