### PR TITLE
Fix svg mimes not being saved correctly

### DIFF
--- a/src/db/file.rs
+++ b/src/db/file.rs
@@ -389,6 +389,7 @@ mod test {
         check_mime("{}", "hello.json","application/json");
         check_mime("hello world", "hello.txt","text/plain");
         check_mime("//! Simple module to ...", "file.rs", "text/rust");
+        check_mime("<svg></svg>", "important.svg", "image/svg+xml");
     }
 
     fn check_mime(content: &str, path: &str, expected_mime: &str) {

--- a/src/db/file.rs
+++ b/src/db/file.rs
@@ -292,7 +292,8 @@ fn correct_mime(mime: &str, file_path: &Path) -> Result<String> {
                 Some("json") => "application/json",
                 _ => mime
             }
-        }
+        },
+        "image/svg" => "image/svg+xml",
         _ => mime
     }.to_owned())
 }

--- a/src/utils/copy.rs
+++ b/src/utils/copy.rs
@@ -63,6 +63,7 @@ mod test {
         fs::write(doc.join("index.txt"), "spooky").unwrap();
         fs::write(doc.join("inner").join("index.html"), "<html>spooky</html>").unwrap();
         fs::write(doc.join("inner").join("index.txt"), "spooky").unwrap();
+        fs::write(doc.join("inner").join("important.svg"), "<svg></svg>").unwrap();
 
         // lets try to copy a src directory to tempdir
         copy_doc_dir(source.path().join("doc"), destination.path()).unwrap();
@@ -70,5 +71,6 @@ mod test {
         assert!(!destination.path().join("index.txt").exists());
         assert!(destination.path().join("inner").join("index.html").exists());
         assert!(!destination.path().join("inner").join("index.txt").exists());
+        assert!(!destination.path().join("inner").join("important.svg").exists());
     }
 }


### PR DESCRIPTION
For some reason, svg's started saving as "image/svg" instead of "image/svg+xml".
Essential files will need to be re-uploaded / edited for the change to work.