### PR TITLE
Allow users to copy dependency text.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN touch build.rs
 COPY src src/
 RUN find src -name "*.rs" -exec touch {} \;
 COPY templates/style.scss templates/
+COPY templates/index.js templates/
 COPY templates/menu.js templates/
 
 RUN cargo build --release

--- a/build.rs
+++ b/build.rs
@@ -52,7 +52,11 @@ fn compile_sass() {
 }
 
 fn copy_js() {
-    let source_path = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/templates/menu.js"));
-    let dest_path = Path::new(&env::var("OUT_DIR").unwrap()).join("menu.js");
-    fs::copy(&source_path, &dest_path).expect("copy template/menu.js to target");
+    ["menu.js", "index.js"].iter()
+        .for_each(|path| {
+            let source_path = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap())
+                .join(format!("templates/{}", path));
+            let dest_path = Path::new(&env::var("OUT_DIR").unwrap()).join(path);
+            fs::copy(&source_path, &dest_path).expect("Copy JavaScript file to target");
+        });
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -439,14 +439,6 @@ fn load_js(file_path_str: &'static str) -> IronResult<Response> {
     Ok(response)
 }
 
-fn menu_js_handler(_: &mut Request) -> IronResult<Response> {
-    load_js(MENU_JS)
-}
-
-fn index_js_handler(_: &mut Request) -> IronResult<Response> {
-    load_js(INDEX_JS)
-}
-
 fn opensearch_xml_handler(_: &mut Request) -> IronResult<Response> {
     let mut response = Response::with((status::Ok, OPENSEARCH_XML));
     let cache = vec![CacheDirective::Public,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -73,6 +73,7 @@ use std::sync::{Arc, Mutex};
 const STATIC_FILE_CACHE_DURATION: u64 = 60 * 60 * 24 * 30 * 12;   // 12 months
 const STYLE_CSS: &'static str = include_str!(concat!(env!("OUT_DIR"), "/style.css"));
 const MENU_JS: &'static str = include_str!(concat!(env!("OUT_DIR"), "/menu.js"));
+const INDEX_JS: &'static str = include_str!(concat!(env!("OUT_DIR"), "/index.js"));
 const OPENSEARCH_XML: &'static [u8] = include_bytes!("opensearch.xml");
 
 const DEFAULT_BIND: &str = "0.0.0.0:3000";
@@ -429,13 +430,21 @@ fn style_css_handler(_: &mut Request) -> IronResult<Response> {
     Ok(response)
 }
 
-fn menu_js_handler(_: &mut Request) -> IronResult<Response> {
-    let mut response = Response::with((status::Ok, MENU_JS));
+fn load_js(file_path_str: &'static str) -> IronResult<Response> {
+    let mut response = Response::with((status::Ok, file_path_str));
     let cache = vec![CacheDirective::Public,
                      CacheDirective::MaxAge(STATIC_FILE_CACHE_DURATION as u32)];
     response.headers.set(ContentType("application/javascript".parse().unwrap()));
     response.headers.set(CacheControl(cache));
     Ok(response)
+}
+
+fn menu_js_handler(_: &mut Request) -> IronResult<Response> {
+    load_js(MENU_JS)
+}
+
+fn index_js_handler(_: &mut Request) -> IronResult<Response> {
+    load_js(INDEX_JS)
 }
 
 fn opensearch_xml_handler(_: &mut Request) -> IronResult<Response> {

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -8,6 +8,7 @@ pub(super) fn build_routes() -> Routes {
     let mut routes = Routes::new();
 
     routes.static_resource("/style.css", super::style_css_handler);
+    routes.static_resource("/index.js", super::index_js_handler);
     routes.static_resource("/menu.js", super::menu_js_handler);
     routes.static_resource("/robots.txt", super::sitemap::robots_txt_handler);
     routes.static_resource("/sitemap.xml", super::sitemap::sitemap_handler);

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -1,6 +1,8 @@
 use iron::middleware::Handler;
 use router::Router;
 use std::collections::HashSet;
+use web::{MENU_JS, INDEX_JS};
+use iron::Request;
 
 const DOC_RUST_LANG_ORG_REDIRECTS: &[&str] = &["alloc", "core", "proc_macro", "std", "test"];
 
@@ -8,8 +10,8 @@ pub(super) fn build_routes() -> Routes {
     let mut routes = Routes::new();
 
     routes.static_resource("/style.css", super::style_css_handler);
-    routes.static_resource("/index.js", super::index_js_handler);
-    routes.static_resource("/menu.js", super::menu_js_handler);
+    routes.static_resource("/index.js", |_: &mut Request| super::load_js(MENU_JS));
+    routes.static_resource("/menu.js", |_: &mut Request| super::load_js(INDEX_JS));
     routes.static_resource("/robots.txt", super::sitemap::robots_txt_handler);
     routes.static_resource("/sitemap.xml", super::sitemap::sitemap_handler);
     routes.static_resource("/opensearch.xml", super::opensearch_xml_handler);

--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -1,5 +1,5 @@
 {{#if varsb.javascript_highlightjs}}<script type="text/javascript" charset="utf-8">hljs.initHighlighting();</script>{{/if}}
 <script type="text/javascript" src="/menu.js?{{cratesfyi_version_safe}}"></script>
-<script type="text/javascript" src="/index.js"></script>
+<script type="text/javascript" src="/index.js?{{cratesfyi_version_safe}}"></script>
 </body>
 </html>

--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -1,4 +1,5 @@
 {{#if varsb.javascript_highlightjs}}<script type="text/javascript" charset="utf-8">hljs.initHighlighting();</script>{{/if}}
 <script type="text/javascript" src="/menu.js?{{cratesfyi_version_safe}}"></script>
+<script type="text/javascript" src="/index.js"></script>
 </body>
 </html>

--- a/templates/index.js
+++ b/templates/index.js
@@ -1,6 +1,6 @@
 function formatCrateName(crateTitleAndVersion) {
     const stringParts = crateTitleAndVersion.split(" ", 2);
-    return stringParts[0] + " = " + stringParts[1];
+    return stringParts[0] + ' = "' + stringParts[1] + '"';
 }
 
 function copyTextHandler() {

--- a/templates/index.js
+++ b/templates/index.js
@@ -17,5 +17,4 @@ function copyTextHandler() {
     temporaryInput.remove();
 }
 
-document.getElementById("clipboard")
-    .addEventListener("click", copyTextHandler);
+document.getElementById("clipboard").addEventListener("click", copyTextHandler);

--- a/templates/index.js
+++ b/templates/index.js
@@ -1,0 +1,21 @@
+function formatCrateName(crateTitleAndVersion) {
+    const stringParts = crateTitleAndVersion.split(" ", 2);
+    return stringParts[0] + " = " + stringParts[1];
+}
+
+function copyTextHandler() {
+    const crateTitleAndVersion = document.getElementById("crate-title").innerText;
+    const temporaryInput = document.createElement("input");
+
+    temporaryInput.type = "text";
+    temporaryInput.value = formatCrateName(crateTitleAndVersion);
+
+    document.body.append(temporaryInput);
+    temporaryInput.select();
+    document.execCommand("copy");
+
+    temporaryInput.remove();
+}
+
+document.getElementById("clipboard")
+    .addEventListener("click", copyTextHandler);

--- a/templates/navigation.hbs
+++ b/templates/navigation.hbs
@@ -32,7 +32,7 @@
     <div class="cratesfyi-package-container">
       <div class="container">
         <h1 id="crate-title">{{#if title}}{{title}}{{else}}{{content.metadata.name}} {{content.metadata.version}}{{/if}}</h1>
-        <i class="fa fa-clipboard fa-1" id="clipboard" aria-hidden="true"></i>
+        <i class="fa fa-clipboard fa-1" id="clipboard" aria-label="Copy crate name and version information"></i>
         <div class="description">{{#if content.metadata.description }}{{content.metadata.description}}{{else}}{{varss.description}}{{/if}}</div>
 
         {{#if ../varsb.show_package_navigation}}

--- a/templates/navigation.hbs
+++ b/templates/navigation.hbs
@@ -31,7 +31,8 @@
     {{#unless varsb.hide_package_navigation}}
     <div class="cratesfyi-package-container">
       <div class="container">
-        <h1>{{#if title}}{{title}}{{else}}{{content.metadata.name}} {{content.metadata.version}}{{/if}}</h1>
+        <h1 id="crate-title">{{#if title}}{{title}}{{else}}{{content.metadata.name}} {{content.metadata.version}}{{/if}}</h1>
+        <i class="fa fa-clipboard fa-1" id="clipboard" aria-hidden="true"></i>
         <div class="description">{{#if content.metadata.description }}{{content.metadata.description}}{{else}}{{varss.description}}{{/if}}</div>
 
         {{#if ../varsb.show_package_navigation}}

--- a/templates/style.scss
+++ b/templates/style.scss
@@ -785,6 +785,14 @@ div.search-page-search-form {
     }
 }
 
+#crate-title {
+    display: inline-block;
+}
+
+#clipboard {
+    cursor: pointer;
+}
+
 i.dependencies.normal {
   visibility: hidden;
   display: none;


### PR DESCRIPTION
Closes #609 

This change adds a clipboard icon next to the crate name that copies the crate information in the format required for the user's TOML file. For example, a user on the page for the `regex` crate at version `1.3.0` will have `regex = "1.3.0"` copied to their clipboard.

Currently, the UX for this is fairly bare-bones. It may be useful to have some kind of notification from the UI that the copy happened, such as using a tooltip or check mark, but I opted to go with the minimal case for this PR, and other changes can always be added later.

![DocsRsClipboard](https://user-images.githubusercontent.com/26661872/75095784-af0b4d00-5566-11ea-9a7c-596e4c06e0b5.png)
