### PR TITLE
Allow using custom docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,11 @@ If you want to explore or edit database manually, you can connect to the databas
 with the `psql` command.
 
 ```sh
+# NOTE: this creates a new container that will keep running after you exit
+# To remove the new container, run `docker-compose down`.
 docker exec -it "$(docker-compose run -d db && sleep 1)" psql -U cratesfyi
+# You only need to start the container once, in the future you can attach to it like so:
+docker exec -it "$(docker container ps | grep postgres | cut -d ' ' -f 1)" psql -U cratesfyi
 ```
 
 The database contains a blacklist of crates that should not be built.

--- a/README.md
+++ b/README.md
@@ -156,9 +156,7 @@ If you want to explore or edit database manually, you can connect to the databas
 with the `psql` command.
 
 ```sh
-# this will print the name of the container it starts
-docker-compose run -d db
-docker exec -it <the container name goes here> psql -U cratesfyi
+docker exec -it "$(docker-compose run -d db && sleep 1)" psql -U cratesfyi
 ```
 
 The database contains a blacklist of crates that should not be built.

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -79,7 +79,7 @@ impl RustwideBuilder {
             .unwrap_or(false);
         let mut builder = WorkspaceBuilder::new(Path::new(workspace_path), USER_AGENT)
             .running_inside_docker(is_docker);
-        if let Ok(custom_image) = std::env::var("DOCS_RS_LOCAL_IMAGE") {
+        if let Ok(custom_image) = std::env::var("DOCS_RS_LOCAL_DOCKER_IMAGE") {
             builder = builder.sandbox_image(SandboxImage::local(&custom_image)?);
         }
 


### PR DESCRIPTION
This will allow people to test changes to `crates-build-env` locally, see #522 for context.

After this I just need to update the wiki.

r? @pietroalbini 