### PR TITLE
Add section to about page that points to how to build a crate's documentation locally

### DIFF
--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -169,7 +169,7 @@ rustc-args = [ "--example-rustc-arg" ]
 rustdoc-args = [ "--example-rustdoc-arg" ]</pre></code>
 
   <h4>Test crate documentation build locally</h4>
-  <p>The <a href="https://github.com/rust-lang/docs.rs/blob/master/README.md#build-subcommand" target="_blank">docs.rs README</a> details how to build an unpublished crate's documentation locally using the same Docker image used by the build agent.</p>
+  <p>The <a href="https://github.com/rust-lang/docs.rs/blob/master/README.md#build-subcommand" target="_blank">docs.rs README</a> describes how to build an unpublished crate's documentation locally using the same build environment as the build agent.</p>
   
   <h4>Version</h4>
   <p>Currently running Docs.rs version is: <strong>{{cratesfyi_version}}</strong>

--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -168,6 +168,9 @@ rustc-args = [ "--example-rustc-arg" ]
 # Additional `RUSTDOCFLAGS` to set (default: none)
 rustdoc-args = [ "--example-rustdoc-arg" ]</pre></code>
 
+  <h4>Test crate documentation build locally</h4>
+  <p>The <a href="https://github.com/rust-lang/docs.rs/blob/master/README.md#build-subcommand" target="_blank">docs.rs README</a> details how to build an unpublished crate's documentation locally using the same Docker image used by the build agent.</p>
+  
   <h4>Version</h4>
   <p>Currently running Docs.rs version is: <strong>{{cratesfyi_version}}</strong>
 


### PR DESCRIPTION
Fixes #574

@jyn514 let me know if you'd like the wording to be changed.