### PR TITLE
Match library properly if multiple crate-types are in use.

### DIFF
--- a/src/utils/cargo_metadata.rs
+++ b/src/utils/cargo_metadata.rs
@@ -80,12 +80,12 @@ pub(crate) struct Package {
 
 impl Package {
     fn library_target(&self) -> Option<&Target> {
-        self.targets
-            .iter()
-            .find(|target| match target.kind.as_slice() {
-                [kind] if kind == "lib" || kind == "proc-macro" => true,
-                _ => false,
-            })
+        self.targets.iter().find(|target| {
+            target
+                .kind
+                .iter()
+                .any(|kind| kind == "lib" || kind == "proc-macro")
+        })
     }
 
     pub(crate) fn is_library(&self) -> bool {


### PR DESCRIPTION
Noticed this in my crate rustyknife was flagged as "not a library".

Cargo.toml snippet:
[lib]
crate-type = ["lib", "cdylib"]