### PR TITLE
Only chain on 404 errors, log and return others as 500

### DIFF
--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -10,6 +10,7 @@ pub enum Nope {
     ResourceNotFound,
     CrateNotFound,
     NoResults,
+    InternalServerError,
 }
 
 impl fmt::Display for Nope {
@@ -18,6 +19,7 @@ impl fmt::Display for Nope {
             Nope::ResourceNotFound => "Requested resource not found",
             Nope::CrateNotFound => "Requested crate not found",
             Nope::NoResults => "Search yielded no results",
+            Nope::InternalServerError => "Internal server error",
         })
     }
 }
@@ -58,6 +60,13 @@ impl Handler for Nope {
                         .title("No results given for empty search query")
                         .to_resp("releases")
                 }
+            }
+            Nope::InternalServerError => {
+                // something went wrong, details should have been logged
+                Page::new("internal server error".to_owned())
+                    .set_status(status::InternalServerError)
+                    .title("Internal server error")
+                    .to_resp("error")
             }
         }
     }


### PR DESCRIPTION
Results in logs like

```
web_1  | 2020/06/02 08:13:07 [ERROR] cratesfyi::web: internal server error: Error rendering "releases_feed" line 10, col 10: Helper not defined: "content"
```

and a page like

<img width="311" alt="image" src="https://user-images.githubusercontent.com/81079/83496856-fbe1b680-a4b9-11ea-96f0-fcffb3408ebb.png">

when I reapply the bug in #728 

Fixes #801 