### PR TITLE
Refactor CrateDetails: add yanked field to Release

### DIFF
--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -76,6 +76,11 @@ impl<'db> FakeRelease<'db> {
         self
     }
 
+    pub(crate) fn cratesio_data_yanked(mut self, new: bool) -> Self {
+        self.cratesio_data.yanked = new;
+        self
+    }
+
     pub(crate) fn create(self) -> Result<i32, Error> {
         let tempdir = tempdir::TempDir::new("docs.rs-fake")?;
 

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -338,11 +338,13 @@ mod tests {
             db.fake_release().name("foo").version("0.0.2").create()?;
             db.fake_release().name("foo").version("0.0.3").build_result_successful(false).create()?;
             db.fake_release().name("foo").version("0.0.4").cratesio_data_yanked(true).create()?;
+            db.fake_release().name("foo").version("0.0.5").build_result_successful(false).cratesio_data_yanked(true).create()?;
 
             assert_last_successful_build_equals(&db, "foo", "0.0.1", None)?;
             assert_last_successful_build_equals(&db, "foo", "0.0.2", None)?;
             assert_last_successful_build_equals(&db, "foo", "0.0.3", Some("0.0.2"))?;
-            // don't test for foo-0.0.4, yanked crates are not displayed
+            assert_last_successful_build_equals(&db, "foo", "0.0.4", None)?;
+            assert_last_successful_build_equals(&db, "foo", "0.0.5", Some("0.0.2"))?;
             Ok(())
         });
     }
@@ -358,7 +360,7 @@ mod tests {
 
             assert_last_successful_build_equals(&db, "foo", "0.0.1", None)?;
             assert_last_successful_build_equals(&db, "foo", "0.0.2", None)?;
-            // don't test for foo-0.0.3, yanked crates are not displayed
+            assert_last_successful_build_equals(&db, "foo", "0.0.3", None)?;
             Ok(())
         });
     }
@@ -375,7 +377,7 @@ mod tests {
 
             assert_last_successful_build_equals(&db, "foo", "0.0.1", None)?;
             assert_last_successful_build_equals(&db, "foo", "0.0.2", Some("0.0.4"))?;
-            // don't test for foo-0.0.3, yanked crates are not displayed
+            assert_last_successful_build_equals(&db, "foo", "0.0.3", None)?;
             assert_last_successful_build_equals(&db, "foo", "0.0.4", None)?;
             Ok(())
         });

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -313,19 +313,13 @@ pub fn crate_details_handler(req: &mut Request) -> IronResult<Response> {
     }
 }
 
+
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test::TestDatabase;
     use failure::Error;
-
-    fn create_release(db: &TestDatabase, package: &str, version: &str, successful: bool) -> Result<i32, Error> {
-        db.fake_release()
-            .name(package)
-            .version(version)
-            .build_result_successful(successful)
-            .create()
-    }
 
     fn assert_last_successful_build_equals(
         db: &TestDatabase,
@@ -349,9 +343,9 @@ mod tests {
         crate::test::wrapper(|env| {
             let db = env.db();
 
-            create_release(&db, "foo", "0.0.1", true)?;
-            create_release(&db, "foo", "0.0.2", true)?;
-            create_release(&db, "foo", "0.0.3", false)?;
+            db.fake_release().name("foo").version("0.0.1").create()?;
+            db.fake_release().name("foo").version("0.0.2").create()?;
+            db.fake_release().name("foo").version("0.0.3").build_result_successful(false).create()?;
 
             assert_last_successful_build_equals(&db, "foo", "0.0.1", None)?;
             assert_last_successful_build_equals(&db, "foo", "0.0.2", None)?;
@@ -365,8 +359,8 @@ mod tests {
         crate::test::wrapper(|env| {
             let db = env.db();
 
-            create_release(&db, "foo", "0.0.1", false)?;
-            create_release(&db, "foo", "0.0.2", false)?;
+            db.fake_release().name("foo").version("0.0.1").build_result_successful(false).create()?;
+            db.fake_release().name("foo").version("0.0.2").build_result_successful(false).create()?;
 
             assert_last_successful_build_equals(&db, "foo", "0.0.1", None)?;
             assert_last_successful_build_equals(&db, "foo", "0.0.2", None)?;
@@ -379,9 +373,9 @@ mod tests {
         crate::test::wrapper(|env| {
             let db = env.db();
 
-            create_release(&db, "foo", "0.0.1", true)?;
-            create_release(&db, "foo", "0.0.2", false)?;
-            create_release(&db, "foo", "0.0.3", true)?;
+            db.fake_release().name("foo").version("0.0.1").create()?;
+            db.fake_release().name("foo").version("0.0.2").build_result_successful(false).create()?;
+            db.fake_release().name("foo").version("0.0.3").create()?;
 
             assert_last_successful_build_equals(&db, "foo", "0.0.1", None)?;
             assert_last_successful_build_equals(&db, "foo", "0.0.2", Some("0.0.3"))?;
@@ -396,13 +390,13 @@ mod tests {
             let db = env.db();
 
             // Add new releases of 'foo' out-of-order since CrateDetails should sort them descending
-            create_release(&db, "foo", "0.1.0", true)?;
-            create_release(&db, "foo", "0.1.1", true)?;
-            create_release(&db, "foo", "0.3.0", false)?;
-            create_release(&db, "foo", "1.0.0", true)?;
-            create_release(&db, "foo", "0.12.0", true)?;
-            create_release(&db, "foo", "0.2.0", true)?;
-            create_release(&db, "foo", "0.2.0-alpha", true)?;
+            db.fake_release().name("foo").version("0.1.0").create()?;
+            db.fake_release().name("foo").version("0.1.1").create()?;
+            db.fake_release().name("foo").version("0.3.0").build_result_successful(false).create()?;
+            db.fake_release().name("foo").version("1.0.0").create()?;
+            db.fake_release().name("foo").version("0.12.0").create()?;
+            db.fake_release().name("foo").version("0.2.0").create()?;
+            db.fake_release().name("foo").version("0.2.0-alpha").create()?;
 
             let details = CrateDetails::new(&db.conn(), "foo", "0.2.0").unwrap();
             assert_eq!(details.releases, vec![

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -240,7 +240,7 @@ impl CrateDetails {
             crate_details.last_successful_build = crate_details.releases.iter()
                 .filter(|release| release.build_status && !release.yanked)
                 .map(|release| release.version.to_owned())
-                .nth(0);
+                .next();
         }
 
         Some(crate_details)

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -94,9 +94,9 @@ impl ToJson for CrateDetails {
 
 #[derive(Debug, Eq, PartialEq)]
 struct Release {
-    pub version: String,
-    pub build_status: bool,
-    pub yanked: bool,
+    version: String,
+    build_status: bool,
+    yanked: bool,
 }
 
 


### PR DESCRIPTION
This is another small refactor from working on #516.

Changes should be easier to check looking at them commit-by-commit.

Basically, the previous implementation had to query the database to determine the last successful build.
But most of the information needed is already present in `releases`. By also fetching the `yanked` data into `Release` we avoid doing an extra query.
Additionally, the `yanked` field will be useful later to improve `latest_version()`, see the issues mentioned by https://github.com/rust-lang/docs.rs/pull/559#issuecomment-573029453.

I will have to merge / rebase these changes on top of #559. But you can already take a look :)