### PR TITLE
Fix search background color on dark theme

### DIFF
--- a/templates/style.scss
+++ b/templates/style.scss
@@ -186,6 +186,7 @@ div.nav-container {
             font-size: 0.8em;
             text-align: right;
             box-shadow: none;
+            background-color: #fff;
             height: 31px;
             display: none;
             @media #{$media-sm} {


### PR DESCRIPTION
Using firefox with dark theme.

Before

![2019-09-28-102501_1366x768_scrot](https://user-images.githubusercontent.com/4687791/65810253-c1ad7000-e1da-11e9-8bb7-f9f77d55706b.png)

After

![2019-09-28-102513_1366x768_scrot](https://user-images.githubusercontent.com/4687791/65810248-b5c1ae00-e1da-11e9-8a64-209c34b68ea7.png)
