### PR TITLE
Mostly switch to chrono

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,7 @@ version = "0.6.0"
 dependencies = [
  "arc-swap 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "badge 0.2.0",
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "comrak 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crates-index-diff 7.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2248,12 +2249,12 @@ name = "postgres-shared"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres-protocol 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ log = "0.4"
 regex = "1"
 structopt = "0.3"
 crates-index-diff = "7"
-time = "0.1"
 reqwest = "0.9"
 semver = "0.9"
 slug = "=0.1.1"
@@ -59,6 +58,10 @@ tera = { version = "1.3.0", features = ["builtins"] }
 arc-swap = "0.4.6"
 notify = "4.0.15"
 
+# Date and Time utilities
+chrono = { version = "0.4.11", features = ["serde"] }
+time = "0.1" # TODO: Remove once `iron` is removed
+
 [target.'cfg(not(windows))'.dependencies]
 libc = "0.2"
 
@@ -70,7 +73,7 @@ path-slash = "0.1.1"
 
 [dependencies.postgres]
 version = "0.15"
-features = ["with-time", "with-serde_json"]
+features = ["with-chrono", "with-serde_json"]
 
 [dev-dependencies]
 once_cell = "1.2.0"

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -85,7 +85,7 @@ pub(crate) fn add_package_into_database(
         &[
             &crate_id,
             &metadata_pkg.version,
-            &cratesio_data.release_time,
+            &cratesio_data.release_time.naive_utc(),
             &serde_json::to_value(&dependencies)?,
             &metadata_pkg.package_name(),
             &cratesio_data.yanked,

--- a/src/db/file.rs
+++ b/src/db/file.rs
@@ -13,8 +13,8 @@ use std::path::{Path, PathBuf};
 
 pub(crate) use crate::storage::Blob;
 
-pub(crate) fn get_path(conn: &Connection, path: &str) -> Option<Blob> {
-    Storage::new(conn).get(path).ok()
+pub(crate) fn get_path(conn: &Connection, path: &str) -> Result<Blob> {
+    Storage::new(conn).get(path)
 }
 
 /// Store all files in a directory and return [[mimetype, filename]] as Json

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -2,6 +2,7 @@ use super::TestDatabase;
 use crate::docbuilder::BuildResult;
 use crate::index::api::RegistryCrateData;
 use crate::utils::{Dependency, MetadataPackage, Target};
+use chrono::{DateTime, Utc};
 use failure::Error;
 
 #[must_use = "FakeRelease does nothing until you call .create()"]
@@ -54,7 +55,7 @@ impl<'a> FakeRelease<'a> {
             doc_targets: Vec::new(),
             default_target: None,
             registry_crate_data: RegistryCrateData {
-                release_time: time::get_time(),
+                release_time: Utc::now(),
                 yanked: false,
                 downloads: 0,
                 owners: Vec::new(),
@@ -74,7 +75,7 @@ impl<'a> FakeRelease<'a> {
         self
     }
 
-    pub(crate) fn release_time(mut self, new: time::Timespec) -> Self {
+    pub(crate) fn release_time(mut self, new: DateTime<Utc>) -> Self {
         self.registry_crate_data.release_time = new;
         self
     }

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -7,6 +7,7 @@ use crate::{
     utils::{github_updater, pubsubhubbub, update_release_activity},
     DocBuilder, DocBuilderOptions,
 };
+use chrono::{Timelike, Utc};
 use log::{debug, error, info, warn};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
@@ -221,8 +222,9 @@ pub fn start_daemon(background: bool) {
         .name("release activity updater".to_string())
         .spawn(move || loop {
             thread::sleep(Duration::from_secs(60));
-            let now = time::now();
-            if now.tm_hour == 23 && now.tm_min == 55 {
+            let now = Utc::now();
+
+            if now.hour() == 23 && now.minute() == 55 {
                 info!("Updating release activity");
                 if let Err(e) = update_release_activity() {
                     error!("Failed to update release activity: {}", e);

--- a/src/utils/release_activity_updater.rs
+++ b/src/utils/release_activity_updater.rs
@@ -1,7 +1,7 @@
 use crate::db::connect_db;
 use crate::error::Result;
+use chrono::{Duration, Utc};
 use serde_json::{Map, Value};
-use time::{now, Duration};
 
 pub fn update_release_activity() -> Result<()> {
     let conn = connect_db()?;
@@ -37,11 +37,10 @@ pub fn update_release_activity() -> Result<()> {
 
         let release_count: i64 = rows.get(0).get(0);
         let failure_count: i64 = failures_count_rows.get(0).get(0);
-        let now = now();
+        let now = Utc::now().naive_utc();
         let date = now - Duration::days(day);
 
-        // unwrap is fine here, as our date format is always valid
-        dates.push(format!("{}", date.strftime("%d %b").unwrap()));
+        dates.push(format!("{}", date.format("%d %b")));
         crate_counts.push(release_count);
         failure_counts.push(failure_count);
     }

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -3,6 +3,7 @@ use super::page::Page;
 use super::pool::Pool;
 use super::MetaData;
 use crate::docbuilder::Limits;
+use chrono::{DateTime, NaiveDateTime, Utc};
 use iron::prelude::*;
 use router::Router;
 use serde::ser::{Serialize, SerializeStruct, Serializer};
@@ -13,7 +14,7 @@ struct Build {
     rustc_version: String,
     cratesfyi_version: String,
     build_status: bool,
-    build_time: time::Timespec,
+    build_time: DateTime<Utc>,
     output: Option<String>,
 }
 
@@ -27,10 +28,7 @@ impl Serialize for Build {
         state.serialize_field("rustc_version", &self.rustc_version)?;
         state.serialize_field("cratesfyi_version", &self.cratesfyi_version)?;
         state.serialize_field("build_status", &self.build_status)?;
-        state.serialize_field(
-            "build_time",
-            &time::at(self.build_time).rfc3339().to_string(),
-        )?;
+        state.serialize_field("build_time", &self.build_time.format("%+").to_string())?;
         state.serialize_field("build_time_relative", &duration_to_str(self.build_time))?;
         state.serialize_field("output", &self.output)?;
 
@@ -102,7 +100,7 @@ pub fn build_list_handler(req: &mut Request) -> IronResult<Response> {
                 rustc_version: row.get(6),
                 cratesfyi_version: row.get(7),
                 build_status: row.get(8),
-                build_time: row.get(9),
+                build_time: DateTime::from_utc(row.get::<_, NaiveDateTime>(9), Utc),
                 output: row.get(10),
             };
 
@@ -153,11 +151,12 @@ pub fn build_list_handler(req: &mut Request) -> IronResult<Response> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
     use serde_json::json;
 
     #[test]
     fn serialize_build() {
-        let time = time::get_time();
+        let time = Utc::now();
         let mut build = Build {
             id: 22,
             rustc_version: "rustc 1.43.0 (4fb7144ed 2020-04-20)".to_string(),
@@ -171,7 +170,7 @@ mod tests {
             "id": 22,
             "rustc_version": "rustc 1.43.0 (4fb7144ed 2020-04-20)",
             "cratesfyi_version": "docsrs 0.6.0 (3dd32ec 2020-05-01)",
-            "build_time": time::at(time).rfc3339().to_string(),
+            "build_time": time.format("%+").to_string(),
             "build_time_relative": duration_to_str(time),
             "output": null,
             "build_status": true
@@ -184,7 +183,7 @@ mod tests {
             "id": 22,
             "rustc_version": "rustc 1.43.0 (4fb7144ed 2020-04-20)",
             "cratesfyi_version": "docsrs 0.6.0 (3dd32ec 2020-05-01)",
-            "build_time": time::at(time).rfc3339().to_string(),
+            "build_time": time.format("%+").to_string(),
             "build_time_relative": duration_to_str(time),
             "output": "some random stuff",
             "build_status": true
@@ -195,7 +194,7 @@ mod tests {
 
     #[test]
     fn serialize_build_page() {
-        let time = time::get_time();
+        let time = Utc::now();
         let build = Build {
             id: 22,
             rustc_version: "rustc 1.43.0 (4fb7144ed 2020-04-20)".to_string(),
@@ -232,7 +231,7 @@ mod tests {
                 "id": 22,
                 "rustc_version": "rustc 1.43.0 (4fb7144ed 2020-04-20)",
                 "cratesfyi_version": "docsrs 0.6.0 (3dd32ec 2020-05-01)",
-                "build_time": time::at(time).rfc3339().to_string(),
+                "build_time": time.format("%+").to_string(),
                 "build_time_relative": duration_to_str(time),
                 "output": null,
                 "build_status": true
@@ -241,7 +240,7 @@ mod tests {
                 "id": 22,
                 "rustc_version": "rustc 1.43.0 (4fb7144ed 2020-04-20)",
                 "cratesfyi_version": "docsrs 0.6.0 (3dd32ec 2020-05-01)",
-                "build_time": time::at(time).rfc3339().to_string(),
+                "build_time": time.format("%+").to_string(),
                 "build_time_relative": duration_to_str(time),
                 "output": null,
                 "build_status": true
@@ -258,7 +257,7 @@ mod tests {
                 "id": 22,
                 "rustc_version": "rustc 1.43.0 (4fb7144ed 2020-04-20)",
                 "cratesfyi_version": "docsrs 0.6.0 (3dd32ec 2020-05-01)",
-                "build_time": time::at(time).rfc3339().to_string(),
+                "build_time": time.format("%+").to_string(),
                 "build_time_relative": duration_to_str(time),
                 "output": null,
                 "build_status": true
@@ -267,7 +266,7 @@ mod tests {
                 "id": 22,
                 "rustc_version": "rustc 1.43.0 (4fb7144ed 2020-04-20)",
                 "cratesfyi_version": "docsrs 0.6.0 (3dd32ec 2020-05-01)",
-                "build_time": time::at(time).rfc3339().to_string(),
+                "build_time": time.format("%+").to_string(),
                 "build_time_relative": duration_to_str(time),
                 "output": null,
                 "build_status": true
@@ -285,7 +284,7 @@ mod tests {
                 "id": 22,
                 "rustc_version": "rustc 1.43.0 (4fb7144ed 2020-04-20)",
                 "cratesfyi_version": "docsrs 0.6.0 (3dd32ec 2020-05-01)",
-                "build_time": time::at(time).rfc3339().to_string(),
+                "build_time": time.format("%+").to_string(),
                 "build_time_relative": duration_to_str(time),
                 "output": null,
                 "build_status": true

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -28,7 +28,7 @@ impl Serialize for Build {
         state.serialize_field("rustc_version", &self.rustc_version)?;
         state.serialize_field("cratesfyi_version", &self.cratesfyi_version)?;
         state.serialize_field("build_status", &self.build_status)?;
-        state.serialize_field("build_time", &self.build_time.format("%+").to_string())?;
+        state.serialize_field("build_time", &self.build_time.format("%+").to_string())?; // RFC 3339
         state.serialize_field("build_time_relative", &duration_to_str(self.build_time))?;
         state.serialize_field("output", &self.output)?;
 

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -4,6 +4,7 @@ use super::pool::Pool;
 use super::{
     duration_to_str, match_version, redirect_base, render_markdown, MatchSemver, MetaData,
 };
+use chrono::{DateTime, NaiveDateTime, Utc};
 use iron::prelude::*;
 use iron::{status, Url};
 use postgres::Connection;
@@ -27,7 +28,7 @@ pub struct CrateDetails {
     dependencies: Option<Value>,
     readme: Option<String>,
     rustdoc: Option<String>, // this is description_long in database
-    release_time: time::Timespec,
+    release_time: DateTime<Utc>,
     build_status: bool,
     last_successful_build: Option<String>,
     rustdoc_status: bool,
@@ -206,7 +207,7 @@ impl CrateDetails {
             dependencies: krate.get("dependencies"),
             readme: krate.get("readme"),
             rustdoc: krate.get("description_long"),
-            release_time: krate.get("release_time"),
+            release_time: DateTime::from_utc(krate.get::<_, NaiveDateTime>("release_time"), Utc),
             build_status: krate.get("build_status"),
             last_successful_build: None,
             rustdoc_status: krate.get("rustdoc_status"),
@@ -287,7 +288,7 @@ impl CrateDetails {
     }
 
     #[cfg(test)]
-    pub fn default_tester(release_time: time::Timespec) -> Self {
+    pub fn default_tester(release_time: DateTime<Utc>) -> Self {
         Self {
             name: "rcc".to_string(),
             version: "100.0.0".to_string(),
@@ -385,6 +386,7 @@ pub fn crate_details_handler(req: &mut Request) -> IronResult<Response> {
 mod tests {
     use super::*;
     use crate::test::TestDatabase;
+    use chrono::Utc;
     use failure::Error;
     use serde_json::json;
 
@@ -634,7 +636,7 @@ mod tests {
 
     #[test]
     fn serialize_crate_details() {
-        let time = time::get_time();
+        let time = Utc::now();
         let mut details = CrateDetails::default_tester(time);
 
         let mut correct_json = json!({

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -56,6 +56,7 @@ mod sitemap;
 mod source;
 
 use self::pool::Pool;
+use chrono::{DateTime, Utc};
 use handlebars_iron::{DirectorySource, HandlebarsEngine, SourceError};
 use iron::headers::{CacheControl, CacheDirective, ContentType, Expires, HttpDate};
 use iron::modifiers::Redirect;
@@ -414,9 +415,10 @@ impl Server {
 }
 
 /// Converts Timespec to nice readable relative time string
-fn duration_to_str(ts: time::Timespec) -> String {
-    let tm = time::at(ts);
-    let delta = time::now() - tm;
+fn duration_to_str(init: DateTime<Utc>) -> String {
+    let now = Utc::now();
+    let delta = now.signed_duration_since(init);
+
     let delta = (
         delta.num_days(),
         delta.num_hours(),
@@ -425,7 +427,7 @@ fn duration_to_str(ts: time::Timespec) -> String {
     );
 
     match delta {
-        (days, ..) if days > 5 => format!("{}", tm.strftime("%b %d, %Y").unwrap()),
+        (days, ..) if days > 5 => format!("{}", init.format("%b %d, %Y")),
         (days @ 2..=5, ..) => format!("{} days ago", days),
         (1, ..) => "one day ago".to_string(),
 

--- a/src/web/page/handlebars.rs
+++ b/src/web/page/handlebars.rs
@@ -152,12 +152,13 @@ fn build_version_safe(version: &str) -> String {
 mod tests {
     use super::*;
     use crate::web::releases::{self, Release};
+    use chrono::Utc;
     use iron::Url;
     use serde_json::json;
 
     #[test]
     fn serialize_page() {
-        let time = time::get_time();
+        let time = Utc::now();
 
         let mut release = Release::default();
         release.name = "lasso".into();
@@ -189,7 +190,7 @@ mod tests {
                 "target_name": null,
                 "rustdoc_status": false,
                 "release_time": super::super::super::duration_to_str(time),
-                "release_time_rfc3339": time::at(time).rfc3339().to_string(),
+                "release_time_rfc3339": time.format("%+").to_string(),
                 "stars": 0
             }],
             "varss": { "test": "works" },

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -1,6 +1,7 @@
 use super::TEMPLATE_DATA;
 use crate::error::Result;
 use arc_swap::ArcSwap;
+use chrono::{DateTime, Utc};
 use serde_json::Value;
 use std::collections::HashMap;
 use tera::{Result as TeraResult, Tera};
@@ -142,9 +143,11 @@ fn rustc_resource_suffix(args: &HashMap<String, Value>) -> TeraResult<Value> {
 // TODO: This can be replaced by chrono
 fn timeformat(value: &Value, args: &HashMap<String, Value>) -> TeraResult<Value> {
     let fmt = if let Some(Value::Bool(true)) = args.get("relative") {
-        let value = time::strptime(value.as_str().unwrap(), "%Y-%m-%dT%H:%M:%S%z").unwrap();
+        let value = DateTime::parse_from_str(value.as_str().unwrap(), "%Y-%m-%dT%H:%M:%S%z")
+            .unwrap()
+            .with_timezone(&Utc);
 
-        super::super::duration_to_str(value.to_timespec())
+        super::super::duration_to_str(value)
     } else {
         const TIMES: &[&str] = &["seconds", "minutes", "hours"];
 

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -1,5 +1,6 @@
 use super::page::Page;
 use super::pool::Pool;
+use chrono::{DateTime, NaiveDateTime, Utc};
 use iron::headers::ContentType;
 use iron::prelude::*;
 use serde_json::Value;
@@ -22,7 +23,9 @@ pub fn sitemap_handler(req: &mut Request) -> IronResult<Response> {
     let releases = query
         .into_iter()
         .map(|row| {
-            let time = format!("{}", time::at(row.get(1)).rfc3339());
+            let time = DateTime::<Utc>::from_utc(row.get::<_, NaiveDateTime>(1), Utc)
+                .format("%+")
+                .to_string();
 
             (row.get(0), time)
         })

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -215,7 +215,7 @@ pub fn source_browser_handler(req: &mut Request) -> IronResult<Response> {
     // try to get actual file first
     // skip if request is a directory
     let file = if !file_path.ends_with('/') {
-        DbFile::from_path(&conn, &file_path)
+        DbFile::from_path(&conn, &file_path).ok()
     } else {
         None
     };


### PR DESCRIPTION
Most of the stuff can be switched to `chrono`, but iron-related timeouts require `time` and won't be able to be removed until `iron` is. 