### PR TITLE
Reduce memory usage when uploading files by a factor of 11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,11 +141,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -335,7 +330,6 @@ dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "magic 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "params 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1032,24 +1026,6 @@ dependencies = [
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "magic"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "magic-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "magic-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "markup5ever"
@@ -3198,7 +3174,6 @@ dependencies = [
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
@@ -3294,8 +3269,6 @@ dependencies = [
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum mac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-"checksum magic 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96f74caec41a12630bb8fd9546530a41addb720eb0c10593855f59ce96a779aa"
-"checksum magic-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17442cc60e34d501588c95bc976da04b6a87c51ab02370e95e1c2893a52df16c"
 "checksum markup5ever 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aae38d669396ca9b707bfc3db254bc382ddb94f57cc5c235f34623a669a01dab"
 "checksum markup5ever 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfedc97d5a503e96816d10fedcd5b42f760b2e525ce2f7ec71f6a41780548475"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ prometheus = { version = "0.7.0", default-features = false }
 lazy_static = "1.0.0"
 rustwide = "0.5.0"
 tempdir = "0.3"
+mime_guess = "2"
 
 # iron dependencies
 iron = "0.5"
@@ -48,11 +49,9 @@ staticfile = { version = "0.4", features = [ "cache" ] }
 
 [target.'cfg(not(windows))'.dependencies]
 libc = "0.2"
-magic = "0.12"
 
 [target.'cfg(windows)'.dependencies]
 path-slash = "0.1.1"
-mime_guess = "2.0.1"
 
 [dependencies.postgres]
 version = "0.15"

--- a/src/db/file.rs
+++ b/src/db/file.rs
@@ -197,7 +197,7 @@ pub fn add_path_into_database<P: AsRef<Path>>(conn: &Connection,
                 futures.push(client.put_object(PutObjectRequest {
                     bucket: S3_BUCKET_NAME.into(),
                     key: bucket_path.clone(),
-                    body: Some(content.clone().into()),
+                    body: Some(content.into()),
                     content_type: Some(mime.to_owned()),
                     ..Default::default()
                 }).inspect(|_| {

--- a/src/db/file.rs
+++ b/src/db/file.rs
@@ -355,21 +355,21 @@ mod test {
     }
     #[test]
     fn test_mime_types() {
-        check_mime("/ignored", ".gitignore", "text/plain");
-        check_mime("[package]", "hello.toml","text/toml");
-        check_mime(".ok { color:red; }", "hello.css","text/css");
-        check_mime("var x = 1", "hello.js","application/javascript");
-        check_mime("<html>", "hello.html","text/html");
-        check_mime("## HELLO", "hello.hello.md","text/markdown");
-        check_mime("## WORLD", "hello.markdown","text/markdown");
-        check_mime("{}", "hello.json","application/json");
-        check_mime("hello world", "hello.txt","text/plain");
-        check_mime("//! Simple module to ...", "file.rs", "text/rust");
-        check_mime("<svg></svg>", "important.svg", "image/svg+xml");
+        check_mime(".gitignore", "text/plain");
+        check_mime("hello.toml","text/toml");
+        check_mime("hello.css","text/css");
+        check_mime("hello.js","application/javascript");
+        check_mime("hello.html","text/html");
+        check_mime("hello.hello.md","text/markdown");
+        check_mime("hello.markdown","text/markdown");
+        check_mime("hello.json","application/json");
+        check_mime("hello.txt","text/plain");
+        check_mime("file.rs", "text/rust");
+        check_mime("important.svg", "image/svg+xml");
     }
 
-    fn check_mime(content: &str, path: &str, expected_mime: &str) {
-        let detected_mime = detect_mime(&content.as_bytes().to_vec(), Path::new(&path));
+    fn check_mime(path: &str, expected_mime: &str) {
+        let detected_mime = detect_mime(Path::new(&path));
         let detected_mime = detected_mime.expect("no mime was given");
         assert_eq!(detected_mime, expected_mime);
     }

--- a/src/db/file.rs
+++ b/src/db/file.rs
@@ -191,7 +191,7 @@ pub fn add_path_into_database<P: AsRef<Path>>(conn: &Connection,
             #[cfg(not(windows))]
             let bucket_path = bucket_path.into_os_string().into_string().unwrap();
 
-            let mime = detect_mime(&content, &file_path)?;
+            let mime = detect_mime(&file_path)?;
 
             if let Some(client) = &client {
                 futures.push(client.put_object(PutObjectRequest {
@@ -254,7 +254,7 @@ pub fn add_path_into_database<P: AsRef<Path>>(conn: &Connection,
     file_list_to_json(file_list_with_mimes)
 }
 
-fn detect_mime(_content: &Vec<u8>, file_path: &Path) -> Result<String> {
+fn detect_mime(file_path: &Path) -> Result<String> {
     let mime = mime_guess::from_path(file_path).first_raw().map(|m| m).unwrap_or("text/plain");
     correct_mime(&mime, &file_path)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,16 +39,13 @@ extern crate tokio;
 extern crate systemstat;
 extern crate rustwide;
 extern crate tempdir;
+extern crate mime_guess;
 
-#[cfg(not(windows))]
-extern crate magic;
 #[cfg(not(windows))]
 extern crate libc;
 
 #[cfg(windows)]
 extern crate path_slash;
-#[cfg(windows)]
-extern crate mime_guess;
 
 #[cfg(test)]
 extern crate once_cell;


### PR DESCRIPTION
Addresses #658. ~~A future PR could reduce usage by a further factor of 2 by removing unnecessary `clone()`s in the upload code.~~ Done.

This uses the Rust mime_guess package instead libmagic.
Most work was already done in https://github.com/rust-lang/docs.rs/pull/600.
This just sets mime_guess to build unconditionally instead of only on Windows.

This improves the memory usage of docs.rs by over a factor of 5 when
uploading files in some cases. This can be tested locally like so:

Run minio in the background:
```
docker run -p 9000:9000 -e MINIO_ACCESS_KEY=password -e MINIO_SECRET_KEY=password minio/minio server /data
```

Navigate to localhost:9000/ and add a new bucket called `rust-docs-rs`.

Now in another terminal, run docs.rs. This assumes you already have the
CRATESFYI_DATABASE_URL set up locally as described in
[developing without docker-compose](https://forge.rust-lang.org/docs-rs/no-docker-compose.html):

```
 # set up a fairly large file
mkdir -p ignored/tmp
yes | head -n $((1024 * 1024 * 50)) > ignored/tmp/100MB

git checkout master
cargo build --release
RUST_LOG=cratesfyi,info S3_ENDPOINT=http://localhost:9000 AWS_ACCESS_KEY_ID=password AWS_SECRET_ACCESS_KEY=password valgrind --tool=massif --massif-out-file=libmagic.massif.out target/release/cratesfyi database add-directory ignored/tmp/
 # this will show ~1.5 GB used, depending on your system
ms_print libmagic.massif.out | less

 # now try without libmagic
git checkout druid
cargo build --release
RUST_LOG=cratesfyi,info S3_ENDPOINT=http://localhost:9000 AWS_ACCESS_KEY_ID=password AWS_SECRET_ACCESS_KEY=password valgrind --tool=massif --massif-out-file=no_libmagic.massif.out target/release/cratesfyi database add-directory ignored/tmp/
 # this will show ~250 MB used, depending on your system
ms_print no_libmagic.massif.out | less
```

cc @Zexbe 

r? @Mark-Simulacrum 