### PR TITLE
Gracefully handle postgres pool timeouts

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -28,10 +28,13 @@ pub fn connect_db() -> Result<Connection, failure::Error> {
 pub(crate) fn create_pool() -> r2d2::Pool<r2d2_postgres::PostgresConnectionManager> {
     let db_url = env::var("CRATESFYI_DATABASE_URL")
         .expect("CRATESFYI_DATABASE_URL environment variable is not exists");
+
     let manager =
         r2d2_postgres::PostgresConnectionManager::new(&db_url[..], r2d2_postgres::TlsMode::None)
             .expect("Failed to create PostgresConnectionManager");
+
     r2d2::Pool::builder()
+        .max_size(90)
         .build(manager)
         .expect("Failed to create r2d2 pool")
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -28,13 +28,19 @@ pub fn connect_db() -> Result<Connection, failure::Error> {
 pub(crate) fn create_pool() -> r2d2::Pool<r2d2_postgres::PostgresConnectionManager> {
     let db_url = env::var("CRATESFYI_DATABASE_URL")
         .expect("CRATESFYI_DATABASE_URL environment variable is not exists");
+    let pool_size = env::var("DOCSRS_POOL_SIZE")
+        .map(|s| {
+            s.parse::<u32>()
+                .expect("DOCSRS_POOL_SIZE must be an integer")
+        })
+        .unwrap_or(90);
 
     let manager =
         r2d2_postgres::PostgresConnectionManager::new(&db_url[..], r2d2_postgres::TlsMode::None)
             .expect("Failed to create PostgresConnectionManager");
 
     r2d2::Pool::builder()
-        .max_size(90)
+        .max_size(pool_size)
         .build(manager)
         .expect("Failed to create r2d2 pool")
 }

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -65,7 +65,7 @@ pub fn build_list_handler(req: &mut Request) -> IronResult<Response> {
     let version = cexpect!(router.find("version"));
     let req_build_id: i32 = router.find("id").unwrap_or("0").parse().unwrap_or(0);
 
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
     let limits = ctry!(Limits::for_crate(&conn, name));
 
     let mut build_list: Vec<Build> = Vec::new();

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -315,7 +315,7 @@ pub fn crate_details_handler(req: &mut Request) -> IronResult<Response> {
     let name = cexpect!(router.find("name"));
     let req_version = router.find("version");
 
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
 
     match match_version(&conn, &name, req_version).and_then(|m| m.assume_exact()) {
         Some(MatchSemver::Exact((version, _))) => {

--- a/src/web/file.rs
+++ b/src/web/file.rs
@@ -47,7 +47,7 @@ pub struct DatabaseFileHandler;
 impl Handler for DatabaseFileHandler {
     fn handle(&self, req: &mut Request) -> IronResult<Response> {
         let path = req.url.path().join("/");
-        let conn = extension!(req, Pool).get();
+        let conn = extension!(req, Pool).get()?;
         if let Some(file) = File::from_path(&conn, &path) {
             Ok(file.serve())
         } else {

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -65,6 +65,12 @@ lazy_static::lazy_static! {
         &["route"]
     )
     .unwrap();
+
+    pub static ref FAILED_DB_CONNECTIONS: IntCounter = register_int_counter!(
+        "docsrs_failed_db_connections",
+        "Number of attempted and failed connections to the database"
+    )
+    .unwrap();
 }
 
 pub fn metrics_handler(req: &mut Request) -> IronResult<Response> {

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -68,7 +68,7 @@ lazy_static::lazy_static! {
 }
 
 pub fn metrics_handler(req: &mut Request) -> IronResult<Response> {
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
 
     QUEUED_CRATES_COUNT.set(
         ctry!(conn.query("SELECT COUNT(*) FROM queue WHERE attempt < 5;", &[]))

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -71,6 +71,12 @@ lazy_static::lazy_static! {
         "Number of attempted and failed connections to the database"
     )
     .unwrap();
+
+    pub static ref CONCURRENT_DB_CONNECTIONS: IntGauge = register_int_gauge!(
+        "docsrs_db_connections",
+        "The number of currently used database connections"
+    )
+    .unwrap();
 }
 
 pub fn metrics_handler(req: &mut Request) -> IronResult<Response> {
@@ -86,6 +92,9 @@ pub fn metrics_handler(req: &mut Request) -> IronResult<Response> {
             .get(0)
             .get(0),
     );
+
+    let pool = extension!(req, Pool);
+    CONCURRENT_DB_CONNECTIONS.set(pool.connections() as i64);
 
     let mut buffer = Vec::new();
     let families = prometheus::gather();

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -368,6 +368,7 @@ impl Server {
         metrics::FAILED_BUILDS.inc_by(0);
         metrics::NON_LIBRARY_BUILDS.inc_by(0);
         metrics::UPLOADED_FILES_TOTAL.inc_by(0);
+        metrics::FAILED_DB_CONNECTIONS.inc_by(0);
 
         let cratesfyi = CratesfyiHandler::new(pool);
         let inner = Iron::new(cratesfyi)

--- a/src/web/pool.rs
+++ b/src/web/pool.rs
@@ -1,10 +1,12 @@
 use crate::db::create_pool;
-use iron::{typemap, BeforeMiddleware, IronResult, Request};
+use iron::{status::Status, typemap, BeforeMiddleware, IronError, IronResult, Request};
 use postgres::Connection;
+use std::marker::PhantomData;
 
 #[cfg(test)]
 use std::sync::{Arc, Mutex, MutexGuard};
 
+#[derive(Debug, Clone)]
 pub(crate) enum Pool {
     R2D2(r2d2::Pool<r2d2_postgres::PostgresConnectionManager>),
     #[cfg(test)]
@@ -20,43 +22,44 @@ impl Pool {
     pub(crate) fn new_simple(conn: Arc<Mutex<Connection>>) -> Self {
         Pool::Simple(conn)
     }
-}
 
-impl typemap::Key for Pool {
-    type Value = PoolConnection;
-}
-
-impl BeforeMiddleware for Pool {
-    fn before(&self, req: &mut Request) -> IronResult<()> {
-        req.extensions.insert::<Pool>(match self {
-            Self::R2D2(pool) => PoolConnection::R2D2(pool.get().unwrap()),
-            #[cfg(test)]
-            Self::Simple(mutex) => PoolConnection::Simple(mutex.clone()),
-        });
-        Ok(())
-    }
-}
-
-pub(crate) enum PoolConnection {
-    R2D2(r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>),
-    #[cfg(test)]
-    Simple(Arc<Mutex<Connection>>),
-}
-
-impl PoolConnection {
-    pub(super) fn get(&self) -> DerefConnection<'_> {
+    pub(super) fn get<'a>(&'a self) -> IronResult<DerefConnection<'a>> {
         match self {
-            Self::R2D2(conn) => DerefConnection::Connection(&conn),
-            #[cfg(test)]
-            Self::Simple(mutex) => {
-                DerefConnection::Guard(mutex.lock().expect("failed to lock the connection"))
+            Self::R2D2(conn) => {
+                let conn = conn.get().map_err(|err| {
+                    log::error!("Error getting db connection: {:?}", err);
+                    IronError::new(err, Status::InternalServerError)
+                })?;
+
+                Ok(DerefConnection::Connection(conn, PhantomData))
             }
+
+            #[cfg(test)]
+            Self::Simple(mutex) => Ok(DerefConnection::Guard(
+                mutex.lock().expect("failed to lock the connection"),
+            )),
         }
     }
 }
 
+impl typemap::Key for Pool {
+    type Value = Pool;
+}
+
+impl BeforeMiddleware for Pool {
+    fn before(&self, req: &mut Request) -> IronResult<()> {
+        req.extensions.insert::<Pool>(self.clone());
+
+        Ok(())
+    }
+}
+
 pub(crate) enum DerefConnection<'a> {
-    Connection(&'a Connection),
+    Connection(
+        r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>,
+        PhantomData<&'a ()>,
+    ),
+
     #[cfg(test)]
     Guard(MutexGuard<'a, Connection>),
 }
@@ -66,7 +69,8 @@ impl<'a> std::ops::Deref for DerefConnection<'a> {
 
     fn deref(&self) -> &Connection {
         match self {
-            Self::Connection(conn) => conn,
+            Self::Connection(conn, ..) => conn,
+
             #[cfg(test)]
             Self::Guard(guard) => &guard,
         }

--- a/src/web/pool.rs
+++ b/src/web/pool.rs
@@ -42,6 +42,15 @@ impl Pool {
             )),
         }
     }
+
+    pub(crate) fn connections(&self) -> u32 {
+        match self {
+            Self::R2D2(conn) => conn.state().connections,
+
+            #[cfg(test)]
+            Self::Simple(..) => 0,
+        }
+    }
 }
 
 impl typemap::Key for Pool {

--- a/src/web/pool.rs
+++ b/src/web/pool.rs
@@ -28,6 +28,8 @@ impl Pool {
             Self::R2D2(conn) => {
                 let conn = conn.get().map_err(|err| {
                     log::error!("Error getting db connection: {:?}", err);
+                    super::metrics::FAILED_DB_CONNECTIONS.inc();
+
                     IronError::new(err, Status::InternalServerError)
                 })?;
 

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -335,7 +335,7 @@ fn get_search_results(
 }
 
 pub fn home_page(req: &mut Request) -> IronResult<Response> {
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
     let packages = get_releases(&conn, 1, RELEASES_IN_HOME, Order::ReleaseTime);
     Page::new(packages)
         .set_true("show_search_form")
@@ -344,7 +344,7 @@ pub fn home_page(req: &mut Request) -> IronResult<Response> {
 }
 
 pub fn releases_feed_handler(req: &mut Request) -> IronResult<Response> {
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
     let packages = get_releases(&conn, 1, RELEASES_IN_FEED, Order::ReleaseTime);
     let mut resp = ctry!(Page::new(packages).to_resp("releases_feed"));
     resp.headers.set(::iron::headers::ContentType(
@@ -391,7 +391,7 @@ pub fn recent_releases_handler(req: &mut Request) -> IronResult<Response> {
         .unwrap_or("1")
         .parse()
         .unwrap_or(1);
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
     let packages = get_releases(&conn, page_number, RELEASES_IN_RELEASES, Order::ReleaseTime);
     releases_handler(
         packages,
@@ -408,7 +408,7 @@ pub fn releases_by_stars_handler(req: &mut Request) -> IronResult<Response> {
         .unwrap_or("1")
         .parse()
         .unwrap_or(1);
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
     let packages = get_releases(&conn, page_number, RELEASES_IN_RELEASES, Order::GithubStars);
     releases_handler(
         packages,
@@ -425,7 +425,7 @@ pub fn releases_recent_failures_handler(req: &mut Request) -> IronResult<Respons
         .unwrap_or("1")
         .parse()
         .unwrap_or(1);
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
     let packages = get_releases(
         &conn,
         page_number,
@@ -447,7 +447,7 @@ pub fn releases_failures_by_stars_handler(req: &mut Request) -> IronResult<Respo
         .unwrap_or("1")
         .parse()
         .unwrap_or(1);
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
     let packages = get_releases(
         &conn,
         page_number,
@@ -468,7 +468,7 @@ pub fn author_handler(req: &mut Request) -> IronResult<Response> {
     // page number of releases
     let page_number: i64 = router.find("page").unwrap_or("1").parse().unwrap_or(1);
 
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
 
     #[allow(clippy::or_fun_call)]
     let author = ctry!(router
@@ -518,7 +518,7 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
     let params = ctry!(req.get::<Params>());
     let query = params.find(&["query"]);
 
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
     if let Some(&Value::String(ref query)) = query {
         // check if I am feeling lucky button pressed and redirect user to crate page
         // if there is a match
@@ -618,7 +618,7 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
 }
 
 pub fn activity_handler(req: &mut Request) -> IronResult<Response> {
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
     let release_activity_data: Json = ctry!(conn.query(
         "SELECT value FROM config WHERE name = 'release_activity'",
         &[]
@@ -635,7 +635,7 @@ pub fn activity_handler(req: &mut Request) -> IronResult<Response> {
 }
 
 pub fn build_queue_handler(req: &mut Request) -> IronResult<Response> {
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
     let mut crates: Vec<(String, String, i32)> = Vec::new();
     for krate in &conn
         .query(

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -133,7 +133,7 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
         } else {
             let path = req.url.path();
             let path = path.join("/");
-            let conn = extension!(req, Pool).get();
+            let conn = extension!(req, Pool).get()?;
             match File::from_path(&conn, &path) {
                 Some(f) => return Ok(f.serve()),
                 None => return Err(IronError::new(Nope::ResourceNotFound, status::NotFound)),
@@ -162,7 +162,7 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
     let req_version = router.find("version");
     let mut target = router.find("target");
 
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
 
     // it doesn't matter if the version that was given was exact or not, since we're redirecting
     // anyway
@@ -213,7 +213,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
     let name = router.find("crate").unwrap_or("").to_string();
     let url_version = router.find("version");
     let version; // pre-declaring it to enforce drop order relative to `req_path`
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
 
     let mut req_path = req.url.path();
 
@@ -406,7 +406,7 @@ pub fn target_redirect_handler(req: &mut Request) -> IronResult<Response> {
     let name = cexpect!(router.find("name"));
     let version = cexpect!(router.find("version"));
 
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
     let base = redirect_base(req);
 
     let crate_details = cexpect!(CrateDetails::new(&conn, &name, &version));
@@ -460,7 +460,7 @@ pub fn badge_handler(req: &mut Request) -> IronResult<Response> {
     };
 
     let name = cexpect!(extension!(req, Router).find("crate"));
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
 
     let options = match match_version(&conn, &name, Some(&version)).and_then(|m| m.assume_exact()) {
         Some(MatchSemver::Exact((version, id))) => {
@@ -527,7 +527,7 @@ impl Handler for SharedResourceHandler {
         let filename = path.last().unwrap(); // unwrap is fine: vector is non-empty
         let suffix = filename.split('.').last().unwrap(); // unwrap is fine: split always works
         if ["js", "css", "woff", "svg"].contains(&suffix) {
-            let conn = extension!(req, Pool).get();
+            let conn = extension!(req, Pool).get()?;
 
             if let Some(file) = File::from_path(&conn, filename) {
                 return Ok(file.serve());

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -6,7 +6,7 @@ use rustc_serialize::json::{Json, ToJson};
 use std::collections::BTreeMap;
 
 pub fn sitemap_handler(req: &mut Request) -> IronResult<Response> {
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
     let mut releases: Vec<(String, String)> = Vec::new();
     for row in &conn
         .query(
@@ -37,7 +37,7 @@ pub fn robots_txt_handler(_: &mut Request) -> IronResult<Response> {
 pub fn about_handler(req: &mut Request) -> IronResult<Response> {
     let mut content = BTreeMap::new();
 
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
     let res = ctry!(conn.query("SELECT value FROM config WHERE name = 'rustc_version'", &[]));
 
     if let Some(row) = res.iter().next() {

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -202,7 +202,7 @@ pub fn source_browser_handler(req: &mut Request) -> IronResult<Response> {
         (path, file_path)
     };
 
-    let conn = extension!(req, Pool).get();
+    let conn = extension!(req, Pool).get()?;
 
     // try to get actual file first
     // skip if request is a directory


### PR DESCRIPTION
Closes #626

* Changes from unwrapping on a failure to get a pool to returning an error
* Adds the `docsrs_failed_db_connections` metric to monitor timed out database connections
  * A metric for concurrent database connections could also be added