### PR TITLE
Reenable searching

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -388,7 +388,6 @@ impl RustwideBuilder {
             format!("-{}", parse_rustc_version(&self.rustc_version)?),
             "--static-root-path".to_string(),
             "/".to_string(),
-            "--disable-per-crate-search".to_string(),
         ];
         for dep in &cargo_metadata.root_dependencies() {
             rustdoc_flags.push("--extern-html-root-url".to_string());


### PR DESCRIPTION
I'm not sure why it was disabled in the first place, but it started
affecting users after https://github.com/rust-lang/docs.rs/pull/496 was
merged.

This is somewhat high priority since searching looks broken for all crates being built, and search will continue to be broken for those crates (even after this is merged) until they are rebuilt.

Example of an affected crate: https://docs.rs/async-std/1.2.0/async_std/