### PR TITLE
Test utilities for the web server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@
 on: [push, pull_request]
 name: CI
 
+env:
+  RUST_BACKTRACE: 1
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Build docs.rs
         run: cargo build
 
+      - name: Prepare the test environment
+        run: |
+          prefix=$(pwd)/ignored/prefix
+          mkdir -p ${prefix}/public-html
+          echo "::set-env name=CRATESFYI_PREFIX::${prefix}"
+
       - name: Test docs.rs
         run: cargo test -- --test-threads=1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,7 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "magic 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "params 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1297,6 +1298,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl"
@@ -3032,6 +3038,7 @@ dependencies = [
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
+"checksum once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed"
 "checksum openssl 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "5af9e83eb3c51ee806387d26a43056f3246d865844caa6dd704d2ba7e831c264"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.45 (registry+https://github.com/rust-lang/crates.io-index)" = "ce906a1d521507a94645974fc9ab0fb70ceeb789f7240b85617ca3d8d2cd2f46"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ prometheus = { version = "0.7.0", default-features = false }
 lazy_static = "1.0.0"
 rustwide = "0.5.0"
 tempdir = "0.3"
-once_cell = "1.2.0"
 
 # iron dependencies
 iron = "0.5"
@@ -52,6 +51,9 @@ staticfile = { version = "0.4", features = [ "cache" ] }
 [dependencies.postgres]
 version = "0.15"
 features = [ "with-time", "with-rustc-serialize" ]
+
+[dev-dependencies]
+once_cell = "1.2.0"
 
 [build-dependencies]
 time = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ prometheus = { version = "0.7.0", default-features = false }
 lazy_static = "1.0.0"
 rustwide = "0.5.0"
 tempdir = "0.3"
+once_cell = "1.2.0"
 
 # iron dependencies
 iron = "0.5"

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 use clap::{Arg, App, AppSettings, SubCommand};
 use cratesfyi::{DocBuilder, RustwideBuilder, DocBuilderOptions, db};
 use cratesfyi::utils::add_crate_to_queue;
-use cratesfyi::start_web_server;
+use cratesfyi::Server;
 use cratesfyi::db::{add_path_into_database, connect_db};
 
 
@@ -268,7 +268,7 @@ pub fn main() {
         }
 
     } else if let Some(matches) = matches.subcommand_matches("start-web-server") {
-        start_web_server(Some(matches.value_of("SOCKET_ADDR").unwrap_or("0.0.0.0:3000")));
+        Server::start(Some(matches.value_of("SOCKET_ADDR").unwrap_or("0.0.0.0:3000")));
 
     } else if let Some(_) = matches.subcommand_matches("daemon") {
         let foreground = matches.subcommand_matches("daemon")

--- a/src/db/blacklist.rs
+++ b/src/db/blacklist.rs
@@ -65,7 +65,9 @@ mod tests {
 
     #[test]
     fn test_list_blacklist() {
-        crate::test::with_database(|db| {
+        crate::test::wrapper(|env| {
+            let db = env.db();
+
             // crates are added out of order to verify sorting
             add_crate(&db.conn(), "crate A")?;
             add_crate(&db.conn(), "crate C")?;
@@ -78,7 +80,9 @@ mod tests {
 
     #[test]
     fn test_add_to_and_remove_from_blacklist() {
-        crate::test::with_database(|db| {
+        crate::test::wrapper(|env| {
+            let db = env.db();
+
             assert!(is_blacklisted(&db.conn(), "crate foo")? == false);
             add_crate(&db.conn(), "crate foo")?;
             assert!(is_blacklisted(&db.conn(), "crate foo")? == true);
@@ -90,7 +94,9 @@ mod tests {
 
     #[test]
     fn test_add_twice_to_blacklist() {
-        crate::test::with_database(|db| {
+        crate::test::wrapper(|env| {
+            let db = env.db();
+
             add_crate(&db.conn(), "crate foo")?;
             assert!(add_crate(&db.conn(), "crate foo").is_err());
             add_crate(&db.conn(), "crate bar")?;
@@ -101,7 +107,9 @@ mod tests {
 
     #[test]
     fn test_remove_non_existing_crate() {
-        crate::test::with_database(|db| {
+        crate::test::wrapper(|env| {
+            let db = env.db();
+
             assert!(remove_crate(&db.conn(), "crate foo").is_err());
 
             Ok(())

--- a/src/db/blacklist.rs
+++ b/src/db/blacklist.rs
@@ -67,11 +67,11 @@ mod tests {
     fn test_list_blacklist() {
         crate::test::with_database(|db| {
             // crates are added out of order to verify sorting
-            add_crate(db.conn(), "crate A")?;
-            add_crate(db.conn(), "crate C")?;
-            add_crate(db.conn(), "crate B")?;
+            add_crate(&db.conn(), "crate A")?;
+            add_crate(&db.conn(), "crate C")?;
+            add_crate(&db.conn(), "crate B")?;
 
-            assert!(list_crates(db.conn())? == vec!["crate A", "crate B", "crate C"]);
+            assert!(list_crates(&db.conn())? == vec!["crate A", "crate B", "crate C"]);
             Ok(())
         });
     }
@@ -79,11 +79,11 @@ mod tests {
     #[test]
     fn test_add_to_and_remove_from_blacklist() {
         crate::test::with_database(|db| {
-            assert!(is_blacklisted(db.conn(), "crate foo")? == false);
-            add_crate(db.conn(), "crate foo")?;
-            assert!(is_blacklisted(db.conn(), "crate foo")? == true);
-            remove_crate(db.conn(), "crate foo")?;
-            assert!(is_blacklisted(db.conn(), "crate foo")? == false);
+            assert!(is_blacklisted(&db.conn(), "crate foo")? == false);
+            add_crate(&db.conn(), "crate foo")?;
+            assert!(is_blacklisted(&db.conn(), "crate foo")? == true);
+            remove_crate(&db.conn(), "crate foo")?;
+            assert!(is_blacklisted(&db.conn(), "crate foo")? == false);
             Ok(())
         });
     }
@@ -91,9 +91,9 @@ mod tests {
     #[test]
     fn test_add_twice_to_blacklist() {
         crate::test::with_database(|db| {
-            add_crate(db.conn(), "crate foo")?;
-            assert!(add_crate(db.conn(), "crate foo").is_err());
-            add_crate(db.conn(), "crate bar")?;
+            add_crate(&db.conn(), "crate foo")?;
+            assert!(add_crate(&db.conn(), "crate foo").is_err());
+            add_crate(&db.conn(), "crate bar")?;
 
             Ok(())
         });
@@ -102,7 +102,7 @@ mod tests {
     #[test]
     fn test_remove_non_existing_crate() {
         crate::test::with_database(|db| {
-            assert!(remove_crate(db.conn(), "crate foo").is_err());
+            assert!(remove_crate(&db.conn(), "crate foo").is_err());
 
             Ok(())
         });

--- a/src/db/delete_crate.rs
+++ b/src/db/delete_crate.rs
@@ -140,7 +140,9 @@ mod tests {
                 .is_empty())
         }
 
-        crate::test::with_database(|db| {
+        crate::test::wrapper(|env| {
+            let db = env.db();
+
             // Create fake packages in the database
             let pkg1_v1_id = db
                 .fake_release()

--- a/src/db/delete_crate.rs
+++ b/src/db/delete_crate.rs
@@ -154,24 +154,24 @@ mod tests {
                 .create()?;
             let pkg2_id = db.fake_release().name("package-2").create()?;
 
-            assert!(crate_exists(db.conn(), "package-1")?);
-            assert!(crate_exists(db.conn(), "package-2")?);
-            assert!(release_exists(db.conn(), pkg1_v1_id)?);
-            assert!(release_exists(db.conn(), pkg1_v2_id)?);
-            assert!(release_exists(db.conn(), pkg2_id)?);
+            assert!(crate_exists(&db.conn(), "package-1")?);
+            assert!(crate_exists(&db.conn(), "package-2")?);
+            assert!(release_exists(&db.conn(), pkg1_v1_id)?);
+            assert!(release_exists(&db.conn(), pkg1_v2_id)?);
+            assert!(release_exists(&db.conn(), pkg2_id)?);
 
-            let pkg1_id = db.conn()
+            let pkg1_id = &db.conn()
                 .query("SELECT id FROM crates WHERE name = 'package-1';", &[])?
                 .get(0)
                 .get("id");
 
-            delete_from_database(db.conn(), "package-1", pkg1_id)?;
+            delete_from_database(&db.conn(), "package-1", *pkg1_id)?;
 
-            assert!(!crate_exists(db.conn(), "package-1")?);
-            assert!(crate_exists(db.conn(), "package-2")?);
-            assert!(!release_exists(db.conn(), pkg1_v1_id)?);
-            assert!(!release_exists(db.conn(), pkg1_v2_id)?);
-            assert!(release_exists(db.conn(), pkg2_id)?);
+            assert!(!crate_exists(&db.conn(), "package-1")?);
+            assert!(crate_exists(&db.conn(), "package-2")?);
+            assert!(!release_exists(&db.conn(), pkg1_v1_id)?);
+            assert!(!release_exists(&db.conn(), pkg1_v2_id)?);
+            assert!(release_exists(&db.conn(), pkg2_id)?);
 
             Ok(())
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ extern crate tokio;
 extern crate systemstat;
 extern crate rustwide;
 extern crate tempdir;
+#[cfg(test)]
 extern crate once_cell;
 
 pub use self::docbuilder::RustwideBuilder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub use self::docbuilder::RustwideBuilder;
 pub use self::docbuilder::DocBuilder;
 pub use self::docbuilder::options::DocBuilderOptions;
 pub use self::docbuilder::metadata::Metadata;
-pub use self::web::start_web_server;
+pub use self::web::Server;
 
 pub mod error;
 pub mod db;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ extern crate tokio;
 extern crate systemstat;
 extern crate rustwide;
 extern crate tempdir;
+extern crate once_cell;
 
 pub use self::docbuilder::RustwideBuilder;
 pub use self::docbuilder::DocBuilder;

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -1,7 +1,7 @@
 use super::TestDatabase;
+use crate::db::CratesIoData;
 use crate::docbuilder::BuildResult;
 use crate::utils::{Dependency, MetadataPackage, Target};
-use crate::db::CratesIoData;
 use failure::Error;
 use rustc_serialize::json::Json;
 
@@ -53,7 +53,7 @@ impl<'db> FakeRelease<'db> {
                 release_time: time::get_time(),
                 yanked: false,
                 downloads: 0,
-                owners: Vec::new()
+                owners: Vec::new(),
             },
             has_docs: true,
             has_examples: false,
@@ -80,7 +80,7 @@ impl<'db> FakeRelease<'db> {
         let tempdir = tempdir::TempDir::new("docs.rs-fake")?;
 
         let release_id = crate::db::add_package_into_database(
-            self.db.conn(),
+            &self.db.conn(),
             &self.package,
             tempdir.path(),
             &self.build_result,
@@ -91,7 +91,7 @@ impl<'db> FakeRelease<'db> {
             self.has_docs,
             self.has_examples,
         )?;
-        crate::db::add_build_into_database(self.db.conn(), &release_id, &self.build_result)?;
+        crate::db::add_build_into_database(&self.db.conn(), &release_id, &self.build_result)?;
 
         Ok(release_id)
     }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,22 +1,14 @@
 mod fakes;
 
+use crate::web::Server;
 use failure::Error;
 use postgres::Connection;
 use std::sync::{Arc, Mutex, MutexGuard};
+use reqwest::{Client, Method, RequestBuilder};
 
 pub(crate) fn with_database(f: impl FnOnce(&TestDatabase) -> Result<(), Error>) {
     let env = TestDatabase::new().expect("failed to initialize the environment");
-
-    if let Err(err) = f(&env) {
-        eprintln!("the test failed: {}", err);
-        for cause in err.iter_causes() {
-            eprintln!("  caused by: {}", cause);
-        }
-
-        eprintln!("{}", err.backtrace());
-
-        panic!("the test failed");
-    }
+    report_error(|| f(&env));
 }
 
 pub(crate) struct TestDatabase {
@@ -42,5 +34,47 @@ impl TestDatabase {
 
     pub(crate) fn fake_release(&self) -> fakes::FakeRelease {
         fakes::FakeRelease::new(self)
+    }
+}
+
+pub(crate) fn with_frontend(db: &TestDatabase, f: impl FnOnce(&TestFrontend) -> Result<(), Error>) {
+    let frontend = TestFrontend::new(db);
+    let result = f(&frontend);
+    frontend.server.leak();
+    report_error(|| result)
+}
+
+pub(crate) struct TestFrontend {
+    server: Server,
+    client: Client,
+}
+
+impl TestFrontend {
+    fn new(db: &TestDatabase) -> Self {
+        Self {
+            server: Server::start_test(db.conn.clone()),
+            client: Client::new(),
+        }
+    }
+
+    fn build_request(&self, method: Method, url: &str) -> RequestBuilder {
+        self.client.request(method, &format!("http://{}{}", self.server.addr(), url))
+    }
+
+    pub(crate) fn get(&self, url: &str) -> RequestBuilder {
+        self.build_request(Method::GET, url)
+    }
+}
+
+fn report_error(f: impl FnOnce() -> Result<(), Error>) {
+    if let Err(err) = f() {
+        eprintln!("the test failed: {}", err);
+        for cause in err.iter_causes() {
+            eprintln!("  caused by: {}", cause);
+        }
+
+        eprintln!("{}", err.backtrace());
+
+        panic!("the test failed");
     }
 }

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -241,7 +241,7 @@ pub fn start_daemon(background: bool) {
 
     // at least start web server
     info!("Starting web server");
-    ::start_web_server(None);
+    ::Server::start(None);
 }
 
 

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -69,7 +69,7 @@ pub fn build_list_handler(req: &mut Request) -> IronResult<Response> {
     let version = cexpect!(router.find("version"));
     let req_build_id: i32 = router.find("id").unwrap_or("0").parse().unwrap_or(0);
 
-    let conn = extension!(req, Pool);
+    let conn = extension!(req, Pool).get();
     let limits = ctry!(Limits::for_crate(&conn, name));
 
     let mut build_list: Vec<Build> = Vec::new();

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -289,7 +289,7 @@ pub fn crate_details_handler(req: &mut Request) -> IronResult<Response> {
     let name = cexpect!(router.find("name"));
     let req_version = router.find("version");
 
-    let conn = extension!(req, Pool);
+    let conn = extension!(req, Pool).get();
 
     match match_version(&conn, &name, req_version) {
         MatchVersion::Exact(version) => {

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -348,7 +348,9 @@ mod tests {
 
     #[test]
     fn test_last_successful_build_when_last_release_failed() {
-        crate::test::with_database(|db| {
+        crate::test::wrapper(|env| {
+            let db = env.db();
+
             create_release(&db, "foo", "0.0.1", true)?;
             create_release(&db, "foo", "0.0.2", true)?;
             create_release(&db, "foo", "0.0.3", false)?;
@@ -362,7 +364,9 @@ mod tests {
 
     #[test]
     fn test_last_successful_build_when_all_releases_failed() {
-        crate::test::with_database(|db| {
+        crate::test::wrapper(|env| {
+            let db = env.db();
+
             create_release(&db, "foo", "0.0.1", false)?;
             create_release(&db, "foo", "0.0.2", false)?;
 
@@ -374,7 +378,9 @@ mod tests {
 
     #[test]
     fn test_last_successful_build_when_an_intermittent_release_failed() {
-        crate::test::with_database(|db| {
+        crate::test::wrapper(|env| {
+            let db = env.db();
+
             create_release(&db, "foo", "0.0.1", true)?;
             create_release(&db, "foo", "0.0.2", false)?;
             create_release(&db, "foo", "0.0.3", true)?;
@@ -388,7 +394,9 @@ mod tests {
 
     #[test]
     fn test_versions() {
-        crate::test::with_database(|db| {
+        crate::test::wrapper(|env| {
+            let db = env.db();
+
             // Add new releases of 'foo' out-of-order since CrateDetails should sort them descending
             create_release(&db, "foo", "0.0.1", true)?;
             create_release(&db, "foo", "0.0.3", false)?;

--- a/src/web/file.rs
+++ b/src/web/file.rs
@@ -46,7 +46,7 @@ pub struct DatabaseFileHandler;
 impl Handler for DatabaseFileHandler {
     fn handle(&self, req: &mut Request) -> IronResult<Response> {
         let path = req.url.path().join("/");
-        let conn = extension!(req, Pool);
+        let conn = extension!(req, Pool).get();
         if let Some(file) = File::from_path(&conn, &path) {
             Ok(file.serve())
         } else {

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -43,7 +43,7 @@ lazy_static! {
 }
 
 pub fn metrics_handler(req: &mut Request) -> IronResult<Response> {
-    let conn = extension!(req, Pool);
+    let conn = extension!(req, Pool).get();
 
     QUEUED_CRATES_COUNT.set(
         ctry!(conn.query("SELECT COUNT(*) FROM queue WHERE attempt < 5;", &[]))

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -538,11 +538,9 @@ mod test {
 
     #[test]
     fn test_index_returns_success() {
-        crate::test::with_database(|db| {
-            crate::test::with_frontend(db, |web| {
-                assert!(web.get("/").send()?.status().is_success());
-                Ok(())
-            });
+        crate::test::wrapper(|env| {
+            let web = env.frontend();
+            assert!(web.get("/").send()?.status().is_success());
             Ok(())
         });
     }

--- a/src/web/pool.rs
+++ b/src/web/pool.rs
@@ -4,13 +4,23 @@ use postgres::Connection;
 use r2d2;
 use r2d2_postgres;
 
+#[cfg(test)]
+use std::sync::{Arc, Mutex, MutexGuard};
+
 pub(crate) enum Pool {
     R2D2(r2d2::Pool<r2d2_postgres::PostgresConnectionManager>),
+    #[cfg(test)]
+    Simple(Arc<Mutex<Connection>>),
 }
 
 impl Pool {
     pub(crate) fn new() -> Pool {
         Pool::R2D2(create_pool())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_simple(conn: Arc<Mutex<Connection>>) -> Self {
+        Pool::Simple(conn)
     }
 }
 
@@ -22,6 +32,8 @@ impl BeforeMiddleware for Pool {
     fn before(&self, req: &mut Request) -> IronResult<()> {
         req.extensions.insert::<Pool>(match self {
             Self::R2D2(pool) => PoolConnection::R2D2(pool.get().unwrap()),
+            #[cfg(test)]
+            Self::Simple(mutex) => PoolConnection::Simple(mutex.clone()),
         });
         Ok(())
     }
@@ -29,18 +41,26 @@ impl BeforeMiddleware for Pool {
 
 pub(crate) enum PoolConnection {
     R2D2(r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>),
+    #[cfg(test)]
+    Simple(Arc<Mutex<Connection>>),
 }
 
 impl PoolConnection {
     pub(super) fn get<'a>(&'a self) -> DerefConnection<'a> {
         match self {
             Self::R2D2(conn) => DerefConnection::Connection(&conn),
+            #[cfg(test)]
+            Self::Simple(mutex) => {
+                DerefConnection::Guard(mutex.lock().expect("failed to lock the connection"))
+            }
         }
     }
 }
 
 pub(crate) enum DerefConnection<'a> {
     Connection(&'a Connection),
+    #[cfg(test)]
+    Guard(MutexGuard<'a, Connection>),
 }
 
 impl<'a> std::ops::Deref for DerefConnection<'a> {
@@ -49,6 +69,8 @@ impl<'a> std::ops::Deref for DerefConnection<'a> {
     fn deref(&self) -> &Connection {
         match self {
             Self::Connection(conn) => conn,
+            #[cfg(test)]
+            Self::Guard(guard) => &guard,
         }
     }
 }

--- a/src/web/pool.rs
+++ b/src/web/pool.rs
@@ -1,29 +1,54 @@
-
-
-use iron::prelude::*;
-use iron::{BeforeMiddleware, typemap};
+use db::create_pool;
+use iron::{typemap, BeforeMiddleware, IronResult, Request};
+use postgres::Connection;
 use r2d2;
 use r2d2_postgres;
-use db::create_pool;
 
-
-pub struct Pool {
-    pool: r2d2::Pool<r2d2_postgres::PostgresConnectionManager>,
-}
-
-impl typemap::Key for Pool {
-    type Value = r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>;
+pub(crate) enum Pool {
+    R2D2(r2d2::Pool<r2d2_postgres::PostgresConnectionManager>),
 }
 
 impl Pool {
-    pub fn new() -> Pool {
-        Pool { pool: create_pool() }
+    pub(crate) fn new() -> Pool {
+        Pool::R2D2(create_pool())
     }
+}
+
+impl typemap::Key for Pool {
+    type Value = PoolConnection;
 }
 
 impl BeforeMiddleware for Pool {
     fn before(&self, req: &mut Request) -> IronResult<()> {
-        req.extensions.insert::<Pool>(self.pool.get().unwrap());
+        req.extensions.insert::<Pool>(match self {
+            Self::R2D2(pool) => PoolConnection::R2D2(pool.get().unwrap()),
+        });
         Ok(())
+    }
+}
+
+pub(crate) enum PoolConnection {
+    R2D2(r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>),
+}
+
+impl PoolConnection {
+    pub(super) fn get<'a>(&'a self) -> DerefConnection<'a> {
+        match self {
+            Self::R2D2(conn) => DerefConnection::Connection(&conn),
+        }
+    }
+}
+
+pub(crate) enum DerefConnection<'a> {
+    Connection(&'a Connection),
+}
+
+impl<'a> std::ops::Deref for DerefConnection<'a> {
+    type Target = Connection;
+
+    fn deref(&self) -> &Connection {
+        match self {
+            Self::Connection(conn) => conn,
+        }
     }
 }

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -7,7 +7,7 @@ use super::pool::Pool;
 use time;
 
 pub fn sitemap_handler(req: &mut Request) -> IronResult<Response> {
-    let conn = extension!(req, Pool);
+    let conn = extension!(req, Pool).get();
     let mut releases: Vec<(String, String)> = Vec::new();
     for row in &conn.query("SELECT DISTINCT ON (crates.name)
                                    crates.name,
@@ -34,7 +34,7 @@ pub fn robots_txt_handler(_: &mut Request) -> IronResult<Response> {
 pub fn about_handler(req: &mut Request) -> IronResult<Response> {
     let mut content = BTreeMap::new();
 
-    let conn = extension!(req, Pool);
+    let conn = extension!(req, Pool).get();
     let res = ctry!(conn.query("SELECT value FROM config WHERE name = 'rustc_version'", &[]));
 
     if let Some(row) = res.iter().next() {

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -209,7 +209,7 @@ pub fn source_browser_handler(req: &mut Request) -> IronResult<Response> {
     };
 
 
-    let conn = extension!(req, Pool);
+    let conn = extension!(req, Pool).get();
 
     // try to get actual file first
     // skip if request is a directory


### PR DESCRIPTION
This PR adds a way to test the web server in `cargo test`, using the dummy database. With it, it's possible to write a test like this:

```rust
#[test]
fn test_index_is_successful() {
    crate::test::wrapper(|env| {
        let web = env.frontend();
        assert!(web.get("/").send()?.status().is_successful());
        Ok(())
    });
}
```

Additionally, to avoid having tons of wrappers, the existing `crate::test::with_database` has to be written this way now:

```rust
#[test]
fn test_db() {
    crate::test::wrapper(|env| {
        let db env.db();
        assert!(!db.conn().query("SELECT 1;", &[]).is_empty());
        Ok(())
    });
}
```

Of course it's possible to mix the two. The PR can be reviewed commit-by-commit.

r? @jyn514 
cc @koenaad 