### PR TITLE
Keep the subpage when going to latest version

### DIFF
--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -20,7 +20,7 @@ use schemamama_postgres::{PostgresAdapter, PostgresMigration};
 ///                               "DROP TABLE test;");
 /// ```
 macro_rules! migration {
-    ($version:expr, $description:expr, $up:expr, $down:expr) => {{
+    ($version:expr, $description:expr, $up:expr, $down:expr $(,)?) => {{
         struct Amigration;
         impl Migration for Amigration {
             fn version(&self) -> Version {

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -202,7 +202,17 @@ pub fn migrate(version: Option<Version>) -> CratesfyiResult<()> {
             "ALTER TABLE releases ALTER COLUMN release_time DROP NOT NULL,
                                   ALTER COLUMN yanked DROP NOT NULL,
                                   ALTER COLUMN downloads DROP NOT NULL"
-        )
+        ),
+        migration!(
+            // version
+            5,
+            // description
+            "Make target_name non-nullable",
+            // upgrade query
+            "ALTER TABLE releases ALTER COLUMN target_name SET NOT NULL",
+            // downgrade query
+            "ALTER TABLE releases ALTER COLUMN target_name DROP NOT NULL",
+        ),
     ];
 
     for migration in migrations {

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -36,7 +36,7 @@ pub struct CrateDetails {
     homepage_url: Option<String>,
     keywords: Option<Json>,
     have_examples: bool, // need to check this manually
-    target_name: Option<String>,
+    pub target_name: String,
     pub versions: Vec<String>,
     github: bool, // is crate hosted in github
     github_stars: Option<i32>,

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -280,13 +280,21 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
         .to_resp("rustdoc")
 }
 
+/// Checks whether the given path (including version and target information) exists.
+/// The crate's `target_name` is used to confirm whether a platform triple is part of the path.
+///
+/// Returns a path that can be appended to `/crate/version/` to create a complete URL.
 fn path_for_version(req_path: &[&str], target_name: &str, conn: &Connection) -> String {
     if File::from_path(&conn, &req_path.join("/")).is_some() {
-        req_path[3..].join("/") // NOTE: this adds 'index.html' if it wasn't there before
-    } else { // this page doesn't exist in the latest version
-        let search_item = if *req_path.last().unwrap() == "index.html" { // this is a module
+        // NOTE: this adds 'index.html' if it wasn't there before
+        req_path[3..].join("/")
+    } else {
+        // this page doesn't exist in the latest version
+        let search_item = if *req_path.last().unwrap() == "index.html" {
+            // this is a module
             req_path[req_path.len() - 2]
-        } else { // this is an item
+        } else {
+            // this is an item
             req_path.last().unwrap().split('.').nth(1)
                 .expect("paths should be of the form <class>.<name>.html")
         };

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -280,8 +280,14 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
         .to_resp("rustdoc")
 }
 
-/// Checks whether the given path (including version and target information) exists.
+/// Checks whether the given path exists.
 /// The crate's `target_name` is used to confirm whether a platform triple is part of the path.
+///
+/// Note that path is overloaded in this context to mean both the path of a URL
+/// and the file path of a static file in the DB.
+///
+/// `req_path` is assumed to have the following format:
+/// `rustdoc/crate/version[/platform]/module/[kind.name.html|index.html]`
 ///
 /// Returns a path that can be appended to `/crate/version/` to create a complete URL.
 fn path_for_version(req_path: &[&str], target_name: &str, conn: &Connection) -> String {
@@ -297,7 +303,7 @@ fn path_for_version(req_path: &[&str], target_name: &str, conn: &Connection) -> 
     } else {
         // this is an item
         req_path.last().unwrap().split('.').nth(1)
-            .expect("paths should be of the form <class>.<name>.html")
+            .expect("paths should be of the form <kind>.<name>.html")
     };
     // check if req_path[3] is the platform choice or the name of the crate
     let concat_path;

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -285,29 +285,29 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
 ///
 /// Returns a path that can be appended to `/crate/version/` to create a complete URL.
 fn path_for_version(req_path: &[&str], target_name: &str, conn: &Connection) -> String {
+    // Simple case: page exists in the latest version, so just change the version number
     if File::from_path(&conn, &req_path.join("/")).is_some() {
         // NOTE: this adds 'index.html' if it wasn't there before
-        req_path[3..].join("/")
-    } else {
-        // this page doesn't exist in the latest version
-        let search_item = if *req_path.last().unwrap() == "index.html" {
-            // this is a module
-            req_path[req_path.len() - 2]
-        } else {
-            // this is an item
-            req_path.last().unwrap().split('.').nth(1)
-                .expect("paths should be of the form <class>.<name>.html")
-        };
-        // check if req_path[3] is the platform choice or the name of the crate
-        let concat_path;
-        let crate_root = if req_path[3] != target_name {
-            concat_path = format!("{}/{}", req_path[3], req_path[4]);
-            &concat_path
-        } else {
-            req_path[3]
-        };
-        format!("{}/?search={}", crate_root, search_item)
+        return req_path[3..].join("/");
     }
+    // this page doesn't exist in the latest version
+    let search_item = if *req_path.last().unwrap() == "index.html" {
+        // this is a module
+        req_path[req_path.len() - 2]
+    } else {
+        // this is an item
+        req_path.last().unwrap().split('.').nth(1)
+            .expect("paths should be of the form <class>.<name>.html")
+    };
+    // check if req_path[3] is the platform choice or the name of the crate
+    let concat_path;
+    let crate_root = if req_path[3] != target_name {
+        concat_path = format!("{}/{}", req_path[3], req_path[4]);
+        &concat_path
+    } else {
+        req_path[3]
+    };
+    format!("{}/?search={}", crate_root, search_item)
 }
 
 pub fn badge_handler(req: &mut Request) -> IronResult<Response> {

--- a/templates/navigation_rustdoc.hbs
+++ b/templates/navigation_rustdoc.hbs
@@ -86,7 +86,7 @@
             </li>
             {{#unless ../../varsb.is_latest_version}}
             <li class="pure-menu-item">
-              <a href="/{{name}}/{{../../varss.latest_version}}" class="pure-menu-link warn" title="You are seeing an outdated version of {{name}} crate. Click here to go to latest version."><i class="fa fa-fw fa-warning"></i><span class="title"> Go to latest version</span></a>
+              <a href="/{{name}}/{{../../varss.latest_version}}/{{../../varss.path_in_latest}}" class="pure-menu-link warn" title="You are seeing an outdated version of {{name}} crate. Click here to go to latest version."><i class="fa fa-fw fa-warning"></i><span class="title"> Go to latest version</span></a>
             </li>
             {{/unless}}
             <li class="pure-menu-item">


### PR DESCRIPTION
Addresses https://github.com/rust-lang/docs.rs/issues/200

If the page does not exist on the latest version, searches for a page with that title.

~~TODO: If
1. Going to a new version that
2. Deleted the existing module/item and
3. The user is looking at a platform other than the default,
then the link will be wrong (it will not include the name of the crate).~~

~~The solution is to check if `req_path[3]` is the crate name or the platform. Once this is done, https://github.com/rust-lang/docs.rs/issues/200#issuecomment-544033326 will be trivial to fix.~~

This is fixed, see below. 