### PR TITLE
Reduce crates.io references

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -189,9 +189,13 @@ struct Build {
     )]
     prefix: PathBuf,
 
-    /// Sets crates.io-index path
-    #[structopt(name = "CRATES_IO_INDEX_PATH", long = "crates-io-index-path")]
-    crates_io_index_path: Option<PathBuf>,
+    /// Sets the registry index path, where on disk the registry index will be cloned to
+    #[structopt(
+        name = "REGISTRY_INDEX_PATH",
+        long = "registry-index-path",
+        alias = "crates-io-index-path"
+    )]
+    registry_index_path: Option<PathBuf>,
 
     /// Skips building documentation if documentation exists
     #[structopt(name = "SKIP_IF_EXISTS", short = "s", long = "skip")]
@@ -218,8 +222,8 @@ impl Build {
         let docbuilder = {
             let mut doc_options = DocBuilderOptions::from_prefix(self.prefix);
 
-            if let Some(crates_io_index_path) = self.crates_io_index_path {
-                doc_options.crates_io_index_path = crates_io_index_path;
+            if let Some(registry_index_path) = self.registry_index_path {
+                doc_options.registry_index_path = registry_index_path;
             }
 
             doc_options.skip_if_exists = self.skip_if_exists;

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -1,22 +1,22 @@
-use crate::docbuilder::BuildResult;
-use crate::utils::MetadataPackage;
-use regex::Regex;
+use std::{
+    fs,
+    io::{BufRead, BufReader},
+    path::Path,
+};
 
-use std::fs;
-use std::io::prelude::*;
-use std::io::BufReader;
-use std::path::Path;
+use crate::{
+    docbuilder::BuildResult,
+    error::Result,
+    index::api::{CrateOwner, RegistryCrateData},
+    utils::MetadataPackage,
+};
 
-use crate::error::Result;
-use failure::err_msg;
 use log::debug;
 use postgres::Connection;
-use reqwest::header::ACCEPT;
-use reqwest::Client;
+use regex::Regex;
 use rustc_serialize::json::{Json, ToJson};
 use semver::Version;
 use slug::slugify;
-use time::Timespec;
 
 /// Adds a package into database.
 ///
@@ -203,9 +203,7 @@ fn get_readme(pkg: &MetadataPackage, source_dir: &Path) -> Result<Option<String>
         return Ok(None);
     }
 
-    let mut reader = fs::File::open(readme_path).map(BufReader::new)?;
-    let mut readme = String::new();
-    reader.read_to_string(&mut readme)?;
+    let readme = fs::read_to_string(readme_path)?;
 
     if readme.is_empty() {
         Ok(None)
@@ -260,93 +258,6 @@ fn read_rust_doc(file_path: &Path) -> Result<Option<String>> {
     } else {
         Ok(Some(rustdoc))
     }
-}
-
-pub(crate) struct RegistryCrateData {
-    pub(crate) release_time: Timespec,
-    pub(crate) yanked: bool,
-    pub(crate) downloads: i32,
-    pub(crate) owners: Vec<CrateOwner>,
-}
-
-impl RegistryCrateData {
-    pub(crate) fn get_from_network(pkg: &MetadataPackage) -> Result<Self> {
-        let (release_time, yanked, downloads) = get_release_time_yanked_downloads(pkg)?;
-        let owners = get_owners(pkg)?;
-
-        Ok(Self {
-            release_time,
-            yanked,
-            downloads,
-            owners,
-        })
-    }
-}
-
-/// Get release_time, yanked and downloads from the registry's API
-fn get_release_time_yanked_downloads(pkg: &MetadataPackage) -> Result<(time::Timespec, bool, i32)> {
-    let url = format!("https://crates.io/api/v1/crates/{}/versions", pkg.name);
-    // FIXME: There is probably better way to do this
-    //        and so many unwraps...
-    let client = Client::new();
-    let mut res = client
-        .get(&url[..])
-        .header(ACCEPT, "application/json")
-        .send()?;
-    let mut body = String::new();
-    res.read_to_string(&mut body).unwrap();
-    let json = Json::from_str(&body[..]).unwrap();
-    let versions = json
-        .as_object()
-        .and_then(|o| o.get("versions"))
-        .and_then(|v| v.as_array())
-        .ok_or_else(|| err_msg("Not a JSON object"))?;
-
-    let (mut release_time, mut yanked, mut downloads) = (None, None, None);
-
-    for version in versions {
-        let version = version
-            .as_object()
-            .ok_or_else(|| err_msg("Not a JSON object"))?;
-        let version_num = version
-            .get("num")
-            .and_then(|v| v.as_string())
-            .ok_or_else(|| err_msg("Not a JSON object"))?;
-
-        if semver::Version::parse(version_num).unwrap().to_string() == pkg.version {
-            let release_time_raw = version
-                .get("created_at")
-                .and_then(|c| c.as_string())
-                .ok_or_else(|| err_msg("Not a JSON object"))?;
-            release_time = Some(
-                time::strptime(release_time_raw, "%Y-%m-%dT%H:%M:%S")
-                    .unwrap()
-                    .to_timespec(),
-            );
-
-            yanked = Some(
-                version
-                    .get("yanked")
-                    .and_then(|c| c.as_boolean())
-                    .ok_or_else(|| err_msg("Not a JSON object"))?,
-            );
-
-            downloads = Some(
-                version
-                    .get("downloads")
-                    .and_then(|c| c.as_i64())
-                    .ok_or_else(|| err_msg("Not a JSON object"))? as i32,
-            );
-
-            break;
-        }
-    }
-
-    Ok((
-        release_time.unwrap_or_else(time::get_time),
-        yanked.unwrap_or(false),
-        downloads.unwrap_or(0),
-    ))
 }
 
 /// Adds keywords into database
@@ -426,73 +337,6 @@ fn add_authors_into_database(
     }
 
     Ok(())
-}
-
-pub(crate) struct CrateOwner {
-    pub(crate) avatar: String,
-    pub(crate) email: String,
-    pub(crate) login: String,
-    pub(crate) name: String,
-}
-
-/// Fetch owners from the registry's API
-fn get_owners(pkg: &MetadataPackage) -> Result<Vec<CrateOwner>> {
-    // owners available in: https://crates.io/api/v1/crates/rand/owners
-    let owners_url = format!("https://crates.io/api/v1/crates/{}/owners", pkg.name);
-    let client = Client::new();
-    let mut res = client
-        .get(&owners_url[..])
-        .header(ACCEPT, "application/json")
-        .send()?;
-    // FIXME: There is probably better way to do this
-    //        and so many unwraps...
-    let mut body = String::new();
-    res.read_to_string(&mut body).unwrap();
-    let json = Json::from_str(&body[..])?;
-
-    let mut result = Vec::new();
-    if let Some(owners) = json
-        .as_object()
-        .and_then(|j| j.get("users"))
-        .and_then(|j| j.as_array())
-    {
-        for owner in owners {
-            // FIXME: I know there is a better way to do this
-            let avatar = owner
-                .as_object()
-                .and_then(|o| o.get("avatar"))
-                .and_then(|o| o.as_string())
-                .unwrap_or("");
-            let email = owner
-                .as_object()
-                .and_then(|o| o.get("email"))
-                .and_then(|o| o.as_string())
-                .unwrap_or("");
-            let login = owner
-                .as_object()
-                .and_then(|o| o.get("login"))
-                .and_then(|o| o.as_string())
-                .unwrap_or("");
-            let name = owner
-                .as_object()
-                .and_then(|o| o.get("name"))
-                .and_then(|o| o.as_string())
-                .unwrap_or("");
-
-            if login.is_empty() {
-                continue;
-            }
-
-            result.push(CrateOwner {
-                avatar: avatar.to_string(),
-                email: email.to_string(),
-                login: login.to_string(),
-                name: name.to_string(),
-            });
-        }
-    }
-
-    Ok(result)
 }
 
 /// Adds owners into database

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -33,7 +33,7 @@ pub(crate) fn add_package_into_database(
     default_target: &str,
     source_files: Option<Json>,
     doc_targets: Vec<String>,
-    cratesio_data: &CratesIoData,
+    cratesio_data: &RegistryCrateData,
     has_docs: bool,
     has_examples: bool,
 ) -> Result<i32> {
@@ -262,14 +262,14 @@ fn read_rust_doc(file_path: &Path) -> Result<Option<String>> {
     }
 }
 
-pub(crate) struct CratesIoData {
+pub(crate) struct RegistryCrateData {
     pub(crate) release_time: Timespec,
     pub(crate) yanked: bool,
     pub(crate) downloads: i32,
     pub(crate) owners: Vec<CrateOwner>,
 }
 
-impl CratesIoData {
+impl RegistryCrateData {
     pub(crate) fn get_from_network(pkg: &MetadataPackage) -> Result<Self> {
         let (release_time, yanked, downloads) = get_release_time_yanked_downloads(pkg)?;
         let owners = get_owners(pkg)?;
@@ -283,7 +283,7 @@ impl CratesIoData {
     }
 }
 
-/// Get release_time, yanked and downloads from crates.io
+/// Get release_time, yanked and downloads from the registry's API
 fn get_release_time_yanked_downloads(pkg: &MetadataPackage) -> Result<(time::Timespec, bool, i32)> {
     let url = format!("https://crates.io/api/v1/crates/{}/versions", pkg.name);
     // FIXME: There is probably better way to do this
@@ -435,7 +435,7 @@ pub(crate) struct CrateOwner {
     pub(crate) name: String,
 }
 
-/// Fetch owners from crates.io
+/// Fetch owners from the registry's API
 fn get_owners(pkg: &MetadataPackage) -> Result<Vec<CrateOwner>> {
     // owners available in: https://crates.io/api/v1/crates/rand/owners
     let owners_url = format!("https://crates.io/api/v1/crates/{}/owners", pkg.name);

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -2,7 +2,6 @@
 
 pub(crate) use self::add_package::add_build_into_database;
 pub(crate) use self::add_package::add_package_into_database;
-pub(crate) use self::add_package::RegistryCrateData;
 pub use self::delete_crate::delete_crate;
 pub use self::file::add_path_into_database;
 pub use self::migrate::migrate;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -2,7 +2,7 @@
 
 pub(crate) use self::add_package::add_build_into_database;
 pub(crate) use self::add_package::add_package_into_database;
-pub(crate) use self::add_package::CratesIoData;
+pub(crate) use self::add_package::RegistryCrateData;
 pub use self::delete_crate::delete_crate;
 pub use self::file::add_path_into_database;
 pub use self::migrate::migrate;

--- a/src/docbuilder/options.rs
+++ b/src/docbuilder/options.rs
@@ -6,7 +6,7 @@ use std::{env, fmt};
 pub struct DocBuilderOptions {
     pub keep_build_directory: bool,
     pub prefix: PathBuf,
-    pub crates_io_index_path: PathBuf,
+    pub registry_index_path: PathBuf,
     pub skip_if_exists: bool,
     pub skip_if_log_exists: bool,
     pub skip_oldest_versions: bool,
@@ -18,11 +18,11 @@ impl Default for DocBuilderOptions {
     fn default() -> DocBuilderOptions {
         let cwd = env::current_dir().unwrap();
 
-        let (prefix, crates_io_index_path) = generate_paths(cwd);
+        let (prefix, registry_index_path) = generate_paths(cwd);
 
         DocBuilderOptions {
             prefix,
-            crates_io_index_path,
+            registry_index_path,
 
             keep_build_directory: false,
             skip_if_exists: false,
@@ -39,10 +39,10 @@ impl fmt::Debug for DocBuilderOptions {
         write!(
             f,
             "DocBuilderOptions {{ \
-                crates_io_index_path: {:?}, \
+                registry_index_path: {:?}, \
                 keep_build_directory: {:?}, skip_if_exists: {:?}, \
                 skip_if_log_exists: {:?}, debug: {:?} }}",
-            self.crates_io_index_path,
+            self.registry_index_path,
             self.keep_build_directory,
             self.skip_if_exists,
             self.skip_if_log_exists,
@@ -54,20 +54,20 @@ impl fmt::Debug for DocBuilderOptions {
 impl DocBuilderOptions {
     /// Creates new DocBuilderOptions from prefix
     pub fn from_prefix(prefix: PathBuf) -> DocBuilderOptions {
-        let (prefix, crates_io_index_path) = generate_paths(prefix);
+        let (prefix, registry_index_path) = generate_paths(prefix);
 
         DocBuilderOptions {
             prefix,
-            crates_io_index_path,
+            registry_index_path,
             ..Default::default()
         }
     }
 
     pub fn check_paths(&self) -> Result<()> {
-        if !self.crates_io_index_path.exists() {
+        if !self.registry_index_path.exists() {
             failure::bail!(
-                "crates.io-index path '{}' does not exist",
-                self.crates_io_index_path.display()
+                "registry index path '{}' does not exist",
+                self.registry_index_path.display()
             );
         }
 
@@ -76,7 +76,7 @@ impl DocBuilderOptions {
 }
 
 fn generate_paths(prefix: PathBuf) -> (PathBuf, PathBuf) {
-    let crates_io_index_path = PathBuf::from(&prefix).join("crates.io-index");
+    let registry_index_path = PathBuf::from(&prefix).join("crates.io-index");
 
-    (prefix, crates_io_index_path)
+    (prefix, registry_index_path)
 }

--- a/src/docbuilder/queue.rs
+++ b/src/docbuilder/queue.rs
@@ -1,4 +1,4 @@
-//! Updates crates.io index and builds new packages
+//! Updates registry index and builds new packages
 
 use super::{DocBuilder, RustwideBuilder};
 use crate::db::connect_db;
@@ -8,11 +8,11 @@ use crates_index_diff::{ChangeKind, Index};
 use log::{debug, error};
 
 impl DocBuilder {
-    /// Updates crates.io-index repository and adds new crates into build queue.
+    /// Updates registry index repository and adds new crates into build queue.
     /// Returns the number of crates added
     pub fn get_new_crates(&mut self) -> Result<usize> {
         let conn = connect_db()?;
-        let index = Index::from_path_or_cloned(&self.options.crates_io_index_path)?;
+        let index = Index::from_path_or_cloned(&self.options.registry_index_path)?;
         let (mut changes, oid) = index.peek_changes()?;
         let mut crates_added = 0;
 

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -2,11 +2,10 @@ use super::DocBuilder;
 use super::Metadata;
 use crate::db::blacklist::is_blacklisted;
 use crate::db::file::add_path_into_database;
-use crate::db::{
-    add_build_into_database, add_package_into_database, connect_db, RegistryCrateData,
-};
+use crate::db::{add_build_into_database, add_package_into_database, connect_db};
 use crate::docbuilder::{crates::crates_from_path, Limits};
 use crate::error::Result;
+use crate::index::api::RegistryCrateData;
 use crate::utils::{copy_doc_dir, parse_rustc_version, CargoMetadata};
 use failure::ResultExt;
 use log::{debug, info, warn, LevelFilter};

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -2,7 +2,9 @@ use super::DocBuilder;
 use super::Metadata;
 use crate::db::blacklist::is_blacklisted;
 use crate::db::file::add_path_into_database;
-use crate::db::{add_build_into_database, add_package_into_database, connect_db, CratesIoData};
+use crate::db::{
+    add_build_into_database, add_package_into_database, connect_db, RegistryCrateData,
+};
 use crate::docbuilder::{crates::crates_from_path, Limits};
 use crate::error::Result;
 use crate::utils::{copy_doc_dir, parse_rustc_version, CargoMetadata};
@@ -259,7 +261,7 @@ impl RustwideBuilder {
     pub fn build_world(&mut self, doc_builder: &mut DocBuilder) -> Result<()> {
         let mut count = 0;
         crates_from_path(
-            &doc_builder.options().crates_io_index_path.clone(),
+            &doc_builder.options().registry_index_path.clone(),
             &mut |name, version| {
                 match self.build_package(doc_builder, name, version, None) {
                     Ok(status) => {
@@ -394,7 +396,7 @@ impl RustwideBuilder {
                     &res.target,
                     files_list,
                     successful_targets,
-                    &CratesIoData::get_from_network(res.cargo_metadata.root())?,
+                    &RegistryCrateData::get_from_network(res.cargo_metadata.root())?,
                     has_docs,
                     has_examples,
                 )?;

--- a/src/index/api.rs
+++ b/src/index/api.rs
@@ -1,0 +1,162 @@
+use std::io::Read;
+
+use crate::{error::Result, utils::MetadataPackage};
+
+use failure::err_msg;
+use reqwest::{header::ACCEPT, Client};
+use rustc_serialize::json::Json;
+use time::Timespec;
+
+pub(crate) struct RegistryCrateData {
+    pub(crate) release_time: Timespec,
+    pub(crate) yanked: bool,
+    pub(crate) downloads: i32,
+    pub(crate) owners: Vec<CrateOwner>,
+}
+
+pub(crate) struct CrateOwner {
+    pub(crate) avatar: String,
+    pub(crate) email: String,
+    pub(crate) login: String,
+    pub(crate) name: String,
+}
+
+impl RegistryCrateData {
+    pub(crate) fn get_from_network(pkg: &MetadataPackage) -> Result<Self> {
+        let (release_time, yanked, downloads) = get_release_time_yanked_downloads(pkg)?;
+        let owners = get_owners(pkg)?;
+
+        Ok(Self {
+            release_time,
+            yanked,
+            downloads,
+            owners,
+        })
+    }
+}
+
+/// Get release_time, yanked and downloads from the registry's API
+fn get_release_time_yanked_downloads(pkg: &MetadataPackage) -> Result<(time::Timespec, bool, i32)> {
+    let url = format!("https://crates.io/api/v1/crates/{}/versions", pkg.name);
+    // FIXME: There is probably better way to do this
+    //        and so many unwraps...
+    let client = Client::new();
+    let mut res = client
+        .get(&url[..])
+        .header(ACCEPT, "application/json")
+        .send()?;
+    let mut body = String::new();
+    res.read_to_string(&mut body).unwrap();
+    let json = Json::from_str(&body[..]).unwrap();
+    let versions = json
+        .as_object()
+        .and_then(|o| o.get("versions"))
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| err_msg("Not a JSON object"))?;
+
+    let (mut release_time, mut yanked, mut downloads) = (None, None, None);
+
+    for version in versions {
+        let version = version
+            .as_object()
+            .ok_or_else(|| err_msg("Not a JSON object"))?;
+        let version_num = version
+            .get("num")
+            .and_then(|v| v.as_string())
+            .ok_or_else(|| err_msg("Not a JSON object"))?;
+
+        if semver::Version::parse(version_num).unwrap().to_string() == pkg.version {
+            let release_time_raw = version
+                .get("created_at")
+                .and_then(|c| c.as_string())
+                .ok_or_else(|| err_msg("Not a JSON object"))?;
+            release_time = Some(
+                time::strptime(release_time_raw, "%Y-%m-%dT%H:%M:%S")
+                    .unwrap()
+                    .to_timespec(),
+            );
+
+            yanked = Some(
+                version
+                    .get("yanked")
+                    .and_then(|c| c.as_boolean())
+                    .ok_or_else(|| err_msg("Not a JSON object"))?,
+            );
+
+            downloads = Some(
+                version
+                    .get("downloads")
+                    .and_then(|c| c.as_i64())
+                    .ok_or_else(|| err_msg("Not a JSON object"))? as i32,
+            );
+
+            break;
+        }
+    }
+
+    Ok((
+        release_time.unwrap_or_else(time::get_time),
+        yanked.unwrap_or(false),
+        downloads.unwrap_or(0),
+    ))
+}
+
+/// Fetch owners from the registry's API
+fn get_owners(pkg: &MetadataPackage) -> Result<Vec<CrateOwner>> {
+    // owners available in: https://crates.io/api/v1/crates/rand/owners
+    let owners_url = format!("https://crates.io/api/v1/crates/{}/owners", pkg.name);
+    let client = Client::new();
+    let mut res = client
+        .get(&owners_url[..])
+        .header(ACCEPT, "application/json")
+        .send()?;
+    // FIXME: There is probably better way to do this
+    //        and so many unwraps...
+    let mut body = String::new();
+    res.read_to_string(&mut body).unwrap();
+    let json = Json::from_str(&body[..])?;
+
+    let mut result = Vec::new();
+    if let Some(owners) = json
+        .as_object()
+        .and_then(|j| j.get("users"))
+        .and_then(|j| j.as_array())
+    {
+        for owner in owners {
+            // FIXME: I know there is a better way to do this
+            let avatar = owner
+                .as_object()
+                .and_then(|o| o.get("avatar"))
+                .and_then(|o| o.as_string())
+                .unwrap_or("");
+            let email = owner
+                .as_object()
+                .and_then(|o| o.get("email"))
+                .and_then(|o| o.as_string())
+                .unwrap_or("");
+            let login = owner
+                .as_object()
+                .and_then(|o| o.get("login"))
+                .and_then(|o| o.as_string())
+                .unwrap_or("");
+            let name = owner
+                .as_object()
+                .and_then(|o| o.get("name"))
+                .and_then(|o| o.as_string())
+                .unwrap_or("");
+
+            if login.is_empty() {
+                continue;
+            }
+
+            result.push(CrateOwner {
+                avatar: avatar.to_string(),
+                email: email.to_string(),
+                login: login.to_string(),
+                name: name.to_string(),
+            });
+        }
+    }
+
+    Ok(result)
+}

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod api;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub use self::web::Server;
 pub mod db;
 mod docbuilder;
 mod error;
+mod index;
 pub mod storage;
 #[cfg(test)]
 mod test;

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -1,5 +1,5 @@
 use super::TestDatabase;
-use crate::db::CratesIoData;
+use crate::db::RegistryCrateData;
 use crate::docbuilder::BuildResult;
 use crate::utils::{Dependency, MetadataPackage, Target};
 use failure::Error;
@@ -15,7 +15,7 @@ pub(crate) struct FakeRelease<'a> {
     rustdoc_files: Vec<(&'a str, &'a [u8])>,
     doc_targets: Vec<String>,
     default_target: Option<&'a str>,
-    cratesio_data: CratesIoData,
+    registry_crate_data: RegistryCrateData,
     has_docs: bool,
     has_examples: bool,
 }
@@ -53,7 +53,7 @@ impl<'a> FakeRelease<'a> {
             rustdoc_files: Vec::new(),
             doc_targets: Vec::new(),
             default_target: None,
-            cratesio_data: CratesIoData {
+            registry_crate_data: RegistryCrateData {
                 release_time: time::get_time(),
                 yanked: false,
                 downloads: 0,
@@ -65,7 +65,7 @@ impl<'a> FakeRelease<'a> {
     }
 
     pub(crate) fn downloads(mut self, downloads: i32) -> Self {
-        self.cratesio_data.downloads = downloads;
+        self.registry_crate_data.downloads = downloads;
         self
     }
 
@@ -75,7 +75,7 @@ impl<'a> FakeRelease<'a> {
     }
 
     pub(crate) fn release_time(mut self, new: time::Timespec) -> Self {
-        self.cratesio_data.release_time = new;
+        self.registry_crate_data.release_time = new;
         self
     }
 
@@ -103,7 +103,7 @@ impl<'a> FakeRelease<'a> {
     }
 
     pub(crate) fn yanked(mut self, new: bool) -> Self {
-        self.cratesio_data.yanked = new;
+        self.registry_crate_data.yanked = new;
         self
     }
 
@@ -216,7 +216,7 @@ impl<'a> FakeRelease<'a> {
             self.default_target.unwrap_or("x86_64-unknown-linux-gnu"),
             source_meta,
             self.doc_targets,
-            &self.cratesio_data,
+            &self.registry_crate_data,
             self.has_docs,
             self.has_examples,
         )?;

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -1,6 +1,6 @@
 use super::TestDatabase;
-use crate::db::RegistryCrateData;
 use crate::docbuilder::BuildResult;
+use crate::index::api::RegistryCrateData;
 use crate::utils::{Dependency, MetadataPackage, Target};
 use failure::Error;
 

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -63,7 +63,7 @@ pub fn start_daemon(background: bool) {
 
     // check new crates every minute
     thread::Builder::new()
-        .name("crates.io reader".to_string())
+        .name("registry index reader".to_string())
         .spawn(move || {
             // space this out to prevent it from clashing against the queue-builder thread on launch
             thread::sleep(Duration::from_secs(30));


### PR DESCRIPTION
Preparation for supporting non-crates.io registries, stop referring to stuff that isn't crates.io specific as crates.io. Also moved stuff accessing the index API out of the database code to integrate it with future index related code.

(I still haven't figured out how to handle `CRATESFYI_PREFIX` nicely, but that's independent of these changes).