### PR TITLE
Fix 404 on /releases/feed

### DIFF
--- a/src/web/page.rs
+++ b/src/web/page.rs
@@ -120,8 +120,10 @@ impl<T: Serialize> Serialize for Page<T> {
         // adding the someness of the global alert to the total. `true`
         // is 1 and `false` is 0, so it increments if the value is some (and therefore
         // needs to be serialized)
-        let mut state =
-            serializer.serialize_struct("Page", 9 + crate::GLOBAL_ALERT.is_some() as usize)?;
+        let mut state = serializer.serialize_struct(
+            "Page",
+            8 + crate::GLOBAL_ALERT.is_some() as usize + self.title.is_some() as usize,
+        )?;
 
         if let Some(ref title) = self.title {
             state.serialize_field("title", title)?;

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -670,7 +670,7 @@ pub fn build_queue_handler(req: &mut Request) -> IronResult<Response> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::wrapper;
+    use crate::test::{assert_success, wrapper};
     use serde_json::json;
 
     #[test]
@@ -1059,5 +1059,13 @@ mod tests {
         });
 
         assert_eq!(correct_json, serde_json::to_value(&release).unwrap());
+    }
+
+    #[test]
+    fn release_feed() {
+        wrapper(|env| {
+            let web = env.frontend();
+            assert_success("/releases/feed", web)
+        })
     }
 }

--- a/templates/releases_feed.hbs
+++ b/templates/releases_feed.hbs
@@ -7,7 +7,7 @@
 <link href="https://pubsubhubbub.appspot.com" rel="hub" />
 <link href="https://pubsubhubbub.superfeedr.com" rel="hub" />
 <id>urn:docs-rs:{{cratesfyi_version_safe}}</id>
-<updated>{{content[0].release_time_rfc3339}}</updated>
+<updated>{{content.[0].release_time_rfc3339}}</updated>
 {{#each content}}
 <entry>
 <title>{{name}}-{{version}}</title>


### PR DESCRIPTION
Handlebars removed the `obj[0]` notation in 0.25: https://github.com/sunng87/handlebars-rust/commit/779df9868ebb713300bab3744137a5cb58c529a3#diff-e0934bb6f70a4f8c3baf22a773c14ec7L35

Closes https://github.com/rust-lang/docs.rs/issues/782

r? @Kixiron 

This also uncovered that we handle failure pretty badly in `impl Handler for CratesfyiHandler`, we always return the first error encountered even if it was a 404, ignoring all future errors. This should be fixed, but I want to get this fix in first.