### PR TITLE
Add tests for limits

### DIFF
--- a/src/docbuilder/limits.rs
+++ b/src/docbuilder/limits.rs
@@ -104,7 +104,7 @@ fn scale(value: usize, interval: usize, labels: &[&str]) -> String {
     // 2.x
     let mut value = format!("{:.1}", value);
     // 2.0 -> 2
-    if &value[value.len() - 1..] == "0" {
+    if value.ends_with(".0") {
         value.truncate(value.len() - 2);
     }
     format!("{} {}", value, chosen_label)

--- a/src/docbuilder/limits.rs
+++ b/src/docbuilder/limits.rs
@@ -101,7 +101,13 @@ fn scale(value: usize, interval: usize, labels: &[&str]) -> String {
             break;
         }
     }
-    format!("{} {}", value.round() as usize, chosen_label)
+    // 2.x
+    let mut value = format!("{:.1}", value);
+    // 2.0 -> 2
+    if &value[value.len() - 1..] == "0" {
+        value.truncate(value.len() - 2);
+    }
+    format!("{} {}", value, chosen_label)
 }
 
 #[cfg(test)]
@@ -170,5 +176,13 @@ mod test {
         assert_eq!(SIZE_SCALE(1073741824), "1 GB");
         assert_eq!(SIZE_SCALE(10737418240), "10 GB");
         assert_eq!(SIZE_SCALE(std::u32::MAX as usize), "4 GB");
+
+        // fractional sizes
+        assert_eq!(TIME_SCALE(90), "1.5 minutes");
+        assert_eq!(TIME_SCALE(5400), "1.5 hours");
+
+        assert_eq!(SIZE_SCALE(1288490189), "1.2 GB");
+        assert_eq!(SIZE_SCALE(3758096384), "3.5 GB");
+        assert_eq!(SIZE_SCALE(1048051712), "999.5 MB");
     }
 }

--- a/src/docbuilder/limits.rs
+++ b/src/docbuilder/limits.rs
@@ -136,4 +136,19 @@ mod test {
             Ok(())
         });
     }
+    #[test]
+    fn display_limits() {
+        let limits = Limits {
+            memory: 102400,
+            timeout: Duration::from_secs(300),
+            targets: 1,
+            ..Limits::default()
+        };
+        let display = limits.for_website();
+        assert_eq!(display.get("Network access".into()), Some(&"blocked".into()));
+        assert_eq!(display.get("Maximum size of a build log".into()), Some(&"100 KB".into()));
+        assert_eq!(display.get("Maximum number of build targets".into()), Some(&limits.targets.to_string()));
+        assert_eq!(display.get("Maximum rustdoc execution time".into()), Some(&"5 minutes".into()));
+        assert_eq!(display.get("Available RAM".into()), Some(&"100 KB".into()));
+    }
 }


### PR DESCRIPTION
We had a queue backup this morning because the builder would panic whenever a crate had limits set (https://github.com/rust-lang/docs.rs/pull/648, https://docs.rs/releases/queue). This adds tests so that doesn't happen again.

r? @kvrhdn 