### PR TITLE
Document proc-macros despite bugs in rustdoc

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -26,7 +26,6 @@ static TARGETS: &[&str] = &[
     "x86_64-pc-windows-msvc",
     "x86_64-unknown-linux-gnu",
 ];
-static DEFAULT_TARGET: &str = "x86_64-unknown-linux-gnu";
 
 static ESSENTIAL_FILES_VERSIONED: &[&str] = &[
     "brush.svg",


### PR DESCRIPTION
Use documentation in /target/doc if /target/$target/doc doesn't exist.
In that case, also don't pass `--target` to rustdoc.

Closes #422.

I also moved `build_target` into a separate function since `build_package` was getting kind of big.

r? @QuietMisdreavus