### PR TITLE
Add ArgRequiredElseHelp to clap commands without default behaviour

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -115,6 +115,7 @@ pub fn main() {
                 .about("Removes a whole crate from the database")
                 .arg(Arg::with_name("CRATE_NAME")
                     .takes_value(true)
+                    .required(true)
                     .help("Name of the crate to delete"))))
         .subcommand(SubCommand::with_name("queue")
             .about("Interactions with the build queue")


### PR DESCRIPTION
In `cratesfyi.rs`, the large if-else structure starting at line 137 is not exhaustive. Sometimes, if no subcommand is specified, the execution of `cratesfyi` will end without printing anything.
This PR adds the `ArgRequiredElseHelp` setting to a number of clap commands.

I have added this setting to all (sub)commands that have subcommands themselves.

For instance before this commit, running `$ cratesfyi database` would print nothing and simply exit.

After these changes it will print the help text and exit:

```
$ target/debug/cratesfyi database
cratesfyi-database 
Database operations

USAGE:
    cratesfyi database [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    add-directory              Adds a directory into database
    delete-crate               Removes a whole crate from the database
    help                       Prints this message or the help of the given subcommand(s)
    migrate                    Run database migrations
    move-to-s3                 
    update-github-fields       Updates github stats for crates.
    update-release-activity    Updates monthly release activity chart
    update-search-index        Updates search index
```