### PR TITLE
[Don't merge] Point people to forge instead of docs.rs

### DIFF
--- a/.github/ISSUE_TEMPLATE/crate-build-failure.md
+++ b/.github/ISSUE_TEMPLATE/crate-build-failure.md
@@ -10,7 +10,7 @@ assignees: ''
 <!-- If you need a system dependency added for your crate to build,
 consider making a PR to https://github.com/rust-lang/crates-build-env
 instead of opening an issue here. There are detailed instructions for this at
-https://github.com/rust-lang/docs.rs/wiki/Making-changes-to-the-build-environment
+https://forge.rust-lang.org/infra/docs/docs-rs/add-dependencies.html
 -->
 
 **Crate name:**

--- a/.github/ISSUE_TEMPLATE/crate-build-failure.md
+++ b/.github/ISSUE_TEMPLATE/crate-build-failure.md
@@ -10,7 +10,7 @@ assignees: ''
 <!-- If you need a system dependency added for your crate to build,
 consider making a PR to https://github.com/rust-lang/crates-build-env
 instead of opening an issue here. There are detailed instructions for this at
-https://forge.rust-lang.org/infra/docs/docs-rs/add-dependencies.html
+https://forge.rust-lang.org/docs-rs/add-dependencies.html
 -->
 
 **Crate name:**


### PR DESCRIPTION
Ideally, we could get rid of the GitHub wiki altogether after this.

Waiting on https://github.com/rust-lang/rust-forge/pull/310.