### PR TITLE
Fix redirects if latest version failed to build

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -43,10 +43,16 @@ pub(crate) fn assert_redirect(path: &str, expected_target: &str, web: &TestFront
     let response = web.get(path).send()?;
     let status = response.status();
 
+    let mut tmp;
     let redirect_target = if expected_target.starts_with("https://") {
         response.url().as_str()
     } else {
-        response.url().path()
+        tmp = String::from(response.url().path());
+        if let Some(query) = response.url().query() {
+            tmp.push('?');
+            tmp.push_str(query);
+        }
+        &tmp
     };
     // Either we followed a redirect to the wrong place, or there was no redirect
     if redirect_target != expected_target {

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -98,11 +98,13 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
                        vers: &str,
                        target_name: &str)
                        -> IronResult<Response> {
-        let url = ctry!(Url::parse(&format!("{}/{}/{}/{}/",
+        let url = ctry!(Url::parse(&format!("{}/{}/{}/{}/?{}",
                                             redirect_base(req),
                                             name,
                                             vers,
-                                            target_name)[..]));
+                                            target_name,
+                                            req.url.query().unwrap_or_default()
+                                           )[..]));
         let mut resp = Response::with((status::Found, Redirect(url)));
         resp.headers.set(Expires(HttpDate(time::now())));
 
@@ -343,7 +345,7 @@ fn path_for_version(req_path: &[&str], target_name: &str, conn: &Connection) -> 
     } else {
         req_path[3]
     };
-    format!("{}/?search={}", crate_root, search_item)
+    format!("{}?search={}", crate_root, search_item)
 }
 
 pub fn badge_handler(req: &mut Request) -> IronResult<Response> {

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -98,13 +98,18 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
                        vers: &str,
                        target_name: &str)
                        -> IronResult<Response> {
-        let url = ctry!(Url::parse(&format!("{}/{}/{}/{}/?{}",
-                                            redirect_base(req),
-                                            name,
-                                            vers,
-                                            target_name,
-                                            req.url.query().unwrap_or_default()
-                                           )[..]));
+        let mut url_str = format!(
+            "{}/{}/{}/{}/",
+            redirect_base(req),
+            name,
+            vers,
+            target_name,
+        );
+        if let Some(query) = req.url.query() {
+            url_str.push('?');
+            url_str.push_str(query);
+        }
+        let url = ctry!(Url::parse(&url_str[..]));
         let mut resp = Response::with((status::Found, Redirect(url)));
         resp.headers.set(Expires(HttpDate(time::now())));
 

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -545,19 +545,22 @@ mod test {
               .rustdoc_file("dummy/blah/blah.html", b"lah")
               .create()?;
 
+            let web = env.frontend();
+
             // check it works at all
-            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/", &env.frontend())?;
+            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/", &web)?;
             assert_eq!(redirect, "/dummy/0.2.0/dummy/index.html");
 
             // check it keeps the subpage
-            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/blah/", &env.frontend())?;
+            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/blah/", &web)?;
             assert_eq!(redirect, "/dummy/0.2.0/dummy/blah/index.html");
-            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/blah/blah.html", &env.frontend())?;
+            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/blah/blah.html", &web)?;
             assert_eq!(redirect, "/dummy/0.2.0/dummy/blah/blah.html");
 
             // check it searches for removed pages
-            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/struct.will-be-deleted.html", &env.frontend())?;
-            assert_eq!(redirect, "/dummy/0.2.0/dummy/?search=will-be-deleted");
+            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/struct.will-be-deleted.html", &web)?;
+            assert_eq!(redirect, "/dummy/0.2.0/dummy?search=will-be-deleted");
+            assert_redirect("/dummy/0.2.0/dummy?search=will-be-deleted", "/dummy/0.2.0/dummy/?search=will-be-deleted", &web).unwrap();
 
             Ok(())
         })
@@ -581,6 +584,23 @@ mod test {
 
             let redirect = latest_version_redirect("/dummy/0.1.0/x86_64-pc-windows-msvc/dummy/", web)?;
             assert_eq!(redirect, "/dummy/0.2.0/x86_64-pc-windows-msvc/dummy/index.html");
+
+            Ok(())
+        })
+    }
+    #[test]
+    fn redirect_latest_goes_to_crate_if_build_failed() {
+        wrapper(|env| {
+            let db = env.db();
+            db.fake_release().name("dummy").version("0.1.0")
+              .rustdoc_file("dummy/index.html", b"lah")
+              .create().unwrap();
+            db.fake_release().name("dummy").version("0.2.0")
+              .build_result_successful(false).create().unwrap();
+
+            let web = env.frontend();
+            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/", web)?;
+            assert_eq!(redirect, "/crate/dummy/0.2.0");
 
             Ok(())
         })


### PR DESCRIPTION
Closes https://github.com/rust-lang/docs.rs/issues/502

The redirector behaved differently for `/:crate/:version/:target` than
for `/:crate/:version/:target/`. This changes the latest version link to
use the former, since it properly accounts for failed builds.

Additionally, this changes the `/:target` redirect to keep the query
parameter so that `?search=` URLs will be kept when going to `/:target/`.

r? @QuietMisdreavus 

Some good crates to test this with:
- isatty 0.1.0, 0.2.0 (0.2.0 failed to build)
- pyo3 0.2.7, 0.8.2 (moved pyo3::exc::ArithmeticError to a different module)