### PR TITLE
Track when crates are yanked and handle yanked status better

### DIFF
--- a/src/docbuilder/queue.rs
+++ b/src/docbuilder/queue.rs
@@ -19,12 +19,26 @@ impl DocBuilder {
         // I belive this will fix ordering of queue if we get more than one crate from changes
         changes.reverse();
 
-        for krate in changes.iter().filter(|k| k.kind != ChangeKind::Yanked) {
-            let priority = get_crate_priority(&conn, &krate.name)?;
-            add_crate_to_queue(&conn, &krate.name, &krate.version, priority).ok();
+        for krate in &changes {
+            match krate.kind {
+                ChangeKind::Yanked => {
+                    // FIXME: remove built doc files? set build as failed?
+                    conn.execute(
+                        "UPDATE releases SET yanked = TRUE FROM crates WHERE \
+                                  crates.id = releases.crate_id AND name = $1 AND version = $2",
+                        &[&krate.name, &krate.version],
+                    )
+                    .ok();
+                    debug!("{}-{} yanked", krate.name, krate.version);
+                }
+                ChangeKind::Added => {
+                    let priority = get_crate_priority(&conn, &krate.name)?;
+                    add_crate_to_queue(&conn, &krate.name, &krate.version, priority).ok();
 
-            debug!("{}-{} added into build queue", krate.name, krate.version);
-            add_count += 1;
+                    debug!("{}-{} added into build queue", krate.name, krate.version);
+                    add_count += 1;
+                }
+            }
         }
 
         Ok(add_count)

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -86,7 +86,7 @@ impl<'a> FakeRelease<'a> {
         self
     }
 
-    pub(crate) fn cratesio_data_yanked(mut self, new: bool) -> Self {
+    pub(crate) fn yanked(mut self, new: bool) -> Self {
         self.cratesio_data.yanked = new;
         self
     }

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -139,54 +139,57 @@ impl<'a> FakeRelease<'a> {
         let package = self.package;
         let db = self.db;
 
-        let upload_files = |prefix: &str, files: &[(&str, &[u8])], target: Option<&str>| {
-            let mut path_prefix = tempdir.path().join(prefix);
-            if let Some(target) = target {
-                path_prefix.push(target);
-            }
-            fs::create_dir(&path_prefix)?;
-
-            for (path, data) in files {
-                // allow `src/main.rs`
-                if let Some(parent) = Path::new(path).parent() {
-                    fs::create_dir_all(path_prefix.join(parent))?;
+        let mut source_meta = None;
+        if self.build_result.successful {
+            let upload_files = |prefix: &str, files: &[(&str, &[u8])], target: Option<&str>| {
+                let mut path_prefix = tempdir.path().join(prefix);
+                if let Some(target) = target {
+                    path_prefix.push(target);
                 }
-                let file = path_prefix.join(&path);
-                log::debug!("writing file {}", file.display());
-                fs::write(file, data)?;
+                fs::create_dir(&path_prefix)?;
+
+                for (path, data) in files {
+                    // allow `src/main.rs`
+                    if let Some(parent) = Path::new(path).parent() {
+                        fs::create_dir_all(path_prefix.join(parent))?;
+                    }
+                    let file = path_prefix.join(&path);
+                    log::debug!("writing file {}", file.display());
+                    fs::write(file, data)?;
+                }
+
+                let prefix = format!(
+                    "{}/{}/{}/{}",
+                    prefix,
+                    package.name,
+                    package.version,
+                    target.unwrap_or("")
+                );
+                log::debug!("adding directory {} from {}", prefix, path_prefix.display());
+                crate::db::add_path_into_database(&db.conn(), &prefix, path_prefix)
+            };
+
+            let index = [&package.name, "index.html"].join("/");
+            let mut rustdoc_files = self.rustdoc_files;
+            if package.is_library() && !rustdoc_files.iter().any(|(path, _)| path == &index) {
+                rustdoc_files.push((&index, b"default index content"));
             }
-
-            let prefix = format!(
-                "{}/{}/{}/{}",
-                prefix,
-                package.name,
-                package.version,
-                target.unwrap_or("")
-            );
-            log::debug!("adding directory {} from {}", prefix, path_prefix.display());
-            crate::db::add_path_into_database(&db.conn(), &prefix, path_prefix)
-        };
-
-        let index = [&package.name, "index.html"].join("/");
-        let mut rustdoc_files = self.rustdoc_files;
-        if package.is_library() && !rustdoc_files.iter().any(|(path, _)| path == &index) {
-            rustdoc_files.push((&index, b"default index content"));
-        }
-        for (source_path, data) in &self.source_files {
-            if source_path.starts_with("src/") {
-                let updated = ["src", &package.name, &source_path[4..]].join("/");
-                rustdoc_files.push((Box::leak(Box::new(updated)), data));
+            for (source_path, data) in &self.source_files {
+                if source_path.starts_with("src/") {
+                    let updated = ["src", &package.name, &source_path[4..]].join("/");
+                    rustdoc_files.push((Box::leak(Box::new(updated)), data));
+                }
             }
-        }
-        let rustdoc_meta = upload_files("rustdoc", &rustdoc_files, None)?;
-        log::debug!("added rustdoc files {}", rustdoc_meta);
-        let source_meta = upload_files("source", &self.source_files, None)?;
-        log::debug!("added source files {}", source_meta);
+            let rustdoc_meta = upload_files("rustdoc", &rustdoc_files, None)?;
+            log::debug!("added rustdoc files {}", rustdoc_meta);
+            source_meta = Some(upload_files("source", &self.source_files, None)?);
+            log::debug!("added source files {}", source_meta.as_ref().unwrap());
 
-        for target in &package.targets[1..] {
-            let platform = target.src_path.as_ref().unwrap();
-            upload_files("rustdoc", &rustdoc_files, Some(platform))?;
-            log::debug!("added platform files for {}", platform);
+            for target in &package.targets[1..] {
+                let platform = target.src_path.as_ref().unwrap();
+                upload_files("rustdoc", &rustdoc_files, Some(platform))?;
+                log::debug!("added platform files for {}", platform);
+            }
         }
 
         let release_id = crate::db::add_package_into_database(
@@ -195,7 +198,7 @@ impl<'a> FakeRelease<'a> {
             tempdir.path(),
             &self.build_result,
             self.default_target.unwrap_or("x86_64-unknown-linux-gnu"),
-            Some(source_meta),
+            source_meta,
             self.doc_targets,
             &self.cratesio_data,
             self.has_docs,

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -527,14 +527,10 @@ mod tests {
             db.fake_release().name("foo").version("0.0.3").create()?;
             db.fake_release().name("foo").version("0.0.2").create()?;
 
-            let details = CrateDetails::new(&db.conn(), "foo", "0.0.1").unwrap();
-            assert_eq!(details.latest_release().version, "0.0.3");
-
-            let details = CrateDetails::new(&db.conn(), "foo", "0.0.2").unwrap();
-            assert_eq!(details.latest_release().version, "0.0.3");
-
-            let details = CrateDetails::new(&db.conn(), "foo", "0.0.3").unwrap();
-            assert_eq!(details.latest_release().version, "0.0.3");
+            for version in &["0.0.1", "0.0.2", "0.0.3"] {
+                let details = CrateDetails::new(&db.conn(), "foo", version).unwrap();
+                assert_eq!(details.latest_release().version, "0.0.3");
+            }
 
             Ok(())
         })
@@ -553,14 +549,10 @@ mod tests {
                 .create()?;
             db.fake_release().name("foo").version("0.0.2").create()?;
 
-            let details = CrateDetails::new(&db.conn(), "foo", "0.0.1").unwrap();
-            assert_eq!(details.latest_release().version, "0.0.2");
-
-            let details = CrateDetails::new(&db.conn(), "foo", "0.0.2").unwrap();
-            assert_eq!(details.latest_release().version, "0.0.2");
-
-            let details = CrateDetails::new(&db.conn(), "foo", "0.0.3").unwrap();
-            assert_eq!(details.latest_release().version, "0.0.2");
+            for version in &["0.0.1", "0.0.2", "0.0.3"] {
+                let details = CrateDetails::new(&db.conn(), "foo", version).unwrap();
+                assert_eq!(details.latest_release().version, "0.0.2");
+            }
 
             Ok(())
         })
@@ -587,14 +579,10 @@ mod tests {
                 .cratesio_data_yanked(true)
                 .create()?;
 
-            let details = CrateDetails::new(&db.conn(), "foo", "0.0.1").unwrap();
-            assert_eq!(details.latest_release().version, "0.0.3");
-
-            let details = CrateDetails::new(&db.conn(), "foo", "0.0.2").unwrap();
-            assert_eq!(details.latest_release().version, "0.0.3");
-
-            let details = CrateDetails::new(&db.conn(), "foo", "0.0.3").unwrap();
-            assert_eq!(details.latest_release().version, "0.0.3");
+            for version in &["0.0.1", "0.0.2", "0.0.3"] {
+                let details = CrateDetails::new(&db.conn(), "foo", version).unwrap();
+                assert_eq!(details.latest_release().version, "0.0.3");
+            }
 
             Ok(())
         })

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -375,13 +375,13 @@ mod tests {
             db.fake_release()
                 .name("foo")
                 .version("0.0.4")
-                .cratesio_data_yanked(true)
+                .yanked(true)
                 .create()?;
             db.fake_release()
                 .name("foo")
                 .version("0.0.5")
                 .build_result_successful(false)
-                .cratesio_data_yanked(true)
+                .yanked(true)
                 .create()?;
 
             assert_last_successful_build_equals(&db, "foo", "0.0.1", None)?;
@@ -411,7 +411,7 @@ mod tests {
             db.fake_release()
                 .name("foo")
                 .version("0.0.3")
-                .cratesio_data_yanked(true)
+                .yanked(true)
                 .create()?;
 
             assert_last_successful_build_equals(&db, "foo", "0.0.1", None)?;
@@ -435,7 +435,7 @@ mod tests {
             db.fake_release()
                 .name("foo")
                 .version("0.0.3")
-                .cratesio_data_yanked(true)
+                .yanked(true)
                 .create()?;
             db.fake_release().name("foo").version("0.0.4").create()?;
 
@@ -465,7 +465,7 @@ mod tests {
             db.fake_release()
                 .name("foo")
                 .version("0.2.0")
-                .cratesio_data_yanked(true)
+                .yanked(true)
                 .create()?;
             db.fake_release()
                 .name("foo")
@@ -545,7 +545,7 @@ mod tests {
             db.fake_release()
                 .name("foo")
                 .version("0.0.3")
-                .cratesio_data_yanked(true)
+                .yanked(true)
                 .create()?;
             db.fake_release().name("foo").version("0.0.2").create()?;
 
@@ -566,17 +566,17 @@ mod tests {
             db.fake_release()
                 .name("foo")
                 .version("0.0.1")
-                .cratesio_data_yanked(true)
+                .yanked(true)
                 .create()?;
             db.fake_release()
                 .name("foo")
                 .version("0.0.3")
-                .cratesio_data_yanked(true)
+                .yanked(true)
                 .create()?;
             db.fake_release()
                 .name("foo")
                 .version("0.0.2")
-                .cratesio_data_yanked(true)
+                .yanked(true)
                 .create()?;
 
             for version in &["0.0.1", "0.0.2", "0.0.3"] {

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -107,6 +107,7 @@ impl ToJson for Release {
         let mut m: BTreeMap<String, Json> = BTreeMap::new();
         m.insert("version".to_string(), self.version.to_json());
         m.insert("build_status".to_string(), self.build_status.to_json());
+        m.insert("yanked".to_string(), self.yanked.to_json());
         m.to_json()
     }
 }

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -96,10 +96,10 @@ impl ToJson for CrateDetails {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-struct Release {
-    version: String,
-    build_status: bool,
-    yanked: bool,
+pub struct Release {
+    pub version: String,
+    pub build_status: bool,
+    pub yanked: bool,
 }
 
 impl ToJson for Release {
@@ -276,15 +276,13 @@ impl CrateDetails {
         Some(crate_details)
     }
 
-    /// Returns the version of the latest non-yanked release of this crate (or latest yanked if
-    /// they are all yanked).
-    pub fn latest_version(&self) -> &str {
-        let release = self
-            .releases
+    /// Returns the latest non-yanked release of this crate (or latest yanked if they are all
+    /// yanked).
+    pub fn latest_release(&self) -> &Release {
+        self.releases
             .iter()
             .find(|release| !release.yanked)
-            .unwrap_or(&self.releases[0]);
-        &release.version
+            .unwrap_or(&self.releases[0])
     }
 }
 
@@ -530,13 +528,13 @@ mod tests {
             db.fake_release().name("foo").version("0.0.2").create()?;
 
             let details = CrateDetails::new(&db.conn(), "foo", "0.0.1").unwrap();
-            assert_eq!(details.latest_version(), "0.0.3");
+            assert_eq!(details.latest_release().version, "0.0.3");
 
             let details = CrateDetails::new(&db.conn(), "foo", "0.0.2").unwrap();
-            assert_eq!(details.latest_version(), "0.0.3");
+            assert_eq!(details.latest_release().version, "0.0.3");
 
             let details = CrateDetails::new(&db.conn(), "foo", "0.0.3").unwrap();
-            assert_eq!(details.latest_version(), "0.0.3");
+            assert_eq!(details.latest_release().version, "0.0.3");
 
             Ok(())
         })
@@ -556,13 +554,13 @@ mod tests {
             db.fake_release().name("foo").version("0.0.2").create()?;
 
             let details = CrateDetails::new(&db.conn(), "foo", "0.0.1").unwrap();
-            assert_eq!(details.latest_version(), "0.0.2");
+            assert_eq!(details.latest_release().version, "0.0.2");
 
             let details = CrateDetails::new(&db.conn(), "foo", "0.0.2").unwrap();
-            assert_eq!(details.latest_version(), "0.0.2");
+            assert_eq!(details.latest_release().version, "0.0.2");
 
             let details = CrateDetails::new(&db.conn(), "foo", "0.0.3").unwrap();
-            assert_eq!(details.latest_version(), "0.0.2");
+            assert_eq!(details.latest_release().version, "0.0.2");
 
             Ok(())
         })
@@ -590,13 +588,13 @@ mod tests {
                 .create()?;
 
             let details = CrateDetails::new(&db.conn(), "foo", "0.0.1").unwrap();
-            assert_eq!(details.latest_version(), "0.0.3");
+            assert_eq!(details.latest_release().version, "0.0.3");
 
             let details = CrateDetails::new(&db.conn(), "foo", "0.0.2").unwrap();
-            assert_eq!(details.latest_version(), "0.0.3");
+            assert_eq!(details.latest_release().version, "0.0.3");
 
             let details = CrateDetails::new(&db.conn(), "foo", "0.0.3").unwrap();
-            assert_eq!(details.latest_version(), "0.0.3");
+            assert_eq!(details.latest_release().version, "0.0.3");
 
             Ok(())
         })

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -40,6 +40,7 @@ pub struct CrateDetails {
     github_issues: Option<i32>,
     pub(crate) metadata: MetaData,
     is_library: bool,
+    yanked: bool,
     pub(crate) doc_targets: Vec<String>,
     license: Option<String>,
     documentation_url: Option<String>,
@@ -83,6 +84,7 @@ impl ToJson for CrateDetails {
         m.insert("github_issues".to_string(), self.github_issues.to_json());
         m.insert("metadata".to_string(), self.metadata.to_json());
         m.insert("is_library".to_string(), self.is_library.to_json());
+        m.insert("yanked".to_string(), self.yanked.to_json());
         m.insert("doc_targets".to_string(), self.doc_targets.to_json());
         m.insert("license".to_string(), self.license.to_json());
         m.insert(
@@ -134,6 +136,7 @@ impl CrateDetails {
                 crates.github_forks,
                 crates.github_issues,
                 releases.is_library,
+                releases.yanked,
                 releases.doc_targets,
                 releases.license,
                 releases.documentation_url,
@@ -180,11 +183,11 @@ impl CrateDetails {
             description: rows.get(0).get(4),
             rustdoc_status: rows.get(0).get(11),
             target_name: rows.get(0).get(16),
-            default_target: rows.get(0).get(25),
+            default_target: rows.get(0).get(26),
         };
 
         let doc_targets = {
-            let data: Json = rows.get(0).get(22);
+            let data: Json = rows.get(0).get(23);
             data.as_array()
                 .map(|array| {
                     array
@@ -221,9 +224,10 @@ impl CrateDetails {
             github_issues: rows.get(0).get(20),
             metadata,
             is_library: rows.get(0).get(21),
+            yanked: rows.get(0).get(22),
             doc_targets,
-            license: rows.get(0).get(23),
-            documentation_url: rows.get(0).get(24),
+            license: rows.get(0).get(24),
+            documentation_url: rows.get(0).get(25),
         };
 
         if let Some(repository_url) = crate_details.repository_url.clone() {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -266,7 +266,7 @@ fn match_version(conn: &Connection, name: &str, version: Option<&str>) -> Option
     let versions: Vec<(String, i32, bool)> = {
         let query = "SELECT name, version, releases.id, releases.yanked
             FROM releases INNER JOIN crates ON releases.crate_id = crates.id
-            WHERE normalize_crate_name(name) = normalize_crate_name($1) AND yanked = false";
+            WHERE normalize_crate_name(name) = normalize_crate_name($1)";
 
         let rows = conn.query(query, &[&name]).unwrap();
         let mut rows = rows.iter().peekable();

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -799,8 +799,46 @@ mod test {
             let redirect = latest_version_redirect("/dummy/0.1.0/dummy/", web)?;
             assert_eq!(redirect, "/dummy/0.2.0/dummy/index.html");
 
-            let redirect = try_latest_version_redirect("/dummy/0.2.0/dummy/", web)?;
-            assert!(redirect.is_none());
+            let redirect = latest_version_redirect("/dummy/0.2.1/dummy/", web)?;
+            assert_eq!(redirect, "/dummy/0.2.0/dummy/index.html");
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn redirect_latest_with_all_yanked() {
+        wrapper(|env| {
+            let db = env.db();
+            db.fake_release()
+                .name("dummy")
+                .version("0.1.0")
+                .rustdoc_file("dummy/index.html", b"lah")
+                .cratesio_data_yanked(true)
+                .create()
+                .unwrap();
+            db.fake_release()
+                .name("dummy")
+                .version("0.2.0")
+                .rustdoc_file("dummy/index.html", b"lah")
+                .cratesio_data_yanked(true)
+                .create()
+                .unwrap();
+            db.fake_release()
+                .name("dummy")
+                .version("0.2.1")
+                .rustdoc_file("dummy/index.html", b"lah")
+                .cratesio_data_yanked(true)
+                .create()
+                .unwrap();
+
+            let web = env.frontend();
+            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/", web)?;
+            assert_eq!(redirect, "/dummy/0.2.1/dummy/index.html");
+
+            let redirect = latest_version_redirect("/dummy/0.2.0/dummy/", web)?;
+            assert_eq!(redirect, "/dummy/0.2.1/dummy/index.html");
+
             Ok(())
         })
     }

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -714,14 +714,12 @@ mod test {
                 .version("0.1.0")
                 .add_platform("x86_64-pc-windows-msvc")
                 .rustdoc_file("dummy/struct.Blah.html", b"lah")
-                .create()
-                .unwrap();
+                .create()?;
             db.fake_release()
                 .name("dummy")
                 .version("0.2.0")
                 .add_platform("x86_64-pc-windows-msvc")
-                .create()
-                .unwrap();
+                .create()?;
 
             let web = env.frontend();
 
@@ -763,14 +761,12 @@ mod test {
                 .name("dummy")
                 .version("0.1.0")
                 .rustdoc_file("dummy/index.html", b"lah")
-                .create()
-                .unwrap();
+                .create()?;
             db.fake_release()
                 .name("dummy")
                 .version("0.2.0")
                 .build_result_successful(false)
-                .create()
-                .unwrap();
+                .create()?;
 
             let web = env.frontend();
             let redirect = latest_version_redirect("/dummy/0.1.0/dummy/", web)?;
@@ -788,21 +784,18 @@ mod test {
                 .name("dummy")
                 .version("0.1.0")
                 .rustdoc_file("dummy/index.html", b"lah")
-                .create()
-                .unwrap();
+                .create()?;
             db.fake_release()
                 .name("dummy")
                 .version("0.2.0")
                 .rustdoc_file("dummy/index.html", b"lah")
-                .create()
-                .unwrap();
+                .create()?;
             db.fake_release()
                 .name("dummy")
                 .version("0.2.1")
                 .rustdoc_file("dummy/index.html", b"lah")
                 .cratesio_data_yanked(true)
-                .create()
-                .unwrap();
+                .create()?;
 
             let web = env.frontend();
             let redirect = latest_version_redirect("/dummy/0.1.0/dummy/", web)?;
@@ -824,22 +817,19 @@ mod test {
                 .version("0.1.0")
                 .rustdoc_file("dummy/index.html", b"lah")
                 .cratesio_data_yanked(true)
-                .create()
-                .unwrap();
+                .create()?;
             db.fake_release()
                 .name("dummy")
                 .version("0.2.0")
                 .rustdoc_file("dummy/index.html", b"lah")
                 .cratesio_data_yanked(true)
-                .create()
-                .unwrap();
+                .create()?;
             db.fake_release()
                 .name("dummy")
                 .version("0.2.1")
                 .rustdoc_file("dummy/index.html", b"lah")
                 .cratesio_data_yanked(true)
-                .create()
-                .unwrap();
+                .create()?;
 
             let web = env.frontend();
             let redirect = latest_version_redirect("/dummy/0.1.0/dummy/", web)?;
@@ -873,8 +863,7 @@ mod test {
                 .version("0.1.0")
                 .rustdoc_file("dummy/index.html", b"lah")
                 .cratesio_data_yanked(true)
-                .create()
-                .unwrap();
+                .create()?;
 
             assert!(has_yanked_warning("/dummy/0.1.0/dummy/", web)?);
 
@@ -883,8 +872,7 @@ mod test {
                 .version("0.2.0")
                 .rustdoc_file("dummy/index.html", b"lah")
                 .cratesio_data_yanked(true)
-                .create()
-                .unwrap();
+                .create()?;
 
             assert!(has_yanked_warning("/dummy/0.1.0/dummy/", web)?);
 
@@ -919,8 +907,7 @@ mod test {
                 .name("fake-crate")
                 .version("0.0.1")
                 .rustdoc_file("fake_crate/index.html", b"some content")
-                .create()
-                .unwrap();
+                .create()?;
 
             let web = env.frontend();
             assert_redirect("/fake%2Dcrate", "/fake-crate/0.0.1/fake_crate/", web)?;

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -320,15 +320,23 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
 
     content.full = file_content;
 
-    let latest_version = crate_details.latest_version().to_owned();
+    let latest_release = crate_details.latest_release();
+    let latest_version = latest_release.version.to_owned();
     let is_latest_version = latest_version == version;
 
-    let path_in_latest = if !is_latest_version {
+    let latest_path = if is_latest_version {
+        format!("/{}/{}", name, latest_version)
+    } else if latest_release.build_status {
         let mut latest_path = req_path.clone();
         latest_path[2] = &latest_version;
-        path_for_version(&latest_path, &crate_details.doc_targets, &conn)
+        format!(
+            "/{}/{}/{}",
+            name,
+            latest_version,
+            path_for_version(&latest_path, &crate_details.doc_targets, &conn)
+        )
     } else {
-        Default::default()
+        format!("/crate/{}/{}", name, latest_version)
     };
 
     // The path within this crate version's rustdoc output
@@ -349,7 +357,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
         .set_true("package_navigation_documentation_tab")
         .set_true("package_navigation_show_platforms_tab")
         .set_bool("is_latest_version", is_latest_version)
-        .set("path_in_latest", &path_in_latest)
+        .set("latest_path", &latest_path)
         .set("latest_version", &latest_version)
         .set("inner_path", &inner_path)
         .to_resp("rustdoc")
@@ -544,9 +552,10 @@ mod test {
         use html5ever::tendril::TendrilSink;
         assert_success(path, web)?;
         let data = web.get(path).send()?.text()?;
+        println!("{}", data);
         let dom = kuchiki::parse_html().one(data);
         if let Some(elem) = dom
-            .select("form ul li a.warn")
+            .select("form > ul > li > a.warn")
             .expect("invalid selector")
             .next()
         {

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -794,7 +794,7 @@ mod test {
                 .name("dummy")
                 .version("0.2.1")
                 .rustdoc_file("dummy/index.html", b"lah")
-                .cratesio_data_yanked(true)
+                .yanked(true)
                 .create()?;
 
             let web = env.frontend();
@@ -816,19 +816,19 @@ mod test {
                 .name("dummy")
                 .version("0.1.0")
                 .rustdoc_file("dummy/index.html", b"lah")
-                .cratesio_data_yanked(true)
+                .yanked(true)
                 .create()?;
             db.fake_release()
                 .name("dummy")
                 .version("0.2.0")
                 .rustdoc_file("dummy/index.html", b"lah")
-                .cratesio_data_yanked(true)
+                .yanked(true)
                 .create()?;
             db.fake_release()
                 .name("dummy")
                 .version("0.2.1")
                 .rustdoc_file("dummy/index.html", b"lah")
-                .cratesio_data_yanked(true)
+                .yanked(true)
                 .create()?;
 
             let web = env.frontend();
@@ -862,7 +862,7 @@ mod test {
                 .name("dummy")
                 .version("0.1.0")
                 .rustdoc_file("dummy/index.html", b"lah")
-                .cratesio_data_yanked(true)
+                .yanked(true)
                 .create()?;
 
             assert!(has_yanked_warning("/dummy/0.1.0/dummy/", web)?);
@@ -871,7 +871,7 @@ mod test {
                 .name("dummy")
                 .version("0.2.0")
                 .rustdoc_file("dummy/index.html", b"lah")
-                .cratesio_data_yanked(true)
+                .yanked(true)
                 .create()?;
 
             assert!(has_yanked_warning("/dummy/0.1.0/dummy/", web)?);

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -1318,4 +1318,29 @@ mod test {
             Ok(())
         });
     }
+
+    #[test]
+    fn test_fully_yanked_crate_404s() {
+        crate::test::wrapper(|env| {
+            let db = env.db();
+
+            db.fake_release()
+                .name("dummy")
+                .version("1.0.0")
+                .yanked(true)
+                .create()?;
+
+            assert_eq!(
+                env.frontend().get("/crate/dummy").send()?.status(),
+                StatusCode::NOT_FOUND
+            );
+
+            assert_eq!(
+                env.frontend().get("/dummy").send()?.status(),
+                StatusCode::NOT_FOUND
+            );
+
+            Ok(())
+        })
+    }
 }

--- a/templates/crate_details.hbs
+++ b/templates/crate_details.hbs
@@ -45,7 +45,11 @@
                 {{#each releases}}
                 <li class="pure-menu-item">
                   {{#if this.yanked}}
-                  <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link warn" title="{{../name}}-{{this.version}} is yanked"><i class="fa fa-fw fa-warning"></i> {{this.version}}</a>
+                    {{#if this.build_status}}
+                    <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link warn" title="{{../name}}-{{this.version}} is yanked"><i class="fa fa-fw fa-warning"></i> {{this.version}}</a>
+                    {{else}}
+                    <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link warn" title="{{../name}}-{{this.version}} is yanked and docs.rs failed to build it"><i class="fa fa-fw fa-warning"></i> {{this.version}}</a>
+                    {{/if}}
                   {{else}}
                     {{#if this.build_status}}
                     <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link">{{this.version}}</a>

--- a/templates/crate_details.hbs
+++ b/templates/crate_details.hbs
@@ -67,6 +67,9 @@
       {{#unless is_library}}
       <div class="warning">{{name}}-{{version}} is not a library.</div>
       {{else}}
+      {{#if yanked}}
+      <div class="warning">{{name}}-{{version}} has been yanked.</div>
+      {{else}}
       {{#unless build_status}}
       <div class="warning">docs.rs failed to build {{name}}-{{version}}<br>Please check the <a href="/crate/{{name}}/{{version}}/builds">build logs</a> and, if you believe this is docs.rs' fault, <a href="https://github.com/rust-lang/docs.rs/issues/new/choose">open an issue</a>.</div>
       {{#if last_successful_build}}
@@ -77,6 +80,7 @@
       <div class="warning">{{name}}-{{version}} doesn't have any documentation.</div>
       {{/unless}}
       {{/unless}}
+      {{/if}}
       {{/unless}}
       {{#if readme}}
         {{{readme}}}

--- a/templates/crate_details.hbs
+++ b/templates/crate_details.hbs
@@ -44,10 +44,14 @@
               <ul class="pure-menu-list">
                 {{#each releases}}
                 <li class="pure-menu-item">
-                  {{#if this.build_status}}
-                  <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link">{{this.version}}</a>
+                  {{#if this.yanked}}
+                  <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link warn" title="{{../name}}-{{this.version}} is yanked"><i class="fa fa-fw fa-warning"></i> {{this.version}}</a>
                   {{else}}
-                  <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link warn" title="docs.rs failed to build {{../name}}-{{this.version}}"><i class="fa fa-fw fa-warning"></i> {{this.version}}</a>
+                    {{#if this.build_status}}
+                    <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link">{{this.version}}</a>
+                    {{else}}
+                    <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link warn" title="docs.rs failed to build {{../name}}-{{this.version}}"><i class="fa fa-fw fa-warning"></i> {{this.version}}</a>
+                    {{/if}}
                   {{/if}}
                 </li>
                 {{/each}}

--- a/templates/navigation_rustdoc.hbs
+++ b/templates/navigation_rustdoc.hbs
@@ -79,7 +79,11 @@
                             {{#each releases}}
                             <li class="pure-menu-item">
                               {{#if this.yanked}}
-                              <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link warn" title="{{../name}}-{{this.version}} is yanked"><i class="fa fa-fw fa-warning"></i> {{this.version}}</a>
+                                {{#if this.build_status}}
+                                <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link warn" title="{{../name}}-{{this.version}} is yanked"><i class="fa fa-fw fa-warning"></i> {{this.version}}</a>
+                                {{else}}
+                                <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link warn" title="{{../name}}-{{this.version}} is yanked and docs.rs failed to build it"><i class="fa fa-fw fa-warning"></i> {{this.version}}</a>
+                                {{/if}}
                               {{else}}
                                 {{#if this.build_status}}
                                 <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link">{{this.version}}</a>

--- a/templates/navigation_rustdoc.hbs
+++ b/templates/navigation_rustdoc.hbs
@@ -93,11 +93,23 @@
                 </div>
               </div>
             </li>
-            {{#unless ../../varsb.is_latest_version}}
-            <li class="pure-menu-item">
-              <a href="/{{name}}/{{../../varss.latest_version}}/{{../../varss.path_in_latest}}" class="pure-menu-link warn" title="You are seeing an outdated version of {{name}} crate. Click here to go to latest version."><i class="fa fa-fw fa-warning"></i><span class="title"> Go to latest version</span></a>
-            </li>
-            {{/unless}}
+            {{#if ../../varsb.is_latest_version}}
+              {{#if yanked}}
+              <li class="pure-menu-item">
+                <span class="pure-menu-link warn"><i class="fa fa-fw fa-warning"></i><span class="title"> This release has been yanked</span></a>
+              </li>
+              {{/if}}
+            {{else}}
+              {{#if ../../content.crate_details.yanked}}
+              <li class="pure-menu-item">
+                <a href="/{{name}}/{{../../varss.latest_version}}/{{../../varss.path_in_latest}}" class="pure-menu-link warn" title="You are seeing a yanked version of {{name}} crate. Click here to go to latest version."><i class="fa fa-fw fa-warning"></i><span class="title"> This release has been yanked, go to latest version</span></a>
+              </li>
+              {{else}}
+              <li class="pure-menu-item">
+                <a href="/{{name}}/{{../../varss.latest_version}}/{{../../varss.path_in_latest}}" class="pure-menu-link warn" title="You are seeing an outdated version of {{name}} crate. Click here to go to latest version."><i class="fa fa-fw fa-warning"></i><span class="title"> Go to latest version</span></a>
+              </li>
+              {{/if}}
+            {{/if}}
             <li class="pure-menu-item">
               <a href="/crate/{{name}}/{{version}}/source/" title="Browse source of {{name}}-{{version}}" class="pure-menu-link{{#if ../../varsb.package_source_tab}} pure-menu-active{{/if}}"><i class="fa fa-fw fa-folder-open-o"></i><span class="title"> Source</span></a>
             </li>

--- a/templates/navigation_rustdoc.hbs
+++ b/templates/navigation_rustdoc.hbs
@@ -106,11 +106,11 @@
             {{else}}
               {{#if ../../content.crate_details.yanked}}
               <li class="pure-menu-item">
-                <a href="/{{name}}/{{../../varss.latest_version}}/{{../../varss.path_in_latest}}" class="pure-menu-link warn" title="You are seeing a yanked version of {{name}} crate. Click here to go to latest version."><i class="fa fa-fw fa-warning"></i><span class="title"> This release has been yanked, go to latest version</span></a>
+                <a href="{{../../varss.latest_path}}" class="pure-menu-link warn" title="You are seeing a yanked version of {{name}} crate. Click here to go to latest version."><i class="fa fa-fw fa-warning"></i><span class="title"> This release has been yanked, go to latest version</span></a>
               </li>
               {{else}}
               <li class="pure-menu-item">
-                <a href="/{{name}}/{{../../varss.latest_version}}/{{../../varss.path_in_latest}}" class="pure-menu-link warn" title="You are seeing an outdated version of {{name}} crate. Click here to go to latest version."><i class="fa fa-fw fa-warning"></i><span class="title"> Go to latest version</span></a>
+                <a href="{{../../varss.latest_path}}" class="pure-menu-link warn" title="You are seeing an outdated version of {{name}} crate. Click here to go to latest version."><i class="fa fa-fw fa-warning"></i><span class="title"> Go to latest version</span></a>
               </li>
               {{/if}}
             {{/if}}

--- a/templates/navigation_rustdoc.hbs
+++ b/templates/navigation_rustdoc.hbs
@@ -78,10 +78,14 @@
                           <ul class="pure-menu-list">
                             {{#each releases}}
                             <li class="pure-menu-item">
-                              {{#if this.build_status}}
-                              <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link">{{this.version}}</a>
+                              {{#if this.yanked}}
+                              <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link warn" title="{{../name}}-{{this.version}} is yanked"><i class="fa fa-fw fa-warning"></i> {{this.version}}</a>
                               {{else}}
-                              <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link warn" title="docs.rs failed to build {{../name}}-{{this.version}}"><i class="fa fa-fw fa-warning"></i> {{this.version}}</a>
+                                {{#if this.build_status}}
+                                <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link">{{this.version}}</a>
+                                {{else}}
+                                <a href="/crate/{{../name}}/{{this.version}}" class="pure-menu-link warn" title="docs.rs failed to build {{../name}}-{{this.version}}"><i class="fa fa-fw fa-warning"></i> {{this.version}}</a>
+                                {{/if}}
                               {{/if}}
                             </li>
                             {{/each}}

--- a/templates/style.scss
+++ b/templates/style.scss
@@ -160,7 +160,7 @@ div.nav-container {
         font-size: 0.8em;
     }
 
-    a {
+    .pure-menu-link {
         font-size: 0.8em;
         font-weight: 400;
     }
@@ -220,11 +220,11 @@ div.nav-container {
     }
 
     // used for latest version warning
-    .warn {
+    .warn, .warn:hover {
         color: $color-type;
     }
 
-    .warn:hover {
+    a.warn:hover {
         color: darken($color-type, 10%);
     }
 


### PR DESCRIPTION
- mark releases as yanked when a yank is detected
- show yanked status on crate details page
- don't redirect to a yanked version if it's the latest
- add test to load handlebars templates
- Don't show latest version redirect to yanked versions
- Allow loading yanked docs via exact version number
- Show yanked status in nav on rustdoc pages
- Show yanked status on crate details version list
- Show yanked status in version drop down

    
I skipped 7a57350e90b5884ec1a322731ab7b40422ec828c from #322 to avoid any conflicts with #721, it may be useful to look into rebasing that too later.
    
fixes #112, #396
closes #322

Screenshots:

nav bar when viewing latest version and all versions are yanked:
<img width="750" alt="image" src="https://user-images.githubusercontent.com/81079/80835420-06770a80-8bf3-11ea-9891-d9415333511b.png">

nav bar when there's at least one non-yanked version, or viewing non-latest version of a fully yanked crate:
<img width="843" alt="image" src="https://user-images.githubusercontent.com/81079/80835461-23134280-8bf3-11ea-92f7-73bc480bffee.png">

crate details page:
<img width="1173" alt="image" src="https://user-images.githubusercontent.com/81079/80835492-30303180-8bf3-11ea-8b00-e44e7cd88fc5.png">

crate details version list:
<img width="242" alt="image" src="https://user-images.githubusercontent.com/81079/80836204-8b165880-8bf4-11ea-9d4b-351b0fb7f729.png">

crate details nav drop-down:
<img width="352" alt="image" src="https://user-images.githubusercontent.com/81079/80836232-9e292880-8bf4-11ea-8ed8-2f02fc3da035.png">
