### PR TITLE
Extend size of `:target`ed elements

### DIFF
--- a/templates/style.scss
+++ b/templates/style.scss
@@ -91,6 +91,17 @@ div.rustdoc {
     right: 0;
     top: $top-navbar-height;
     max-height: calc(100vh - #{$top-navbar-height});
+
+    // this prevents the current fragment target (the element that the browser
+    // scrolls to when following a link with a `#fragment`) from hiding under
+    // the navbar bar
+    :target::before {
+        content: " ";
+        margin-top: -$top-navbar-height;
+        display: block;
+        height: $top-navbar-height;
+        pointer-events: none;
+    }
 }
 
 body {


### PR DESCRIPTION
When the browser follows a link with a `#fragment`, it scrolls up or
down to put the element with the matching `id` attribute at the top
of the window. In rustdoc output, that's usually section headers.

docs.rs's floating top navbar hides that element. This PR extends
the height of the element the browser is scrolling to, in a way that
doesn't affect its visual appearance, so that it lands below the
navbar and is visible to the user.