### PR TITLE
Improve link fallback

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -111,7 +111,7 @@ impl CratesfyiHandler {
 
         let shared_resources = Self::chain(&pool_factory, rustdoc::SharedResourceHandler);
         let router_chain = Self::chain(&pool_factory, routes.iron_router());
-        let prefix = PathBuf::from(env::var("CRATESFYI_PREFIX").unwrap()).join("public_html");
+        let prefix = PathBuf::from(env::var("CRATESFYI_PREFIX").expect("CRATESFYI_PREFIX environment variable does not exists")).join("public_html");
         let static_handler = Static::new(prefix)
             .cache(Duration::from_secs(STATIC_FILE_CACHE_DURATION));
 


### PR DESCRIPTION
Improve handling of urls that are missing a /
Ex: http://127.0.0.1:3000/hyper/0.13.2/hyper/client/conn

Fix #288 