### PR TITLE
Build local packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ docker-compose run web build crate <CRATE_NAME> <CRATE_VERSION>
 # Builds every crate and adds them into database
 # (beware: this may take months to finish)
 docker-compose run web build world
+
+# Builds a local package you have at <SOURCE> and adds it to the database.
+# The package does not have to be on crates.io.
+# The package must be on the local filesystem, git urls are not allowed.
+docker-compose run -v "$(realpath <SOURCE>)":/build web build crate --local /build
 ```
 
 

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -161,7 +161,7 @@ pub fn main() {
             docbuilder.save_cache().expect("Failed to save cache");
         } else if let Some(matches) = matches.subcommand_matches("crate") {
             docbuilder.load_cache().expect("Failed to load cache");
-            let mut builder = RustwideBuilder::init().unwrap();
+            let mut builder = RustwideBuilder::init().expect("failed to initialize rustwide");
             match matches.value_of("LOCAL") {
                 Some(path) => builder.build_local_package(&mut docbuilder, Path::new(path)),
                 None => builder.build_package(&mut docbuilder,

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -288,7 +288,7 @@ fn read_rust_doc(file_path: &Path) -> Result<Option<String>> {
 /// Get release_time, yanked and downloads from crates.io
 fn get_release_time_yanked_downloads(
     pkg: &MetadataPackage,
-) -> Result<(Option<time::Timespec>, Option<bool>, Option<i32>)> {
+) -> Result<(time::Timespec, bool, i32)> {
     let url = format!("https://crates.io/api/v1/crates/{}/versions", pkg.name);
     // FIXME: There is probably better way to do this
     //        and so many unwraps...
@@ -332,7 +332,7 @@ fn get_release_time_yanked_downloads(
         }
     }
 
-    Ok((release_time, yanked, downloads))
+    Ok((release_time.unwrap_or(time::get_time()), yanked.unwrap_or(false), downloads.unwrap_or(0)))
 }
 
 

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -193,6 +193,16 @@ pub fn migrate(version: Option<Version>) -> CratesfyiResult<()> {
             // downgrade query
             "DROP TABLE sandbox_overrides;"
         ),
+        migration!(
+            4,
+            "Make more fields not null",
+            "ALTER TABLE releases ALTER COLUMN release_time SET NOT NULL,
+                                  ALTER COLUMN yanked SET NOT NULL,
+                                  ALTER COLUMN downloads SET NOT NULL",
+            "ALTER TABLE releases ALTER COLUMN release_time DROP NOT NULL,
+                                  ALTER COLUMN yanked DROP NOT NULL,
+                                  ALTER COLUMN downloads DROP NOT NULL"
+        )
     ];
 
     for migration in migrations {

--- a/src/docbuilder/queue.rs
+++ b/src/docbuilder/queue.rs
@@ -59,7 +59,7 @@ impl DocBuilder {
         let name: String = query.get(0).get(1);
         let version: String = query.get(0).get(2);
 
-        match builder.build_package(self, &name, &version) {
+        match builder.build_package(self, &name, &version, None) {
             Ok(_) => {
                 let _ = conn.execute("DELETE FROM queue WHERE id = $1", &[&id]);
                 ::web::metrics::TOTAL_BUILDS.inc();


### PR DESCRIPTION
- Add a flag to make it possible
- Add documentation to the readme (since docker-compose makes it not very intuitive)

Note: this breaks backwards compatibility for `build_package`. This could be avoided by adding a private `build_package_impl` function but that seems ugly :/ I'm open to suggestions on how to make this backwards compatible.