### PR TITLE
navigation_rustdoc: show whether a build failed in the Versions list

### DIFF
--- a/templates/navigation_rustdoc.hbs
+++ b/templates/navigation_rustdoc.hbs
@@ -74,7 +74,13 @@
                         <div class="pure-menu pure-menu-scrollable sub-menu">
                           <ul class="pure-menu-list">
                             {{#each releases}}
-                            <li class="pure-menu-item"><a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link">{{this.version}}</a></li>
+                            <li class="pure-menu-item">
+                              {{#if this.build_status}}
+                              <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link">{{this.version}}</a>
+                              {{else}}
+                              <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link warn" title="docs.rs failed to build {{../name}}-{{this.version}}"><i class="fa fa-fw fa-warning"></i> {{this.version}}</a>
+                              {{/if}}
+                            </li>
                             {{/each}}
                           </ul>
                         </div>


### PR DESCRIPTION
Changes in this PR are very similar to #546. In fact, the code introduced here is exactly the same as in [`crate_details.hbs`](https://github.com/rust-lang/docs.rs/blob/master/templates/crate_details.hbs#L44)

This PR impacts the navigation bar in the rustdoc view: in the dropdown menu, versions that failed to build will also have a ⚠️ sign now.

Screenshot taken with changes from this PR:

<img width="391" alt="Screenshot 2020-01-11 at 04 30 58" src="https://user-images.githubusercontent.com/7748404/72198366-8ef75280-342c-11ea-8fd0-15f55cb6830f.png">
