### PR TITLE
Only build one target by default

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -106,7 +106,7 @@ impl Config {
             local_docker_image: maybe_env("DOCS_RS_LOCAL_DOCKER_IMAGE")?,
             toolchain: env("CRATESFYI_TOOLCHAIN", "nightly".to_string())?,
             build_cpu_limit: maybe_env("DOCS_RS_BUILD_CPU_LIMIT")?,
-            include_default_targets: env("DOCSRS_INCLUDE_DEFAULT_TARGETS", true)?,
+            include_default_targets: env("DOCSRS_INCLUDE_DEFAULT_TARGETS", false)?,
             disable_memory_limit: env("DOCSRS_DISABLE_MEMORY_LIMIT", false)?,
         })
     }

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -762,7 +762,9 @@ mod tests {
             let version = DUMMY_CRATE_VERSION;
             let default_target = "x86_64-unknown-linux-gnu";
 
-            assert_eq!(env.config().include_default_targets, true);
+            env.override_config(|config| {
+                config.include_default_targets = true;
+            });
 
             let mut builder = RustwideBuilder::init(env).unwrap();
             builder


### PR DESCRIPTION
Closes https://github.com/rust-lang/docs.rs/issues/343.

:warning: :warning: **DO NOT MERGE** :warning: :warning:  until we've (at the minimum):

- made an 'Inside Rust' blog post saying that we won't be building all targets anymore
- linked to that post on every page that will be affected (or every page globally if that's easier)
- left the warning up for at least a few weeks

Most of the following comments are related to https://github.com/rust-lang/docs.rs/pull/550 and can be safely ignored.