### PR TITLE
[WIP] Test on more platforms and channels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
             ${{ runner.os }}-cargo-build-target-${{ env.CURRENT_RUSTC_VERSION }}-
 
       - name: Launch the postgres image
+        if: contains(matrix.channel, 'stable')
         run: |
           cp .env.sample .env
           . .env
@@ -64,19 +65,29 @@ jobs:
           psql "${CRATESFYI_DATABASE_URL}"
 
       - name: Run rustfmt
+        if: contains(matrix.channel, 'stable')
         run: cargo fmt -- --check
 
       - name: Run clippy
+        if: contains(matrix.channel, 'stable')
         run: cargo clippy --locked -- -D warnings
 
       - name: Build docs.rs
+        if: contains(matrix.channel, 'stable')
         run: cargo build --locked
 
       - name: Test docs.rs
+        if: contains(matrix.channel, 'stable')
         run: cargo test --locked -- --test-threads=1
 
       - name: Clean up the database
+        if: contains(matrix.channel, 'stable')
         run: docker-compose down --volumes
+
+      # we aren't actually testing anything, just that it continues to compile
+      - name: Check docs.rs
+        if: "!contains(matrix.channel, 'stable')"
+        run: cargo check --locked
 
   docker:
     name: Docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,21 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
 
     strategy:
       fail-fast: false
+      matrix:
+        os: [ubuntu, macos, windows]
+        channel: [stable, beta, nightly]
 
     steps:
       - uses: actions/checkout@master
         with:
           fetch-depth: 2
 
-      - name: Install stable Rust
-        run: rustup update stable && rustup default stable
+      - name: Install Rust
+        run: rustup update ${{ matrix.channel }} && rustup default ${{ matrix.channel }}
 
       - name: Set rustc version
         run: echo "::set-env name=CURRENT_RUSTC_VERSION::$(rustc -V)"


### PR DESCRIPTION
Essentially the same as https://github.com/rust-lang/docs.rs/pull/724, but much simpler now that postgres is containerized. Also, this only runs `cargo check` on channels besides `stable`.

This is currently failing because `docker-compose` isn't installed on windows and mac, not sure how to do that.

r? @XAMPPRocky