### PR TITLE
Add a metric on the number of uploaded files

### DIFF
--- a/src/db/file.rs
+++ b/src/db/file.rs
@@ -196,7 +196,10 @@ pub fn add_path_into_database<P: AsRef<Path>>(conn: &Connection,
                     match s3_res {
                         // we've successfully uploaded the content, so steal it;
                         // we don't want to put it in the DB
-                        Ok(_) => break None,
+                        Ok(_) => {
+                            crate::web::metrics::UPLOADED_FILES_TOTAL.inc_by(1);
+                            break None;
+                        },
                         // Since s3 was configured, we want to panic on failure to upload.
                         Err(e) => {
                             log::error!("failed to upload to {}: {:?}", bucket_path, e);
@@ -240,6 +243,7 @@ pub fn add_path_into_database<P: AsRef<Path>>(conn: &Connection,
                                 WHERE path = $1",
                                 &[&path, &mime, &content]));
             }
+            crate::web::metrics::UPLOADED_FILES_TOTAL.inc_by(1);
         }
     }
 

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -35,6 +35,11 @@ lazy_static! {
         "Number of builds that did not complete due to not being a library"
     )
     .unwrap();
+    pub static ref UPLOADED_FILES_TOTAL: IntCounter = register_int_counter!(
+        "docsrs_uploaded_files_total",
+        "Number of files uploaded to S3 or stored in the database"
+    )
+    .unwrap();
 }
 
 pub fn metrics_handler(req: &mut Request) -> IronResult<Response> {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -438,6 +438,7 @@ pub fn start_web_server(sock_addr: Option<&str>) {
     metrics::SUCCESSFUL_BUILDS.inc_by(0);
     metrics::FAILED_BUILDS.inc_by(0);
     metrics::NON_LIBRARY_BUILDS.inc_by(0);
+    metrics::UPLOADED_FILES_TOTAL.inc_by(0);
 
     let cratesfyi = CratesfyiHandler::new();
     Iron::new(cratesfyi).http(sock_addr.unwrap_or("0.0.0.0:3000")).unwrap();


### PR DESCRIPTION
This commit adds a new Prometheus metric to track how much files we uploaed to S3 or added to the database. This will be useful to track the usefulness of parallel S3 upload once we land it.

cc https://github.com/rust-lang/docs.rs/pull/393
r? @Mark-Simulacrum 