### PR TITLE
Hide clipboard if request is not a 2xx.

### DIFF
--- a/src/web/page.rs
+++ b/src/web/page.rs
@@ -137,6 +137,7 @@ impl<T: ToJson> ToJson for Page<T> {
         }
 
         tree.insert("content".to_owned(), self.content.to_json());
+        tree.insert("is_successful_request".to_owned(), self.status.is_success().to_json());
         tree.insert("rustc_resource_suffix".to_owned(), self.rustc_resource_suffix.to_json());
         tree.insert("cratesfyi_version".to_owned(), ::BUILD_VERSION.to_json());
         tree.insert("cratesfyi_version_safe".to_owned(),

--- a/templates/navigation.hbs
+++ b/templates/navigation.hbs
@@ -35,7 +35,7 @@
     <div class="cratesfyi-package-container">
       <div class="container">
         <h1 id="crate-title">{{#if title}}{{title}}{{else}}{{content.metadata.name}} {{content.metadata.version}}{{/if}}</h1>
-        <i class="fa fa-clipboard fa-1" id="clipboard" aria-label="Copy crate name and version information"></i>
+        {{#if is_successful_request}}<i class="fa fa-clipboard fa-1" id="clipboard" aria-label="Copy crate name and version information"></i>{{/if}}
         <div class="description">{{#if content.metadata.description }}{{content.metadata.description}}{{else}}{{varss.description}}{{/if}}</div>
 
         {{#if ../varsb.show_package_navigation}}


### PR DESCRIPTION
Resolves #622 

This change conditionally shows the clipboard only if the request was a 2xx, preventing it from showing in 404 pages.