### PR TITLE
Add a dependency audit to the CI flow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,18 @@
+name: Audit
+
+on:
+  push:
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* Adds a dependency audit to the CI
  * Dependencies audited against the [rustsec](https://rustsec.org/) database using [cargo-audit](https://github.com/RustSec/cargo-audit)
  * Runs on pushes that modify the Cargo.toml or Cargo.lock (Not needed on pushes that don't change these, will help speed things up
  * Runs on its own once per day