### PR TITLE
attempt to look up crates with -/_ replaced before 404ing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ dependencies = [
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2_postgres 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ features = [ "with-time", "with-rustc-serialize" ]
 once_cell = "1.2.0"
 kuchiki = "0.8"
 criterion = "0.3"
+rand = "0.7.3"
 
 [[bench]]
 name = "html5ever"

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -4,31 +4,6 @@ use crate::error::Result as CratesfyiResult;
 use postgres::{transaction::Transaction, Connection, Error as PostgresError};
 use schemamama::{Migration, Migrator, Version};
 use schemamama_postgres::{PostgresAdapter, PostgresMigration};
-use std::borrow::Cow;
-
-#[derive(Copy, Clone)]
-enum ApplyMode {
-    Permanent,
-    #[cfg(test)]
-    Temporary,
-}
-
-#[derive(Copy, Clone)]
-struct MigrationContext {
-    apply_mode: ApplyMode,
-}
-
-impl MigrationContext {
-    fn format_query<'a>(&self, query: &'a str) -> Cow<'a, str> {
-        match self.apply_mode {
-            ApplyMode::Permanent => Cow::Borrowed(query),
-            #[cfg(test)]
-            ApplyMode::Temporary => {
-                Cow::Owned(query.replace("CREATE TABLE", "CREATE TEMPORARY TABLE"))
-            }
-        }
-    }
-}
 
 /// Creates a new PostgresMigration from upgrade and downgrade queries.
 /// Downgrade query should return database to previous state.
@@ -43,9 +18,7 @@ impl MigrationContext {
 /// ```
 macro_rules! migration {
     ($context:expr, $version:expr, $description:expr, $up:expr, $down:expr $(,)?) => {{
-        struct Amigration {
-            ctx: MigrationContext,
-        };
+        struct Amigration;
         impl Migration for Amigration {
             fn version(&self) -> Version {
                 $version
@@ -61,9 +34,7 @@ macro_rules! migration {
                     self.version(),
                     self.description()
                 );
-                transaction
-                    .batch_execute(&self.ctx.format_query($up))
-                    .map(|_| ())
+                transaction.batch_execute($up).map(|_| ())
             }
             fn down(&self, transaction: &Transaction) -> Result<(), PostgresError> {
                 info!(
@@ -71,35 +42,16 @@ macro_rules! migration {
                     self.version(),
                     self.description()
                 );
-                transaction
-                    .batch_execute(&self.ctx.format_query($down))
-                    .map(|_| ())
+                transaction.batch_execute($down).map(|_| ())
             }
         }
-        Box::new(Amigration { ctx: $context })
+        Box::new(Amigration)
     }};
 }
 
 pub fn migrate(version: Option<Version>, conn: &Connection) -> CratesfyiResult<()> {
-    migrate_inner(version, conn, ApplyMode::Permanent)
-}
-
-#[cfg(test)]
-pub fn migrate_temporary(version: Option<Version>, conn: &Connection) -> CratesfyiResult<()> {
-    migrate_inner(version, conn, ApplyMode::Temporary)
-}
-
-fn migrate_inner(
-    version: Option<Version>,
-    conn: &Connection,
-    apply_mode: ApplyMode,
-) -> CratesfyiResult<()> {
-    let context = MigrationContext { apply_mode };
-
     conn.execute(
-        &context.format_query(
-            "CREATE TABLE IF NOT EXISTS database_versions (version BIGINT PRIMARY KEY);",
-        ),
+        "CREATE TABLE IF NOT EXISTS database_versions (version BIGINT PRIMARY KEY);",
         &[],
     )?;
     let adapter = PostgresAdapter::with_metadata_table(conn, "database_versions");

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -6,8 +6,6 @@ pub(crate) use self::add_package::CratesIoData;
 pub use self::delete_crate::delete_crate;
 pub use self::file::{add_path_into_database, move_to_s3};
 pub use self::migrate::migrate;
-#[cfg(test)]
-pub(crate) use self::migrate::migrate_temporary;
 
 use postgres::error::Error;
 use postgres::{Connection, TlsMode};

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -2,7 +2,7 @@ use super::error::Nope;
 use super::page::Page;
 use super::pool::Pool;
 use super::{
-    duration_to_str, match_version, redirect_base, render_markdown, MatchVersion, MetaData,
+    duration_to_str, match_version, redirect_base, render_markdown, MatchSemver, MetaData,
 };
 use iron::prelude::*;
 use iron::{status, Url};
@@ -299,8 +299,8 @@ pub fn crate_details_handler(req: &mut Request) -> IronResult<Response> {
 
     let conn = extension!(req, Pool).get();
 
-    match match_version(&conn, &name, req_version) {
-        MatchVersion::Exact((version, _)) => {
+    match match_version(&conn, &name, req_version).and_then(|m| m.assume_exact()) {
+        Some(MatchSemver::Exact((version, _))) => {
             let details = CrateDetails::new(&conn, &name, &version);
 
             Page::new(details)
@@ -309,14 +309,14 @@ pub fn crate_details_handler(req: &mut Request) -> IronResult<Response> {
                 .set_true("package_navigation_crate_tab")
                 .to_resp("crate_details")
         }
-        MatchVersion::Semver((version, _)) => {
+        Some(MatchSemver::Semver((version, _))) => {
             let url = ctry!(Url::parse(
                 &format!("{}/crate/{}/{}", redirect_base(req), name, version)[..]
             ));
 
             Ok(super::redirect(url))
         }
-        MatchVersion::None => Err(IronError::new(Nope::CrateNotFound, status::NotFound)),
+        None => Err(IronError::new(Nope::CrateNotFound, status::NotFound)),
     }
 }
 

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -533,7 +533,9 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
             // since we never pass a version into `match_version` here, we'll never get
             // `MatchVersion::Exact`, so the distinction between `Exact` and `Semver` doesn't
             // matter
-            if let Some((version, id)) = match_version(&conn, &query, None).into_option() {
+            if let Some(matchver) = match_version(&conn, &query, None) {
+                let (version, id) = matchver.version.into_parts();
+                let query = matchver.corrected_name.unwrap_or_else(|| query.to_string());
                 // FIXME: This is a super dirty way to check if crate have rustdocs generated.
                 //        match_version should handle this instead of this code block.
                 //        This block is introduced to fix #163


### PR DESCRIPTION
- attempt to look up crates with -/_ replaced before 404ing
- Add tests for mismatched -/_ handling
- Normalize crate name in database and handle mixed -/_ separators

fixes #105
closes #348
