### PR TITLE
Update 'Contact' to reflect new Docs.rs team

### DIFF
--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -169,8 +169,8 @@ rustdoc-args = [ "--example-rustdoc-arg" ]</pre></code>
 
   <h4>Contact</h4>
   <p>
-    Docs.rs is run and maintained by <a href="https://www.rust-lang.org/governance/teams/dev-tools#rustdoc" target="_blank">Rustdoc team</a>.
-    You can find us in #docs-rs on <a href="https://discord.gg/rust-lang" target="_blank">Discord</a>.
+    Docs.rs is run and maintained by the <a href="https://www.rust-lang.org/governance/teams/dev-tools#docs-rs" target="_blank">Docs.rs team</a>.
+    You can find us in #docs-rs on <a href="https://discordapp.com/invite/f7mTXPW/" target="_blank">Discord</a>.
   </p>
 
 </div>


### PR DESCRIPTION
I took the Discord link from the rust-lang.org teams page.

r? @QuietMisdreavus

Thanks to @ophilli for pointing out the outdated link.