### PR TITLE
Forward package rustdoc_args to rustdoc

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -365,6 +365,9 @@ impl RustwideBuilder {
                 dep.version
             ));
         }
+        if let Some(package_rustdoc_args) = &metadata.rustdoc_args {
+            rustdoc_flags.append(&mut package_rustdoc_args.iter().map(|s| s.to_owned()).collect());
+        }
         let mut cargo_args = vec![
             "doc".to_owned(),
             "--lib".to_owned(),


### PR DESCRIPTION
This fixes a regression that happened in the recent docs.rs changes where the package rustdoc_args would not get forwarded to the rustdoc flags.

fixes #421