### PR TITLE
web: show the priority in the queue

### DIFF
--- a/templates/releases_queue.hbs
+++ b/templates/releases_queue.hbs
@@ -13,7 +13,14 @@
 
     <ol class="queue-list">
     {{#each content}}
-    <li><a href="https://crates.io/crates/{{this.[0]}}">{{this.[0]}}-{{this.[1]}}</a></li>
+    <li>
+        <a href="https://crates.io/crates/{{this.[0]}}">
+            {{this.[0]}} {{this.[1]}}
+        </a>
+        {{#if this.[2]}}
+        (priority: {{this.[2]}})
+        {{/if}}
+    </li>
     {{/each}}
     </ol>
   </div>


### PR DESCRIPTION
One of the tools docs.rs operators have to ensure a fair build queue to everyone is to manually deprioritize slow-to-build crates. Before this the priority wasn't exposed anywhere in the UI though, making the queue look weird when a bunch of crates were deprioritized.

This changes the queue page to show the priority in the build queue if it's not '0'.

![2019-11-25--11-39-07](https://user-images.githubusercontent.com/2299951/69533832-deff8000-0f78-11ea-8312-85b96ace5021.png)

r? @jyn514 