### PR TITLE
Don't build default target twice

### DIFF
--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -26,6 +26,7 @@ pub(crate) fn add_package_into_database(conn: &Connection,
                                  metadata_pkg: &MetadataPackage,
                                  source_dir: &Path,
                                  res: &BuildResult,
+                                 default_target: &str,
                                  files: Option<Json>,
                                  doc_targets: Vec<String>,
                                  cratesio_data: &CratesIoData,
@@ -82,7 +83,7 @@ pub(crate) fn add_package_into_database(conn: &Connection,
                                          &is_library,
                                          &res.rustc_version,
                                          &metadata_pkg.documentation,
-                                         &res.target])?;
+                                         &default_target])?;
             // return id
             rows.get(0).get(0)
 
@@ -136,7 +137,7 @@ pub(crate) fn add_package_into_database(conn: &Connection,
                               &is_library,
                               &res.rustc_version,
                               &metadata_pkg.documentation,
-                              &res.target])?;
+                              &default_target])?;
             rows.get(0).get(0)
         }
     };

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -28,7 +28,6 @@ pub(crate) fn add_package_into_database(conn: &Connection,
                                  res: &BuildResult,
                                  files: Option<Json>,
                                  doc_targets: Vec<String>,
-                                 default_target: &Option<String>,
                                  cratesio_data: &CratesIoData,
                                  has_docs: bool,
                                  has_examples: bool)
@@ -83,7 +82,7 @@ pub(crate) fn add_package_into_database(conn: &Connection,
                                          &is_library,
                                          &res.rustc_version,
                                          &metadata_pkg.documentation,
-                                         &default_target])?;
+                                         &res.target])?;
             // return id
             rows.get(0).get(0)
 
@@ -137,7 +136,7 @@ pub(crate) fn add_package_into_database(conn: &Connection,
                               &is_library,
                               &res.rustc_version,
                               &metadata_pkg.documentation,
-                              &default_target])?;
+                              &res.target])?;
             rows.get(0).get(0)
         }
     };

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -269,6 +269,19 @@ fn migrate_inner(version: Option<Version>, conn: &Connection, apply_mode: ApplyM
             // downgrade query
             "DROP TABLE blacklisted_crates;"
         ),
+        migration!(
+            context,
+            // version
+            7,
+            // description
+            "Make default_target non-nullable",
+            // upgrade query
+            "UPDATE releases SET default_target = 'x86_64-unknown-linux-gnu' WHERE default_target IS NULL;
+             ALTER TABLE releases ALTER COLUMN default_target SET NOT NULL",
+            // downgrade query
+            "ALTER TABLE releases ALTER COLUMN default_target DROP NOT NULL;
+             ALTER TABLE releases ALTER COLUMN default_target DROP DEFAULT",
+        ),
     ];
 
     for migration in migrations {

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -474,6 +474,14 @@ impl RustwideBuilder {
                 .run()
                 .is_ok()
         });
+        if let Some(explicit_target) = target {
+            // mv target/$explicit_target/doc target/doc
+            let target_dir = build.host_target_dir();
+            let old_dir = target_dir.join(explicit_target).join("doc");
+            let new_dir = target_dir.join("doc");
+            debug!("rename {} to {}", old_dir.display(), new_dir.display());
+            std::fs::rename(old_dir, new_dir)?;
+        }
 
         Ok(FullBuildResult {
             result: BuildResult {

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -189,7 +189,7 @@ impl RustwideBuilder {
                 }
 
                 info!("copying essential files for {}", self.rustc_version);
-                let source = build.host_target_dir().join(&res.target).join("doc");
+                let source = build.host_target_dir().join("doc");
                 let dest = ::tempdir::TempDir::new("essential-files")?;
 
                 let files = ESSENTIAL_FILES_VERSIONED
@@ -303,7 +303,7 @@ impl RustwideBuilder {
             .build(&self.toolchain, &krate, sandbox)
             .run(|build| {
                 let mut files_list = None;
-                let (mut has_docs, mut in_target) = (false, false);
+                let mut has_docs = false;
                 let mut successful_targets = Vec::new();
 
                 // Do an initial build and then copy the sources in the database
@@ -319,20 +319,7 @@ impl RustwideBuilder {
 
                     if let Some(name) = res.cargo_metadata.root().library_name() {
                         let host_target = build.host_target_dir();
-                        if host_target
-                            .join(&res.target)
-                            .join("doc")
-                            .join(&name)
-                            .is_dir()
-                        {
-                            has_docs = true;
-                            in_target = true;
-                        // hack for proc-macro documentation:
-                        // it really should be in target/$target/doc,
-                        // but rustdoc has a bug and puts it in target/doc
-                        } else if host_target.join("doc").join(name).is_dir() {
-                            has_docs = true;
-                        }
+                        has_docs = host_target.join("doc").join(name).is_dir();
                     }
                 }
 
@@ -341,26 +328,24 @@ impl RustwideBuilder {
                     self.copy_docs(
                         &build.host_target_dir(),
                         local_storage.path(),
-                        if in_target { &res.target } else { "" },
+                        "",
                         true,
                     )?;
 
                     successful_targets.push(res.target.clone());
-                    if in_target {
-                        // Then build the documentation for all the targets
-                        for target in TARGETS {
-                            debug!("building package {} {} for {}", name, version, target);
-                            if *target == res.target {
-                                continue;
-                            }
-                            self.build_target(
-                                target,
-                                &build,
-                                &limits,
-                                &local_storage.path(),
-                                &mut successful_targets,
-                            )?;
+                    // Then build the documentation for all the targets
+                    for target in TARGETS {
+                        if *target == res.target {
+                            continue;
                         }
+                        debug!("building package {} {} for {}", name, version, &target);
+                        self.build_target(
+                            &target,
+                            &build,
+                            &limits,
+                            &local_storage.path(),
+                            &mut successful_targets,
+                        )?;
                     }
                     self.upload_docs(&conn, name, version, local_storage.path())?;
                 }
@@ -380,7 +365,6 @@ impl RustwideBuilder {
                     &res.result,
                     files_list,
                     successful_targets,
-                    &res.default_target,
                     &CratesIoData::get_from_network(res.cargo_metadata.root())?,
                     has_docs,
                     has_examples,
@@ -555,4 +539,5 @@ pub(crate) struct BuildResult {
     pub(crate) docsrs_version: String,
     pub(crate) build_log: String,
     pub(crate) successful: bool,
+    pub(crate) target: String,
 }

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -18,10 +18,11 @@ use std::path::Path;
 use utils::{copy_doc_dir, parse_rustc_version, CargoMetadata};
 use Metadata;
 
-static USER_AGENT: &str = "docs.rs builder (https://github.com/rust-lang/docs.rs)";
-static DEFAULT_RUSTWIDE_WORKSPACE: &str = ".rustwide";
+const USER_AGENT: &str = "docs.rs builder (https://github.com/rust-lang/docs.rs)";
+const DEFAULT_RUSTWIDE_WORKSPACE: &str = ".rustwide";
 
-static TARGETS: &[&str] = &[
+const DEFAULT_TARGET: &str = "x86_64-unknown-linux-gnu";
+const TARGETS: &[&str] = &[
     "i686-pc-windows-msvc",
     "i686-unknown-linux-gnu",
     "x86_64-apple-darwin",
@@ -29,7 +30,7 @@ static TARGETS: &[&str] = &[
     "x86_64-unknown-linux-gnu",
 ];
 
-static ESSENTIAL_FILES_VERSIONED: &[&str] = &[
+const ESSENTIAL_FILES_VERSIONED: &[&str] = &[
     "brush.svg",
     "wheel.svg",
     "down-arrow.svg",
@@ -46,7 +47,7 @@ static ESSENTIAL_FILES_VERSIONED: &[&str] = &[
     "noscript.css",
     "rust-logo.png",
 ];
-static ESSENTIAL_FILES_UNVERSIONED: &[&str] = &[
+const ESSENTIAL_FILES_UNVERSIONED: &[&str] = &[
     "FiraSans-Medium.woff",
     "FiraSans-Regular.woff",
     "SourceCodePro-Regular.woff",
@@ -56,8 +57,8 @@ static ESSENTIAL_FILES_UNVERSIONED: &[&str] = &[
     "SourceSerifPro-It.ttf.woff",
 ];
 
-static DUMMY_CRATE_NAME: &str = "acme-client";
-static DUMMY_CRATE_VERSION: &str = "0.0.0";
+const DUMMY_CRATE_NAME: &str = "acme-client";
+const DUMMY_CRATE_VERSION: &str = "0.0.0";
 
 pub struct RustwideBuilder {
     workspace: Workspace,
@@ -363,6 +364,7 @@ impl RustwideBuilder {
                     res.cargo_metadata.root(),
                     &build.host_source_dir(),
                     &res.result,
+                    &res.target,
                     files_list,
                     successful_targets,
                     &CratesIoData::get_from_network(res.cargo_metadata.root())?,
@@ -481,8 +483,7 @@ impl RustwideBuilder {
                 successful,
             },
             cargo_metadata,
-            target: target.unwrap_or("x86_64-unknown-linux-gnu").to_string(),
-            default_target: metadata.default_target.clone(),
+            target: target.unwrap_or(DEFAULT_TARGET).to_string(),
         })
     }
 
@@ -530,7 +531,6 @@ impl RustwideBuilder {
 struct FullBuildResult {
     result: BuildResult,
     target: String,
-    default_target: Option<String>,
     cargo_metadata: CargoMetadata,
 }
 
@@ -539,5 +539,4 @@ pub(crate) struct BuildResult {
     pub(crate) docsrs_version: String,
     pub(crate) build_log: String,
     pub(crate) successful: bool,
-    pub(crate) target: String,
 }

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -345,6 +345,7 @@ impl RustwideBuilder {
                         true,
                     )?;
 
+                    successful_targets.push(res.target.clone());
                     if in_target {
                         // Then build the documentation for all the targets
                         for target in TARGETS {
@@ -496,7 +497,7 @@ impl RustwideBuilder {
                 successful,
             },
             cargo_metadata,
-            target: target.unwrap_or_default().to_string(),
+            target: target.unwrap_or("x86_64-unknown-linux-gnu").to_string(),
             default_target: metadata.default_target.clone(),
         })
     }

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -349,6 +349,9 @@ impl RustwideBuilder {
                         // Then build the documentation for all the targets
                         for target in TARGETS {
                             debug!("building package {} {} for {}", name, version, target);
+                            if *target == res.target {
+                                continue;
+                            }
                             self.build_target(
                                 target,
                                 &build,

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -84,6 +84,7 @@ impl<'db> FakeRelease<'db> {
             &self.package,
             tempdir.path(),
             &self.build_result,
+            &self.default_target.unwrap_or("x86_64-unknown-linux-gnu"),
             self.files,
             self.doc_targets,
             &self.cratesio_data,

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -86,7 +86,6 @@ impl<'db> FakeRelease<'db> {
             &self.build_result,
             self.files,
             self.doc_targets,
-            &self.default_target,
             &self.cratesio_data,
             self.has_docs,
             self.has_examples,

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -84,7 +84,7 @@ impl<'db> FakeRelease<'db> {
             &self.package,
             tempdir.path(),
             &self.build_result,
-            &self.default_target.unwrap_or("x86_64-unknown-linux-gnu"),
+            self.default_target.as_deref().unwrap_or("x86_64-unknown-linux-gnu"),
             self.files,
             self.doc_targets,
             &self.cratesio_data,

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -43,7 +43,7 @@ pub struct CrateDetails {
     github_stars: Option<i32>,
     github_forks: Option<i32>,
     github_issues: Option<i32>,
-    metadata: MetaData,
+    pub metadata: MetaData,
     is_library: bool,
     doc_targets: Option<Json>,
     license: Option<String>,
@@ -120,7 +120,8 @@ impl CrateDetails {
                             releases.is_library,
                             releases.doc_targets,
                             releases.license,
-                            releases.documentation_url
+                            releases.documentation_url,
+                            releases.default_target
                      FROM releases
                      INNER JOIN crates ON releases.crate_id = crates.id
                      WHERE crates.name = $1 AND releases.version = $2;";
@@ -160,6 +161,7 @@ impl CrateDetails {
             description: rows.get(0).get(4),
             rustdoc_status: rows.get(0).get(11),
             target_name: rows.get(0).get(16),
+            default_target: rows.get(0).get(25),
         };
 
         let mut crate_details = CrateDetails {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -451,6 +451,7 @@ pub struct MetaData {
     pub description: Option<String>,
     pub target_name: Option<String>,
     pub rustdoc_status: bool,
+    pub default_target: String,
 }
 
 
@@ -460,7 +461,8 @@ impl MetaData {
                                        releases.version,
                                        releases.description,
                                        releases.target_name,
-                                       releases.rustdoc_status
+                                       releases.rustdoc_status,
+                                       releases.default_target
                                 FROM releases
                                 INNER JOIN crates ON crates.id = releases.crate_id
                                 WHERE crates.name = $1 AND releases.version = $2",
@@ -473,6 +475,7 @@ impl MetaData {
                 description: row.get(2),
                 target_name: row.get(3),
                 rustdoc_status: row.get(4),
+                default_target: row.get(5),
             });
         }
 
@@ -489,6 +492,7 @@ impl ToJson for MetaData {
         m.insert("description".to_owned(), self.description.to_json());
         m.insert("target_name".to_owned(), self.target_name.to_json());
         m.insert("rustdoc_status".to_owned(), self.rustdoc_status.to_json());
+        m.insert("default_target".to_owned(), self.default_target.to_json());
         m.to_json()
     }
 }

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -226,6 +226,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
     req_path.insert(2, &version);
 
     // if visiting the full path to the default target, remove the target from the path
+    // expects a req_path that looks like `/rustdoc/:crate/:version[/:target]/.*`
     let crate_details = cexpect!(CrateDetails::new(&conn, &name, &version));
     if req_path[3] == crate_details.metadata.default_target {
         let path = [base, req_path[1..3].join("/"), req_path[4..].join("/")].join("/");
@@ -242,16 +243,6 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
         }
         path
     };
-
-    // if visiting the full path to the default target, remove the target from the path
-    // expects a req_path that looks like `/rustdoc/:crate/:version[/:target]/.*`
-    let crate_details = cexpect!(CrateDetails::new(&conn, &name, &version));
-    debug!("req_path: {}, default_target: {}", req_path.join("/"), crate_details.metadata.default_target);
-    if req_path[3] == crate_details.metadata.default_target {
-        let path = [base, req_path[1..3].join("/"), req_path[4..].join("/")].join("/");
-        let canonical = Url::parse(&path).expect("got an invalid URL to start");
-        return Ok(super::redirect(canonical));
-    }
 
     let file = match File::from_path(&conn, &path) {
         Some(f) => f,

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -224,6 +224,14 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
     req_path.insert(1, &name);
     req_path.insert(2, &version);
 
+    // if visiting the full path to the default target, remove the target from the path
+    let crate_details = cexpect!(CrateDetails::new(&conn, &name, &version));
+    if req_path[3] == crate_details.metadata.default_target {
+        let canonical = Url::parse(&req_path[..2].join("/"))
+            .expect("got an invalid URL to start");
+        return Ok(super::redirect(canonical));
+    }
+
     let path = {
         let mut path = req_path.join("/");
         if path.ends_with('/') {
@@ -261,7 +269,6 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
     content.body_class = body_class;
 
     content.full = file_content;
-    let crate_details = cexpect!(CrateDetails::new(&conn, &name, &version));
     let (path, version) = if let Some(version) = latest_version(&crate_details.versions, &version) {
         req_path[2] = &version;
         (path_for_version(&req_path, &crate_details.target_name, &conn), version)

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -193,6 +193,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
     let url_version = router.find("version");
     let version; // pre-declaring it to enforce drop order relative to `req_path`
     let conn = extension!(req, Pool);
+    let base = redirect_base(req);
 
     let mut req_path = req.url.path();
 
@@ -208,7 +209,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
             // versions, redirect the browser to the returned version instead of loading it
             // immediately
             let url = ctry!(Url::parse(&format!("{}/{}/{}/{}",
-                                                redirect_base(req),
+                                                base,
                                                 name,
                                                 v,
                                                 req_path.join("/"))[..]));
@@ -227,8 +228,8 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
     // if visiting the full path to the default target, remove the target from the path
     let crate_details = cexpect!(CrateDetails::new(&conn, &name, &version));
     if req_path[3] == crate_details.metadata.default_target {
-        let canonical = Url::parse(&req_path[..2].join("/"))
-            .expect("got an invalid URL to start");
+        let path = [base, req_path[1..3].join("/"), req_path[4..].join("/")].join("/");
+        let canonical = Url::parse(&path).expect("got an invalid URL to start");
         return Ok(super::redirect(canonical));
     }
 
@@ -241,6 +242,16 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
         }
         path
     };
+
+    // if visiting the full path to the default target, remove the target from the path
+    // expects a req_path that looks like `/rustdoc/:crate/:version[/:target]/.*`
+    let crate_details = cexpect!(CrateDetails::new(&conn, &name, &version));
+    debug!("req_path: {}, default_target: {}", req_path.join("/"), crate_details.metadata.default_target);
+    if req_path[3] == crate_details.metadata.default_target {
+        let path = [base, req_path[1..3].join("/"), req_path[4..].join("/")].join("/");
+        let canonical = Url::parse(&path).expect("got an invalid URL to start");
+        return Ok(super::redirect(canonical));
+    }
 
     let file = match File::from_path(&conn, &path) {
         Some(f) => f,

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -93,7 +93,8 @@ impl FileList {
                                       releases.description,
                                       releases.target_name,
                                       releases.rustdoc_status,
-                                      releases.files
+                                      releases.files,
+                                      releases.default_target
                                FROM releases
                                LEFT OUTER JOIN crates ON crates.id = releases.crate_id
                                WHERE crates.name = $1 AND releases.version = $2",
@@ -173,6 +174,7 @@ impl FileList {
                 description: rows.get(0).get(2),
                 target_name: rows.get(0).get(3),
                 rustdoc_status: rows.get(0).get(4),
+                default_target: rows.get(0).get(5),
             },
             files: file_list,
         })

--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -138,7 +138,7 @@ name = "test"
 
 [package.metadata.docs.rs]
 
-# Features to pass to Cargo (default: none)
+# Features to pass to Cargo (default: [])
 features = [ "feature1", "feature2" ]
 
 # Whether to pass `--all-features` to Cargo (default: false)
@@ -158,10 +158,10 @@ no-default-features = true
 # - i686-pc-windows-msvc
 default-target = "x86_64-unknown-linux-gnu"
 
-# Additional `RUSTFLAGS` to set (default: none)
+# Additional `RUSTFLAGS` to set (default: [])
 rustc-args = [ "--example-rustc-arg" ]
 
-# Additional `RUSTDOCFLAGS` to set (default: none)
+# Additional `RUSTDOCFLAGS` to set (default: [])
 rustdoc-args = [ "--example-rustdoc-arg" ]</pre></code>
 
   <h4>Version</h4>

--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -127,21 +127,41 @@
     </tbody>
   </table>
 
-  <h4>Metadata for custom builds</h4>
+  <h4 id="metadata"><a href="#metadata">Metadata for custom builds</a></h4>
 
   <p>You can customize docs.rs builds by defining <code>[package.metadata.docs.rs]</code> table in your crates' `Cargo.toml`.</p>
 
-  <p>An example metadata:</p>
+  <p>The available configuration flags you can customize are:</p>
 
   <pre><code>[package]
 name = "test"
 
 [package.metadata.docs.rs]
+
+# Features to pass to Cargo (default: none)
 features = [ "feature1", "feature2" ]
+
+# Whether to pass `--all-features` to Cargo (default: false)
 all-features = true
+
+# Whether to pass `--no-default-features` to Cargo (default: false)
 no-default-features = true
+
+# Target to test build on, used as the default landing page (default: "x86_64-unknown-linux-gnu")
+#
+# Available targets:
+# - x86_64-unknown-linux-gnu
+# - x86_64-apple-darwin
+# - x86_64-pc-windows-msvc
+# - i686-unknown-linux-gnu
+# - i686-apple-darwin
+# - i686-pc-windows-msvc
 default-target = "x86_64-unknown-linux-gnu"
+
+# Additional `RUSTFLAGS` to set (default: none)
 rustc-args = [ "--example-rustc-arg" ]
+
+# Additional `RUSTDOCFLAGS` to set (default: none)
 rustdoc-args = [ "--example-rustdoc-arg" ]</pre></code>
 
   <h4>Version</h4>


### PR DESCRIPTION
This is the non-breaking changes from #532. I also kept the additional documentation for existing metadata.

Copy/pasted from that PR for convenience:

## Architecture Changes

This removes the duplicated 'default' build which is run twice.

- The default build no longer passes `--target` to Cargo for the common case where `default-target` is not set. This will fix #440. As a side effect, it removes most of the hacking around I had to do to get proc macros to work.
- The target for the default build is now stored in the database. As before, the default target is `x86_64-unknown-linux-gnu` and can be overriden with `default-target = ...` in Cargo.toml
- The target for the default build is no longer run twice
- The web server redirects requests to `/:crate/:version/:default-target` to `/:crate/:version/`, keeping the subpage if it exists.

This has been tested both by building with the new code and by building with the old code and running `cratesfyi database migrate`. Note that if `cratesfyi database migrate` is _not_ run, the web server will panic whenever viewing a crate built with the old code.

r? @pietroalbini 