### PR TITLE
Attempt to retain current location when loading a different platform

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -euv
 
 export CRATESFYI_PREFIX=/opt/docsrs/prefix
 export DOCS_RS_DOCKER=true
-export RUST_LOG=cratesfyi,rustwide=info
+export RUST_LOG=${RUST_LOG-cratesfyi,rustwide=info}
 export PATH="$PATH:/build/target/release"
 
 # Try migrating the database multiple times if it fails

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -310,6 +310,21 @@ pub fn migrate(version: Option<Version>, conn: &Connection) -> CratesfyiResult<(
             // downgrade query
             "DROP TABLE crate_priorities;",
         ),
+        migration!(
+            context,
+            // version
+            12,
+            // description
+            "Mark doc_targets non-nullable (it has a default of empty array anyway)",
+            // upgrade query
+            "
+                ALTER TABLE releases ALTER COLUMN doc_targets SET NOT NULL;
+            ",
+            // downgrade query
+            "
+                ALTER TABLE releases ALTER COLUMN doc_targets DROP NOT NULL;
+            "
+        ),
     ];
 
     for migration in migrations {

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -97,7 +97,13 @@ impl<'a> FakeRelease<'a> {
     }
 
     pub(crate) fn default_target(mut self, target: &'a str) -> Self {
+        self = self.add_target(target);
         self.default_target = Some(target);
+        self
+    }
+
+    pub(crate) fn add_target(mut self, target: &str) -> Self {
+        self.doc_targets.push(target.into());
         self
     }
 

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -118,9 +118,11 @@ impl<'a> FakeRelease<'a> {
     }
 
     pub(crate) fn add_platform<S: Into<String>>(mut self, platform: S) -> Self {
+        let platform = platform.into();
         let name = self.package.targets[0].name.clone();
-        let target = Target::dummy_lib(name, Some(platform.into()));
+        let target = Target::dummy_lib(name, Some(platform.clone()));
         self.package.targets.push(target);
+        self.doc_targets.push(platform);
         self
     }
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -93,6 +93,8 @@ pub(crate) struct TestEnvironment {
 
 impl TestEnvironment {
     fn new() -> Self {
+        // If this fails it's probably already initialized
+        let _ = env_logger::try_init();
         Self {
             db: OnceCell::new(),
             frontend: OnceCell::new(),

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -42,7 +42,7 @@ pub struct CrateDetails {
     github_issues: Option<i32>,
     pub(crate) metadata: MetaData,
     is_library: bool,
-    doc_targets: Option<Json>,
+    pub(crate) doc_targets: Option<Json>,
     license: Option<String>,
     documentation_url: Option<String>,
 }

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -42,7 +42,7 @@ pub struct CrateDetails {
     github_issues: Option<i32>,
     pub(crate) metadata: MetaData,
     is_library: bool,
-    doc_targets: Option<Json>,
+    pub(crate) doc_targets: Vec<String>,
     license: Option<String>,
     documentation_url: Option<String>,
 }
@@ -185,6 +185,18 @@ impl CrateDetails {
             default_target: rows.get(0).get(25),
         };
 
+        let doc_targets = {
+            let data: Json = rows.get(0).get(22);
+            data.as_array()
+                .map(|array| {
+                    array
+                        .iter()
+                        .filter_map(|item| item.as_string().map(|s| s.to_owned()))
+                        .collect()
+                })
+                .unwrap_or_else(Vec::new)
+        };
+
         let mut crate_details = CrateDetails {
             name: rows.get(0).get(2),
             version: rows.get(0).get(3),
@@ -211,7 +223,7 @@ impl CrateDetails {
             github_issues: rows.get(0).get(20),
             metadata,
             is_library: rows.get(0).get(21),
-            doc_targets: rows.get(0).get(22),
+            doc_targets,
             license: rows.get(0).get(23),
             documentation_url: rows.get(0).get(24),
         };

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -42,7 +42,7 @@ pub struct CrateDetails {
     github_issues: Option<i32>,
     pub(crate) metadata: MetaData,
     is_library: bool,
-    pub(crate) doc_targets: Option<Json>,
+    doc_targets: Option<Json>,
     license: Option<String>,
     documentation_url: Option<String>,
 }

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -87,6 +87,10 @@ pub(super) fn build_routes() -> Routes {
         "/crate/:name/:version/source/*",
         super::source::source_browser_handler,
     );
+    routes.internal_page(
+        "/crate/:name/:version/target-redirect/*",
+        super::rustdoc::target_redirect_handler,
+    );
 
     routes.rustdoc_page("/:crate", super::rustdoc::rustdoc_redirector_handler);
     routes.rustdoc_page("/:crate/", super::rustdoc::rustdoc_redirector_handler);

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -381,11 +381,6 @@ pub fn target_redirect_handler(req: &mut Request) -> IronResult<Response> {
         file_path.remove(3);
         if file_path[3] == crate_details.metadata.default_target {
             file_path.remove(3);
-        } else if file_path[4] != crate_details.target_name {
-            // For non-default targets we only redirect to paths within the current crate
-            file_path.drain(4..);
-            file_path.push(&crate_details.target_name);
-            file_path.push("index.html");
         }
         if let Some(last) = file_path.last_mut() {
             if *last == "" {
@@ -1032,6 +1027,7 @@ mod test {
                 .rustdoc_file("dummy/index.html", b"some content")
                 .rustdoc_file("dummy/struct.Dummy.html", b"some other content")
                 .rustdoc_file("dummy/struct.DefaultOnly.html", b"some otter content")
+                .rustdoc_file("x86_64-pc-windows-msvc/settings.html", b"top-level items")
                 .rustdoc_file("x86_64-pc-windows-msvc/dummy/index.html", b"some content")
                 .rustdoc_file(
                     "x86_64-pc-windows-msvc/dummy/struct.Dummy.html",
@@ -1053,7 +1049,7 @@ mod test {
                 &[
                     (
                         "x86_64-pc-windows-msvc",
-                        "/dummy/0.4.0/x86_64-pc-windows-msvc/dummy/index.html",
+                        "/dummy/0.4.0/x86_64-pc-windows-msvc/settings.html",
                     ),
                     ("x86_64-unknown-linux-gnu", "/dummy/0.4.0/settings.html"),
                 ],

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -675,6 +675,7 @@ mod test {
                 .name("dummy")
                 .version("0.1.0")
                 .add_platform("x86_64-pc-windows-msvc")
+                .rustdoc_file("dummy/struct.Blah.html", b"lah")
                 .create()
                 .unwrap();
             db.fake_release()
@@ -700,9 +701,22 @@ mod test {
                 "/dummy/0.2.0/x86_64-pc-windows-msvc/dummy/index.html"
             );
 
+            // With deleted file platform specific redirect also handles search
+            let redirect = latest_version_redirect(
+                "/dummy/0.1.0/x86_64-pc-windows-msvc/dummy/struct.Blah.html",
+                web,
+            )?;
+            assert_eq!(redirect, "/dummy/0.2.0/x86_64-pc-windows-msvc?search=Blah");
+            assert_redirect(
+                &redirect,
+                "/dummy/0.2.0/x86_64-pc-windows-msvc/dummy/?search=Blah",
+                web,
+            )?;
+
             Ok(())
         })
     }
+
     #[test]
     fn redirect_latest_goes_to_crate_if_build_failed() {
         wrapper(|env| {

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -867,6 +867,29 @@ mod test {
     }
 
     #[test]
+    fn no_target_target_redirect_404s() {
+        wrapper(|env| {
+            assert_eq!(
+                env.frontend()
+                    .get("/crate/dummy/0.1.0/target-redirect")
+                    .send()?
+                    .status(),
+                StatusCode::NOT_FOUND
+            );
+
+            assert_eq!(
+                env.frontend()
+                    .get("/crate/dummy/0.1.0/target-redirect/")
+                    .send()?
+                    .status(),
+                StatusCode::NOT_FOUND
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn platform_links_go_to_current_path() {
         fn get_platform_links(
             path: &str,

--- a/templates/navigation_rustdoc.hbs
+++ b/templates/navigation_rustdoc.hbs
@@ -104,8 +104,8 @@
             <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
               <a href="#" class="pure-menu-link" aria-label="Platform"><i class="fa fa-fw fa-gears"></i><span class="title"> Platform</span></a>
               <ul class="pure-menu-children">
-                {{#each doc_targets}}
-                <li class="pure-menu-item"><a href="/{{../../content.crate_details.name}}/{{../../content.crate_details.version}}/{{this}}/{{../../content.crate_details.target_name}}/" class="pure-menu-link">{{this}}</a></li>
+                {{#each ../content.platforms as |platform path|}}
+                  <li class="pure-menu-item"><a href="{{path}}" class="pure-menu-link">{{platform}}</a></li>
                 {{/each}}
               </ul>
             </li>

--- a/templates/navigation_rustdoc.hbs
+++ b/templates/navigation_rustdoc.hbs
@@ -104,8 +104,8 @@
             <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
               <a href="#" class="pure-menu-link" aria-label="Platform"><i class="fa fa-fw fa-gears"></i><span class="title"> Platform</span></a>
               <ul class="pure-menu-children">
-                {{#each ../content.platforms as |platform path|}}
-                  <li class="pure-menu-item"><a href="{{path}}" class="pure-menu-link">{{platform}}</a></li>
+                {{#each doc_targets}}
+                  <li class="pure-menu-item"><a href="/crate/{{../../content.crate_details.name}}/{{../../content.crate_details.version}}/target-redirect/{{this}}/{{../../varss.inner_path}}" class="pure-menu-link">{{this}}</a></li>
                 {{/each}}
               </ul>
             </li>


### PR DESCRIPTION
For each target platform, if the current location exists within that platform then generate a link directly to it. Otherwise link to the root of the crate in that platform like normal.

fixes #24
