### PR TITLE
Use a docker image for testing on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,23 +49,16 @@ jobs:
           restore-key: |
             ${{ runner.os }}-cargo-build-target-${{ env.CURRENT_RUSTC_VERSION }}-
 
-      - name: Prepare the test environment
-        run: |
-          prefix=$(pwd)/ignored/prefix
-          mkdir -p ${prefix}/public-html
-          echo "::set-env name=CRATESFYI_PREFIX::${prefix}"
-
       - name: Launch the postgres image
         run: |
-          touch .env
+          cp .env.sample .env
+          . .env
+          mkdir -p ${CRATESFYI_PREFIX}/public-html
           docker-compose up -d db
-          # TODO: try to avoid hard-coding this username/password
-          export CRATESFYI_DATABASE_URL="postgresql://cratesfyi:password@localhost:5432/"
-          # Make sure the database is actually working
           # Give the database enough time to start up
           sleep 5
-          psql "$CRATESFYI_DATABASE_URL"
-          echo "::set-env name=CRATESFYI_DATABASE_URL::${CRATESFYI_DATABASE_URL}"
+          # Make sure the database is actually working
+          psql "${CRATESFYI_DATABASE_URL}"
 
       - name: Run rustfmt
         run: cargo fmt -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,31 +49,38 @@ jobs:
           restore-key: |
             ${{ runner.os }}-cargo-build-target-${{ env.CURRENT_RUSTC_VERSION }}-
 
-      - name: Install PostgreSQL
-        run: |
-          sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y postgresql
-          sudo systemctl start postgresql
-          sudo -u postgres createuser $(whoami) -w
-          sudo -u postgres createdb $(whoami) -O $(whoami)
-          echo "::set-env name=CRATESFYI_DATABASE_URL::postgresql://$(whoami)@%2Fvar%2Frun%2Fpostgresql/$(whoami)"
-
-      - name: Build docs.rs
-        run: cargo build --locked
-
-      - name: Run rustfmt
-        run: cargo fmt -- --check
-
-      - name: Run clippy
-        run: cargo clippy -- -D warnings
-
       - name: Prepare the test environment
         run: |
           prefix=$(pwd)/ignored/prefix
           mkdir -p ${prefix}/public-html
           echo "::set-env name=CRATESFYI_PREFIX::${prefix}"
 
+      - name: Launch the postgres image
+        run: |
+          touch .env
+          docker-compose up -d db
+          # TODO: try to avoid hard-coding this username/password
+          export CRATESFYI_DATABASE_URL="postgresql://cratesfyi:password@localhost:5432/"
+          # Make sure the database is actually working
+          # Give the database enough time to start up
+          sleep 5
+          psql "$CRATESFYI_DATABASE_URL"
+          echo "::set-env name=CRATESFYI_DATABASE_URL::${CRATESFYI_DATABASE_URL}"
+
+      - name: Run rustfmt
+        run: cargo fmt -- --check
+
+      - name: Run clippy
+        run: cargo clippy --locked -- -D warnings
+
+      - name: Build docs.rs
+        run: cargo build --locked
+
       - name: Test docs.rs
         run: cargo test --locked -- --test-threads=1
+
+      - name: Clean up the database
+        run: docker-compose down --volumes
 
   docker:
     name: Docker

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -7,6 +7,7 @@ pub use self::delete_crate::delete_crate;
 pub use self::file::{add_path_into_database, move_to_s3};
 pub use self::migrate::migrate;
 
+use failure::Fail;
 use postgres::error::Error;
 use postgres::{Connection, TlsMode};
 use std::env;
@@ -19,8 +20,8 @@ mod migrate;
 
 /// Connects to database
 pub fn connect_db() -> Result<Connection, failure::Error> {
-    // FIXME: unwrap might not be the best here
-    let db_url = env::var("CRATESFYI_DATABASE_URL")?;
+    let err = "CRATESFYI_DATABASE_URL environment variable is not set";
+    let db_url = env::var("CRATESFYI_DATABASE_URL").map_err(|e| e.context(err))?;
     Connection::connect(&db_url[..], TlsMode::None).map_err(Into::into)
 }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -18,11 +18,10 @@ pub(crate) mod file;
 mod migrate;
 
 /// Connects to database
-pub fn connect_db() -> Result<Connection, Error> {
+pub fn connect_db() -> Result<Connection, failure::Error> {
     // FIXME: unwrap might not be the best here
-    let db_url = env::var("CRATESFYI_DATABASE_URL")
-        .expect("CRATESFYI_DATABASE_URL environment variable is not exists");
-    Connection::connect(&db_url[..], TlsMode::None)
+    let db_url = env::var("CRATESFYI_DATABASE_URL")?;
+    Connection::connect(&db_url[..], TlsMode::None).map_err(Into::into)
 }
 
 pub(crate) fn create_pool() -> r2d2::Pool<r2d2_postgres::PostgresConnectionManager> {


### PR DESCRIPTION
This makes it easier to add custom extensions to the database (e.g. for #721). It also makes sure that we're testing the same things that contributors are running. Finally, it makes it easier to test on different platforms (i.e. #621).