### PR TITLE
Parse URL for rustlang.org redirector once.

### DIFF
--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -66,24 +66,24 @@ impl ToJson for RustdocPage {
 }
 
 pub struct RustLangRedirector {
-    target: &'static str,
+    url: Url,
 }
 
 impl RustLangRedirector {
     pub fn new(target: &'static str) -> Self {
-        Self { target }
+        let url = url::Url::parse("https://doc.rust-lang.org/stable/")
+            .expect("failed to parse rust-lang.org base URL")
+            .join(target)
+            .expect("failed to append crate name to rust-lang.org base URL");
+        let url = Url::from_generic_url(url)
+            .expect("failed to convert url::Url to iron::Url");
+        Self { url }
     }
 }
 
 impl iron::Handler for RustLangRedirector {
     fn handle(&self, _req: &mut Request) -> IronResult<Response> {
-        let url = url::Url::parse("https://doc.rust-lang.org/stable/")
-            .expect("failed to parse rust-lang.org base URL")
-            .join(self.target)
-            .expect("failed to append crate name to rust-lang.org base URL");
-        let url = Url::from_generic_url(url)
-            .expect("failed to convert url::Url to iron::Url");
-        Ok(Response::with((status::Found, Redirect(url))))
+        Ok(Response::with((status::Found, Redirect(self.url.clone()))))
     }
 }
 


### PR DESCRIPTION
A colleague of mine pointed out that the rustlang redirector could have parsed the URL once in the `new` function. She was right, so this PR moves the URL building from the `handle` function to the `new` function.

Even though the parsing/joining/converting can't really fail, now at-least it would do so at startup, rather than during a request. And it's technically more efficient, even though I'm pretty sure nobody will ever notice.