### PR TITLE
Updated the GitHub Actions script to include caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,28 @@ jobs:
         with:
           fetch-depth: 2
 
+      # Caching
+      - name: Cache Cargo Registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache Cargo Bin
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-bin-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache Cargo Git
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache Cargo Build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install stable Rust
         run: rustup update stable && rustup default stable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Install stable Rust
+        run: rustup update stable && rustup default stable
+
+      - name: Set rustc version
+        run: echo "::set-env name=CURRENT_RUSTC_VERSION::$(rustc -V)"
+
       # Caching
       - name: Cache Cargo Registry
         uses: actions/cache@v1
@@ -36,12 +42,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ steps.rustc.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-build-target-${{ CURRENT_RUSTC_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
           restore-key: |
-            ${{ runner.os }}-cargo-build-target-${{ steps.rustc.outputs.version }}-
-
-      - name: Install stable Rust
-        run: rustup update stable && rustup default stable
+            ${{ runner.os }}-cargo-build-target-${{ CURRENT_RUSTC_VERSION }}-
 
       - name: Install PostgreSQL
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ CURRENT_RUSTC_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-build-target-${{ env.CURRENT_RUSTC_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
           restore-key: |
-            ${{ runner.os }}-cargo-build-target-${{ CURRENT_RUSTC_VERSION }}-
+            ${{ runner.os }}-cargo-build-target-${{ env.CURRENT_RUSTC_VERSION }}-
 
       - name: Install PostgreSQL
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-build-target-${{ steps.rustc.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-key: |
+            ${{ runner.os }}-cargo-build-target-${{ steps.rustc.outputs.version }}-
 
       - name: Install stable Rust
         run: rustup update stable && rustup default stable


### PR DESCRIPTION
* Added caching to the Actions flow
  * Caches the cargo registry at `~/.cargo/registry`
  * Caches cargo binaries at `~/.cargo/bin`
  * Caches cargo git at `~/.cargo/git`
  * Caches `/target` build artifacts
  * Caches based off of the hash of the Cargo.lock, so changes that alter it will require full rebuilds
  * Will hopefully provide faster CI build/test times