### PR TITLE
[Refactor] Removed the search index updater

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,7 +27,6 @@ while true; do
 done
 set -e
 
-cratesfyi database update-search-index
 cratesfyi database update-release-activity
 
 if ! [ -d "${CRATESFYI_PREFIX}/crates.io-index/.git" ]; then

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -381,9 +381,6 @@ enum DatabaseSubcommand {
     /// Updates monthly release activity chart
     UpdateReleaseActivity,
 
-    /// Updates search index
-    UpdateSearchIndex,
-
     /// Removes a whole crate from the database
     DeleteCrate {
         /// Name of the crate to delete
@@ -419,11 +416,6 @@ impl DatabaseSubcommand {
             // FIXME: This is actually util command not database
             Self::UpdateReleaseActivity => cratesfyi::utils::update_release_activity()
                 .expect("Failed to update release activity"),
-
-            Self::UpdateSearchIndex => {
-                let conn = db::connect_db().expect("failed to connect to the database");
-                db::update_search_index(&conn).expect("Failed to update search index");
-            }
 
             Self::DeleteCrate { crate_name } => {
                 let conn = db::connect_db().expect("failed to connect to the database");

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -325,6 +325,21 @@ pub fn migrate(version: Option<Version>, conn: &Connection) -> CratesfyiResult<(
                 ALTER TABLE releases ALTER COLUMN doc_targets DROP NOT NULL;
             "
         ),
+        migration!(
+            context,
+            // version
+            13,
+            // description
+            "Remove the content column and releases column",
+            // upgrade query
+            "ALTER TABLE crates
+             DROP COLUMN content,
+             DROP COLUMN versions;",
+            // downgrade query
+            "ALTER TABLE crates
+             ADD COLUMN content,
+             ADD COLUMN versions;"
+        ),
     ];
 
     for migration in migrations {

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -3,7 +3,6 @@
 //! This daemon will start web server, track new packages and build them
 
 use crate::{
-    db::{connect_db, update_search_index},
     docbuilder::RustwideBuilder,
     utils::{github_updater, pubsubhubbub, update_release_activity},
     DocBuilder, DocBuilderOptions,
@@ -228,18 +227,6 @@ pub fn start_daemon(background: bool) {
                 if let Err(e) = update_release_activity() {
                     error!("Failed to update release activity: {}", e);
                 }
-            }
-        })
-        .unwrap();
-
-    // update search index every 3 hours
-    thread::Builder::new()
-        .name("search index updater".to_string())
-        .spawn(move || loop {
-            thread::sleep(Duration::from_secs(60 * 60 * 3));
-            let conn = connect_db().expect("Failed to connect database");
-            if let Err(e) = update_search_index(&conn) {
-                error!("Failed to update search index: {}", e);
             }
         })
         .unwrap();


### PR DESCRIPTION
* Removed the `update-search-index` command and service
* Updating is now relegated to `add_package_into_database`, so changes are reflected instantly
* Removed the unneeded `content` and `versions` columns from the `crates` table
* Made `CrateDetails::new()` use strings for getting query rows instead of indices for readability

Unanswered Questions:
* [`CrateDetails.rustdoc`](https://github.com/rust-lang/docs.rs/compare/master...Kixiron:update-refactor?expand=1#diff-07b7024fe121ba3b5acf483a50bf3000L217) gets its data from [`crates.description_long`](https://github.com/rust-lang/docs.rs/compare/master...Kixiron:update-refactor?expand=1#diff-07b7024fe121ba3b5acf483a50bf3000L126), maybe a rename is in order?