### PR TITLE
Don't add newlines after code snippets in headers

### DIFF
--- a/templates/style.scss
+++ b/templates/style.scss
@@ -813,6 +813,6 @@ i.dependencies.normal {
 }
 
 /* Don't put a newline after code fragments in headers */
-h3 > code {
-  display: inline;
+h3 > code, h4 > code {
+  display: inline-block;
 }

--- a/templates/style.scss
+++ b/templates/style.scss
@@ -811,3 +811,8 @@ i.dependencies.normal {
   visibility: hidden;
   display: none;
 }
+
+/* Don't put a newline after code fragments in headers */
+h3 > code {
+  display: inline;
+}


### PR DESCRIPTION
Fixes the very odd behavior on https://docs.rs/crate/winapi/0.3.8

Closes https://github.com/rust-lang/docs.rs/issues/645

r? @GuillaumeGomez 