### PR TITLE
Disable outline on focused rustdoc element to workaround safari performance issue

### DIFF
--- a/templates/style.scss
+++ b/templates/style.scss
@@ -294,6 +294,10 @@ div.nav-container-rustdoc {
     z-index: 999;
 }
 
+.rustdoc:focus {
+    outline: unset;
+}
+
 div.landing {
     text-align: center;
     padding-top: 30px;


### PR DESCRIPTION
Tested on Safari 13.1 and Safari Tech Preview 13.2, fixes scrolling issues on the rustdoc portion of the page when it's focused (as happens automatically whenever the page is navigated to) and stops the page from jumping around when switched to.

Tested on some pages in production via userstyle injection as well, to see that it works with pages built with older rustdoc.

fixes #725 