### PR TITLE
Improve handling of urls missing /

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -111,7 +111,7 @@ impl CratesfyiHandler {
 
         let shared_resources = Self::chain(&pool_factory, rustdoc::SharedResourceHandler);
         let router_chain = Self::chain(&pool_factory, routes.iron_router());
-        let prefix = PathBuf::from(env::var("CRATESFYI_PREFIX").unwrap()).join("public_html");
+        let prefix = PathBuf::from(env::var("CRATESFYI_PREFIX").expect("the CRATESFYI_PREFIX environment variable is not set")).join("public_html");
         let static_handler = Static::new(prefix)
             .cache(Duration::from_secs(STATIC_FILE_CACHE_DURATION));
 

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -251,7 +251,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
     let file = match File::from_path(&conn, &path) {
         Some(f) => f,
         None => {
-            //If it fails, we try again with /index.html at the end
+            // If it fails, we try again with /index.html at the end
             path.push_str("/index.html");
             req_path.push("index.html");
             match File::from_path(&conn, &path) {
@@ -447,8 +447,8 @@ mod test {
               .name("buggy").version("0.1.0")
               .build_result_successful(true)
               .rustdoc_file("settings.html", b"some data")
-              .rustdoc_file("directoty_1/index.html", b"some data 1")
-              .rustdoc_file("directoty_2.html/index.html", b"some data 1")
+              .rustdoc_file("directory_1/index.html", b"some data 1")
+              .rustdoc_file("directory_2.html/index.html", b"some data 1")
               .rustdoc_file("all.html", b"some data 2")
               .rustdoc_file("directory_3/.gitignore", b"*.ext")
               .rustdoc_file("directory_4/empty_file_no_ext", b"")
@@ -460,8 +460,8 @@ mod test {
             let web = env.frontend();
             assert_success("/", web)?;
             assert_success("/crate/buggy/0.1.0/", web)?;
-            assert_success("/buggy/0.1.0/directoty_1/index.html", web)?;
-            assert_success("/buggy/0.1.0/directoty_2.html/index.html", web)?;
+            assert_success("/buggy/0.1.0/directory_1/index.html", web)?;
+            assert_success("/buggy/0.1.0/directory_2.html/index.html", web)?;
             assert_success("/buggy/0.1.0/directory_3/.gitignore", web)?;
             assert_success("/buggy/0.1.0/settings.html", web)?;
             assert_success("/buggy/0.1.0/all.html", web)?;


### PR DESCRIPTION
Improve handling of urls missing /
Ex: http://127.0.0.1:3000/hyper/0.13.2/hyper/client/conn

Fix #288
Previous Attempt: https://github.com/rust-lang/docs.rs/pull/582