### PR TITLE
add updated Source Code Pro to essential files

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -48,8 +48,9 @@ static ESSENTIAL_FILES_VERSIONED: &[&str] = &[
 static ESSENTIAL_FILES_UNVERSIONED: &[&str] = &[
     "FiraSans-Medium.woff",
     "FiraSans-Regular.woff",
-    "SourceCodePro-Regular.woff",
-    "SourceCodePro-Semibold.woff",
+    "SourceCodePro-Regular.ttf.woff",
+    "SourceCodePro-Semibold.ttf.woff",
+    "SourceCodePro-It.ttf.woff",
     "SourceSerifPro-Bold.ttf.woff",
     "SourceSerifPro-Regular.ttf.woff",
     "SourceSerifPro-It.ttf.woff",


### PR DESCRIPTION
This is a PR to update our builder to accommodate https://github.com/rust-lang/rust/pull/65665. **Do not deploy this** until a nightly is released with that PR (should be 2019-11-21, but confirm ahead of time). Pin the nightly to the current one for now, and unpin it while deploying this change.