### PR TITLE
Allow crates to opt-in to building a single target

### DIFF
--- a/src/docbuilder/metadata.rs
+++ b/src/docbuilder/metadata.rs
@@ -125,7 +125,7 @@ impl Metadata {
                         .and_then(|v| v.as_bool()).unwrap_or(metadata.all_features);
                     metadata.default_target = table.get("default-target")
                         .and_then(|v| v.as_str()).map(|v| v.to_owned());
-                    metadata.targets = table.get("extra-targets").and_then(|f| f.as_array())
+                    metadata.targets = table.get("targets").and_then(|f| f.as_array())
                         .and_then(|f| f.iter().map(|v| v.as_str().map(|v| v.to_owned())).collect());
                     metadata.rustc_args = table.get("rustc-args").and_then(|f| f.as_array())
                         .and_then(|f| f.iter().map(|v| v.as_str().map(|v| v.to_owned())).collect());
@@ -191,7 +191,7 @@ mod test {
             all-features = true
             no-default-features = true
             default-target = "x86_64-unknown-linux-gnu"
-            extra-targets = [ "x86_64-apple-darwin", "x86_64-pc-windows-msvc" ]
+            targets = [ "x86_64-apple-darwin", "x86_64-pc-windows-msvc" ]
             rustc-args = [ "--example-rustc-arg" ]
             rustdoc-args = [ "--example-rustdoc-arg" ]
         "#;
@@ -248,7 +248,7 @@ mod test {
         // extra targets explicitly set to empty array
         let metadata = Metadata::from_str(r#"
             [package.metadata.docs.rs]
-            extra-targets = []
+            targets = []
         "#);
         assert!(metadata.targets.unwrap().is_empty());
     }
@@ -257,7 +257,7 @@ mod test {
         use crate::docbuilder::rustwide_builder::{HOST_TARGET, TARGETS};
 
         let mut metadata = Metadata::default();
-        // unchanged default_target, extra targets not specified
+        // unchanged default_target, targets not specified
         let (default, tier_one) = metadata.targets();
         assert_eq!(default, HOST_TARGET);
         // should be equal to TARGETS \ {HOST_TARGET}

--- a/src/docbuilder/metadata.rs
+++ b/src/docbuilder/metadata.rs
@@ -290,5 +290,26 @@ mod test {
         let (default, others) = metadata.targets();
         assert_eq!(default, "i686-pc-windows-msvc");
         assert!(others.is_empty());
+
+        // make sure that `default_target` always takes priority over `targets`
+        metadata.default_target = Some("i686-apple-darwin".into());
+        let (default, others) = metadata.targets();
+        assert_eq!(default, "i686-apple-darwin");
+        assert_eq!(others.len(), 1);
+        assert!(others.contains(&"i686-pc-windows-msvc"));
+
+        // make sure that `default_target` takes priority over `HOST_TARGET`
+        metadata.extra_targets = Some(vec![]);
+        let (default, others) = metadata.targets();
+        assert_eq!(default, "i686-apple-darwin");
+        assert!(others.is_empty());
+
+        // and if `extra_targets` is unset, it should still be set to `TARGETS`
+        metadata.extra_targets = None;
+        let (default, others) = metadata.targets();
+        assert_eq!(default, "i686-apple-darwin");
+        let tier_one_targets_no_default: Vec<_> = TARGETS.iter().filter(|&&t| t != "i686-apple-darwin").copied().collect();
+        assert_eq!(others, tier_one_targets_no_default);
+
     }
 }

--- a/src/docbuilder/metadata.rs
+++ b/src/docbuilder/metadata.rs
@@ -44,10 +44,12 @@ pub struct Metadata {
     /// is always built on this target. You can change default target by setting this.
     pub default_target: Option<String>,
 
-    /// Docs.rs doesn't automatically build extra targets for crates. If you want a crate to build
-    /// for multiple targets, set `extra-targets` to the list of targets to build, in addition to
-    /// `default-target`.
-    pub extra_targets: Vec<String>,
+    /// If you want a crate to build only for specific targets,
+    /// set `extra-targets` to the list of targets to build, in addition to `default-target`.
+    ///
+    /// If you do not set `extra_targets`, all of the tier 1 supported targets will be built.
+    /// If you set `extra_targets` to an empty array, only the default target will be built.
+    pub extra_targets: Option<Vec<String>>,
 
     /// List of command line arguments for `rustc`.
     pub rustc_args: Option<Vec<String>>,
@@ -93,7 +95,7 @@ impl Metadata {
             default_target: None,
             rustc_args: None,
             rustdoc_args: None,
-            extra_targets: Vec::new(),
+            extra_targets: None,
         }
     }
 
@@ -119,8 +121,7 @@ impl Metadata {
                     metadata.default_target = table.get("default-target")
                         .and_then(|v| v.as_str()).map(|v| v.to_owned());
                     metadata.extra_targets = table.get("extra-targets").and_then(|f| f.as_array())
-                        .and_then(|f| f.iter().map(|v| v.as_str().map(|v| v.to_owned())).collect())
-                        .unwrap_or_default();
+                        .and_then(|f| f.iter().map(|v| v.as_str().map(|v| v.to_owned())).collect());
                     metadata.rustc_args = table.get("rustc-args").and_then(|f| f.as_array())
                         .and_then(|f| f.iter().map(|v| v.as_str().map(|v| v.to_owned())).collect());
                     metadata.rustdoc_args = table.get("rustdoc-args").and_then(|f| f.as_array())

--- a/src/docbuilder/metadata.rs
+++ b/src/docbuilder/metadata.rs
@@ -130,7 +130,7 @@ impl Metadata {
         metadata
     }
     pub(super) fn select_extra_targets<'a: 'ret, 'b: 'ret, 'ret>(&'a self) -> (&'ret str, Vec<&'ret str>) {
-        use super::rustwide_builder::{DEFAULT_TARGET, TARGETS};
+        use super::rustwide_builder::{HOST_TARGET, TARGETS};
         // Let people opt-in to only having specific targets
         // Ideally this would use Iterator instead of Vec so I could collect to a `HashSet`,
         // but I had trouble with `chain()` ¯\_(ツ)_/¯
@@ -142,7 +142,7 @@ impl Metadata {
 
         // default_target unset and extra_targets set to `[]`
         let landing_page = if all_targets.is_empty() {
-            DEFAULT_TARGET
+            HOST_TARGET
         } else {
             // This `swap_remove` has to come before the `sort()` to keep the ordering
             // `swap_remove` is ok because ordering doesn't matter except for first element

--- a/src/docbuilder/metadata.rs
+++ b/src/docbuilder/metadata.rs
@@ -171,7 +171,7 @@ mod test {
 
         assert_eq!(metadata.default_target.unwrap(), "x86_64-unknown-linux-gnu".to_owned());
 
-        let extra_targets = metadata.extra_targets;
+        let extra_targets = metadata.extra_targets.expect("should have explicit extra target");
         assert_eq!(extra_targets.len(), 2);
         assert_eq!(extra_targets[0], "x86_64-apple-darwin");
         assert_eq!(extra_targets[1], "x86_64-pc-windows-msvc");
@@ -183,5 +183,33 @@ mod test {
         let rustdoc_args = metadata.rustdoc_args.unwrap();
         assert_eq!(rustdoc_args.len(), 1);
         assert_eq!(rustdoc_args[0], "--example-rustdoc-arg".to_owned());
+    }
+
+    #[test]
+    fn test_no_extra_targets() {
+        // metadata section but no extra_targets
+        let manifest = r#"
+            [package]
+            name = "test"
+
+            [package.metadata.docs.rs]
+            features = [ "feature1", "feature2" ]
+        "#;
+        let metadata = Metadata::from_str(manifest);
+        assert!(metadata.extra_targets.is_none());
+
+        // no package.metadata.docs.rs section
+        let metadata = Metadata::from_str(r#"
+            [package]
+            name = "test"
+        "#);
+        assert!(metadata.extra_targets.is_none());
+
+        // extra targets explicitly set to empty array
+        let metadata = Metadata::from_str(r#"
+            [package.metadata.docs.rs]
+            extra-targets = []
+        "#);
+        assert!(metadata.extra_targets.unwrap().is_empty());
     }
 }

--- a/src/docbuilder/metadata.rs
+++ b/src/docbuilder/metadata.rs
@@ -211,7 +211,7 @@ mod test {
 
         assert_eq!(metadata.default_target.unwrap(), "x86_64-unknown-linux-gnu".to_owned());
 
-        let targets = metadata.targets.expect("should have explicit extra target");
+        let targets = metadata.targets.expect("should have explicit target");
         assert_eq!(targets.len(), 2);
         assert_eq!(targets[0], "x86_64-apple-darwin");
         assert_eq!(targets[1], "x86_64-pc-windows-msvc");
@@ -245,7 +245,7 @@ mod test {
         "#);
         assert!(metadata.targets.is_none());
 
-        // extra targets explicitly set to empty array
+        // targets explicitly set to empty array
         let metadata = Metadata::from_str(r#"
             [package.metadata.docs.rs]
             targets = []
@@ -272,13 +272,13 @@ mod test {
             }
         }
 
-        // unchanged default_target, extra targets specified to be empty
+        // unchanged default_target, targets specified to be empty
         metadata.targets = Some(Vec::new());
         let (default, others) = metadata.targets();
         assert_eq!(default, HOST_TARGET);
         assert!(others.is_empty());
 
-        // unchanged default_target, extra targets non-empty
+        // unchanged default_target, targets non-empty
         metadata.targets = Some(vec!["i686-pc-windows-msvc".into(), "i686-apple-darwin".into()]);
         let (default, others) = metadata.targets();
         assert_eq!(default, "i686-pc-windows-msvc");

--- a/src/docbuilder/metadata.rs
+++ b/src/docbuilder/metadata.rs
@@ -316,6 +316,5 @@ mod test {
         assert_eq!(default, "i686-apple-darwin");
         let tier_one_targets_no_default: Vec<_> = TARGETS.iter().filter(|&&t| t != "i686-apple-darwin").copied().collect();
         assert_eq!(others, tier_one_targets_no_default);
-
     }
 }

--- a/src/docbuilder/metadata.rs
+++ b/src/docbuilder/metadata.rs
@@ -145,7 +145,6 @@ impl Metadata {
 
         metadata
     }
-    // Return (default_target, all other targets that should be built with duplicates removed)
     pub(super) fn targets(&self) -> BuildTargets<'_> {
         use super::rustwide_builder::{HOST_TARGET, TARGETS};
 

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -314,11 +314,13 @@ impl RustwideBuilder {
         let res = build_dir
             .build(&self.toolchain, &krate, sandbox)
             .run(|build| {
+                use docbuilder::metadata::BuildTargets;
+
                 let mut files_list = None;
                 let mut has_docs = false;
                 let mut successful_targets = Vec::new();
                 let metadata = Metadata::from_source_dir(&build.host_source_dir())?;
-                let (default_target, other_targets) = metadata.targets();
+                let BuildTargets { default_target, other_targets } = metadata.targets();
 
                 // Do an initial build and then copy the sources in the database
                 let res = self.execute_build(default_target, true, &build, &limits, &metadata)?;

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -491,7 +491,7 @@ impl RustwideBuilder {
         // However, if this is the default build, we don't want it there,
         // we want it in `target/doc`.
         if target != HOST_TARGET && is_default_target {
-            // mv target/target/doc target/doc
+            // mv target/$target/doc target/doc
             let target_dir = build.host_target_dir();
             let old_dir = target_dir.join(target).join("doc");
             let new_dir = target_dir.join("doc");

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -342,8 +342,18 @@ impl RustwideBuilder {
                     )?;
 
                     successful_targets.push(res.target.clone());
+
+                    // this is a breaking change, don't enable it by default
+                    let build_specific = std::env::var("DOCS_RS_BUILD_ONLY_SPECIFIED_TARGETS")
+                        .map(|s| s == "true").unwrap_or(false);
+                    let strs: Vec<_>;
+                    let targets: &[&str] = if build_specific {
+                        strs = metadata.extra_targets.iter().map(|s| s.as_str()).collect();
+                        &strs
+                    } else { TARGETS };
+
                     // Then build the documentation for all the targets
-                    for target in TARGETS {
+                    for target in targets {
                         if *target == res.target {
                             continue;
                         }

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -318,7 +318,7 @@ impl RustwideBuilder {
                 let mut has_docs = false;
                 let mut successful_targets = Vec::new();
                 let metadata = Metadata::from_source_dir(&build.host_source_dir())?;
-                let (default_target, other_targets) = metadata.select_extra_targets();
+                let (default_target, other_targets) = metadata.targets();
 
                 // Do an initial build and then copy the sources in the database
                 let res = self.execute_build(default_target, true, &build, &limits, &metadata)?;

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -365,13 +365,13 @@ impl RustwideBuilder {
                     };
 
                     // Then build the documentation for all the targets
-                    for target in targets {
-                        if *target == res.target {
+                    for &target in targets {
+                        if target == res.target {
                             continue;
                         }
-                        debug!("building package {} {} for {}", name, version, &target);
+                        debug!("building package {} {} for {}", name, version, target);
                         self.build_target(
-                            &target,
+                            target,
                             &build,
                             &limits,
                             &local_storage.path(),

--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -162,10 +162,16 @@ no-default-features = true
 # - i686-pc-windows-msvc
 default-target = "x86_64-unknown-linux-gnu"
 
-# Targets to build in addition to `default-target` (default: all tier 1 targets)
+# Targets to build (default: all tier 1 targets)
+#
 # Same available targets as `default-target`.
 # Set this to `[]` to only build the default target.
-extra-targets = [ "x86_64-apple-darwin", "x86_64-pc-windows-msvc" ]
+#
+# If `default-target` is unset, the first element of `targets` is treated as the default target.
+# Otherwise, these `targets` are built in addition to the default target.
+# If both `default-target` and `targets` are unset,
+#   all tier-one targets will be built and `x86_64-unknown-linux-gnu` will be used as the default target.
+targets = [ "x86_64-apple-darwin", "x86_64-pc-windows-msvc" ]
 
 # Additional `RUSTFLAGS` to set (default: none)
 rustc-args = [ "--example-rustc-arg" ]

--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -162,6 +162,9 @@ no-default-features = true
 # - i686-pc-windows-msvc
 default-target = "x86_64-unknown-linux-gnu"
 
+# Extra targets to build, same available targets as `default-target` (default: none)
+extra-targets = [ "x86_64-apple-darwin", "x86_64-pc-windows-msvc" ]
+
 # Additional `RUSTFLAGS` to set (default: none)
 rustc-args = [ "--example-rustc-arg" ]
 

--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -162,7 +162,10 @@ no-default-features = true
 # - i686-pc-windows-msvc
 default-target = "x86_64-unknown-linux-gnu"
 
-# Extra targets to build, same available targets as `default-target` (default: none)
+# Targets to build in addition to `default-target` (default: all tier 1 targets)
+# Same available targets as `default-target`.
+# If not specified, builds all tier 1 targets.
+# Set this to `[]` to only build the default target.
 extra-targets = [ "x86_64-apple-darwin", "x86_64-pc-windows-msvc" ]
 
 # Additional `RUSTFLAGS` to set (default: none)

--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -164,7 +164,6 @@ default-target = "x86_64-unknown-linux-gnu"
 
 # Targets to build in addition to `default-target` (default: all tier 1 targets)
 # Same available targets as `default-target`.
-# If not specified, builds all tier 1 targets.
 # Set this to `[]` to only build the default target.
 extra-targets = [ "x86_64-apple-darwin", "x86_64-pc-windows-msvc" ]
 


### PR DESCRIPTION
Based off of #532, but backwards compatible.

Closes #627.

Motivation: If crates are only built on one target, I'd be much more comfortable raising limits on a case-by-case basis (e.g. #608, #616). I would also be more comfortable adding more targets (i.e. not tier 1: #563), since specifying those targets would require setting `extra-targets` and thereby opting out of all others.

~~Waiting on me to test that this actually works since we don't have unit tests for builds.~~ Done.

- [x] Can build from a clean cache (no `.rustwide-docker` directory)
- [x] Can add essential files (`build add-essential-files`)
- [x] Does not pass `--target` for proc-macros (and in general, for the default build unless `default-target` is explicitly set) (`build crate rstest 0.4.0`, testing for https://github.com/rust-lang/docs.rs/issues/422)
- [x] Builds for cross-compiled targets work
- [x] Builds for host target work
- [x] `targets` behaves as documented (I only tested `targets = ["x86_64-pc-windows-msvc"]` and unset `default-target`; others are tested with unit tests)
- [x] Passing a duplicate `default-target` still only builds the default target once