### PR TITLE
metrics: fix docsrs_prioritized_crates_count

### DIFF
--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -124,9 +124,12 @@ pub fn metrics_handler(req: &mut Request) -> IronResult<Response> {
                 .get(0),
         );
         PRIORITIZED_CRATES_COUNT.set(
-            ctry!(conn.query("SELECT COUNT(*) FROM queue WHERE attempts < 5 AND priority <= 0;", &[]))
-                .get(0)
-                .get(0),
+            ctry!(conn.query(
+                "SELECT COUNT(*) FROM queue WHERE attempts < 5 AND priority <= 0;",
+                &[]
+            ))
+            .get(0)
+            .get(0),
         );
         FAILED_CRATES_COUNT.set(
             ctry!(conn.query("SELECT COUNT(*) FROM queue WHERE attempt >= 5;", &[]))

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -124,7 +124,7 @@ pub fn metrics_handler(req: &mut Request) -> IronResult<Response> {
                 .get(0),
         );
         PRIORITIZED_CRATES_COUNT.set(
-            ctry!(conn.query("SELECT COUNT(*) FROM queue WHERE priority >= 0;", &[]))
+            ctry!(conn.query("SELECT COUNT(*) FROM queue WHERE attempts < 5 AND priority <= 0;", &[]))
                 .get(0)
                 .get(0),
         );


### PR DESCRIPTION
The metric was including failed crates, and didn't consider that the priority is stored with the wrong sign in the database (a positive priority means a negative priority, for whatever reason).

r? @Kixiron 
fixes https://github.com/rust-lang/docs.rs/issues/718