### PR TITLE
refactor match version

### DIFF
--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -283,7 +283,7 @@ pub fn crate_details_handler(req: &mut Request) -> IronResult<Response> {
     let conn = extension!(req, Pool).get();
 
     match match_version(&conn, &name, req_version) {
-        MatchVersion::Exact(version) => {
+        MatchVersion::Exact((version, _)) => {
             let details = CrateDetails::new(&conn, &name, &version);
 
             Page::new(details)
@@ -292,7 +292,7 @@ pub fn crate_details_handler(req: &mut Request) -> IronResult<Response> {
                 .set_true("package_navigation_crate_tab")
                 .to_resp("crate_details")
         }
-        MatchVersion::Semver(version) => {
+        MatchVersion::Semver((version, _)) => {
             let url = ctry!(Url::parse(&format!("{}/crate/{}/{}",
                                                 redirect_base(req),
                                                 name,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -286,7 +286,7 @@ fn match_version(conn: &Connection, name: &str, version: Option<&str>) -> MatchV
     // semver is acting weird for '*' (any) range if a crate only have pre-release versions
     // return first version if requested version is '*'
     if req_version == "*" && !versions_sem.is_empty() {
-        return MatchVersion::Semver((format!("{}", versions_sem[0].0), versions_sem[0].1));
+        return MatchVersion::Semver((versions_sem[0].0.to_string(), versions_sem[0].1));
     }
 
     MatchVersion::None

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -187,6 +187,7 @@ impl Handler for CratesfyiHandler {
 }
 
 /// Represents the possible results of attempting to load a version requirement.
+/// The id (i32) of the release is stored to simplify successive queries.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum MatchVersion {
     /// `match_version` was given an exact version, which matched a saved crate version.
@@ -207,6 +208,10 @@ impl MatchVersion {
             MatchVersion::Exact(v) | MatchVersion::Semver(v) => Some(v),
             MatchVersion::None => None,
         }
+    }
+
+    fn strip_id(self) -> Option<String> {
+        self.into_option().map(|(version, _id)| version)
     }
 }
 
@@ -274,7 +279,7 @@ fn match_version(conn: &Connection, name: &str, version: Option<&str>) -> MatchV
 
     for version in &versions_sem {
         if req_sem_ver.matches(&version.0) {
-            return MatchVersion::Semver((format!("{}", version.0), version.1));
+            return MatchVersion::Semver((version.0.to_string(), version.1));
         }
     }
 
@@ -522,19 +527,15 @@ mod test {
         db.fake_release().name("foo").version(version).create().unwrap()
     }
     fn version(v: Option<&str>, db: &TestDatabase) -> Option<String> {
-        strip_id(match_version(&db.conn(), "foo", v))
-    }
-
-    fn strip_id(v: MatchVersion) -> Option<String> {
-        v.into_option().map(|(version, _id)| version)
+        match_version(&db.conn(), "foo", v).strip_id()
     }
 
     fn semver(version: &'static str) -> Option<String> {
-        strip_id(MatchVersion::Semver((version.into(), DEFAULT_ID)))
+        MatchVersion::Semver((version.into(), DEFAULT_ID)).strip_id()
     }
 
     fn exact(version: &'static str) -> Option<String> {
-        strip_id(MatchVersion::Exact((version.into(), DEFAULT_ID)))
+        MatchVersion::Exact((version.into(), DEFAULT_ID)).strip_id()
     }
 
     #[test]
@@ -581,8 +582,8 @@ mod test {
             let release_id = release("0.3.0", db);
             let query = "UPDATE releases SET yanked = true WHERE id = $1 AND version = '0.3.0'";
             db.conn().query(query, &[&release_id]).unwrap();
-            assert_eq!(version(None, db), strip_id(MatchVersion::None));
-            assert_eq!(version(Some("0.3"), db), strip_id(MatchVersion::None));
+            assert_eq!(version(None, db), MatchVersion::None.strip_id());
+            assert_eq!(version(Some("0.3"), db), MatchVersion::None.strip_id());
 
             release("0.1.0+4.1", db);
             assert_eq!(version(Some("0.1.0+4.1"), db), exact("0.1.0+4.1"));

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -582,8 +582,8 @@ mod test {
             let release_id = release("0.3.0", db);
             let query = "UPDATE releases SET yanked = true WHERE id = $1 AND version = '0.3.0'";
             db.conn().query(query, &[&release_id]).unwrap();
-            assert_eq!(version(None, db), MatchVersion::None.strip_id());
-            assert_eq!(version(Some("0.3"), db), MatchVersion::None.strip_id());
+            assert_eq!(version(None, db), None);
+            assert_eq!(version(Some("0.3"), db), None);
 
             release("0.1.0+4.1", db);
             assert_eq!(version(Some("0.1.0+4.1"), db), exact("0.1.0+4.1"));

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -483,17 +483,15 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
             // since we never pass a version into `match_version` here, we'll never get
             // `MatchVersion::Exact`, so the distinction between `Exact` and `Semver` doesn't
             // matter
-            if let Some(version) = match_version(&conn, &query, None).into_option() {
+            if let Some((version, id)) = match_version(&conn, &query, None).into_option() {
                 // FIXME: This is a super dirty way to check if crate have rustdocs generated.
                 //        match_version should handle this instead of this code block.
                 //        This block is introduced to fix #163
                 let rustdoc_status = {
                     let rows = ctry!(conn.query("SELECT rustdoc_status
                                                  FROM releases
-                                                 INNER JOIN crates
-                                                 ON crates.id = releases.crate_id
-                                                 WHERE crates.name = $1 AND releases.version = $2",
-                                                &[query, &version]));
+                                                 WHERE releases.id = $1",
+                                                &[&id]));
                     if rows.is_empty() {
                         false
                     } else {


### PR DESCRIPTION
Refactor `MatchVersion` to contain also the id of the release in order to simplify successive queries.

fix #569 