### PR TITLE
Crate details page: show whether a build failed in the Versions list

### DIFF
--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -343,4 +343,21 @@ mod tests {
             Ok(())
         });
     }
+
+    #[test]
+    fn test_versions() {
+        crate::test::with_database(|db| {
+            // Add new releases of 'foo' out-of-order since CrateDetails should sort them descending
+            create_release(&db, "foo", "0.0.1", true)?;
+            create_release(&db, "foo", "0.0.3", false)?;
+            create_release(&db, "foo", "1.0.0", true)?;
+            create_release(&db, "foo", "0.0.2", true)?;
+
+            let details = CrateDetails::new(&db.conn(), "foo", "0.0.2").unwrap();
+
+            assert_eq!(details.versions, vec!["1.0.0", "0.0.3", "0.0.2", "0.0.1"]);
+
+            Ok(())
+        });
+    }
 }

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -262,7 +262,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
 
     content.full = file_content;
     let crate_details = cexpect!(CrateDetails::new(&conn, &name, &version));
-    let (path, version) = if let Some(version) = latest_version(&crate_details.versions, &version) {
+    let (path, version) = if let Some(version) = latest_version(&crate_details.versions(), &version) {
         req_path[2] = &version;
         (path_for_version(&req_path, &crate_details.target_name, &conn), version)
     } else {

--- a/templates/crate_details.hbs
+++ b/templates/crate_details.hbs
@@ -47,7 +47,7 @@
                   {{#if this.build_status}}
                   <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link">{{this.version}}</a>
                   {{else}}
-                  <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link warn"><i class="fa fa-fw fa-warning"></i> {{this.version}} (build failed)</a>
+                  <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link warn" title="docs.rs failed to build {{../name}}-{{this.version}}"><i class="fa fa-fw fa-warning"></i> {{this.version}}</a>
                   {{/if}}
                 </li>
                 {{/each}}

--- a/templates/crate_details.hbs
+++ b/templates/crate_details.hbs
@@ -42,8 +42,14 @@
           <li class="pure-menu-item">
             <div class="pure-menu pure-menu-scrollable sub-menu">
               <ul class="pure-menu-list">
-                {{#each versions}}
-                <li class="pure-menu-item"><a href="/crate/{{../name}}/{{this}}" class="pure-menu-link">{{this}}</a></li>
+                {{#each releases}}
+                <li class="pure-menu-item">
+                  {{#if this.build_status}}
+                  <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link">{{this.version}}</a>
+                  {{else}}
+                  <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link warn"><i class="fa fa-fw fa-warning"></i> {{this.version}} (build failed)</a>
+                  {{/if}}
+                </li>
                 {{/each}}
               </ul>
             </div>

--- a/templates/style.scss
+++ b/templates/style.scss
@@ -521,6 +521,11 @@ div.package-page-container {
             background-color: $color-background-code;
         }
 
+        // used for versions that failed to build
+        a.warn {
+            color: $color-type;
+        }
+
         div.sub-menu {
             max-height: 135px;
             overflow-y: auto;


### PR DESCRIPTION
_Implements second change related to #516.
I was planning to rebase these commits on top of the commits in #543 if that PR gets approved & merged. But this can be merged indepedently._

This pull request changes the Crate Details page to display whether a build failed in the _Versions_ list.

Current design:

<img width="1227" alt="Screenshot 2020-01-04 at 18 59 21" src="https://user-images.githubusercontent.com/7748404/71771707-1ed66180-2f40-11ea-84eb-8182e9eed799.png">

Page after these commits:

<img width="1234" alt="Screenshot 2020-01-04 at 18 59 32" src="https://user-images.githubusercontent.com/7748404/71771709-2564d900-2f40-11ea-8c31-d618ac56bd07.png">

I performed the changes in two commits, this should make it a bit easier to reason about them. _Hopefully..._

521b8ae
- I added an extra test case for CrateDetails::versions.
- Most code is the same as 0a56ff7 from PR #543, this was necessary to create the test. This code should be removed from the commits when doing a rebase.

da358f8
- In `CrateDetails` I replaced the field `versions` with `releases`. The type changed from a raw String to `Release`, which holds a `version` string and a `build_status` boolean.
- I create a fn `versions()` which has the same behaviour as the removed `versions` field.
- I set `releases` in `CrateDetails::new` but I took care to change as little code as possible. Hence the introduction of `map_to_release`. This entire function can be refactored to be more efficient / perform less queries on the database, but that's for a later PR.
- Lastly, I edited `crate_details.hbs` to use the additional information and show a ⚠️  sign when appropriate.

