### PR TITLE
Allow non-tier-one targets to be built

### DIFF
--- a/.github/ISSUE_TEMPLATE/sandbox-limits-increase-request.md
+++ b/.github/ISSUE_TEMPLATE/sandbox-limits-increase-request.md
@@ -16,5 +16,6 @@ assignees: ''
 
 **Requested RAM limit:**
 **Requested timeout:**
+**Requested number of targets:**
 
 **Why your crate needs the resource increases:**

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -296,6 +296,17 @@ fn migrate_inner(version: Option<Version>, conn: &Connection, apply_mode: ApplyM
             "ALTER TABLE releases ALTER COLUMN default_target DROP NOT NULL;
              ALTER TABLE releases ALTER COLUMN default_target DROP DEFAULT",
         ),
+        migration!(
+            context,
+            // version
+            9,
+            // description
+            "Allow max number of targets to be overriden",
+            // upgrade query
+            "ALTER TABLE sandbox_overrides ADD COLUMN targets INT;",
+            // downgrade query
+            "ALTER TABLE sandbox_overrides DROP COLUMN targets;"
+        ),
     ];
 
     for migration in migrations {

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -303,9 +303,9 @@ fn migrate_inner(version: Option<Version>, conn: &Connection, apply_mode: ApplyM
             // description
             "Allow max number of targets to be overriden",
             // upgrade query
-            "ALTER TABLE sandbox_overrides ADD COLUMN targets INT;",
+            "ALTER TABLE sandbox_overrides ADD COLUMN max_targets INT;",
             // downgrade query
-            "ALTER TABLE sandbox_overrides DROP COLUMN targets;"
+            "ALTER TABLE sandbox_overrides DROP COLUMN max_targets;"
         ),
     ];
 

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -354,7 +354,8 @@ impl RustwideBuilder {
                     successful_targets.push(res.target.clone());
 
                     // Then build the documentation for all the targets
-                    for target in other_targets {
+                    // Limit the number of targets so that no one can try to build all 200000 possible targets
+                    for target in other_targets.into_iter().take(limits.targets()) {
                         debug!("building package {} {} for {}", name, version, target);
                         self.build_target(
                             target,

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -130,6 +130,9 @@ impl RustwideBuilder {
         //
         // Removing it beforehand works fine, and prevents rustup from blocking the update later in
         // the method.
+        //
+        // Note that this means that non tier-one targets will be uninstalled on every update,
+        // and will not be reinstalled until explicitly requested by a crate.
         for target in installed_targets {
             if !targets_to_install.remove(&target) {
                 self.toolchain.remove_target(&self.workspace, &target)?;
@@ -453,6 +456,11 @@ impl RustwideBuilder {
         }
         let mut cargo_args = vec!["doc".to_owned(), "--lib".to_owned(), "--no-deps".to_owned()];
         if target != HOST_TARGET {
+            // If the explicit target is not a tier one target, we need to install it.
+            if !TARGETS.contains(&target) {
+                // This is a no-op if the target is already installed.
+                self.toolchain.add_target(&self.workspace, target)?;
+            }
             cargo_args.push("--target".to_owned());
             cargo_args.push(target.to_owned());
         };

--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -153,18 +153,20 @@ no-default-features = true
 
 # Target to test build on, used as the default landing page (default: "x86_64-unknown-linux-gnu")
 #
-# Available targets:
+# Any target supported by rustup can be used.
+default-target = "x86_64-unknown-linux-gnu"
+
+# Targets to build (default: see below)
+#
+# Any target supported by rustup can be used.
+#
+# Default targets:
 # - x86_64-unknown-linux-gnu
 # - x86_64-apple-darwin
 # - x86_64-pc-windows-msvc
 # - i686-unknown-linux-gnu
-# - i686-apple-darwin
 # - i686-pc-windows-msvc
-default-target = "x86_64-unknown-linux-gnu"
-
-# Targets to build (default: all tier 1 targets)
 #
-# Same available targets as `default-target`.
 # Set this to `[]` to only build the default target.
 #
 # If `default-target` is unset, the first element of `targets` is treated as the default target.


### PR DESCRIPTION
Closes #563.
~~Waiting on #632.~~ Merged.

This uses rustup to install toolchains if they are not already installed. These toolchains will be removed on the next toolchain update, and will be downloaded again on request.

~~Only the last few commits are related to #563, all others are from #632.~~