### PR TITLE
allow building locally as well as with docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 /.rustwide
+/.rustwide-docker
 /ignored
 **/target

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 .sass-cache
 .vagrant
 .rustwide
+.rustwide-docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,10 @@ services:
             - "3000:3000"
         volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
-            - ".rustwide-docker:/home/cratesfyi/rustwide"
+            - ".rustwide-docker:/opt/docsrs/rustwide"
             - "cratesio-index:/opt/docsrs/prefix/crates.io-index"
         environment:
-            CRATESFYI_RUSTWIDE_WORKSPACE: /home/cratesfyi/rustwide
+            CRATESFYI_RUSTWIDE_WORKSPACE: /opt/docsrs/rustwide
             CRATESFYI_DATABASE_URL: postgresql://cratesfyi:password@db
         env_file:
             - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
             - "3000:3000"
         volumes:
             - "/var/run/docker.sock:/var/run/docker.sock"
-            - ".rustwide:/home/cratesfyi/rustwide"
+            - ".rustwide-docker:/home/cratesfyi/rustwide"
             - "cratesio-index:/opt/docsrs/prefix/crates.io-index"
         environment:
             CRATESFYI_RUSTWIDE_WORKSPACE: /home/cratesfyi/rustwide

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -euv
 


### PR DESCRIPTION
If docker uses the `.rustwide` directory, it will only be readable and writable by root.
This uses a different scratch directory so that the `.rustwide` directory can be used for local builds.