### PR TITLE
Link to docs for changing the build environment in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/crate-build-failure.md
+++ b/.github/ISSUE_TEMPLATE/crate-build-failure.md
@@ -7,6 +7,12 @@ assignees: ''
 
 ---
 
+<!-- If you need a system dependency added for your crate to build,
+consider making a PR to https://github.com/rust-lang/crates-build-env
+instead of opening an issue here. There are detailed instructions for this at
+https://github.com/rust-lang/docs.rs/wiki/Making-changes-to-the-build-environment
+-->
+
 **Crate name:**
 **Build failure link:**
 

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ docker-compose run -p 3000:3000 web daemon --foreground
 
 ### Changing the build environment
 
-To make a change to https://github.com/rust-lang/crates-build-env
-and test that it works on docs.rs, see https://github.com/rust-lang/docs.rs/wiki/Making-changes-to-the-build-environment.
+To make a change to [the build environment](https://github.com/rust-lang/crates-build-env)
+and test that it works on docs.rs, see [the wiki](https://github.com/rust-lang/docs.rs/wiki/Making-changes-to-the-build-environment).
 
 ### Contact
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ docker exec -it <the container name goes here> psql -U cratesfyi
 docker-compose run -p 3000:3000 web daemon --foreground
 ```
 
+### Changing the build environment
+
+To make a change to https://github.com/rust-lang/crates-build-env
+and test that it works on docs.rs, see https://github.com/rust-lang/docs.rs/wiki/Making-changes-to-the-build-environment.
+
 ### Contact
 
 Docs.rs is run and maintained by [Rustdoc team](https://www.rust-lang.org/governance/teams/dev-tools#rustdoc).


### PR DESCRIPTION
Addresses https://github.com/rust-lang/docs.rs/issues/504

The motivation here is to reduce the maintenance burder on the docs.rs team by having people submit PRs to https://github.com/rust-lang/crates-build-env directly. This has 2 main benefits:

1. Crate authors already know the packages they need, so they don't have to tell us and have us make a PR ourselves; this removes an intermediate step.
2. If crate authors are wrong about the packages they need (for instance, https://github.com/rust-lang/docs.rs/issues/483 needed liblapack-dev, not just gfortran), they get immediate feedback instead of having to wait for a deploy and republish their package.