### PR TITLE
Mark all crates as libraries that aren't bins

### DIFF
--- a/src/utils/cargo_metadata.rs
+++ b/src/utils/cargo_metadata.rs
@@ -84,7 +84,7 @@ impl Package {
             target
                 .kind
                 .iter()
-                .any(|kind| kind == "lib" || kind == "proc-macro")
+                .any(|kind| kind != "bin")
         })
     }
 

--- a/src/utils/cargo_metadata.rs
+++ b/src/utils/cargo_metadata.rs
@@ -80,12 +80,9 @@ pub(crate) struct Package {
 
 impl Package {
     fn library_target(&self) -> Option<&Target> {
-        self.targets.iter().find(|target| {
-            target
-                .kind
-                .iter()
-                .any(|kind| kind != "bin")
-        })
+        self.targets
+            .iter()
+            .find(|target| target.crate_types.iter().any(|kind| kind != "bin"))
     }
 
     pub(crate) fn is_library(&self) -> bool {
@@ -110,7 +107,7 @@ impl Package {
 #[derive(RustcDecodable)]
 pub(crate) struct Target {
     pub(crate) name: String,
-    pub(crate) kind: Vec<String>,
+    crate_types: Vec<String>,
     pub(crate) src_path: Option<String>,
 }
 


### PR DESCRIPTION
Closes https://github.com/rust-lang/docs.rs/issues/503

See that issue for context on why `kind` was changed to `crate_types`.

r? @pietroalbini 