### PR TITLE
Add minio container to mock s3 locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,17 @@ information on how to setup this environment.
 
 ### Docker-Compose
 
+The services started by Docker-Compose are defined in [docker-compose.yml].
+Three services are defined:
+
+| name | access                | credentials                | description                            |
+|------|-----------------------|----------------------------|----------------------------------------|
+| web  | http://localhost:3000 | N/A                        | A container running the docs.rs binary |
+| db   | /                     | N/A                        | Postgres database used by web          |
+| s3   | http://localhost:9000 | `cratesfyi` - `secret_key` | Minio (simulates AWS S3) used by web   |
+
+[docker-compose.yml]: ./docker-compose.yml
+
 #### Rebuilding Containers
 
 To rebuild the site, run `docker-compose build`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
         build: .
         depends_on:
             - db
+            - s3
         ports:
             - "3000:3000"
         volumes:
@@ -13,6 +14,9 @@ services:
         environment:
             CRATESFYI_RUSTWIDE_WORKSPACE: /opt/docsrs/rustwide
             CRATESFYI_DATABASE_URL: postgresql://cratesfyi:password@db
+            S3_ENDPOINT: http://s3:9000
+            AWS_ACCESS_KEY_ID: cratesfyi
+            AWS_SECRET_ACCESS_KEY: secret_key
         env_file:
             - .env
     db:
@@ -22,6 +26,17 @@ services:
         environment:
             POSTGRES_USER: cratesfyi
             POSTGRES_PASSWORD: password
+    s3:
+        image: minio/minio
+        command: server /data
+        ports:
+            - "9000:9000"
+        volumes:
+            - minio-data:/data
+        environment:
+            MINIO_ACCESS_KEY: cratesfyi
+            MINIO_SECRET_KEY: secret_key
 volumes:
     postgres-data: {}
+    minio-data: {}
     cratesio-index: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,11 @@ services:
             POSTGRES_PASSWORD: password
     s3:
         image: minio/minio
-        command: server /data
+        entrypoint: >
+            /bin/sh -c "
+                mkdir /data/rust-docs-rs;
+                minio server /data;
+            "
         ports:
             - "9000:9000"
         volumes:


### PR DESCRIPTION
Extends docker-compose.yml to also launch an container with minio, backed by a persistent volume.
Closes #463

It seems to work, but I can't test it reliably due this other issue I'm having right now: https://github.com/rust-lang/docs.rs/pull/594#issuecomment-583657798