### PR TITLE
Refactor web::latest_version, move logic into CrateDetails

### DIFF
--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -255,13 +255,6 @@ impl CrateDetails {
         Some(crate_details)
     }
 
-    /// Returns all versions of this crate.
-    pub fn versions(&self) -> Vec<String> {
-        self.releases.iter()
-            .map(|release| release.version.clone())
-            .collect()
-    }
-
     /// Returns whether this release is the latest release of this crate.
     pub fn is_latest_version(&self) -> bool {
         self.version == self.latest_version()
@@ -403,7 +396,7 @@ mod tests {
     }
 
     #[test]
-    fn test_versions() {
+    fn test_releases_should_be_sorted() {
         crate::test::wrapper(|env| {
             let db = env.db();
 
@@ -414,8 +407,6 @@ mod tests {
             create_release(&db, "foo", "0.0.2", true)?;
 
             let details = CrateDetails::new(&db.conn(), "foo", "0.0.2").unwrap();
-
-            assert_eq!(details.versions(), vec!["1.0.0", "0.0.3", "0.0.2", "0.0.1"]);
             assert_eq!(details.releases, vec![
                 Release { version: "1.0.0".to_string(), build_status: true },
                 Release { version: "0.0.3".to_string(), build_status: false },

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -262,8 +262,8 @@ impl CrateDetails {
 
     /// Returns the version of the latest release of this crate.
     pub fn latest_version(&self) -> &str {
-        // this is safe to unwrap: releases will always contain at least the version of this release
-        &self.releases.get(0).unwrap().version
+        // releases will always contain at least one element
+        &self.releases[0].version
     }
 }
 

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -396,17 +396,23 @@ mod tests {
             let db = env.db();
 
             // Add new releases of 'foo' out-of-order since CrateDetails should sort them descending
-            create_release(&db, "foo", "0.0.1", true)?;
-            create_release(&db, "foo", "0.0.3", false)?;
+            create_release(&db, "foo", "0.1.0", true)?;
+            create_release(&db, "foo", "0.1.1", true)?;
+            create_release(&db, "foo", "0.3.0", false)?;
             create_release(&db, "foo", "1.0.0", true)?;
-            create_release(&db, "foo", "0.0.2", true)?;
+            create_release(&db, "foo", "0.12.0", true)?;
+            create_release(&db, "foo", "0.2.0", true)?;
+            create_release(&db, "foo", "0.2.0-alpha", true)?;
 
-            let details = CrateDetails::new(&db.conn(), "foo", "0.0.2").unwrap();
+            let details = CrateDetails::new(&db.conn(), "foo", "0.2.0").unwrap();
             assert_eq!(details.releases, vec![
                 Release { version: "1.0.0".to_string(), build_status: true },
-                Release { version: "0.0.3".to_string(), build_status: false },
-                Release { version: "0.0.2".to_string(), build_status: true },
-                Release { version: "0.0.1".to_string(), build_status: true },
+                Release { version: "0.12.0".to_string(), build_status: true },
+                Release { version: "0.3.0".to_string(), build_status: false },
+                Release { version: "0.2.0".to_string(), build_status: true },
+                Release { version: "0.2.0-alpha".to_string(), build_status: true },
+                Release { version: "0.1.1".to_string(), build_status: true },
+                Release { version: "0.1.0".to_string(), build_status: true },
             ]);
 
             Ok(())

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -255,11 +255,6 @@ impl CrateDetails {
         Some(crate_details)
     }
 
-    /// Returns whether this release is the latest release of this crate.
-    pub fn is_latest_version(&self) -> bool {
-        self.version == self.latest_version()
-    }
-
     /// Returns the version of the latest release of this crate.
     pub fn latest_version(&self) -> &str {
         // releases will always contain at least one element
@@ -428,15 +423,12 @@ mod tests {
             db.fake_release().name("foo").version("0.0.2").create()?;
 
             let details = CrateDetails::new(&db.conn(), "foo", "0.0.1").unwrap();
-            assert_eq!(details.is_latest_version(), false);
             assert_eq!(details.latest_version(), "0.0.3");
 
             let details = CrateDetails::new(&db.conn(), "foo", "0.0.2").unwrap();
-            assert_eq!(details.is_latest_version(), false);
             assert_eq!(details.latest_version(), "0.0.3");
 
             let details = CrateDetails::new(&db.conn(), "foo", "0.0.3").unwrap();
-            assert_eq!(details.is_latest_version(), true);
             assert_eq!(details.latest_version(), "0.0.3");
 
             Ok(())

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -313,39 +313,6 @@ fn render_markdown(text: &str) -> String {
 
 
 
-/// Returns latest version if required version is not the latest
-/// req_version must be an exact version
-fn latest_version(versions_json: &Vec<String>, req_version: &str) -> Option<String> {
-    let req_version = match Version::parse(req_version) {
-        Ok(v) => v,
-        Err(_) => return None,
-    };
-    let versions = {
-        let mut versions: Vec<Version> = Vec::new();
-        for version in versions_json {
-            let version = match Version::parse(&version) {
-                Ok(v) => v,
-                Err(_) => return None,
-            };
-            versions.push(version);
-        }
-
-        versions.sort();
-        versions.reverse();
-        versions
-    };
-
-    if req_version != versions[0] {
-        for i in 1..versions.len() {
-            if req_version == versions[i]  {
-                return Some(format!("{}", versions[0]))
-            }
-        }
-    }
-    None
-}
-
-
 pub struct Server {
     inner: Listening,
 }
@@ -537,7 +504,6 @@ impl ToJson for MetaData {
 #[cfg(test)]
 mod test {
     extern crate env_logger;
-    use super::*;
 
     #[test]
     fn test_index_returns_success() {
@@ -546,17 +512,5 @@ mod test {
             assert!(web.get("/").send()?.status().is_success());
             Ok(())
         });
-    }
-
-    #[test]
-    fn test_latest_version() {
-        let versions = vec!["1.0.0".to_string(),
-                            "1.1.0".to_string(),
-                            "0.9.0".to_string(),
-                            "0.9.1".to_string()];
-        assert_eq!(latest_version(&versions, "1.1.0"), None);
-        assert_eq!(latest_version(&versions, "1.0.0"), Some("1.1.0".to_owned()));
-        assert_eq!(latest_version(&versions, "0.9.0"), Some("1.1.0".to_owned()));
-        assert_eq!(latest_version(&versions, "invalidversion"), None);
     }
 }

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -3,7 +3,7 @@
 
 use super::pool::Pool;
 use super::file::File;
-use super::{latest_version, redirect_base};
+use super::redirect_base;
 use super::crate_details::CrateDetails;
 use iron::prelude::*;
 use iron::{status, Url};
@@ -262,7 +262,9 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
 
     content.full = file_content;
     let crate_details = cexpect!(CrateDetails::new(&conn, &name, &version));
-    let (path, latest_version) = if let Some(latest_version) = latest_version(&crate_details.versions(), &version) {
+
+    let (path, latest_version) = if !crate_details.is_latest_version() {
+        let latest_version = crate_details.latest_version().to_string();
         req_path[2] = &latest_version;
         (path_for_version(&req_path, &crate_details.target_name, &conn), latest_version)
     } else {

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -263,10 +263,12 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
     content.full = file_content;
     let crate_details = cexpect!(CrateDetails::new(&conn, &name, &version));
 
-    let (path, latest_version) = if !crate_details.is_latest_version() {
-        let latest_version = crate_details.latest_version().to_string();
+    let latest_version = crate_details.latest_version().to_owned();
+    let is_latest_version = latest_version == version;
+
+    let path = if !is_latest_version {
         req_path[2] = &latest_version;
-        (path_for_version(&req_path, &crate_details.target_name, &conn), latest_version)
+        path_for_version(&req_path, &crate_details.target_name, &conn)
     } else {
         Default::default()
     };
@@ -277,7 +279,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
         .set_true("show_package_navigation")
         .set_true("package_navigation_documentation_tab")
         .set_true("package_navigation_show_platforms_tab")
-        .set_bool("is_latest_version", path.is_empty())
+        .set_bool("is_latest_version", is_latest_version)
         .set("path_in_latest", &path)
         .set("latest_version", &latest_version)
         .to_resp("rustdoc")

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -262,9 +262,9 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
 
     content.full = file_content;
     let crate_details = cexpect!(CrateDetails::new(&conn, &name, &version));
-    let (path, version) = if let Some(version) = latest_version(&crate_details.versions(), &version) {
-        req_path[2] = &version;
-        (path_for_version(&req_path, &crate_details.target_name, &conn), version)
+    let (path, latest_version) = if let Some(latest_version) = latest_version(&crate_details.versions(), &version) {
+        req_path[2] = &latest_version;
+        (path_for_version(&req_path, &crate_details.target_name, &conn), latest_version)
     } else {
         Default::default()
     };
@@ -277,7 +277,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
         .set_true("package_navigation_show_platforms_tab")
         .set_bool("is_latest_version", path.is_empty())
         .set("path_in_latest", &path)
-        .set("latest_version", &version)
+        .set("latest_version", &latest_version)
         .to_resp("rustdoc")
 }
 


### PR DESCRIPTION
I noticed `web/mod.rs` contained a really complicated `latest_version` function: https://github.com/rust-lang/docs.rs/blob/master/src/web/mod.rs#L316
The bulk of the work was spent in converting the version strings into `semver::Version`, to sort the array. Something that is already done in `CrateDetails`...

The original `latest_version` would return:
- `None` if `req_version` was an invalid function or if `req_version` is the latest version
- `Some(version)` if this crate has a more recent version

I have split what this function does in two functions:
- `CrateDetails::is_latest_version` --> check if this is the most recent release
- `CrateDetails::latest_version` --> grab the most recent release

I like how it is much easier to reason about now 😊

These changes should be easy to follow commit-by-commit. The real changes happen in the second commit: 309ea7a