### PR TITLE
Fix panics when viewing source of failed build (redux)

### DIFF
--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -104,7 +104,7 @@ impl FileList {
             return None;
         }
 
-        let files: Json = rows.get(0).get(5);
+        let files: Json = rows.get(0).get_opt(5).unwrap().ok()?;
 
         let mut file_list: Vec<File> = Vec::new();
 

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -234,6 +234,11 @@ pub fn source_browser_handler(req: &mut Request) -> IronResult<Response> {
     };
 
     let list = FileList::from_path(&conn, &name, &version, &req_path);
+    if list.is_none() {
+        use iron::status;
+        use super::error::Nope;
+        return Err(IronError::new(Nope::NoResults, status::NotFound));
+    }
 
     let page = Page::new(list)
         .set_bool("show_parent_link", !req_path.is_empty())


### PR DESCRIPTION
This reverts all the changes from #519 except for actually fixing the panic. I tested this with directory listings as well as individual files:

- If no files exist, gives a 200 with an empty page (not ideal but better than the panic + blank screen from before). This can be tested with e.g. pam-sys 1.0.0-alpha1.
- If a directory listing exists, show that. Can be tested with most crates, e.g. rand 0.7.2.
- If a file exists, show that (no logic changed)

r? @pietroalbini 