### PR TITLE
Crate details page: when a build has failed, display a message that links to last successful build

### DIFF
--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -71,6 +71,11 @@ impl<'db> FakeRelease<'db> {
         self
     }
 
+    pub(crate) fn build_result_successful(mut self, new: bool) -> Self {
+        self.build_result.successful = new;
+        self
+    }
+
     pub(crate) fn create(self) -> Result<i32, Error> {
         let tempdir = tempdir::TempDir::new("docs.rs-fake")?;
 

--- a/templates/crate_details.hbs
+++ b/templates/crate_details.hbs
@@ -63,6 +63,9 @@
       {{else}}
       {{#unless build_status}}
       <div class="warning">docs.rs failed to build {{name}}-{{version}}<br>Please check the <a href="/crate/{{name}}/{{version}}/builds">build logs</a> and, if you believe this is docs.rs' fault, <a href="https://github.com/rust-lang/docs.rs/issues/new/choose">open an issue</a>.</div>
+      {{#if last_successful_build}}
+      <div class="info">Visit the last successful build: <a href="/crate/{{name}}/{{last_successful_build}}">{{name}}-{{last_successful_build}}</a></div>
+      {{/if}}
       {{else}}
       {{#unless rustdoc_status}}
       <div class="warning">{{name}}-{{version}} doesn't have any documentation.</div>

--- a/templates/style.scss
+++ b/templates/style.scss
@@ -706,10 +706,10 @@ div.cratesfyi-package-container-rustdoc {
     margin-bottom: 10px;
 }
 
-div.warning {
+div.info {
     font-family: $font-family-sans;
     border-radius: 4px;
-    background-color: lighten($color-type, 45%);
+    background-color: $color-background-code;
     padding: .4em 1em;
     text-align: center;
     margin-bottom: 10px;
@@ -718,6 +718,11 @@ div.warning {
         color: $color-url;
         text-decoration: underline;
     }
+}
+
+div.warning {
+    @extend div.info;
+    background-color: lighten($color-type, 45%);
 }
 
 div.search-page-search-form {


### PR DESCRIPTION
Implements part of #516.

When a build of a release failed and any other release was successfully built (before or after this release), this commit will add a message that links to the _last successful_ build.
If no other release was built successfully, this message will not be displayed.

I had to extend `test::fakes::FakeRelease` a bit to be able to create a test with releases that had failed to build.

And I also adapted `style.scss` a bit:
- `div.info` is the base styling of a message box
- `div.warning` inherits all properties of `div.info` but sets `background-color` to orange

There _might_ be cleaner ways to do this, I am not a SCSS expert 😅

---

Crate details page before this PR (https://docs.rs/crate/fie/0.16.2):

<img width="1191" alt="Screenshot 2020-01-04 at 01 09 26" src="https://user-images.githubusercontent.com/7748404/71756231-fd696d00-2e8e-11ea-9d72-93f0b60b4142.png">

Crate details page after this PR:

<img width="1192" alt="Screenshot 2020-01-04 at 01 07 40" src="https://user-images.githubusercontent.com/7748404/71756237-02c6b780-2e8f-11ea-9625-e79fe09285e8.png">

The displayed link is `/crate/fie/0.15.0`, which will resolve to https://docs.rs/crate/fie/0.15.0