### PR TITLE
Change layout to fix missing scrollbar highlighting (chromium) Attempt 2

### DIFF
--- a/templates/style.scss
+++ b/templates/style.scss
@@ -84,15 +84,6 @@ div.rustdoc {
             }
         }
     }
-
-    // this is actual fix for docs.rs navigation and rustdoc sidebar
-    position: fixed;
-    top: $top-navbar-height;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    display: block;
-    overflow-y: auto;
 }
 
 body {
@@ -810,4 +801,17 @@ div.search-page-search-form {
 i.dependencies.normal {
   visibility: hidden;
   display: none;
+}
+
+// Fix position of theme-picker
+.theme-picker {
+    margin-top: $top-navbar-height;
+}
+
+// Fix for anchors, so that they are well positioned right below the sticky header
+.section-header::before {
+    display: block;
+    content: "";
+    height: 3rem;
+    margin-top: -3rem;
 }


### PR DESCRIPTION
See the previous PR (#635 ) for more insights. However this PR includes a fix for the broken anchors, which is now fixed. <sub>The solution was borrowed from the bootstrap css framework. thanks.</sub>