### PR TITLE
Don't ignore DB cache if local cache is empty

### DIFF
--- a/src/docbuilder/mod.rs
+++ b/src/docbuilder/mod.rs
@@ -44,12 +44,10 @@ impl DocBuilder {
         let path = PathBuf::from(&self.options.prefix).join("cache");
         let reader = fs::File::open(path).map(|f| BufReader::new(f));
 
-        if reader.is_err() {
-            return Ok(());
-        }
-
-        for line in reader.unwrap().lines() {
-            self.cache.insert(line?);
+        if let Ok(reader) = reader {
+            for line in reader.lines() {
+                self.cache.insert(line?);
+            }
         }
 
         self.load_database_cache()?;


### PR DESCRIPTION
This greatly speeds up builds using `--skip` + docker-compose, for which the local cache will _always_ be empty.

This will be helpful for speeding up CI builds, which will (for the most part) test the functionality of the website, not the builder.