### PR TITLE
Improve search functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,6 @@ jobs:
           sleep 5
           # Make sure the database is actually working
           psql "${CRATESFYI_DATABASE_URL}"
-          psql "${CRATESFYI_DATABASE_URL}" -c "CREATE EXTENSION IF NOT EXISTS fuzzystrsearch"
-
-      - name: Build docs.rs
-        run: cargo build --locked
 
       - name: Run rustfmt
         run: cargo fmt -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           sleep 5
           # Make sure the database is actually working
           psql "${CRATESFYI_DATABASE_URL}"
-          sudo -u postgres psql -c "CREATE EXTENSION IF NOT EXISTS fuzzystrsearch"
+          psql "${CRATESFYI_DATABASE_URL}" -c "CREATE EXTENSION IF NOT EXISTS fuzzystrsearch"
 
       - name: Build docs.rs
         run: cargo build --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 ---
-
 on: [push, pull_request]
 name: CI
 
@@ -59,6 +58,10 @@ jobs:
           sleep 5
           # Make sure the database is actually working
           psql "${CRATESFYI_DATABASE_URL}"
+          sudo -u postgres psql -c "CREATE EXTENSION IF NOT EXISTS fuzzystrsearch"
+
+      - name: Build docs.rs
+        run: cargo build --locked
 
       - name: Run rustfmt
         run: cargo fmt -- --check
@@ -79,7 +82,6 @@ jobs:
     name: Docker
     runs-on: ubuntu-latest
     steps:
-
       - uses: actions/checkout@master
         with:
           fetch-depth: 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
     web:
         build: .
@@ -20,7 +20,9 @@ services:
         env_file:
             - .env
     db:
-        image: postgres:alpine
+        build:
+            context: .
+            dockerfile: ./postgres/Dockerfile
         volumes:
             - postgres-data:/var/lib/postgresql/data
         environment:

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,0 +1,4 @@
+FROM postgres:alpine
+EXPOSE 5432
+
+COPY ./postgres/install_extensions.sql /docker-entrypoint-initdb.d/

--- a/postgres/install_extensions.sql
+++ b/postgres/install_extensions.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -330,19 +330,11 @@ pub fn migrate(version: Option<Version>, conn: &Connection) -> CratesfyiResult<(
             // version
             13,
             // description
-            "Add string searching",
+            "Add fuzzy string searching",
             // upgrade query
-            "DO $$ BEGIN
-                IF (SELECT COUNT(*) FROM pg_extension WHERE extname = 'fuzzystrmatch') = 0 THEN
-                    CREATE EXTENSION fuzzystrmatch;
-                END IF;
-            END $$;",
+            "CREATE EXTENSION IF NOT EXISTS fuzzystrmatch",
             // downgrade query
-            "DO $$ BEGIN
-                IF (SELECT COUNT(*) FROM pg_extension WHERE extname = 'fuzzystrmatch') > 0 THEN
-                    DROP EXTENSION fuzzystrmatch;
-                END IF;
-            END $$;",
+            "DROP EXTENSION IF EXISTS fuzzystrmatch;",
         ),
     ];
 

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -325,6 +325,25 @@ pub fn migrate(version: Option<Version>, conn: &Connection) -> CratesfyiResult<(
                 ALTER TABLE releases ALTER COLUMN doc_targets DROP NOT NULL;
             "
         ),
+        migration!(
+            context,
+            // version
+            13,
+            // description
+            "Add string searching",
+            // upgrade query
+            "DO $$ BEGIN
+                IF (SELECT COUNT(*) FROM pg_extension WHERE extname = 'fuzzystrmatch') = 0 THEN
+                    CREATE EXTENSION fuzzystrmatch;
+                END IF;
+            END $$;",
+            // downgrade query
+            "DO $$ BEGIN
+                IF (SELECT COUNT(*) FROM pg_extension WHERE extname = 'fuzzystrmatch') > 0 THEN
+                    DROP EXTENSION fuzzystrmatch;
+                END IF;
+            END $$;",
+        ),
     ];
 
     for migration in migrations {

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -325,17 +325,6 @@ pub fn migrate(version: Option<Version>, conn: &Connection) -> CratesfyiResult<(
                 ALTER TABLE releases ALTER COLUMN doc_targets DROP NOT NULL;
             "
         ),
-        migration!(
-            context,
-            // version
-            13,
-            // description
-            "Add fuzzy string searching",
-            // upgrade query
-            "CREATE EXTENSION IF NOT EXISTS fuzzystrmatch",
-            // downgrade query
-            "DROP EXTENSION IF EXISTS fuzzystrmatch;",
-        ),
     ];
 
     for migration in migrations {

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -64,6 +64,11 @@ impl<'a> FakeRelease<'a> {
         }
     }
 
+    pub(crate) fn description(mut self, new: impl Into<String>) -> Self {
+        self.package.description = Some(new.into());
+        self
+    }
+
     pub(crate) fn name(mut self, new: &str) -> Self {
         self.package.name = new.into();
         self.package.id = format!("{}-id", new);

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -64,8 +64,18 @@ impl<'a> FakeRelease<'a> {
         }
     }
 
+    pub(crate) fn downloads(mut self, downloads: i32) -> Self {
+        self.cratesio_data.downloads = downloads;
+        self
+    }
+
     pub(crate) fn description(mut self, new: impl Into<String>) -> Self {
         self.package.description = Some(new.into());
+        self
+    }
+
+    pub(crate) fn release_time(mut self, new: time::Timespec) -> Self {
+        self.cratesio_data.release_time = new;
         self
     }
 

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -82,6 +82,7 @@ impl<'a> FakeRelease<'a> {
     }
 
     pub(crate) fn build_result_successful(mut self, new: bool) -> Self {
+        self.has_docs = new;
         self.build_result.successful = new;
         self
     }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -139,7 +139,7 @@ impl TestDatabase {
         conn.batch_execute(&format!(
             "
                 CREATE SCHEMA {0};
-                SET search_path TO {0};
+                SET search_path TO {0}, public;
             ",
             schema
         ))?;

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -769,7 +769,7 @@ mod tests {
             db.fake_release()
                 .name("regex")
                 .version("0.0.0")
-                .cratesio_data_yanked(true)
+                .yanked(true)
                 .create()?;
 
             let (num_results, results) = get_search_results(&db.conn(), "regex", 1, 100);


### PR DESCRIPTION
Closes #489, #156 and #13

* Use fuzzy searching, pattern matching and description text searching to get better search matches
* Fuzzy search gives better results and gives accurate rankings
* Description searching allows you to search for concepts as well as crates, so `serialization` will also pull up results for `serde` (With any better name matches before it)
* Also trimmed the string, so the leading/trailing whitespace thing ain't a thing