### PR TITLE
Fix scrolling on some browsers

### DIFF
--- a/templates/style.scss
+++ b/templates/style.scss
@@ -85,14 +85,7 @@ div.rustdoc {
         }
     }
 
-    // this is actual fix for docs.rs navigation and rustdoc sidebar
-    position: fixed;
-    top: $top-navbar-height;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    display: block;
-    overflow-y: auto;
+    position: relative;
 }
 
 body {


### PR DESCRIPTION
By making the body of rustdoc position: relative instead of fixed, scrolling on many browsers (like qutebrowser and iOS Safari) works like it should. This change has no impact on how the page looks (although you might want to test it some more).