### PR TITLE
Remove unused rule from stylesheet

### DIFF
--- a/templates/style.scss
+++ b/templates/style.scss
@@ -730,28 +730,6 @@ div.search-page-search-form {
 }
 
 
-footer {
-    margin-top: 60px;
-    margin-bottom: 10px;
-    text-align: center;
-    ul {
-        list-style-type: none;
-        li {
-            list-style-type: none;
-            margin-bottom: 10px;
-
-            a {
-                font-weight: 500;
-                color: $color-url;
-            }
-        }
-        li.hosting {
-            font-size: .8em;
-        }
-    }
-}
-
-
 .about {
     font-family: $font-family-serif;
     padding: .4em 1em;


### PR DESCRIPTION
The rules matching a `footer` tag were originally there for styling of a sponsor logo (as shown by `git blame`) on crates.fyi.

None of the templates output a `footer` tag anymore, so this rule is unused.

What's more, this unused rule will interfere with the look of any docs outputs themselves when these contain one or more `footer` tags nested inside of `blockquote` like http://html5doctor.com/cite-and-blockquote-reloaded/ suggests that one might one to do when quoting some other work.

Specifically, you can see this happen in the docs for one of mine crates;

  * https://docs.rs/persistence/0.0.2/persistence/#what-this-library-is-and-what-it-is-not
  * https://github.com/ctsrc/persistence/blob/2375f30ae37ac5b8fa42af96cd35afd66a79bd76/src/lib.rs#L81-L96

Originally, I was planning on suggesting that the rule be limited to be more specific, but since I see that it goes unused, I suggest removing it all-together.