### PR TITLE
Document asterick in url path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@ crates' documentation easily. Example of URL redirections for `clap` crate:
 | <https://docs.rs/clap/~2.9>                   | 2.9.* version                                    |
 | <https://docs.rs/clap/2.9.3>                  | 2.9.3 version (you don't need = unlike semver)   |
 | <https://docs.rs/clap/*/clap/struct.App.html> | Latest version of this page (if it still exists).|
-The crates.fyi domain will redirect to docs.rs, supporting all of the
-redirects discussed above
-
 
 ### Badges
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ If a crate doesn't have this field, no README will be displayed.
 Docs.rs is using semver to parse URLs. You can use this feature to access
 crates' documentation easily. Example of URL redirections for `clap` crate:
 
-| URL                          | Redirects to documentation of                  |
-|------------------------------|------------------------------------------------|
-| <https://docs.rs/clap>       | Latest version of clap                         |
-| <https://docs.rs/clap/~2>    | 2.* version                                    |
-| <https://docs.rs/clap/~2.9>  | 2.9.* version                                  |
-| <https://docs.rs/clap/2.9.3> | 2.9.3 version (you don't need = unlike semver) |
-
+| URL                                           | Redirects to documentation of                    |
+|-----------------------------------------------|--------------------------------------------------|
+| <https://docs.rs/clap>                        | Latest version of clap                           |
+| <https://docs.rs/clap/~2>                     | 2.* version                                      |
+| <https://docs.rs/clap/~2.9>                   | 2.9.* version                                    |
+| <https://docs.rs/clap/2.9.3>                  | 2.9.3 version (you don't need = unlike semver)   |
+| <https://docs.rs/clap/*/clap/struct.App.html> | Latest version of this page (if it still exists).|
 The crates.fyi domain will redirect to docs.rs, supporting all of the
 redirects discussed above
 

--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -89,6 +89,10 @@
         <td><a href="https://docs.rs/clap/2.9.3">docs.rs/clap/2.9.3</a></td>
         <td>2.9.3 version (you don't need <code>=</code> unlike semver)</td>
       </tr>
+      <tr>
+        <td><a href="https://docs.rs/clap/*/clap/struct.App.html">docs.rs/clap/*/clap/struct.App.html</a></td>
+        <td>Latest version of this page (if it still exists). "latest" or "newest" work as well as <code>*</code>.</td>
+      </tr>
     </tbody>
   </table>
 


### PR DESCRIPTION
Adds information about asterisk to the README.md, and the about page
Finishes this PR: https://github.com/rust-lang/docs.rs/pull/362