### PR TITLE
Add crate file size upload limits

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -3,8 +3,7 @@ use std::path::PathBuf;
 
 use cratesfyi::db::{self, add_path_into_database, connect_db};
 use cratesfyi::utils::{add_crate_to_queue, remove_crate_priority, set_crate_priority};
-use cratesfyi::Server;
-use cratesfyi::{DocBuilder, DocBuilderOptions, RustwideBuilder};
+use cratesfyi::{DocBuilder, DocBuilderOptions, Limits, RustwideBuilder, Server};
 use structopt::StructOpt;
 
 pub fn main() {
@@ -412,7 +411,7 @@ impl DatabaseSubcommand {
 
             Self::AddDirectory { directory, prefix } => {
                 let conn = db::connect_db().expect("failed to connect to the database");
-                add_path_into_database(&conn, &prefix, directory)
+                add_path_into_database(&conn, &prefix, directory, &Limits::default())
                     .expect("Failed to add directory into database");
             }
 

--- a/src/db/file.rs
+++ b/src/db/file.rs
@@ -4,8 +4,7 @@
 //! They are using so many inodes and it is better to store them in database instead of
 //! filesystem. This module is adding files into database and retrieving them.
 
-use crate::error::Result;
-use crate::storage::Storage;
+use crate::{docbuilder::Limits, error::Result, storage::Storage};
 use postgres::Connection;
 
 use serde_json::Value;
@@ -30,9 +29,11 @@ pub fn add_path_into_database<P: AsRef<Path>>(
     conn: &Connection,
     prefix: &str,
     path: P,
+    limits: &Limits,
 ) -> Result<Value> {
     let mut backend = Storage::new(conn);
-    let file_list = backend.store_all(conn, prefix, path.as_ref())?;
+    let file_list = backend.store_all(conn, prefix, path.as_ref(), limits)?;
+
     file_list_to_json(file_list.into_iter().collect())
 }
 

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -325,6 +325,17 @@ pub fn migrate(version: Option<Version>, conn: &Connection) -> CratesfyiResult<(
                 ALTER TABLE releases ALTER COLUMN doc_targets DROP NOT NULL;
             "
         ),
+        migration!(
+            context,
+            // version
+            13,
+            // description
+            "Allow max file upload size to be overridden",
+            // upgrade query
+            "ALTER TABLE sandbox_overrides ADD COLUMN upload_size INT;",
+            // downgrade query
+            "ALTER TABLE sandbox_overrides DROP COLUMN upload_size;"
+        ),
     ];
 
     for migration in migrations {

--- a/src/docbuilder/mod.rs
+++ b/src/docbuilder/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod options;
 mod queue;
 mod rustwide_builder;
 
-pub(crate) use self::limits::Limits;
+pub use self::limits::Limits;
 pub(self) use self::metadata::Metadata;
 pub(crate) use self::rustwide_builder::BuildResult;
 pub use self::rustwide_builder::RustwideBuilder;

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -242,7 +242,7 @@ impl RustwideBuilder {
                     })?;
                 }
 
-                add_path_into_database(&conn, "", &dest)?;
+                add_path_into_database(&conn, "", &dest, &limits)?;
                 conn.query(
                     "INSERT INTO config (name, value) VALUES ('rustc_version', $1) \
                      ON CONFLICT (name) DO UPDATE SET value = $1;",
@@ -349,6 +349,7 @@ impl RustwideBuilder {
                         &conn,
                         &prefix,
                         build.host_source_dir(),
+                        &limits,
                     )?);
 
                     if let Some(name) = res.cargo_metadata.root().library_name() {
@@ -376,7 +377,7 @@ impl RustwideBuilder {
                             &metadata,
                         )?;
                     }
-                    self.upload_docs(&conn, name, version, local_storage.path())?;
+                    self.upload_docs(&conn, name, version, local_storage.path(), &limits)?;
                 }
 
                 let has_examples = build.host_source_dir().join("examples").is_dir();
@@ -572,13 +573,16 @@ impl RustwideBuilder {
         name: &str,
         version: &str,
         local_storage: &Path,
+        limits: &Limits,
     ) -> Result<()> {
         debug!("Adding documentation into database");
         add_path_into_database(
             conn,
             &format!("rustdoc/{}/{}", name, version),
             local_storage,
+            limits,
         )?;
+
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 pub use self::docbuilder::options::DocBuilderOptions;
 pub use self::docbuilder::DocBuilder;
-pub use self::docbuilder::RustwideBuilder;
+pub use self::docbuilder::{Limits, RustwideBuilder};
 pub use self::web::Server;
 
 pub mod db;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3,16 +3,19 @@ pub(crate) mod s3;
 
 pub(crate) use self::database::DatabaseBackend;
 pub(crate) use self::s3::S3Backend;
-use failure::Error;
-use time::Timespec;
 
+use crate::docbuilder::Limits;
 use failure::err_msg;
+use failure::Error;
 use postgres::{transaction::Transaction, Connection};
-use std::collections::HashMap;
-use std::ffi::OsStr;
-use std::fs;
-use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    ffi::OsStr,
+    fs::File,
+    io::Read,
+    path::{Path, PathBuf},
+};
+use time::Timespec;
 
 const MAX_CONCURRENT_UPLOADS: usize = 1000;
 
@@ -72,6 +75,7 @@ impl<'a> Storage<'a> {
             DatabaseBackend::new(conn).into()
         }
     }
+
     pub(crate) fn get(&self, path: &str) -> Result<Blob, Error> {
         match self {
             Self::Database(db) => db.get(path),
@@ -97,6 +101,7 @@ impl<'a> Storage<'a> {
         conn: &Connection,
         prefix: &str,
         root_dir: &Path,
+        limits: &Limits,
     ) -> Result<HashMap<PathBuf, String>, Error> {
         let trans = conn.transaction()?;
         let mut file_paths_and_mimes = HashMap::new();
@@ -107,9 +112,19 @@ impl<'a> Storage<'a> {
                 // Some files have insufficient permissions
                 // (like .lock file created by cargo in documentation directory).
                 // Skip these files.
-                fs::File::open(root_dir.join(&file_path))
+                let (path, file) = File::open(root_dir.join(&file_path))
                     .ok()
-                    .map(|file| (file_path, file))
+                    .map(|file| (file_path, file))?;
+
+                // Filter out files which are larger than the current crate's upload limit
+                let file_size = file.metadata().unwrap().len();
+                if file_size <= limits.upload_size() {
+                    Some((path, file))
+                } else {
+                    log::error!("Failed to upload {:?}, {} bytes is larger than the crate limit of {} bytes", path, file_size, limits.upload_size());
+
+                    None
+                }
             })
             .map(|(file_path, mut file)| -> Result<_, Error> {
                 let mut content: Vec<u8> = Vec::new();
@@ -188,7 +203,7 @@ impl<'a> From<S3Backend<'a>> for Storage<'a> {
 mod test {
     use super::*;
     use crate::test::wrapper;
-    use std::env;
+    use std::{env, fs};
 
     pub(crate) fn assert_blob_eq(blob: &Blob, actual: &Blob) {
         assert_eq!(blob.path, actual.path);
@@ -197,24 +212,29 @@ mod test {
         // NOTE: this does _not_ compare the upload time since min.io doesn't allow this to be configured
     }
 
-    pub(crate) fn test_roundtrip(blobs: &[Blob]) {
+    pub(crate) fn test_roundtrip(blobs: &[Blob], limits: &Limits) {
         let dir = tempfile::Builder::new()
             .prefix("docs.rs-upload-test")
             .tempdir()
             .unwrap();
+
         for blob in blobs {
             let path = dir.path().join(&blob.path);
             if let Some(parent) = path.parent() {
                 fs::create_dir_all(parent).unwrap();
             }
+
             fs::write(path, &blob.content).expect("failed to write to file");
         }
+
         wrapper(|env| {
             let db = env.db();
             let conn = db.conn();
+
             let mut backend = Storage::Database(DatabaseBackend::new(&conn));
-            let stored_files = backend.store_all(&conn, "", dir.path()).unwrap();
+            let stored_files = backend.store_all(&conn, "", dir.path(), limits).unwrap();
             assert_eq!(stored_files.len(), blobs.len());
+
             for blob in blobs {
                 let name = Path::new(&blob.path);
                 assert!(stored_files.contains_key(name));
@@ -230,23 +250,32 @@ mod test {
     #[test]
     fn test_uploads() {
         use std::fs;
+
+        let limits = Limits::default();
         let dir = tempfile::Builder::new()
             .prefix("docs.rs-upload-test")
             .tempdir()
             .unwrap();
+
         let files = ["Cargo.toml", "src/main.rs"];
         for &file in &files {
             let path = dir.path().join(file);
             if let Some(parent) = path.parent() {
                 fs::create_dir_all(parent).unwrap();
             }
+
             fs::write(path, "data").expect("failed to write to file");
         }
+
         wrapper(|env| {
             let db = env.db();
             let conn = db.conn();
+
             let mut backend = Storage::Database(DatabaseBackend::new(&conn));
-            let stored_files = backend.store_all(&conn, "rustdoc", dir.path()).unwrap();
+            let stored_files = backend
+                .store_all(&conn, "rustdoc", dir.path(), &limits)
+                .unwrap();
+
             assert_eq!(stored_files.len(), files.len());
             for name in &files {
                 let name = Path::new(name);
@@ -276,6 +305,7 @@ mod test {
 
     #[test]
     fn test_batched_uploads() {
+        let limits = Limits::default();
         let uploads: Vec<_> = (0..=MAX_CONCURRENT_UPLOADS + 1)
             .map(|i| Blob {
                 mime: "text/rust".into(),
@@ -284,7 +314,8 @@ mod test {
                 date_updated: Timespec::new(42, 0),
             })
             .collect();
-        test_roundtrip(&uploads);
+
+        test_roundtrip(&uploads, &limits);
     }
 
     #[test]

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -1,7 +1,9 @@
 use super::TestDatabase;
-use crate::docbuilder::BuildResult;
-use crate::index::api::RegistryCrateData;
-use crate::utils::{Dependency, MetadataPackage, Target};
+use crate::{
+    docbuilder::{BuildResult, Limits},
+    index::api::RegistryCrateData,
+    utils::{Dependency, MetadataPackage, Target},
+};
 use failure::Error;
 
 #[must_use = "FakeRelease does nothing until you call .create()"]
@@ -181,8 +183,14 @@ impl<'a> FakeRelease<'a> {
                     package.version,
                     target.unwrap_or("")
                 );
+
                 log::debug!("adding directory {} from {}", prefix, path_prefix.display());
-                crate::db::add_path_into_database(&db.conn(), &prefix, path_prefix)
+                crate::db::add_path_into_database(
+                    &db.conn(),
+                    &prefix,
+                    path_prefix,
+                    &Limits::default(),
+                )
             };
 
             let index = [&package.name, "index.html"].join("/");


### PR DESCRIPTION
Limits the maximum file size for uploaded files, configurable via `Limits`. The current default I have right now is 5 GB, but I just set that because I didn't know what the preferred number would be

Closes #588