### PR TITLE
Add basic smoke tests for docs.rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             wget https://github.com/ericchiang/pup/releases/download/v0.4.0/pup_v0.4.0_linux_amd64.zip &&
             [ "$(sha256sum pup_v0.4.0_linux_amd64.zip | cut -d ' ' -f 1)" =
             ec3d29e9fb375b87ac492c8b546ad6be84b0c0b49dab7ff4c6b582eac71ba01c ] &&
-            unzip pup_v0.4.0_linux_arm64.zip &&
+            unzip pup_v0.4.0_linux_amd64.zip &&
             mv pup /usr/local/bin
 
       - name: Test docs.rs more thoroughly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             unzip pup_v0.4.0_linux_amd64.zip
 
       - name: Test docs.rs more thoroughly
-        run: PATH="$PATH:." ./test.sh
+        run: cp .env.sample .env && PATH="$PATH:." ./test.sh
 
   docker:
     name: Docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,17 @@ jobs:
       - name: Test docs.rs
         run: cargo test -- --test-threads=1
 
+      - name: Install HTML parser
+        # TODO: don't hardcode this for amd64
+        run: >
+            wget https://github.com/ericchiang/pup/releases/download/v0.4.0/pup_v0.4.0_linux_arm64.zip &&
+            [ "$(sha256sum pup_v0.4.0_linux_arm64.zip)" = ec3d29e9fb375b87ac492c8b546ad6be84b0c0b49dab7ff4c6b582eac71ba01c ] &&
+            unzip pup_v0.4.0_linux_arm64.zip &&
+            mv pup /usr/local/bin
+
+      - name: Test docs.rs more thoroughly
+        run: ./test.sh
+
   docker:
     name: Docker
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,32 +30,10 @@ jobs:
             ec3d29e9fb375b87ac492c8b546ad6be84b0c0b49dab7ff4c6b582eac71ba01c ] &&
             unzip pup_v0.4.0_linux_amd64.zip
 
-      - name: Cache Rustwide directory
-        uses: actions/cache@v1
-        with:
-          key: always
-          path: .rustwide-docker
-
-      - name: Setup local docker directory
-        run: >
-            mkdir -p ignored/docker &&
-            sudo systemctl stop docker &&
-            sudo rm -rf /var/lib/docker &&
-            sudo ln -sf "$(realpath ignored/docker)" /var/lib/docker &&
-            sudo systemctl start docker
-
-      - name: Cache docker directory
-        uses: actions/cache@v1
-        with:
-          key: always
-          path: ignored/docker
-
       - name: Test docs.rs more thoroughly
         run: >
             cp .env.sample .env &&
             PATH="$PATH:." ./test.sh &&
-            find ignored/docker -type d -exec sudo chmod a+rx {} \; &&
-            find ignored/docker -type f -exec sudo chmod a+r {} \; # hack so that caching works
 
   docker:
     name: Docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,7 @@ jobs:
             unzip pup_v0.4.0_linux_amd64.zip
 
       - name: Test docs.rs more thoroughly
-        run: >
-            cp .env.sample .env &&
-            PATH="$PATH:." ./test.sh &&
+        run: cp .env.sample .env && PATH="$PATH:." ./test.sh
 
   docker:
     name: Docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,10 @@ jobs:
             wget https://github.com/ericchiang/pup/releases/download/v0.4.0/pup_v0.4.0_linux_amd64.zip &&
             [ "$(sha256sum pup_v0.4.0_linux_amd64.zip | cut -d ' ' -f 1)" =
             ec3d29e9fb375b87ac492c8b546ad6be84b0c0b49dab7ff4c6b582eac71ba01c ] &&
-            unzip pup_v0.4.0_linux_amd64.zip &&
-            mv pup /usr/local/bin
+            unzip pup_v0.4.0_linux_amd64.zip
 
       - name: Test docs.rs more thoroughly
-        run: ./test.sh
+        run: PATH="$PATH:." ./test.sh
 
   docker:
     name: Docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,18 @@ jobs:
           key: always
           path: .rustwide-docker
 
+      - name: Setup local docker directory
+        run: >
+            mkdir -p ignored/docker &&
+            sudo rm -rf /var/lib/docker &&
+            sudo ln -sf "$(realpath ignored/docker)" /var/lib/docker
+
+      - name: Cache docker directory
+        uses: actions/cache@v1
+        with:
+          key: always
+          path: ignored/docker
+
       - name: Test docs.rs more thoroughly
         run: cp .env.sample .env && PATH="$PATH:." ./test.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,9 @@ jobs:
       - name: Install HTML parser
         # TODO: don't hardcode this for amd64
         run: >
-            wget https://github.com/ericchiang/pup/releases/download/v0.4.0/pup_v0.4.0_linux_arm64.zip &&
-            [ "$(sha256sum pup_v0.4.0_linux_arm64.zip)" = ec3d29e9fb375b87ac492c8b546ad6be84b0c0b49dab7ff4c6b582eac71ba01c ] &&
+            wget https://github.com/ericchiang/pup/releases/download/v0.4.0/pup_v0.4.0_linux_amd64.zip &&
+            [ "$(sha256sum pup_v0.4.0_linux_amd64.zip | cut -d ' ' -f 1)" =
+            ec3d29e9fb375b87ac492c8b546ad6be84b0c0b49dab7ff4c6b582eac71ba01c ] &&
             unzip pup_v0.4.0_linux_arm64.zip &&
             mv pup /usr/local/bin
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
             ec3d29e9fb375b87ac492c8b546ad6be84b0c0b49dab7ff4c6b582eac71ba01c ] &&
             unzip pup_v0.4.0_linux_amd64.zip
 
+      - name: Cache Rustwide directory
+        uses: actions/cache@v1
+        with:
+          key: always
+          path: .rustwide-docker
+
       - name: Test docs.rs more thoroughly
         run: cp .env.sample .env && PATH="$PATH:." ./test.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,11 @@ jobs:
           path: ignored/docker
 
       - name: Test docs.rs more thoroughly
-        run: cp .env.sample .env && PATH="$PATH:." ./test.sh
+        run: >
+            cp .env.sample .env &&
+            PATH="$PATH:." ./test.sh &&
+            find ignored/docker -type d -exec sudo chmod a+rx {} \; &&
+            find ignored/docker -type f -exec sudo chmod a+r {} \; # hack so that caching works
 
   docker:
     name: Docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,10 @@ jobs:
       - name: Setup local docker directory
         run: >
             mkdir -p ignored/docker &&
+            sudo systemctl stop docker &&
             sudo rm -rf /var/lib/docker &&
-            sudo ln -sf "$(realpath ignored/docker)" /var/lib/docker
+            sudo ln -sf "$(realpath ignored/docker)" /var/lib/docker &&
+            sudo systemctl start docker
 
       - name: Cache docker directory
         uses: actions/cache@v1

--- a/src/docbuilder/mod.rs
+++ b/src/docbuilder/mod.rs
@@ -44,12 +44,10 @@ impl DocBuilder {
         let path = PathBuf::from(&self.options.prefix).join("cache");
         let reader = fs::File::open(path).map(|f| BufReader::new(f));
 
-        if reader.is_err() {
-            return Ok(());
-        }
-
-        for line in reader.unwrap().lines() {
-            self.cache.insert(line?);
+        if let Ok(reader) = reader {
+            for line in reader.lines() {
+                self.cache.insert(line?);
+            }
         }
 
         self.load_database_cache()?;

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -73,8 +73,12 @@ impl RustwideBuilder {
         let is_docker = std::env::var("DOCS_RS_DOCKER")
             .map(|s| s == "true")
             .unwrap_or(false);
+        let fast_init = std::env::var("DOCS_RS_FAST_INIT")
+            .map(|s| s == "true")
+            .unwrap_or(false);
         let workspace = WorkspaceBuilder::new(Path::new(workspace_path), USER_AGENT)
             .running_inside_docker(is_docker)
+            .fast_init(fast_init)
             .init()?;
         workspace.purge_all_build_dirs()?;
 

--- a/src/utils/copy.rs
+++ b/src/utils/copy.rs
@@ -89,7 +89,6 @@ mod test {
     use super::*;
 
     #[test]
-    #[ignore]
     fn test_copy_dir() {
         let destination = tempdir::TempDir::new("cratesfyi").unwrap();
 

--- a/src/web/badge/badge.rs
+++ b/src/web/badge/badge.rs
@@ -166,7 +166,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_to_svg() {
         use std::fs::File;
         use std::io::Write;

--- a/test.sh
+++ b/test.sh
@@ -111,5 +111,12 @@ assert_version_redirect /rand/0.6.5/rand/rngs/struct.JitterRng.html \
 # for renamed items
 assert_version_redirect /pyo3/0.2.7/pyo3/exc/struct.ArithmeticError.html \
                         "/pyo3/0.8.3/pyo3/?search=ArithmeticError"
+# check std library redirects
+for crate in std alloc core proc_macro test; do
+	echo $crate
+	# with or without slash
+	assert_eq "$(redirect /$crate)" https://doc.rust-lang.org/stable/$crate/
+	assert_eq "$(redirect /$crate/)" https://doc.rust-lang.org/stable/$crate/
+done
 
 docker-compose down

--- a/test.sh
+++ b/test.sh
@@ -9,6 +9,16 @@ set -euv
 
 HOST=http://localhost:3000
 
+cp .env .env.bak
+
+cleanup() {
+	mv .env.bak .env
+	docker-compose down
+}
+
+trap cleanup exit
+echo DOCS_RS_FAST_INIT=true >> .env
+
 docker-compose build
 # run a dummy command so that the next background command starts up quickly
 # and doesn't try to compete with `build` commands
@@ -118,5 +128,3 @@ for crate in std alloc core proc_macro test; do
 	assert_eq "$(redirect /$crate)" https://doc.rust-lang.org/stable/$crate/
 	assert_eq "$(redirect /$crate/)" https://doc.rust-lang.org/stable/$crate/
 done
-
-docker-compose down

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# test script for docs.rs
+# requires the following tools installed:
+# - docker-compose
+# - curl
+# - pup (https://github.com/EricChiang/pup)
+
+set -euv
+
+docker-compose build
+# this never exits, run it in the background
+# TODO: catch errors if `up` failed
+docker-compose up --build -d
+
+# build a crate and store it in the database
+build() {
+	docker-compose run web build crate "$@"
+}
+
+# build a few types of crates
+# library
+build rand 0.7.2
+# binary
+build bat 0.12.1
+# proc-macro
+build rstest 0.4.1
+# multiple crate types
+build sysinfo 0.10.0
+# renamed crate
+build constellation-rs 0.1.8
+# used later for latest version
+build rand 0.7.1
+build pyo3 0.2.7
+build pyo3 0.8.3
+
+HOST=localhost:3000
+
+# small wrapper around curl to hide extraneous output
+curl() {
+    command curl -s -o /dev/null
+}
+
+# give the HTTP status of a page hosted locally
+status() {
+	curl -I -w %{http_code} "$HOST/$1"
+}
+
+# give the URL a page hosted locally redirects to
+# if the page does not redirect, returns the same page it was given
+redirect() {
+	curl -IL -w %{url_effective} "$HOST/$1"
+}
+
+version_redirect() {
+    curl "$1" | pup "form ul li a.warn attr{href}"
+}
+
+assert_status() {
+	[ "$(status "$1")" = "$2" ]
+}
+assert_redirect() {
+	[ "$(redirect "$1")" = "$HOST/$2" ]
+}
+assert_version_redirect() {
+	[ "$(version_redirect "$1")" = "$HOST/$2" ]
+}
+
+# make sure the crates built successfully
+for crate in /rand/0.7.2/rand /rstest/0.12.1/rstest /sysinfo/0.10.0/sysinfo /constellation-rs/0.1.8/constellation; do
+	assert_status "$crate" 200
+done
+
+assert_redirect /bat/0.12.1/bat /crate/bat/0.12.1
+
+# make sure it shows source code for rustdoc
+assert_status /constellation-rs/0.1.8/src/constellation/lib.rs.html 200
+# make sure it shows source code for docs.rs
+assert_status /crate/constellation-rs/0.1.8/source/ 200
+# with or without trailing slashes
+assert_status /crate/constellation-rs/0.1.8/source 200
+
+# check 'Go to latest version' keeps the current page
+assert_version_redirect /rand/0.6.5/rand/trait.Rng.html \
+                        /rand/0.7.2/rand/trait.Rng.html
+# and the current platform
+assert_version_redirect /rand/0.6.5/x86_64-unknown-linux-gnu/rand/fn.thread_rng.html \
+                        /rand/0.7.2/x86_64-unknown-linux-gnu/rand/fn.thread_rng.html
+# latest version searches for deleted items
+assert_version_redirect /rand/0.6.5/rand/rngs/struct.JitterRng.html \
+                        "/rand/0.7.2/rand/?search=JitterRng"
+# for renamed items
+assert_version_redirect /pyo3/0.2.7/pyo3/exc/struct.ArithmeticError.html \
+                        "/pyo3/0.8.3/pyo3/?search=ArithmeticError"
+
+docker-compose down

--- a/test.sh
+++ b/test.sh
@@ -12,9 +12,9 @@ docker-compose build
 # TODO: catch errors if `up` failed
 docker-compose up --build -d
 
-# build a crate and store it in the database
+# build a crate and store it in the database if it does not already exist
 build() {
-	docker-compose run web build crate "$@"
+	docker-compose run web build --skip --skip-if-log-exists crate "$@"
 }
 
 # build a few types of crates

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # test script for docs.rs
 # requires the following tools installed:
 # - docker-compose
@@ -19,7 +19,7 @@ docker-compose up -d
 for i in $(seq 1 5); do
 	curl -I $HOST && break
 	# if we've tried 5 times, exit with error
-	! [ $i = 5 ]
+	! [ "$i" = 5 ]
 	sleep 5
 done
 
@@ -57,13 +57,13 @@ die() {
 
 # give the HTTP status of a page hosted locally
 status() {
-	curl -I -w %{http_code} "$HOST$1"
+	curl -I -w "%{http_code}" "$HOST$1"
 }
 
 # give the URL a page hosted locally redirects to
 # if the page does not redirect, returns the same page it was given
 redirect() {
-	curl -IL -w %{url_effective} "$HOST$1"
+	curl -IL -w "%{url_effective}" "$HOST$1"
 }
 
 version_redirect() {

--- a/test.sh
+++ b/test.sh
@@ -42,13 +42,13 @@ curl() {
 
 # give the HTTP status of a page hosted locally
 status() {
-	curl -I -w %{http_code} "$HOST/$1"
+	curl -I -w %{http_code} "$HOST$1"
 }
 
 # give the URL a page hosted locally redirects to
 # if the page does not redirect, returns the same page it was given
 redirect() {
-	curl -IL -w %{url_effective} "$HOST/$1"
+	curl -IL -w %{url_effective} "$HOST$1"
 }
 
 version_redirect() {

--- a/test.sh
+++ b/test.sh
@@ -37,7 +37,7 @@ HOST=localhost:3000
 
 # small wrapper around curl to hide extraneous output
 curl() {
-    command curl -s -o /dev/null
+    command curl -s -o /dev/null "$@"
 }
 
 # give the HTTP status of a page hosted locally


### PR DESCRIPTION
After the fiasco with #519, I figured I'd write this before making any new PRs.

This is very much an integration test, not a unit test. It should catch things like 'docs.rs doesn't build with an empty `.rustwide` cache', but because of that, it takes a very long time to run (~45 minutes on Github Actions). I tried to set up caching, but the permissions weren't working quite right: https://github.com/actions/cache/issues/131

This runs reasonably quickly locally, ~5 minutes if everything is cached.

This depends on the changes from #523 (because otherwise the tests take about 25 minutes locally). Either that PR should be merged first or it should be closed when this one is merged.

Finally, this also uncomments two `#[ignore]` tests that were passing. The rest are left commented since they're currently failing.

There should be no change in behavior to the production server, since it doesn't run builds with `-s` anyway.

r? @pietroalbini 