### PR TITLE
Disabled fail-fast for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,11 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    steps:
 
+    strategy:
+      fail-fast: false
+
+    steps:
       - uses: actions/checkout@master
         with:
           fetch-depth: 2


### PR DESCRIPTION
Stops the CI from stopping at the first error, allowing us to see the actual test results, even if there's a rustfmt or clippy error