### PR TITLE
Cleanup local docs after a build

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -30,11 +30,6 @@ pub fn main() {
                 .short("P")
                 .long("prefix")
                 .takes_value(true))
-            .arg(Arg::with_name("DESTINATION")
-                .short("d")
-                .long("destination")
-                .help("Sets destination path")
-                .takes_value(true))
             .arg(Arg::with_name("CRATES_IO_INDEX_PATH")
                 .long("crates-io-index-path")
                 .help("Sets crates.io-index path")
@@ -137,11 +132,6 @@ pub fn main() {
             } else {
                 DocBuilderOptions::default()
             };
-
-            // set options
-            if let Some(destination) = matches.value_of("DESTINATION") {
-                docbuilder_opts.destination = PathBuf::from(destination);
-            }
 
             if let Some(crates_io_index_path) = matches.value_of("CRATES_IO_INDEX_PATH") {
                 docbuilder_opts.crates_io_index_path = PathBuf::from(crates_io_index_path);

--- a/src/docbuilder/options.rs
+++ b/src/docbuilder/options.rs
@@ -8,7 +8,6 @@ use error::Result;
 pub struct DocBuilderOptions {
     pub keep_build_directory: bool,
     pub prefix: PathBuf,
-    pub destination: PathBuf,
     pub crates_io_index_path: PathBuf,
     pub skip_if_exists: bool,
     pub skip_if_log_exists: bool,
@@ -24,12 +23,11 @@ impl Default for DocBuilderOptions {
 
         let cwd = env::current_dir().unwrap();
 
-        let (prefix, destination, crates_io_index_path) =
+        let (prefix, crates_io_index_path) =
             generate_paths(cwd);
 
         DocBuilderOptions {
             prefix: prefix,
-            destination: destination,
             crates_io_index_path: crates_io_index_path,
 
             keep_build_directory: false,
@@ -46,11 +44,10 @@ impl Default for DocBuilderOptions {
 impl fmt::Debug for DocBuilderOptions {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f,
-               "DocBuilderOptions {{ destination: {:?}, \
+               "DocBuilderOptions {{ \
                 crates_io_index_path: {:?}, \
                 keep_build_directory: {:?}, skip_if_exists: {:?}, \
                 skip_if_log_exists: {:?}, debug: {:?} }}",
-               self.destination,
                self.crates_io_index_path,
                self.keep_build_directory,
                self.skip_if_exists,
@@ -63,11 +60,10 @@ impl fmt::Debug for DocBuilderOptions {
 impl DocBuilderOptions {
     /// Creates new DocBuilderOptions from prefix
     pub fn from_prefix(prefix: PathBuf) -> DocBuilderOptions {
-        let (prefix, destination, crates_io_index_path) =
+        let (prefix, crates_io_index_path) =
             generate_paths(prefix);
         DocBuilderOptions {
             prefix: prefix,
-            destination: destination,
             crates_io_index_path: crates_io_index_path,
 
             ..Default::default()
@@ -76,9 +72,6 @@ impl DocBuilderOptions {
 
 
     pub fn check_paths(&self) -> Result<()> {
-        if !self.destination.exists() {
-            bail!("destination path '{}' does not exist", self.destination.display());
-        }
         if !self.crates_io_index_path.exists() {
             bail!("crates.io-index path '{}' does not exist", self.crates_io_index_path.display());
         }
@@ -88,9 +81,8 @@ impl DocBuilderOptions {
 
 
 
-fn generate_paths(prefix: PathBuf) -> (PathBuf, PathBuf, PathBuf) {
-    let destination = PathBuf::from(&prefix).join("documentations");
+fn generate_paths(prefix: PathBuf) -> (PathBuf, PathBuf) {
     let crates_io_index_path = PathBuf::from(&prefix).join("crates.io-index");
 
-    (prefix, destination, crates_io_index_path)
+    (prefix, crates_io_index_path)
 }


### PR DESCRIPTION
Before uploading them to the database/S3, the documentation builder needs to copy the generated files from the target directory (which will be purged) to another local directory.

That directory is not needed after the whole crate is built, but the code after the rustwide refactory didn't delete it. This caused an outage due to the disk being full.

This PR replaces the local directory inside the prefix with temporary directories removed when the build finishes, which both fixes the problem and also reduces the uses of the prefix.

Fixes https://github.com/rust-lang/docs.rs/issues/441
r? @QuietMisdreavus 