### PR TITLE
Also redirect the remaining rust-lang.org crates.

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -103,11 +103,14 @@ impl CratesfyiHandler {
         router.get("/robots.txt", sitemap::robots_txt_handler, "robots_txt");
         router.get("/sitemap.xml", sitemap::sitemap_handler, "sitemap_xml");
         router.get("/opensearch.xml", opensearch_xml_handler, "opensearch_xml");
+
+        // Redirect standard library crates to rust-lang.org
         router.get("/alloc", rustdoc::RustLangRedirector::new("alloc"), "alloc");
         router.get("/core", rustdoc::RustLangRedirector::new("core"), "core");
         router.get("/proc_macro", rustdoc::RustLangRedirector::new("proc_macro"), "proc_macro");
         router.get("/std", rustdoc::RustLangRedirector::new("std"), "std");
         router.get("/test", rustdoc::RustLangRedirector::new("test"), "test");
+
         router.get("/releases", releases::recent_releases_handler, "releases");
         router.get("/releases/feed",
                    releases::releases_feed_handler,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -103,7 +103,11 @@ impl CratesfyiHandler {
         router.get("/robots.txt", sitemap::robots_txt_handler, "robots_txt");
         router.get("/sitemap.xml", sitemap::sitemap_handler, "sitemap_xml");
         router.get("/opensearch.xml", opensearch_xml_handler, "opensearch_xml");
-        router.get("/std", rustdoc::std_redirector_handler, "std");
+        router.get("/alloc", rustdoc::RustLangRedirector::new("alloc"), "alloc");
+        router.get("/core", rustdoc::RustLangRedirector::new("core"), "core");
+        router.get("/proc_macro", rustdoc::RustLangRedirector::new("proc_macro"), "proc_macro");
+        router.get("/std", rustdoc::RustLangRedirector::new("std"), "std");
+        router.get("/test", rustdoc::RustLangRedirector::new("test"), "test");
         router.get("/releases", releases::recent_releases_handler, "releases");
         router.get("/releases/feed",
                    releases::releases_feed_handler,

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -78,10 +78,11 @@ impl RustLangRedirector {
 impl iron::Handler for RustLangRedirector {
     fn handle(&self, _req: &mut Request) -> IronResult<Response> {
         let url = url::Url::parse("https://doc.rust-lang.org/stable/")
-            .unwrap()
+            .expect("failed to parse rust-lang.org base URL")
             .join(self.target)
-            .unwrap();
-        let url = Url::from_generic_url(url).unwrap();
+            .expect("failed to append crate name to rust-lang.org base URL");
+        let url = Url::from_generic_url(url)
+            .expect("failed to convert url::Url to iron::Url");
         Ok(Response::with((status::Found, Redirect(url))))
     }
 }

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -65,11 +65,25 @@ impl ToJson for RustdocPage {
     }
 }
 
+pub struct RustLangRedirector {
+    target: &'static str,
+}
 
-/// Handler called for the `/std`. Redirects to the official standard library docs.
-pub fn std_redirector_handler(_req: &mut Request) -> IronResult<Response> {
-    let url = Url::parse("https://doc.rust-lang.org/stable/std/").unwrap();
-    Ok(Response::with((status::Found, Redirect(url))))
+impl RustLangRedirector {
+    pub fn new(target: &'static str) -> Self {
+        Self { target }
+    }
+}
+
+impl iron::Handler for RustLangRedirector {
+    fn handle(&self, _req: &mut Request) -> IronResult<Response> {
+        let url = url::Url::parse("https://doc.rust-lang.org/stable/")
+            .unwrap()
+            .join(self.target)
+            .unwrap();
+        let url = Url::from_generic_url(url).unwrap();
+        Ok(Response::with((status::Found, Redirect(url))))
+    }
 }
 
 /// Handler called for `/:crate` and `/:crate/:version` URLs. Automatically redirects to the docs


### PR DESCRIPTION
This PR adds redirects for `alloc`, `core`, `proc_macro` and `test`. Together with `std` that covers all crates from rust-lang.org :)

Should resolve #433.