### PR TITLE
Use ON CONFLICT DO UPDATE

### DIFF
--- a/src/utils/github_updater.rs
+++ b/src/utils/github_updater.rs
@@ -21,15 +21,15 @@ pub fn github_updater() -> Result<()> {
     //       always the same across all versions of a crate
     for row in &conn.query(
         "SELECT DISTINCT ON (crates.name)
-                                        crates.name,
-                                        crates.id,
-                                        releases.repository_url
-                                 FROM crates
-                                 INNER JOIN releases ON releases.crate_id = crates.id
-                                 WHERE releases.repository_url ~ '^https*://github.com' AND
-                                       (crates.github_last_update < NOW() - INTERVAL '1 day' OR
-                                        crates.github_last_update IS NULL)
-                                 ORDER BY crates.name, releases.release_time DESC",
+                crates.name,
+                crates.id,
+                releases.repository_url
+         FROM crates
+         INNER JOIN releases ON releases.crate_id = crates.id
+         WHERE releases.repository_url ~ '^https*://github.com' AND
+               (crates.github_last_update < NOW() - INTERVAL '1 day' OR
+                crates.github_last_update IS NULL)
+         ORDER BY crates.name, releases.release_time DESC",
         &[],
     )? {
         let crate_name: String = row.get(0);
@@ -42,10 +42,10 @@ pub fn github_updater() -> Result<()> {
             .and_then(|fields| {
                 conn.execute(
                     "UPDATE crates
-                              SET github_description = $1,
-                                  github_stars = $2, github_forks = $3,
-                                  github_issues = $4, github_last_commit = $5,
-                                  github_last_update = NOW() WHERE id = $6",
+                     SET github_description = $1,
+                         github_stars = $2, github_forks = $3,
+                         github_issues = $4, github_last_commit = $5,
+                         github_last_update = NOW() WHERE id = $6",
                     &[
                         &fields.description,
                         &(fields.stars as i32),

--- a/src/utils/github_updater.rs
+++ b/src/utils/github_updater.rs
@@ -26,7 +26,7 @@ pub fn github_updater() -> Result<()> {
                 releases.repository_url
          FROM crates
          INNER JOIN releases ON releases.crate_id = crates.id
-         WHERE releases.repository_url ~ '^https*://github.com' AND
+         WHERE releases.repository_url ~ '^https?://github.com' AND
                (crates.github_last_update < NOW() - INTERVAL '1 day' OR
                 crates.github_last_update IS NULL)
          ORDER BY crates.name, releases.release_time DESC",

--- a/src/utils/github_updater.rs
+++ b/src/utils/github_updater.rs
@@ -45,7 +45,8 @@ pub fn github_updater() -> Result<()> {
                      SET github_description = $1,
                          github_stars = $2, github_forks = $3,
                          github_issues = $4, github_last_commit = $5,
-                         github_last_update = NOW() WHERE id = $6",
+                         github_last_update = NOW()
+                     WHERE id = $6",
                     &[
                         &fields.description,
                         &(fields.stars as i32),

--- a/src/utils/release_activity_updater.rs
+++ b/src/utils/release_activity_updater.rs
@@ -61,15 +61,11 @@ pub fn update_release_activity() -> Result<()> {
     };
 
     conn.query(
-        "INSERT INTO config (name, value) VALUES ('release_activity', $1)",
+        "INSERT INTO config (name, value) VALUES ('release_activity', $1)
+         ON CONFLICT (name)
+            SET value = $1 WHERE name = 'release_activity'",
         &[&map],
-    )
-    .or_else(|_| {
-        conn.query(
-            "UPDATE config SET value = $1 WHERE name = 'release_activity'",
-            &[&map],
-        )
-    })?;
+    )?;
 
     Ok(())
 }

--- a/src/utils/release_activity_updater.rs
+++ b/src/utils/release_activity_updater.rs
@@ -62,8 +62,8 @@ pub fn update_release_activity() -> Result<()> {
 
     conn.query(
         "INSERT INTO config (name, value) VALUES ('release_activity', $1)
-         ON CONFLICT (name)
-            SET value = $1 WHERE name = 'release_activity'",
+         ON CONFLICT (name) DO UPDATE
+            SET value = $1 WHERE config.name = 'release_activity'",
         &[&map],
     )?;
 

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -74,21 +74,21 @@ pub fn build_list_handler(req: &mut Request) -> IronResult<Response> {
     // FIXME: getting builds.output may cause performance issues when release have tons of builds
     for row in &ctry!(conn.query(
         "SELECT crates.name,
-                                         releases.version,
-                                         releases.description,
-                                         releases.rustdoc_status,
-                                         releases.target_name,
-                                         builds.id,
-                                         builds.rustc_version,
-                                         builds.cratesfyi_version,
-                                         builds.build_status,
-                                         builds.build_time,
-                                         builds.output
-                                  FROM builds
-                                  INNER JOIN releases ON releases.id = builds.rid
-                                  INNER JOIN crates ON releases.crate_id = crates.id
-                                  WHERE crates.name = $1 AND releases.version = $2
-                                  ORDER BY id DESC",
+                releases.version,
+                releases.description,
+                releases.rustdoc_status,
+                releases.target_name,
+                builds.id,
+                builds.rustc_version,
+                builds.cratesfyi_version,
+                builds.build_status,
+                builds.build_time,
+                builds.output
+         FROM builds
+         INNER JOIN releases ON releases.id = builds.rid
+         INNER JOIN crates ON releases.crate_id = crates.id
+         WHERE crates.name = $1 AND releases.version = $2
+         ORDER BY id DESC",
         &[&name, &version]
     )) {
         let id: i32 = row.get(5);

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -113,34 +113,34 @@ impl CrateDetails {
     pub fn new(conn: &Connection, name: &str, version: &str) -> Option<CrateDetails> {
         // get all stuff, I love you rustfmt
         let query = "SELECT crates.id,
-                            releases.id,
-                            crates.name,
-                            releases.version,
-                            releases.description,
-                            releases.authors,
-                            releases.dependencies,
-                            releases.readme,
-                            releases.description_long,
-                            releases.release_time,
-                            releases.build_status,
-                            releases.rustdoc_status,
-                            releases.repository_url,
-                            releases.homepage_url,
-                            releases.keywords,
-                            releases.have_examples,
-                            releases.target_name,
-                            crates.versions,
-                            crates.github_stars,
-                            crates.github_forks,
-                            crates.github_issues,
-                            releases.is_library,
-                            releases.doc_targets,
-                            releases.license,
-                            releases.documentation_url,
-                            releases.default_target
-                     FROM releases
-                     INNER JOIN crates ON releases.crate_id = crates.id
-                     WHERE crates.name = $1 AND releases.version = $2;";
+                releases.id,
+                crates.name,
+                releases.version,
+                releases.description,
+                releases.authors,
+                releases.dependencies,
+                releases.readme,
+                releases.description_long,
+                releases.release_time,
+                releases.build_status,
+                releases.rustdoc_status,
+                releases.repository_url,
+                releases.homepage_url,
+                releases.keywords,
+                releases.have_examples,
+                releases.target_name,
+                crates.versions,
+                crates.github_stars,
+                crates.github_forks,
+                crates.github_issues,
+                releases.is_library,
+                releases.doc_targets,
+                releases.license,
+                releases.documentation_url,
+                releases.default_target
+         FROM releases
+         INNER JOIN crates ON releases.crate_id = crates.id
+         WHERE crates.name = $1 AND releases.version = $2;";
 
         let rows = conn.query(query, &[&name, &version]).unwrap();
 


### PR DESCRIPTION
Closes #719

Use the postgres `ON CONFLICT` function to update tables instead of manually writing the queries and error handling out