### PR TITLE
Refactored the badges crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ env_logger = "0.7"
 r2d2 = "0.8"
 r2d2_postgres = "0.14"
 url = "1.4"
-badge = { version = "0", path = "src/web/badge" }
+badge = { path = "src/web/badge" }
 failure = "0.1.3"
 comrak = { version = "0.3", default-features = false }
 toml = "0.5"

--- a/src/web/badge/Cargo.toml
+++ b/src/web/badge/Cargo.toml
@@ -6,9 +6,7 @@ authors = ["Onur Aslan <onur@onur.im>"]
 license-file = "LICENSE"
 repository = "https://github.com/rust-lang/docs.rs"
 documentation = "https://docs.rs/badge"
-
-[lib]
-path = "badge.rs"
+edition = "2018"
 
 [dependencies]
 base64 = "0.9.0"

--- a/src/web/badge/src/lib.rs
+++ b/src/web/badge/src/lib.rs
@@ -1,17 +1,10 @@
 //! Simple badge generator
 
-extern crate base64;
-extern crate rusttype;
-
-
 use base64::display::Base64Display;
-use rusttype::{Font, FontCollection, Scale, point, Point, PositionedGlyph};
+use rusttype::{point, Font, FontCollection, Point, PositionedGlyph, Scale};
 
-
-const FONT_DATA: &'static [u8] = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"),
-                                                        "/DejaVuSans.ttf"));
-const FONT_SIZE: f32 = 11.;
-
+const FONT_DATA: &[u8] = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/DejaVuSans.ttf"));
+const FONT_SIZE: f32 = 11.0;
 
 pub struct BadgeOptions {
     /// Subject will be displayed on the left side of badge
@@ -21,7 +14,6 @@ pub struct BadgeOptions {
     /// HTML color of badge
     pub color: String,
 }
-
 
 impl Default for BadgeOptions {
     fn default() -> BadgeOptions {
@@ -33,7 +25,6 @@ impl Default for BadgeOptions {
     }
 }
 
-
 pub struct Badge {
     options: BadgeOptions,
     font: Font<'static>,
@@ -41,87 +32,89 @@ pub struct Badge {
     offset: Point<f32>,
 }
 
-
 impl Badge {
     pub fn new(options: BadgeOptions) -> Result<Badge, String> {
         let collection = FontCollection::from_bytes(FONT_DATA).expect("Failed to parse FONT_DATA");
+
         // this should never fail in practice
-        let font = collection.into_font().map_err(|_| "Failed to load font data".to_owned())?;
+        let font = collection
+            .into_font()
+            .map_err(|_| "Failed to load font data".to_owned())?;
+
         let scale = Scale {
             x: FONT_SIZE,
             y: FONT_SIZE,
         };
+
         let v_metrics = font.v_metrics(scale);
         let offset = point(0.0, v_metrics.ascent);
+
         if options.status.is_empty() || options.subject.is_empty() {
             return Err(String::from("status and subject must not be empty"));
         }
+
         Ok(Badge {
-            options: options,
-            font: font,
-            scale: scale,
-            offset: offset,
+            options,
+            font,
+            scale,
+            offset,
         })
     }
 
-
     pub fn to_svg_data_uri(&self) -> String {
-        format!("data:image/svg+xml;base64,{}",
-            Base64Display::standard(self.to_svg().as_bytes()))
+        format!(
+            "data:image/svg+xml;base64,{}",
+            Base64Display::standard(self.to_svg().as_bytes())
+        )
     }
-
 
     pub fn to_svg(&self) -> String {
         let left_width = self.calculate_width(&self.options.subject) + 6;
         let right_width = self.calculate_width(&self.options.status) + 6;
 
-        let svg = format!(r###"<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{}" height="20">
-  <linearGradient id="smooth" x2="0" y2="100%">
-    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
-    <stop offset="1" stop-opacity=".1"/>
-  </linearGradient>
+        let svg = format!(
+            r##"<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{badge_width}" height="20">
+              <linearGradient id="smooth" x2="0" y2="100%">
+                <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+                <stop offset="1" stop-opacity=".1"/>
+              </linearGradient>
 
-  <mask id="round">
-    <rect width="{}" height="20" rx="3" fill="#fff"/>
-  </mask>
+              <mask id="round">
+                <rect width="{badge_width}" height="20" rx="3" fill="#fff"/>
+              </mask>
 
-  <g mask="url(#round)">
-    <rect width="{}" height="20" fill="#555"/>
-    <rect x="{}" width="{}" height="20" fill="{}"/>
-    <rect width="{}" height="20" fill="url(#smooth)"/>
-  </g>
+              <g mask="url(#round)">
+                <rect width="{left_width}" height="20" fill="#555"/>
+                <rect x="{left_width}" width="{right_width}" height="20" fill="{color}"/>
+                <rect width="{badge_width}" height="20" fill="url(#smooth)"/>
+              </g>
 
-  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-    <text x="{}" y="15" fill="#010101" fill-opacity=".3">{}</text>
-    <text x="{}" y="14">{}</text>
-    <text x="{}" y="15" fill="#010101" fill-opacity=".3">{}</text>
-    <text x="{}" y="14">{}</text>
-  </g>
-</svg>"###,
-            left_width + right_width,
-            left_width + right_width,
-            left_width,
-            left_width,
-            right_width,
-            self.options.color,
-            left_width + right_width,
-            (left_width) / 2,
-            self.options.subject,
-            (left_width) / 2,
-            self.options.subject,
-            left_width + (right_width / 2),
-            self.options.status,
-            left_width + (right_width / 2),
-            self.options.status);
+              <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+                <text x="{subject_x}" y="15" fill="#010101" fill-opacity=".3">{subject}</text>
+                <text x="{subject_x}" y="14">{subject}</text>
+                <text x="{status_x}" y="15" fill="#010101" fill-opacity=".3">{status}</text>
+                <text x="{status_x}" y="14">{status}</text>
+              </g>
+            </svg>"##,
+            badge_width = left_width + right_width,
+            left_width = left_width,
+            right_width = right_width,
+            color = self.options.color,
+            subject_x = left_width / 2,
+            subject = self.options.subject,
+            status_x = left_width + (right_width / 2),
+            status = self.options.status
+        );
 
         svg
     }
 
-
     fn calculate_width(&self, text: &str) -> u32 {
         let glyphs: Vec<PositionedGlyph> =
             self.font.layout(text, self.scale, self.offset).collect();
-        let width: u32 = glyphs.iter()
+
+        let width: u32 = glyphs
+            .iter()
             .rev()
             .filter_map(|g| {
                 g.pixel_bounding_box()
@@ -130,11 +123,10 @@ impl Badge {
             .next()
             .unwrap_or(0.0)
             .ceil() as u32;
+
         width + ((text.len() as u32 - 1) * 2)
     }
 }
-
-
 
 #[cfg(test)]
 mod tests {
@@ -144,7 +136,6 @@ mod tests {
         BadgeOptions::default()
     }
 
-
     #[test]
     fn test_new() {
         assert!(Badge::new(options()).is_ok());
@@ -152,7 +143,7 @@ mod tests {
         let mut bad_options_status = options();
         bad_options_status.status = "".to_owned();
         assert!(Badge::new(bad_options_status).is_err());
-        
+
         let mut bad_options_subject = options();
         bad_options_subject.subject = "".to_owned();
         assert!(Badge::new(bad_options_subject).is_err());
@@ -161,22 +152,28 @@ mod tests {
     #[test]
     fn test_calculate_width() {
         let badge = Badge::new(options()).unwrap();
+
         assert_eq!(badge.calculate_width("build"), 31);
         assert_eq!(badge.calculate_width("passing"), 48);
     }
 
     #[test]
-    #[ignore]
     fn test_to_svg() {
-        use std::fs::File;
-        use std::io::Write;
-        let mut file = File::create("test.svg").unwrap();
+        const TEST_BADGE: &str =
+            include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/test_badge.svg"));
+
         let options = BadgeOptions {
-            subject: "build".to_owned(),
-            status: "passing".to_owned(),
-            ..BadgeOptions::default()
+            subject: "docs".to_owned(),
+            status: "0.5.3".to_owned(),
+            color: "#4d76ae".to_owned(),
         };
         let badge = Badge::new(options).unwrap();
-        file.write_all(badge.to_svg().as_bytes()).unwrap();
+
+        // I don't like this any more than you do, but the alternative is making sure that
+        // both svgs match, space for space and newline for newline
+        assert_eq!(
+            badge.to_svg().split_whitespace().collect::<String>(),
+            TEST_BADGE.split_whitespace().collect::<String>()
+        );
     }
 }

--- a/src/web/badge/test_badge.svg
+++ b/src/web/badge/test_badge.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" 
+    xmlns:xlink="http://www.w3.org/1999/xlink" width="73" height="20">
+    <linearGradient id="smooth" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+
+    <mask id="round">
+        <rect width="73" height="20" rx="3" fill="#fff"/>
+    </mask>
+
+    <g mask="url(#round)">
+        <rect width="34" height="20" fill="#555"/>
+        <rect x="34" width="39" height="20" fill="#4d76ae"/>
+        <rect width="73" height="20" fill="url(#smooth)"/>
+    </g>
+
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="17" y="15" fill="#010101" fill-opacity=".3">docs</text>
+        <text x="17" y="14">docs</text>
+        <text x="53" y="15" fill="#010101" fill-opacity=".3">0.5.3</text>
+        <text x="53" y="14">0.5.3</text>
+    </g>
+</svg>


### PR DESCRIPTION
* Basic formatting and style changes
  * Reworked the `format!` call in `Badge::to_svg` to use named parameters for less confusion
* Removed the ignored `version` parameter for the badges crate from the main Cargo.toml
* Reworked badges into a standard crate layout
  * Renamed `badge.rs` to `lib.rs` and moved it into the `/src` directory
  * Removed the `[lib]` label from badge's Cargo.toml
* Upgraded the badges crate to the 2018 edition of Rust
* Reworked and unignored the `test_to_svg` test, no longer writes to disk and compares against a known good badge
* Added `test_badge.svg` as a known good baseline svg