### PR TITLE
add build success/fail counts to metrics

### DIFF
--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -37,10 +37,7 @@ pub(crate) fn add_package_into_database(conn: &Connection,
     let rustdoc = get_rustdoc(metadata_pkg, source_dir).unwrap_or(None);
     let readme = get_readme(metadata_pkg, source_dir).unwrap_or(None);
     let (release_time, yanked, downloads) = try!(get_release_time_yanked_downloads(metadata_pkg));
-    let is_library = match metadata_pkg.targets[0].kind.as_slice() {
-        &[ref kind] if kind == "lib" || kind == "proc-macro" => true,
-        _ => false,
-    };
+    let is_library = metadata_pkg.is_library();
     let metadata = Metadata::from_source_dir(source_dir)?;
 
     let release_id: i32 = {

--- a/src/docbuilder/queue.rs
+++ b/src/docbuilder/queue.rs
@@ -62,6 +62,7 @@ impl DocBuilder {
         match builder.build_package(self, &name, &version) {
             Ok(_) => {
                 let _ = conn.execute("DELETE FROM queue WHERE id = $1", &[&id]);
+                ::web::metrics::TOTAL_BUILDS.inc();
             }
             Err(e) => {
                 // Increase attempt count
@@ -70,6 +71,7 @@ impl DocBuilder {
                 let attempt: i32 = rows.get(0).get(0);
                 if attempt >= 5 {
                     ::web::metrics::FAILED_BUILDS.inc();
+                    ::web::metrics::TOTAL_BUILDS.inc();
                 }
                 error!("Failed to build package {}-{} from queue: {}",
                        name,

--- a/src/docbuilder/queue.rs
+++ b/src/docbuilder/queue.rs
@@ -43,7 +43,7 @@ impl DocBuilder {
     ) -> Result<bool> {
         let conn = try!(connect_db());
 
-        let query = try!(conn.query("SELECT id, name, version
+        let query = try!(conn.query("SELECT id, name, version, attempt
                                      FROM queue
                                      WHERE attempt < 5
                                      ORDER BY priority ASC, attempt ASC, id ASC
@@ -58,6 +58,7 @@ impl DocBuilder {
         let id: i32 = query.get(0).get(0);
         let name: String = query.get(0).get(1);
         let version: String = query.get(0).get(2);
+        let attempt: i32 = query.get(0).get(3);
 
         match builder.build_package(self, &name, &version) {
             Ok(_) => {
@@ -65,8 +66,12 @@ impl DocBuilder {
             }
             Err(e) => {
                 // Increase attempt count
-                let _ = conn.execute("UPDATE queue SET attempt = attempt + 1 WHERE id = $1",
-                                     &[&id]);
+                let attempt = attempt + 1;
+                let _ = conn.execute("UPDATE queue SET attempt = $1 WHERE id = $2",
+                                     &[&attempt, &id]);
+                if attempt >= 5 {
+                    ::web::metrics::FAILED_BUILDS.inc();
+                }
                 error!("Failed to build package {}-{} from queue: {}",
                        name,
                        version,

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -310,19 +310,12 @@ impl RustwideBuilder {
                 }
 
                 let has_examples = build.host_source_dir().join("examples").is_dir();
-                let metadata = res.cargo_metadata.root();
-                let is_library = match metadata.targets[0].kind.as_slice() {
-                    &[ref kind] if kind == "lib" || kind == "proc-macro" => true,
-                    _ => false,
-                };
                 if res.successful {
                     ::web::metrics::SUCCESSFUL_BUILDS.inc();
+                } else if res.cargo_metadata.root().is_library() {
+                    ::web::metrics::FAILED_BUILDS.inc();
                 } else {
-                    if is_library {
-                        ::web::metrics::FAILED_BUILDS.inc();
-                    } else {
-                        ::web::metrics::NON_LIBRARY_BUILDS.inc();
-                    }
+                    ::web::metrics::NON_LIBRARY_BUILDS.inc();
                 }
                 let release_id = add_package_into_database(
                     &conn,

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -310,6 +310,20 @@ impl RustwideBuilder {
                 }
 
                 let has_examples = build.host_source_dir().join("examples").is_dir();
+                let metadata = res.cargo_metadata.root();
+                let is_library = match metadata.targets[0].kind.as_slice() {
+                    &[ref kind] if kind == "lib" || kind == "proc-macro" => true,
+                    _ => false,
+                };
+                if res.successful {
+                    ::web::metrics::SUCCESSFUL_BUILDS.inc();
+                } else {
+                    if is_library {
+                        ::web::metrics::FAILED_BUILDS.inc();
+                    } else {
+                        ::web::metrics::NON_LIBRARY_BUILDS.inc();
+                    }
+                }
                 let release_id = add_package_into_database(
                     &conn,
                     res.cargo_metadata.root(),

--- a/src/utils/cargo_metadata.rs
+++ b/src/utils/cargo_metadata.rs
@@ -78,6 +78,15 @@ pub(crate) struct Package {
     pub(crate) authors: Vec<String>,
 }
 
+impl Package {
+    pub(crate) fn is_library(&self) -> bool {
+        match self.targets[0].kind.as_slice() {
+            &[ref kind] if kind == "lib" || kind == "proc-macro" => true,
+            _ => false,
+        }
+    }
+}
+
 #[derive(RustcDecodable)]
 pub(crate) struct Target {
     pub(crate) name: String,

--- a/src/utils/queue.rs
+++ b/src/utils/queue.rs
@@ -4,6 +4,7 @@ use postgres::Connection;
 use error::Result;
 
 pub fn add_crate_to_queue(conn: &Connection, name: &str, version: &str, priority: i32) -> Result<()> {
+    ::web::metrics::TOTAL_BUILDS.inc();
     try!(conn.execute("INSERT INTO queue (name, version, priority) VALUES ($1, $2, $3)",
                       &[&name, &version, &priority]));
     Ok(())

--- a/src/utils/queue.rs
+++ b/src/utils/queue.rs
@@ -4,7 +4,6 @@ use postgres::Connection;
 use error::Result;
 
 pub fn add_crate_to_queue(conn: &Connection, name: &str, version: &str, priority: i32) -> Result<()> {
-    ::web::metrics::TOTAL_BUILDS.inc();
     try!(conn.execute("INSERT INTO queue (name, version, priority) VALUES ($1, $2, $3)",
                       &[&name, &version, &priority]));
     Ok(())

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -2,7 +2,7 @@ use super::pool::Pool;
 use iron::headers::ContentType;
 use iron::prelude::*;
 use iron::status::Status;
-use prometheus::{Encoder, IntGauge, TextEncoder};
+use prometheus::{Encoder, IntGauge, IntCounter, TextEncoder};
 
 lazy_static! {
     static ref QUEUED_CRATES_COUNT: IntGauge = register_int_gauge!(
@@ -13,6 +13,26 @@ lazy_static! {
     static ref FAILED_CRATES_COUNT: IntGauge = register_int_gauge!(
         "docsrs_failed_crates_count",
         "Number of crates that failed to build"
+    )
+    .unwrap();
+    pub static ref TOTAL_BUILDS: IntCounter = register_int_counter!(
+        "docsrs_total_builds",
+        "Number of crates built"
+    )
+    .unwrap();
+    pub static ref SUCCESSFUL_BUILDS: IntCounter = register_int_counter!(
+        "docsrs_successful_builds",
+        "Number of builds that successfully generated docs"
+    )
+    .unwrap();
+    pub static ref FAILED_BUILDS: IntCounter = register_int_counter!(
+        "docsrs_failed_builds",
+        "Number of builds that generated a compile error"
+    )
+    .unwrap();
+    pub static ref NON_LIBRARY_BUILDS: IntCounter = register_int_counter!(
+        "docsrs_non_library_builds",
+        "Number of builds that did not complete due to not being a library"
     )
     .unwrap();
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -44,7 +44,7 @@ mod file;
 mod builds;
 mod error;
 mod sitemap;
-mod metrics;
+pub mod metrics;
 
 use std::{env, fmt};
 use std::error::Error;

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -433,6 +433,12 @@ fn latest_version(versions_json: &Vec<String>, req_version: &str) -> Option<Stri
 
 /// Starts cratesfyi web server
 pub fn start_web_server(sock_addr: Option<&str>) {
+    // poke all the metrics counters to instantiate and register them
+    metrics::TOTAL_BUILDS.inc_by(0);
+    metrics::SUCCESSFUL_BUILDS.inc_by(0);
+    metrics::FAILED_BUILDS.inc_by(0);
+    metrics::NON_LIBRARY_BUILDS.inc_by(0);
+
     let cratesfyi = CratesfyiHandler::new();
     Iron::new(cratesfyi).http(sock_addr.unwrap_or("0.0.0.0:3000")).unwrap();
 }


### PR DESCRIPTION
This PR adds four new records to the `/about/metrics` endpoint:

- The total number of crates built in the last six hours
- The number of crates built successfully in the last six hours
- The number of crates which failed to build in the last six hours, due to a compile error
- The number of crates which failed to build in the last six hours, due to being flagged "not a library"

By making the metrics a sliding window of "the last six hours", we can better track the rate of failures, rather than any individual success/failure count. For example, calculating `failures / total builds`, we can get a rolling calculation of our build failure rate.

(It would be really cool to have some kind of inspection of the build logs to flag errors due to build scripts, `pkg-config` failing, etc, to get an idea of crates that need some kind of system dependency versus those that may be due to our own build configuration causing an issue, but queries on the build output take too long to be repeatedly polled. Perhaps something like that can be tracked as a counter that is incremented after a build finishes, rather than a query that's repeatedly executed.)

cc @pietroalbini 