### PR TITLE
limits: allow overriding memory limits to more than 4GB

### DIFF
--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -269,6 +269,17 @@ fn migrate_inner(version: Option<Version>, conn: &Connection, apply_mode: ApplyM
             // downgrade query
             "DROP TABLE blacklisted_crates;"
         ),
+        migration!(
+            context,
+            // version
+            7,
+            // description
+            "Change sandbox_overrides's max_memory_bytes to BIGINT",
+            // upgrade query
+            "ALTER TABLE sandbox_overrides ALTER COLUMN max_memory_bytes TYPE BIGINT;",
+            // downgrade query
+            "ALTER TABLE sandbox_overrides ALTER COLUMN max_memory_bytes TYPE INTEGER;"
+        ),
     ];
 
     for migration in migrations {

--- a/src/docbuilder/limits.rs
+++ b/src/docbuilder/limits.rs
@@ -31,7 +31,7 @@ impl Limits {
         )?;
         if !res.is_empty() {
             let row = res.get(0);
-            if let Some(memory) = row.get::<_, Option<i32>>("max_memory_bytes") {
+            if let Some(memory) = row.get::<_, Option<i64>>("max_memory_bytes") {
                 limits.memory = memory as usize;
             }
             if let Some(timeout) = row.get::<_, Option<i32>>("timeout_seconds") {


### PR DESCRIPTION
Before this, the overridden memory limits were stored as the allowed number of bytes in a 32-bit integer, which couldn't represent more than 4GB of RAM.

This switches the database table to use a BIGINT (64-bit integer) as the column type, fixing the issue and allowing us to add big overrides.

r? @jyn514 