### PR TITLE
Add compression for uploaded documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,7 @@ dependencies = [
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zstd 0.5.2+zstd.1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -965,6 +966,11 @@ dependencies = [
  "openssl-sys 0.9.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "globset"
@@ -4115,6 +4121,34 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "zstd"
+version = "0.5.2+zstd.1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "zstd-safe 2.0.4+zstd.1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "2.0.4+zstd.1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zstd-sys 1.4.16+zstd.1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.4.16+zstd.1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum addr2line 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
@@ -4223,6 +4257,7 @@ dependencies = [
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum gimli 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 "checksum git2 0.13.6 (registry+https://github.com/rust-lang/crates.io-index)" = "11e4b2082980e751c4bf4273e9cbb4a02c655729c8ee8a79f66cad03c8f4d31e"
+"checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum globset 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120"
 "checksum globwalk 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "178270263374052c40502e9f607134947de75302c1348d1a0e31db67c1691446"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
@@ -4560,3 +4595,6 @@ dependencies = [
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
+"checksum zstd 0.5.2+zstd.1.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "644352b10ce7f333d6e0af85bd4f5322dc449416dc1211c6308e95bca8923db4"
+"checksum zstd-safe 2.0.4+zstd.1.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7113c0c9aed2c55181f2d9f5b0a36e7d2c0183b11c058ab40b35987479efe4d7"
+"checksum zstd-sys 1.4.16+zstd.1.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c442965efc45353be5a9b9969c9b0872fff6828c7e06d118dda2cb2d0bb11d5a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,10 @@ rand = "0.7.3"
 name = "html5ever"
 harness = false
 
+[[bench]]
+name = "compression"
+harness = false
+
 [build-dependencies]
 time = "0.1"
 git2 = { version = "0.13", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ lazy_static = "1.0.0"
 rustwide = "0.7.1"
 mime_guess = "2"
 dotenv = "0.15"
+zstd = "0.5"
 
 # Data serialization and deserialization
 serde = { version = "1.0", features = ["derive"] }

--- a/benches/compression.rs
+++ b/benches/compression.rs
@@ -9,9 +9,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("compress regex html", |b| {
         b.iter(|| compress(black_box(html_slice)))
     });
-    let compressed = compress(html_slice).unwrap();
+    let (compressed, alg) = compress(html_slice).unwrap();
     c.bench_function("decompress regex html", |b| {
-        b.iter(|| decompress(black_box(compressed.as_slice())))
+        b.iter(|| decompress(black_box(compressed.as_slice()), alg))
     });
 }
 

--- a/benches/compression.rs
+++ b/benches/compression.rs
@@ -1,0 +1,19 @@
+use cratesfyi::storage::{compress, decompress};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    // this isn't a great benchmark because it only tests on one file
+    // ideally we would build a whole crate and compress each file, taking the average
+    let html = std::fs::read_to_string("benches/struct.CaptureMatches.html").unwrap();
+    let html_slice = html.as_bytes();
+    c.bench_function("compress regex html", |b| {
+        b.iter(|| compress(black_box(html_slice)))
+    });
+    let compressed = compress(html_slice).unwrap();
+    c.bench_function("decompress regex html", |b| {
+        b.iter(|| decompress(black_box(compressed.as_slice())))
+    });
+}
+
+criterion_group!(compression, criterion_benchmark);
+criterion_main!(compression);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
         image: minio/minio
         entrypoint: >
             /bin/sh -c "
-                mkdir /data/rust-docs-rs;
+                mkdir -p /data/rust-docs-rs;
                 minio server /data;
             "
         ports:

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -361,15 +361,10 @@ fn add_compression_into_database<I>(conn: &Connection, algorithms: I, release_id
 where
     I: Iterator<Item = CompressionAlgorithm>,
 {
-    let sql = "
-    INSERT INTO compression_rels (release, algorithm)
-    VALUES (
-        $1,
-        (SELECT id FROM compression WHERE name = $2)
-    )";
+    let sql = "INSERT INTO compression_rels (release, algorithm) VALUES ($1, $2);";
     let prepared = conn.prepare_cached(sql)?;
     for alg in algorithms {
-        prepared.execute(&[&release_id, &alg.to_string()])?;
+        prepared.execute(&[&release_id, &(alg as i32)])?;
     }
     Ok(())
 }

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -361,7 +361,10 @@ fn add_compression_into_database<I>(conn: &Connection, algorithms: I, release_id
 where
     I: Iterator<Item = CompressionAlgorithm>,
 {
-    let sql = "INSERT INTO compression_rels (release, algorithm) VALUES ($1, $2);";
+    let sql = "
+    INSERT INTO compression_rels (release, algorithm)
+    VALUES ($1, $2)
+    ON CONFLICT DO NOTHING;";
     let prepared = conn.prepare_cached(sql)?;
     for alg in algorithms {
         prepared.execute(&[&release_id, &(alg as i32)])?;

--- a/src/db/file.rs
+++ b/src/db/file.rs
@@ -5,7 +5,7 @@
 //! filesystem. This module is adding files into database and retrieving them.
 
 use crate::error::Result;
-use crate::storage::Storage;
+use crate::storage::{CompressionAlgorithms, Storage};
 use postgres::Connection;
 
 use serde_json::Value;
@@ -30,10 +30,13 @@ pub fn add_path_into_database<P: AsRef<Path>>(
     conn: &Connection,
     prefix: &str,
     path: P,
-) -> Result<Value> {
+) -> Result<(Value, CompressionAlgorithms)> {
     let mut backend = Storage::new(conn);
-    let file_list = backend.store_all(conn, prefix, path.as_ref())?;
-    file_list_to_json(file_list.into_iter().collect())
+    let (file_list, algorithms) = backend.store_all(conn, prefix, path.as_ref())?;
+    Ok((
+        file_list_to_json(file_list.into_iter().collect())?,
+        algorithms,
+    ))
 }
 
 fn file_list_to_json(file_list: Vec<(PathBuf, String)>) -> Result<Value> {

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -348,25 +348,21 @@ pub fn migrate(version: Option<Version>, conn: &Connection) -> CratesfyiResult<(
             "Add compression",
             // upgrade query
             "
-            CREATE TABLE compression (
-                id SERIAL PRIMARY KEY,
-                name VARCHAR(100)
-            );
-            INSERT INTO compression (name) VALUES ('zstd');
-            -- NULL indicates the file was not compressed
-            ALTER TABLE files ADD COLUMN compression INT REFERENCES compression(id);
+            -- NULL indicates the file was not compressed.
+            -- There is no meaning assigned to the compression id in the database itself,
+            -- it is instead interpreted by the application.
+            ALTER TABLE files ADD COLUMN compression INT;
             -- many to many table between releases and compression
             -- stores the set of all compression algorithms used in the release files
             CREATE TABLE compression_rels (
                 release INT NOT NULL REFERENCES releases(id),
-                algorithm INT REFERENCES compression(id),
+                algorithm INT,
                 -- make sure we don't store duplicates by accident
                 UNIQUE(release, algorithm)
             );",
             // downgrade query
             "DROP TABLE compression_rels;
-             ALTER TABLE files DROP COLUMN compression;
-             DROP TABLE compression;",
+             ALTER TABLE files DROP COLUMN compression;"
         ),
     ];
 

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -365,6 +365,7 @@ pub fn migrate(version: Option<Version>, conn: &Connection) -> CratesfyiResult<(
             );",
             // downgrade query
             "DROP TABLE compression_rels;
+             ALTER TABLE files DROP COLUMN compression;
              DROP TABLE compression;",
         ),
     ];

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -340,6 +340,17 @@ pub fn migrate(version: Option<Version>, conn: &Connection) -> CratesfyiResult<(
              ADD COLUMN content tsvector,
              ADD COLUMN versions JSON DEFAULT '[]';"
         ),
+        migration!(
+            context,
+            // version
+            14,
+            // description
+            "Add a field for compression",
+            // upgrade query
+            "ALTER TABLE files ADD COLUMN compressed BOOLEAN NOT NULL DEFAULT false;",
+            // downgrade query
+            "ALTER TABLE files DROP COLUMN compressed;",
+        ),
     ];
 
     for migration in migrations {

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -345,11 +345,23 @@ pub fn migrate(version: Option<Version>, conn: &Connection) -> CratesfyiResult<(
             // version
             14,
             // description
-            "Add a field for compression",
+            "Add compression",
             // upgrade query
-            "ALTER TABLE files ADD COLUMN compression VARCHAR;",
+            "
+            CREATE TABLE compression (
+                id SERIAL PRIMARY KEY,
+                name VARCHAR(100)
+            );
+            INSERT INTO compression (name) VALUES ('zstd');
+            -- many to many table between releases and compression
+            -- stores the set of all compression algorithms used in the release files
+            CREATE TABLE compression_rels (
+                release INT NOT NULL REFERENCES releases(id),
+                algorithm INT NOT NULL REFERENCES compression(id)
+            );",
             // downgrade query
-            "ALTER TABLE files DROP COLUMN compression;",
+            "DROP TABLE compression_rels;
+             DROP TABLE compression;",
         ),
     ];
 

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -353,11 +353,15 @@ pub fn migrate(version: Option<Version>, conn: &Connection) -> CratesfyiResult<(
                 name VARCHAR(100)
             );
             INSERT INTO compression (name) VALUES ('zstd');
+            -- NULL indicates the file was not compressed
+            ALTER TABLE files ADD COLUMN compression INT REFERENCES compression(id);
             -- many to many table between releases and compression
             -- stores the set of all compression algorithms used in the release files
             CREATE TABLE compression_rels (
                 release INT NOT NULL REFERENCES releases(id),
-                algorithm INT NOT NULL REFERENCES compression(id)
+                algorithm INT REFERENCES compression(id),
+                -- make sure we don't store duplicates by accident
+                UNIQUE(release, algorithm)
             );",
             // downgrade query
             "DROP TABLE compression_rels;

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -347,9 +347,9 @@ pub fn migrate(version: Option<Version>, conn: &Connection) -> CratesfyiResult<(
             // description
             "Add a field for compression",
             // upgrade query
-            "ALTER TABLE files ADD COLUMN compressed BOOLEAN NOT NULL DEFAULT false;",
+            "ALTER TABLE files ADD COLUMN compression VARCHAR;",
             // downgrade query
-            "ALTER TABLE files DROP COLUMN compressed;",
+            "ALTER TABLE files DROP COLUMN compression;",
         ),
     ];
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -312,6 +312,21 @@ mod test {
     }
 
     #[test]
+    fn test_compression() {
+        let orig = "fn main() {}";
+        let compressed = compress(orig.as_bytes()).unwrap();
+        let blob = Blob {
+            mime: "text/rust".into(),
+            content: compressed.clone(),
+            path: "main.rs".into(),
+            date_updated: Timespec::new(42, 0),
+            compressed: true,
+        };
+        test_roundtrip(std::slice::from_ref(&blob));
+        assert_eq!(decompress(compressed.as_slice()).unwrap(), orig.as_bytes());
+    }
+
+    #[test]
     fn test_mime_types() {
         check_mime(".gitignore", "text/plain");
         check_mime("hello.toml", "text/toml");

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -116,10 +116,7 @@ impl<'a> Storage<'a> {
                     .map(|file| (file_path, file))
             })
             .map(|(file_path, file)| -> Result<_, Error> {
-                //let mut content: Vec<u8> = Vec::new();
-                //file.read_to_end(&mut content)?;
                 let content = compress(file)?;
-
                 let bucket_path = Path::new(prefix).join(&file_path);
 
                 #[cfg(windows)] // On windows, we need to normalize \\ to / so the route logic works

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -256,7 +256,7 @@ mod test {
             let db = env.db();
             let conn = db.conn();
             let mut backend = Storage::Database(DatabaseBackend::new(&conn));
-            let (stored_files, algs) = backend.store_all(&conn, "", dir.path()).unwrap();
+            let (stored_files, _algs) = backend.store_all(&conn, "", dir.path()).unwrap();
             assert_eq!(stored_files.len(), blobs.len());
             for blob in blobs {
                 let name = Path::new(&blob.path);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -152,11 +152,12 @@ impl<'a> Storage<'a> {
     }
 }
 
-fn compress(content: impl Read) -> Result<Vec<u8>, Error> {
+// public for benchmarking
+pub fn compress(content: impl Read) -> Result<Vec<u8>, Error> {
     zstd::encode_all(content, 5).map_err(Into::into)
 }
 
-fn decompress(content: impl Read) -> Result<Vec<u8>, Error> {
+pub fn decompress(content: impl Read) -> Result<Vec<u8>, Error> {
     zstd::decode_all(content).map_err(Into::into)
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -289,7 +289,7 @@ mod test {
             let db = env.db();
             let conn = db.conn();
             let mut backend = Storage::Database(DatabaseBackend::new(&conn));
-            let (stored_files, algs) = backend.store_all(&conn, "rustdoc", dir.path()).unwrap();
+            let (stored_files, _algs) = backend.store_all(&conn, "rustdoc", dir.path()).unwrap();
             assert_eq!(stored_files.len(), files.len());
             for name in &files {
                 let name = Path::new(name);
@@ -354,7 +354,7 @@ mod test {
             mime: "text/rust".into(),
             content: data.clone(),
             path: "main.rs".into(),
-            date_updated: Timespec::new(42, 0),
+            date_updated: Utc::now(),
             compression: Some(alg),
         };
         test_roundtrip(std::slice::from_ref(&blob));

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -256,7 +256,7 @@ mod test {
             let db = env.db();
             let conn = db.conn();
             let mut backend = Storage::Database(DatabaseBackend::new(&conn));
-            let stored_files = backend.store_all(&conn, "", dir.path()).unwrap();
+            let (stored_files, algs) = backend.store_all(&conn, "", dir.path()).unwrap();
             assert_eq!(stored_files.len(), blobs.len());
             for blob in blobs {
                 let name = Path::new(&blob.path);
@@ -289,7 +289,7 @@ mod test {
             let db = env.db();
             let conn = db.conn();
             let mut backend = Storage::Database(DatabaseBackend::new(&conn));
-            let stored_files = backend.store_all(&conn, "rustdoc", dir.path()).unwrap();
+            let (stored_files, algs) = backend.store_all(&conn, "rustdoc", dir.path()).unwrap();
             assert_eq!(stored_files.len(), files.len());
             for name in &files {
                 let name = Path::new(name);

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -17,37 +17,46 @@ const MAX_CONCURRENT_UPLOADS: usize = 1000;
 
 pub type CompressionAlgorithms = HashSet<CompressionAlgorithm>;
 
-// NOTE: the `TryFrom` impl must be updated whenever a new variant is added.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub enum CompressionAlgorithm {
-    Zstd = 0,
-}
+macro_rules! enum_id {
+    ($vis:vis enum $name:ident { $($variant:ident = $discriminant:expr,)* }) => {
+        #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+        $vis enum $name {
+            $($variant = $discriminant,)*
+        }
 
-impl fmt::Display for CompressionAlgorithm {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            CompressionAlgorithm::Zstd => write!(f, "zstd"),
+        impl fmt::Display for CompressionAlgorithm {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                match self {
+                    $(Self::$variant => write!(f, stringify!($variant)),)*
+                }
+            }
+        }
+
+        impl std::str::FromStr for CompressionAlgorithm {
+            type Err = ();
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                match s {
+                    $(stringify!($variant) => Ok(Self::$variant),)*
+                    _ => Err(()),
+                }
+            }
+        }
+
+        impl std::convert::TryFrom<i32> for CompressionAlgorithm {
+            type Error = i32;
+            fn try_from(i: i32) -> Result<Self, Self::Error> {
+                match i {
+                    $($discriminant => Ok(Self::$variant),)*
+                    _ => Err(i),
+                }
+            }
         }
     }
 }
 
-impl std::str::FromStr for CompressionAlgorithm {
-    type Err = ();
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "zstd" => Ok(CompressionAlgorithm::Zstd),
-            _ => Err(()),
-        }
-    }
-}
-
-impl std::convert::TryFrom<i32> for CompressionAlgorithm {
-    type Error = i32;
-    fn try_from(i: i32) -> Result<Self, Self::Error> {
-        match i {
-            0 => Ok(Self::Zstd),
-            _ => Err(i),
-        }
+enum_id! {
+    pub enum CompressionAlgorithm {
+        Zstd = 0,
     }
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -154,7 +154,7 @@ impl<'a> Storage<'a> {
 
 // public for benchmarking
 pub fn compress(content: impl Read) -> Result<Vec<u8>, Error> {
-    zstd::encode_all(content, 5).map_err(Into::into)
+    zstd::encode_all(content, 9).map_err(Into::into)
 }
 
 pub fn decompress(content: impl Read) -> Result<Vec<u8>, Error> {

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -51,19 +51,25 @@ impl<'a> S3Backend<'a> {
         b.read_to_end(&mut content).unwrap();
 
         let date_updated = parse_timespec(&res.last_modified.unwrap())?;
+        let compressed = res.metadata.unwrap_or_default().get("compressed").is_some();
 
         Ok(Blob {
             path: path.into(),
             mime: res.content_type.unwrap(),
             date_updated,
             content,
+            compressed,
         })
     }
 
     pub(super) fn store_batch(&mut self, batch: &[Blob]) -> Result<(), Error> {
         use futures::stream::FuturesUnordered;
         use futures::stream::Stream;
+        use std::collections::HashMap;
+
         let mut attempts = 0;
+        let mut compressed = HashMap::with_capacity(1);
+        compressed.insert("compressed".into(), "true".into());
 
         loop {
             let mut futures = FuturesUnordered::new();
@@ -75,6 +81,7 @@ impl<'a> S3Backend<'a> {
                             key: blob.path.clone(),
                             body: Some(blob.content.clone().into()),
                             content_type: Some(blob.mime.clone()),
+                            metadata: Some(compressed.clone()),
                             ..Default::default()
                         })
                         .inspect(|_| {
@@ -168,6 +175,7 @@ pub(crate) mod tests {
                 mime: "text/plain".into(),
                 date_updated: Utc::now(),
                 content: "Hello world!".into(),
+                compressed: false,
             };
 
             // Add a test file to the database
@@ -204,6 +212,7 @@ pub(crate) mod tests {
                     mime: "text/plain".into(),
                     date_updated: Utc::now(),
                     content: "Hello world!".into(),
+                    compressed: false,
                 })
                 .collect();
 

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -85,15 +85,15 @@ impl FileList {
         let rows = conn
             .query(
                 "SELECT crates.name,
-                                      releases.version,
-                                      releases.description,
-                                      releases.target_name,
-                                      releases.rustdoc_status,
-                                      releases.files,
-                                      releases.default_target
-                               FROM releases
-                               LEFT OUTER JOIN crates ON crates.id = releases.crate_id
-                               WHERE crates.name = $1 AND releases.version = $2",
+                        releases.version,
+                        releases.description,
+                        releases.target_name,
+                        releases.rustdoc_status,
+                        releases.files,
+                        releases.default_target
+                FROM releases
+                LEFT OUTER JOIN crates ON crates.id = releases.crate_id
+                WHERE crates.name = $1 AND releases.version = $2",
                 &[&name, &version],
             )
             .unwrap();


### PR DESCRIPTION
This needs some tests, but otherwise I think it should be fine as is, it was super simple after #643 :)

This uses `zstd 5`, but it's very easy to change the compression now and reasonably easy to change it after it's merged (we just have to change `compression` from a boolean into an enum and continue supporting `zstd`).

This compresses transparently, so that calling `backend.get()` automatically decompresses files as needed. If the files were not compressed before uploading, they are not decompressed when downloading.

Closes https://github.com/rust-lang/docs.rs/issues/379

cc @namibj
r? @pietroalbini 