### PR TITLE
Treat proc-macros as libraries

### DIFF
--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -38,7 +38,7 @@ pub(crate) fn add_package_into_database(conn: &Connection,
     let readme = get_readme(metadata_pkg, source_dir).unwrap_or(None);
     let (release_time, yanked, downloads) = try!(get_release_time_yanked_downloads(metadata_pkg));
     let is_library = match metadata_pkg.targets[0].kind.as_slice() {
-        &[ref kind] if kind == "lib" => true,
+        &[ref kind] if kind == "lib" || kind == "proc-macro" => true,
         _ => false,
     };
     let metadata = Metadata::from_source_dir(source_dir)?;


### PR DESCRIPTION
Before this commit crates containing only proc-macros weren't
documented, as docs.rs treated them as binaries. Proc macros are
supposed to be documented though, and that behavior was a regression of
the rustwide deployment.

This commit fixes the regression by treating proc macros as libraries.

r? @Mark-Simulacrum 
fixes https://github.com/rust-lang/docs.rs/issues/422