### PR TITLE
Refactor the router

### DIFF
--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -71,7 +71,7 @@ pub(super) fn build_routes() -> Routes {
         super::builds::build_list_handler,
     );
     routes.internal_page(
-        "/crate/:name/:version/source",
+        "/crate/:name/:version/source/",
         super::source::source_browser_handler,
     );
     routes.internal_page(

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -125,9 +125,17 @@ pub(super) fn build_routes() -> Routes {
     routes
 }
 
+/// This wrapper class aids the construction of iron's Router, with docs.rs-specific additions to
+/// it. Routes are supposed to be added by the build_routes function, which calls methods in this
+/// struct depending on the type of route being added.
 pub(super) struct Routes {
+    /// Normal GET routes.
     get: Vec<(String, Box<dyn Handler>)>,
+    /// GET routes serving rustdoc content. The BlockBlacklistedPrefixes middleware is added
+    /// automatically to all of them.
     rustdoc_get: Vec<(String, Box<dyn Handler>)>,
+    /// Prefixes of all the internal routes. This data is used to power the
+    /// BlockBlacklistedPrefixes middleware.
     page_prefixes: HashSet<String>,
 }
 

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -1,0 +1,257 @@
+use iron::middleware::Handler;
+use router::Router;
+use std::collections::HashSet;
+
+const DOC_RUST_LANG_ORG_REDIRECTS: &[&str] = &["alloc", "core", "proc_macro", "std", "test"];
+
+pub(super) fn build_routes() -> Routes {
+    let mut routes = Routes::new();
+
+    routes.static_resource("/style.css", super::style_css_handler);
+    routes.static_resource("/robots.txt", super::sitemap::robots_txt_handler);
+    routes.static_resource("/sitemap.xml", super::sitemap::sitemap_handler);
+    routes.static_resource("/opensearch.xml", super::opensearch_xml_handler);
+
+    routes.internal_page("/", super::releases::home_page);
+
+    routes.internal_page("/about", super::sitemap::about_handler);
+    routes.internal_page("/about/metrics", super::metrics::metrics_handler);
+
+    routes.internal_page("/releases", super::releases::recent_releases_handler);
+    routes.static_resource("/releases/feed", super::releases::releases_feed_handler);
+    routes.internal_page("/releases/:author", super::releases::author_handler);
+    routes.internal_page("/releases/:author/:page", super::releases::author_handler);
+    routes.internal_page("/releases/activity", super::releases::activity_handler);
+    routes.internal_page("/releases/search", super::releases::search_handler);
+    routes.internal_page("/releases/queue", super::releases::build_queue_handler);
+    routes.internal_page(
+        "/releases/recent/:page",
+        super::releases::recent_releases_handler,
+    );
+    routes.internal_page(
+        "/releases/stars",
+        super::releases::releases_by_stars_handler,
+    );
+    routes.internal_page(
+        "/releases/stars/:page",
+        super::releases::releases_by_stars_handler,
+    );
+    routes.internal_page(
+        "/releases/recent-failures",
+        super::releases::releases_recent_failures_handler,
+    );
+    routes.internal_page(
+        "/releases/recent-failures/:page",
+        super::releases::releases_recent_failures_handler,
+    );
+    routes.internal_page(
+        "/releases/failures",
+        super::releases::releases_failures_by_stars_handler,
+    );
+    routes.internal_page(
+        "/releases/failures/:page",
+        super::releases::releases_failures_by_stars_handler,
+    );
+
+    routes.internal_page("/crate/:name", super::crate_details::crate_details_handler);
+    routes.internal_page(
+        "/crate/:name/:version",
+        super::crate_details::crate_details_handler,
+    );
+    routes.internal_page(
+        "/crate/:name/:version/builds",
+        super::builds::build_list_handler,
+    );
+    routes.static_resource(
+        "/crate/:name/:version/builds.json",
+        super::builds::build_list_handler,
+    );
+    routes.internal_page(
+        "/crate/:name/:version/builds/:id",
+        super::builds::build_list_handler,
+    );
+    routes.internal_page(
+        "/crate/:name/:version/source",
+        super::source::source_browser_handler,
+    );
+    routes.internal_page(
+        "/crate/:name/:version/source/*",
+        super::source::source_browser_handler,
+    );
+
+    routes.rustdoc_page("/:crate", super::rustdoc::rustdoc_redirector_handler);
+    routes.rustdoc_page("/:crate/", super::rustdoc::rustdoc_redirector_handler);
+    routes.rustdoc_page("/:crate/badge.svg", super::rustdoc::badge_handler);
+    routes.rustdoc_page(
+        "/:crate/:version",
+        super::rustdoc::rustdoc_redirector_handler,
+    );
+    routes.rustdoc_page(
+        "/:crate/:version/",
+        super::rustdoc::rustdoc_redirector_handler,
+    );
+    routes.rustdoc_page(
+        "/:crate/:version/settings.html",
+        super::rustdoc::rustdoc_html_server_handler,
+    );
+    routes.rustdoc_page(
+        "/:crate/:version/all.html",
+        super::rustdoc::rustdoc_html_server_handler,
+    );
+    routes.rustdoc_page(
+        "/:crate/:version/:target",
+        super::rustdoc::rustdoc_redirector_handler,
+    );
+    routes.rustdoc_page(
+        "/:crate/:version/:target/",
+        super::rustdoc::rustdoc_html_server_handler,
+    );
+    routes.rustdoc_page(
+        "/:crate/:version/:target/*.html",
+        super::rustdoc::rustdoc_html_server_handler,
+    );
+
+    for redirect in DOC_RUST_LANG_ORG_REDIRECTS {
+        routes.internal_page(
+            &format!("/{}", redirect),
+            super::rustdoc::RustLangRedirector::new(redirect),
+        );
+    }
+
+    routes
+}
+
+pub(super) struct Routes {
+    get: Vec<(String, Box<dyn Handler>)>,
+    rustdoc_get: Vec<(String, Box<dyn Handler>)>,
+    page_prefixes: HashSet<String>,
+}
+
+impl Routes {
+    fn new() -> Self {
+        Self {
+            get: Vec::new(),
+            rustdoc_get: Vec::new(),
+            page_prefixes: HashSet::new(),
+        }
+    }
+
+    pub(super) fn page_prefixes(&self) -> HashSet<String> {
+        self.page_prefixes.clone()
+    }
+
+    pub(super) fn iron_router(mut self) -> Router {
+        let mut router = Router::new();
+        for (pattern, handler) in self.get.drain(..) {
+            router.get(&pattern, handler, calculate_id(&pattern));
+        }
+
+        // All rustdoc pages have the prefixes of other docs.rs pages blacklisted. This prevents,
+        // for example, a crate named "about" from hijacking /about/0.1.0/index.html.
+        let blacklist = self.page_prefixes();
+        for (pattern, handler) in self.rustdoc_get.drain(..) {
+            router.get(
+                &pattern,
+                BlockBlacklistedPrefixes::new(blacklist.clone(), handler),
+                calculate_id(&pattern),
+            );
+        }
+
+        router
+    }
+
+    /// A static resource is a normal page without any special behavior on the router side.
+    fn static_resource(&mut self, pattern: &str, handler: impl Handler) {
+        self.get.push((pattern.to_string(), Box::new(handler)));
+    }
+
+    /// Internal pages are docs.rs's own pages, instead of the documentation of a crate uploaded by
+    /// an user. The router adds these extra things when adding a new internal page:
+    ///
+    /// - The first component of the page's URL will be registered as a "page prefix". Page
+    /// prefixes are blacklisted by rustdoc pages, to prevent a crate named the same as a prefix
+    /// from hijacking docs.rs's own URLs.
+    ///
+    /// - If the page URL doesn't end with a slash, a redirect from the URL with the trailing slash
+    /// to the one without is automatically added.
+    fn internal_page(&mut self, pattern: &str, handler: impl Handler) {
+        self.get.push((pattern.to_string(), Box::new(handler)));
+
+        // Automatically add another route ending with / that redirects to the slash-less route.
+        if !pattern.ends_with('/') {
+            let pattern = format!("{}/", pattern);
+            self.get
+                .push((pattern.to_string(), Box::new(remove_slashes)));
+        }
+
+        // Register the prefix if it's not the home page and the first path component is not a
+        // pattern or a wildcard.
+        if pattern != "/" {
+            if let Some(first_component) = pattern.trim_matches('/').split('/').next() {
+                if !first_component.contains('*') && !first_component.starts_with(':') {
+                    self.page_prefixes.insert(first_component.to_string());
+                }
+            }
+        }
+    }
+
+    /// A rustdoc page is a page serving generated documentation. It's similar to a static
+    /// resource, but path prefixes are automatically blacklisted (see internal pages to learn more
+    /// about page prefixes).
+    fn rustdoc_page(&mut self, pattern: &str, handler: impl Handler) {
+        self.rustdoc_get
+            .push((pattern.to_string(), Box::new(handler)));
+    }
+}
+
+/// Simple Iron route that redirects to the same path without the trailing slash, for example
+/// /foo/bar/baz/ to /foo/bar/baz.
+fn remove_slashes(req: &mut iron::Request) -> iron::IronResult<iron::Response> {
+    let mut url: iron::url::Url = req.url.clone().into();
+    url.set_path(&url.path().trim_end_matches('/').to_string());
+    Ok(iron::Response::with((
+        iron::status::Found,
+        iron::modifiers::Redirect(iron::Url::parse(&url.to_string()).unwrap()),
+    )))
+}
+
+/// Iron Middleware that prevents requests to blacklisted prefixes.
+///
+/// In our application, a prefix is blacklisted if a docs.rs page exists below it. For example,
+/// since /releases/queue is a docs.rs page, /releases is a blacklisted prefix.
+///
+/// The middleware must be used for all the pages serving crates at the top level, to prevent a
+/// crate from putting their own content in an URL that's supposed to be used by docs.rs.
+pub(super) struct BlockBlacklistedPrefixes {
+    blacklist: HashSet<String>,
+    handler: Box<dyn Handler>,
+}
+
+impl BlockBlacklistedPrefixes {
+    pub(super) fn new(blacklist: HashSet<String>, handler: Box<dyn Handler>) -> Self {
+        Self { blacklist, handler }
+    }
+}
+
+impl Handler for BlockBlacklistedPrefixes {
+    fn handle(&self, req: &mut iron::Request) -> iron::IronResult<iron::Response> {
+        if let Some(prefix) = req.url.path().get(0) {
+            if self.blacklist.contains(*prefix) {
+                return Err(iron::IronError::new(
+                    super::error::Nope::CrateNotFound,
+                    iron::status::NotFound,
+                ));
+            }
+        }
+        self.handler.handle(req)
+    }
+}
+
+/// Automatically generate a Route ID from a pattern. Every non-alphanumeric character is replaced
+/// with `_`.
+fn calculate_id(pattern: &str) -> String {
+    pattern
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '_' })
+        .collect()
+}

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -66,6 +66,7 @@ impl ToJson for RustdocPage {
     }
 }
 
+#[derive(Clone)]
 pub struct RustLangRedirector {
     url: Url,
 }


### PR DESCRIPTION
:warning::warning: **This PR is already deployed to production!** :warning::warning:

This PR refactors the router to use a custom wrapper. In addition to registering the route, the wrapper:

- For internal pages (like `/about`, `/releases/queue`...), it setups a redirect from the URL with a trailing slash to the URL without it.

- It registers all the prefixes of internal pages (`/about`, `/releases`, `/crate`) and blacklists those prefixes from the rustdoc routes. This prevents, for example, the `/about/0.1.0/` page from being hijacked by the author of the about crate.

r? @QuietMisdreavus 