### PR TITLE
Revert style changes to search bar

### DIFF
--- a/templates/navigation.hbs
+++ b/templates/navigation.hbs
@@ -3,7 +3,7 @@
         <div class="pure-menu pure-menu-horizontal" role="navigation" aria-label="Main navigation">
           <form action="/releases/search" method="GET" class="landing-search-form-nav">
             {{#unless varsb.show_search_form}}
-            <input class="search-input-nav" name="query" type="text" aria-label="Find crate by search query" placeholder="Find crate &#x1F50D;"{{#if varss.search_query}} value="{{varss.search_query}}"{{/if}}>
+            <input class="search-input-nav" name="query" type="text" aria-label="Find crate by search query" placeholder="Find crate"{{#if varss.search_query}} value="{{varss.search_query}}"{{/if}}>
             {{/unless}}
           <a href="/" class="pure-menu-heading pure-menu-link" aria-label="Docs.rs"><i class="fa fa-cubes fa-fw"></i> Docs.rs</a>
           <ul class="pure-menu-list">

--- a/templates/navigation.hbs
+++ b/templates/navigation.hbs
@@ -3,10 +3,7 @@
         <div class="pure-menu pure-menu-horizontal" role="navigation" aria-label="Main navigation">
           <form action="/releases/search" method="GET" class="landing-search-form-nav">
             {{#unless varsb.show_search_form}}
-            <div class="search-input-nav">
-              <label for="nav-search"><i class="fa fa-fw fa-search"></i></label>
-              <input id="nav-search" name="query" type="text" aria-label="Find crate by search query" placeholder="Find crate"{{#if varss.search_query}} value="{{varss.search_query}}"{{/if}}>
-            </div>
+            <input class="search-input-nav" name="query" type="text" aria-label="Find crate by search query" placeholder="Find crate &#x1F50D;"{{#if varss.search_query}} value="{{varss.search_query}}"{{/if}}>
             {{/unless}}
           <a href="/" class="pure-menu-heading pure-menu-link" aria-label="Docs.rs"><i class="fa fa-cubes fa-fw"></i> Docs.rs</a>
           <ul class="pure-menu-list">

--- a/templates/navigation_rustdoc.hbs
+++ b/templates/navigation_rustdoc.hbs
@@ -3,7 +3,7 @@
         <div class="pure-menu pure-menu-horizontal">
           <form action="/releases/search" method="GET" class="landing-search-form-nav">
             {{#unless varsb.show_search_form}}
-            <input class="search-input-nav" name="query" aria-label="Find crate by search query" tabindex="-1" type="text" placeholder="Find crate &#x1F50D;"{{#if varss.search_query}} value="{{varss.search_query}}"{{/if}}>
+            <input class="search-input-nav" name="query" aria-label="Find crate by search query" tabindex="-1" type="text" placeholder="Find crate"{{#if varss.search_query}} value="{{varss.search_query}}"{{/if}}>
             {{/unless}}
             <a href="/" class="pure-menu-heading pure-menu-link"><i class="fa fa-cubes fa-fw"></i><span class="title"> Docs.rs</span></a>
           {{#with content.crate_details}}

--- a/templates/navigation_rustdoc.hbs
+++ b/templates/navigation_rustdoc.hbs
@@ -3,10 +3,7 @@
         <div class="pure-menu pure-menu-horizontal">
           <form action="/releases/search" method="GET" class="landing-search-form-nav">
             {{#unless varsb.show_search_form}}
-            <div class="search-input-nav">
-              <label for="nav-search"><i class="fa fa-fw fa-search"></i></label>
-              <input id="nav-search" name="query" type="text" aria-label="Find crate by search query" placeholder="Find crate"{{#if varss.search_query}} value="{{varss.search_query}}"{{/if}}>
-            </div>
+            <input class="search-input-nav" name="query" aria-label="Find crate by search query" tabindex="-1" type="text" placeholder="Find crate &#x1F50D;"{{#if varss.search_query}} value="{{varss.search_query}}"{{/if}}>
             {{/unless}}
             <a href="/" class="pure-menu-heading pure-menu-link"><i class="fa fa-cubes fa-fw"></i><span class="title"> Docs.rs</span></a>
           {{#with content.crate_details}}

--- a/templates/style.scss
+++ b/templates/style.scss
@@ -184,7 +184,6 @@ div.nav-container {
             background-color: #fff;
             height: 31px;
             display: none;
-            box-shadow: 0px 0px 2px #000;
 
             @media #{$media-sm} {
                 display: block;

--- a/templates/style.scss
+++ b/templates/style.scss
@@ -173,37 +173,23 @@ div.nav-container {
     form.landing-search-form-nav {
         max-width: 1200px;
 
-        div.search-input-nav {
+        input.search-input-nav {
             float: right;
-            max-width: 150px;
+            max-width: 200px;
+            border: none;
+            margin: 0 1em 0 0;
+            font-size: 0.8em;
+            text-align: right;
+            box-shadow: none;
+            background-color: #fff;
+            height: 31px;
             display: none;
-            border-left: 1px solid $color-border;
+            box-shadow: 0px 0px 2px #000;
 
             @media #{$media-sm} {
                 display: block;
             }
-
-            @media #{$media-md} {
-                max-width: 200px;
-            }
-
-            label {
-                color: #777;
-                cursor: pointer;
-                padding-left: 0.5rem;
-                font-size: 0.8em;
-            }
-
-            input {
-                border: none;
-                margin: 0 1em 0 0;
-                font-size: 0.8em;
-                box-shadow: none;
-                background-color: #fff;
-                height: 31px;
-            }
         }
-        
 
         input.search-input-nav:focus {
             outline: unset;


### PR DESCRIPTION
Since the changes to search have caused a number of issues (#595, [images no longer showing up](https://discordapp.com/channels/442252698964721669/541978667522195476/678004143301984268)), I think it makes sense to revert and think about a better solution.

Let me know if I missed any commit, I made this by hitting the 'revert' button on https://github.com/rust-lang/docs.rs/pull/587 and then on top of that running `git revert` on the only commit in https://github.com/rust-lang/docs.rs/pull/577.

r? @GuillaumeGomez 

cc @Zexbe 