### PR TITLE
Load registry config to determine which API to use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
  "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zstd 0.5.2+zstd.1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3766,6 +3766,7 @@ dependencies = [
  "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,6 +2591,7 @@ dependencies = [
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2891,6 +2892,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ log = "0.4"
 regex = "1"
 structopt = "0.3"
 crates-index-diff = "7"
-reqwest = { version = "0.10.6", features = ["blocking"] } # TODO: Remove blocking when async is ready
-semver = "0.9"
+reqwest = { version = "0.10.6", features = ["blocking", "json"] } # TODO: Remove blocking when async is ready
+semver = { version = "0.9", features = ["serde"] }
 slug = "=0.1.1"
 env_logger = "0.7"
 r2d2 = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ rustwide = "0.7.1"
 mime_guess = "2"
 dotenv = "0.15"
 zstd = "0.5"
+git2 = { version = "0.13.6", default-features = false }
 
 # Data serialization and deserialization
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,9 @@ slug = "=0.1.1"
 env_logger = "0.7"
 r2d2 = "0.8"
 r2d2_postgres = "0.14"
-url = "1.4"
+# iron needs url@1, but it reexports it as iron::url, so we can start using
+# url@2 for other usecases
+url = { version = "2.1.1", features = ["serde"] }
 badge = { path = "src/web/badge" }
 failure = "0.1.3"
 comrak = { version = "0.3", default-features = false }

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -32,7 +32,7 @@ pub(crate) fn add_package_into_database(
     default_target: &str,
     source_files: Option<Value>,
     doc_targets: Vec<String>,
-    cratesio_data: &RegistryCrateData,
+    registry_data: &RegistryCrateData,
     has_docs: bool,
     has_examples: bool,
     compression_algorithms: std::collections::HashSet<CompressionAlgorithm>,
@@ -87,10 +87,10 @@ pub(crate) fn add_package_into_database(
         &[
             &crate_id,
             &metadata_pkg.version,
-            &cratesio_data.release_time.naive_utc(),
+            &registry_data.release_time.naive_utc(),
             &serde_json::to_value(&dependencies)?,
             &metadata_pkg.package_name(),
-            &cratesio_data.yanked,
+            &registry_data.yanked,
             &res.successful,
             &has_docs,
             &false, // TODO: Add test status somehow
@@ -103,7 +103,7 @@ pub(crate) fn add_package_into_database(
             &serde_json::to_value(&metadata_pkg.authors)?,
             &serde_json::to_value(&metadata_pkg.keywords)?,
             &has_examples,
-            &cratesio_data.downloads,
+            &registry_data.downloads,
             &source_files,
             &serde_json::to_value(&doc_targets)?,
             &is_library,
@@ -117,7 +117,7 @@ pub(crate) fn add_package_into_database(
 
     add_keywords_into_database(&conn, &metadata_pkg, release_id)?;
     add_authors_into_database(&conn, &metadata_pkg, release_id)?;
-    add_owners_into_database(&conn, &cratesio_data.owners, crate_id)?;
+    add_owners_into_database(&conn, &registry_data.owners, crate_id)?;
     add_compression_into_database(&conn, compression_algorithms.into_iter(), release_id)?;
 
     // Update the crates table with the new release

--- a/src/docbuilder/mod.rs
+++ b/src/docbuilder/mod.rs
@@ -11,6 +11,7 @@ pub(crate) use self::rustwide_builder::BuildResult;
 pub use self::rustwide_builder::RustwideBuilder;
 
 use crate::error::Result;
+use crate::index::Index;
 use crate::DocBuilderOptions;
 use log::debug;
 use std::collections::BTreeSet;
@@ -22,14 +23,17 @@ use std::path::PathBuf;
 /// chroot based documentation builder
 pub struct DocBuilder {
     options: DocBuilderOptions,
+    index: Index,
     cache: BTreeSet<String>,
     db_cache: BTreeSet<String>,
 }
 
 impl DocBuilder {
     pub fn new(options: DocBuilderOptions) -> DocBuilder {
+        let index = Index::new(&options.registry_index_path).expect("valid index");
         DocBuilder {
             options,
+            index,
             cache: BTreeSet::new(),
             db_cache: BTreeSet::new(),
         }

--- a/src/docbuilder/queue.rs
+++ b/src/docbuilder/queue.rs
@@ -4,7 +4,7 @@ use super::{DocBuilder, RustwideBuilder};
 use crate::db::connect_db;
 use crate::error::Result;
 use crate::utils::{add_crate_to_queue, get_crate_priority};
-use crates_index_diff::{ChangeKind, Index};
+use crates_index_diff::ChangeKind;
 use log::{debug, error};
 
 impl DocBuilder {
@@ -12,8 +12,7 @@ impl DocBuilder {
     /// Returns the number of crates added
     pub fn get_new_crates(&mut self) -> Result<usize> {
         let conn = connect_db()?;
-        let index = Index::from_path_or_cloned(&self.options.registry_index_path)?;
-        let (mut changes, oid) = index.peek_changes()?;
+        let (mut changes, oid) = self.index.diff().peek_changes()?;
         let mut crates_added = 0;
 
         // I believe this will fix ordering of queue if we get more than one crate from changes
@@ -59,7 +58,7 @@ impl DocBuilder {
             }
         }
 
-        index.set_last_seen_reference(oid)?;
+        self.index.diff().set_last_seen_reference(oid)?;
 
         Ok(crates_added)
     }

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -389,6 +389,17 @@ impl RustwideBuilder {
                 } else {
                     crate::web::metrics::NON_LIBRARY_BUILDS.inc();
                 }
+                let registry_data = if let Some(api) = doc_builder.index.api() {
+                    api.get_crate_data(name, version)?
+                } else {
+                    // If the index has no API, we insert empty data
+                    RegistryCrateData {
+                        release_time: chrono::Utc::now(),
+                        yanked: false,
+                        downloads: 0,
+                        owners: vec![],
+                    }
+                };
                 let release_id = add_package_into_database(
                     &conn,
                     res.cargo_metadata.root(),
@@ -397,7 +408,7 @@ impl RustwideBuilder {
                     &res.target,
                     files_list,
                     successful_targets,
-                    &RegistryCrateData::get_from_network(name, version)?,
+                    &registry_data,
                     has_docs,
                     has_examples,
                     algs,

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -397,7 +397,7 @@ impl RustwideBuilder {
                     &res.target,
                     files_list,
                     successful_targets,
-                    &RegistryCrateData::get_from_network(res.cargo_metadata.root())?,
+                    &RegistryCrateData::get_from_network(name, version)?,
                     has_docs,
                     has_examples,
                     algs,

--- a/src/index/api.rs
+++ b/src/index/api.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use failure::err_msg;
-use log::info;
+use log::warn;
 use reqwest::header::{HeaderValue, ACCEPT, USER_AGENT};
 use semver::Version;
 use serde::Deserialize;
@@ -59,12 +59,12 @@ impl Api {
         let (release_time, yanked, downloads) = self
             .get_release_time_yanked_downloads(name, version)
             .unwrap_or_else(|err| {
-                info!("Failed to get crate data for {}-{}: {}", name, version, err);
+                warn!("Failed to get crate data for {}-{}: {}", name, version, err);
                 (Utc::now(), false, 0)
             });
 
         let owners = self.get_owners(name).unwrap_or_else(|err| {
-            info!("Failed to get owners for {}-{}: {}", name, version, err);
+            warn!("Failed to get owners for {}-{}: {}", name, version, err);
             Vec::new()
         });
 

--- a/src/index/api.rs
+++ b/src/index/api.rs
@@ -5,6 +5,7 @@ use failure::err_msg;
 use reqwest::header::{HeaderValue, ACCEPT, USER_AGENT};
 use semver::Version;
 use serde_json::Value;
+use url::Url;
 
 use crate::error::Result;
 
@@ -13,6 +14,10 @@ const APP_USER_AGENT: &str = concat!(
     " ",
     include_str!(concat!(env!("OUT_DIR"), "/git_version"))
 );
+
+pub(crate) struct Api<'a> {
+    api_base: &'a Url,
+}
 
 pub(crate) struct RegistryCrateData {
     pub(crate) release_time: DateTime<Utc>,
@@ -26,20 +31,6 @@ pub(crate) struct CrateOwner {
     pub(crate) email: String,
     pub(crate) login: String,
     pub(crate) name: String,
-}
-
-impl RegistryCrateData {
-    pub(crate) fn get_from_network(name: &str, version: &str) -> Result<Self> {
-        let (release_time, yanked, downloads) = get_release_time_yanked_downloads(name, version)?;
-        let owners = get_owners(name)?;
-
-        Ok(Self {
-            release_time,
-            yanked,
-            downloads,
-            owners,
-        })
-    }
 }
 
 fn client() -> Result<reqwest::blocking::Client> {
@@ -57,120 +48,152 @@ fn client() -> Result<reqwest::blocking::Client> {
     Ok(client)
 }
 
-/// Get release_time, yanked and downloads from the registry's API
-fn get_release_time_yanked_downloads(
-    name: &str,
-    version: &str,
-) -> Result<(DateTime<Utc>, bool, i32)> {
-    let url = format!("https://crates.io/api/v1/crates/{}/versions", name);
-    // FIXME: There is probably better way to do this
-    //        and so many unwraps...
-    let mut res = client()?.get(&url).send()?;
-
-    let mut body = String::new();
-    res.read_to_string(&mut body)?;
-
-    let json: Value = serde_json::from_str(&body)?;
-    let versions = json
-        .as_object()
-        .and_then(|o| o.get("versions"))
-        .and_then(|v| v.as_array())
-        .ok_or_else(|| err_msg("Not a JSON object"))?;
-
-    let (mut release_time, mut yanked, mut downloads) = (None, None, None);
-
-    for version_data in versions {
-        let version_data = version_data
-            .as_object()
-            .ok_or_else(|| err_msg("Not a JSON object"))?;
-        let version_num = version_data
-            .get("num")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| err_msg("Not a JSON object"))?;
-
-        if Version::parse(version_num)?.to_string() == version {
-            let release_time_raw = version_data
-                .get("created_at")
-                .and_then(|c| c.as_str())
-                .ok_or_else(|| err_msg("Not a JSON object"))?;
-
-            release_time = Some(
-                DateTime::parse_from_str(release_time_raw, "%Y-%m-%dT%H:%M:%S%.f%:z")?
-                    .with_timezone(&Utc),
-            );
-
-            yanked = Some(
-                version_data
-                    .get("yanked")
-                    .and_then(|c| c.as_bool())
-                    .ok_or_else(|| err_msg("Not a JSON object"))?,
-            );
-
-            downloads = Some(
-                version_data
-                    .get("downloads")
-                    .and_then(|c| c.as_i64())
-                    .ok_or_else(|| err_msg("Not a JSON object"))? as i32,
-            );
-
-            break;
-        }
+impl<'a> Api<'a> {
+    pub(super) fn new(api_base: &'a Url) -> Self {
+        Self { api_base }
     }
 
-    Ok((
-        release_time.unwrap_or_else(Utc::now),
-        yanked.unwrap_or(false),
-        downloads.unwrap_or(0),
-    ))
-}
+    pub(crate) fn get_crate_data(&self, name: &str, version: &str) -> Result<RegistryCrateData> {
+        let (release_time, yanked, downloads) =
+            self.get_release_time_yanked_downloads(name, version)?;
+        let owners = self.get_owners(name)?;
 
-/// Fetch owners from the registry's API
-fn get_owners(name: &str) -> Result<Vec<CrateOwner>> {
-    let owners_url = format!("https://crates.io/api/v1/crates/{}/owners", name);
-    let mut res = client()?.get(&owners_url[..]).send()?;
-    // FIXME: There is probably better way to do this
-    //        and so many unwraps...
-    let mut body = String::new();
-    res.read_to_string(&mut body).unwrap();
-    let json: Value = serde_json::from_str(&body[..])?;
+        Ok(RegistryCrateData {
+            release_time,
+            yanked,
+            downloads,
+            owners,
+        })
+    }
 
-    let owners = json
-        .as_object()
-        .and_then(|j| j.get("users"))
-        .and_then(|j| j.as_array());
+    /// Get release_time, yanked and downloads from the registry's API
+    fn get_release_time_yanked_downloads(
+        &self,
+        name: &str,
+        version: &str,
+    ) -> Result<(DateTime<Utc>, bool, i32)> {
+        let url = {
+            let mut url = self.api_base.clone();
+            url.path_segments_mut()
+                .map_err(|()| err_msg("Invalid API url"))?
+                .extend(&["api", "v1", "crates", name, "versions"]);
+            url
+        };
+        // FIXME: There is probably better way to do this
+        //        and so many unwraps...
+        // TODO: When reqwest is upgraded remove the `as_str` here
+        let mut res = client()?.get(url.as_str()).send()?;
+        let mut body = String::new();
+        res.read_to_string(&mut body).unwrap();
+        let json: Value = serde_json::from_str(&body[..])?;
+        let versions = json
+            .as_object()
+            .and_then(|o| o.get("versions"))
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| err_msg("Not a JSON object"))?;
 
-    let result = if let Some(owners) = owners {
-        owners
-            .iter()
-            .filter_map(|owner| {
-                fn extract<'a>(owner: &'a Value, field: &str) -> &'a str {
-                    owner
-                        .as_object()
-                        .and_then(|o| o.get(field))
-                        .and_then(|o| o.as_str())
-                        .unwrap_or_default()
-                }
+        let (mut release_time, mut yanked, mut downloads) = (None, None, None);
 
-                let avatar = extract(owner, "avatar");
-                let email = extract(owner, "email");
-                let login = extract(owner, "login");
-                let name = extract(owner, "name");
+        for version_data in versions {
+            let version_data = version_data
+                .as_object()
+                .ok_or_else(|| err_msg("Not a JSON object"))?;
+            let version_num = version_data
+                .get("num")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| err_msg("Not a JSON object"))?;
 
-                if login.is_empty() {
-                    return None;
-                }
+            if Version::parse(version_num)?.to_string() == version {
+                let release_time_raw = version_data
+                    .get("created_at")
+                    .and_then(|c| c.as_str())
+                    .ok_or_else(|| err_msg("Not a JSON object"))?;
 
-                Some(CrateOwner {
-                    avatar: avatar.to_string(),
-                    email: email.to_string(),
-                    login: login.to_string(),
-                    name: name.to_string(),
+                release_time = Some(
+                    DateTime::parse_from_str(release_time_raw, "%Y-%m-%dT%H:%M:%S%.f%:z")?
+                        .with_timezone(&Utc),
+                );
+
+                yanked = Some(
+                    version_data
+                        .get("yanked")
+                        .and_then(|c| c.as_bool())
+                        .ok_or_else(|| err_msg("Not a JSON object"))?,
+                );
+
+                downloads = Some(
+                    version_data
+                        .get("downloads")
+                        .and_then(|c| c.as_i64())
+                        .ok_or_else(|| err_msg("Not a JSON object"))? as i32,
+                );
+
+                break;
+            }
+        }
+
+        Ok((
+            release_time.unwrap_or_else(Utc::now),
+            yanked.unwrap_or(false),
+            downloads.unwrap_or(0),
+        ))
+    }
+
+    /// Fetch owners from the registry's API
+    fn get_owners(&self, name: &str) -> Result<Vec<CrateOwner>> {
+        let url = {
+            let mut url = self.api_base.clone();
+            url.path_segments_mut()
+                .map_err(|()| err_msg("Invalid API url"))?
+                .extend(&["api", "v1", "crates", name, "owners"]);
+            url
+        };
+        // TODO: When reqwest is upgraded remove the `as_str` here
+        let mut res = client()?.get(url.as_str()).send()?;
+        // FIXME: There is probably better way to do this
+        //        and so many unwraps...
+        let mut body = String::new();
+        res.read_to_string(&mut body).unwrap();
+        let json: Value = serde_json::from_str(&body[..])?;
+
+        let owners = json
+            .as_object()
+            .and_then(|j| j.get("users"))
+            .and_then(|j| j.as_array());
+
+        let result = if let Some(owners) = owners {
+            owners
+                .iter()
+                .filter_map(|owner| {
+                    fn extract<'a>(owner: &'a Value, field: &str) -> &'a str {
+                        owner
+                            .as_object()
+                            .and_then(|o| o.get(field))
+                            .and_then(|o| o.as_str())
+                            .unwrap_or_default()
+                    }
+
+                    let avatar = extract(owner, "avatar");
+                    let email = extract(owner, "email");
+                    let login = extract(owner, "login");
+                    let name = extract(owner, "name");
+
+                    if login.is_empty() {
+                        return None;
+                    }
+
+                    Some(CrateOwner {
+                        avatar: avatar.to_string(),
+                        email: email.to_string(),
+                        login: login.to_string(),
+                        name: name.to_string(),
+                    })
                 })
-            })
-            .collect()
-    } else {
-        Vec::new()
-    };
+                .collect()
+        } else {
+            Vec::new()
+        };
 
-    Ok(result)
+        Ok(result)
+    }
 }

--- a/src/index/api.rs
+++ b/src/index/api.rs
@@ -1,10 +1,9 @@
-use std::io::Read;
-
 use chrono::{DateTime, Utc};
 use failure::err_msg;
+use log::info;
 use reqwest::header::{HeaderValue, ACCEPT, USER_AGENT};
 use semver::Version;
-use serde_json::Value;
+use serde::Deserialize;
 use url::Url;
 
 use crate::error::Result;
@@ -16,7 +15,7 @@ const APP_USER_AGENT: &str = concat!(
 );
 
 pub(crate) struct Api {
-    api_base: Url,
+    api_base: Option<Url>,
     client: reqwest::blocking::Client,
 }
 
@@ -35,7 +34,7 @@ pub(crate) struct CrateOwner {
 }
 
 impl Api {
-    pub(super) fn new(api_base: &Url) -> Result<Self> {
+    pub(super) fn new(api_base: Option<Url>) -> Result<Self> {
         let headers = vec![
             (USER_AGENT, HeaderValue::from_static(APP_USER_AGENT)),
             (ACCEPT, HeaderValue::from_static("application/json")),
@@ -47,23 +46,34 @@ impl Api {
             .default_headers(headers)
             .build()?;
 
-        Ok(Self {
-            api_base: api_base.clone(),
-            client,
-        })
+        Ok(Self { api_base, client })
     }
 
-    pub(crate) fn get_crate_data(&self, name: &str, version: &str) -> Result<RegistryCrateData> {
-        let (release_time, yanked, downloads) =
-            self.get_release_time_yanked_downloads(name, version)?;
-        let owners = self.get_owners(name)?;
+    fn api_base(&self) -> Result<Url> {
+        self.api_base
+            .clone()
+            .ok_or_else(|| err_msg("index is missing an api base url"))
+    }
 
-        Ok(RegistryCrateData {
+    pub(crate) fn get_crate_data(&self, name: &str, version: &str) -> RegistryCrateData {
+        let (release_time, yanked, downloads) = self
+            .get_release_time_yanked_downloads(name, version)
+            .unwrap_or_else(|err| {
+                info!("Failed to get crate data for {}-{}: {}", name, version, err);
+                (Utc::now(), false, 0)
+            });
+
+        let owners = self.get_owners(name).unwrap_or_else(|err| {
+            info!("Failed to get owners for {}-{}: {}", name, version, err);
+            Vec::new()
+        });
+
+        RegistryCrateData {
             release_time,
             yanked,
             downloads,
             owners,
-        })
+        }
     }
 
     /// Get release_time, yanked and downloads from the registry's API
@@ -73,126 +83,81 @@ impl Api {
         version: &str,
     ) -> Result<(DateTime<Utc>, bool, i32)> {
         let url = {
-            let mut url = self.api_base.clone();
+            let mut url = self.api_base()?;
             url.path_segments_mut()
                 .map_err(|()| err_msg("Invalid API url"))?
                 .extend(&["api", "v1", "crates", name, "versions"]);
             url
         };
-        // FIXME: There is probably better way to do this
-        //        and so many unwraps...
-        // TODO: When reqwest is upgraded remove the `as_str` here
-        let mut res = self.client.get(url.as_str()).send()?;
-        let mut body = String::new();
-        res.read_to_string(&mut body).unwrap();
-        let json: Value = serde_json::from_str(&body[..])?;
-        let versions = json
-            .as_object()
-            .and_then(|o| o.get("versions"))
-            .and_then(|v| v.as_array())
-            .ok_or_else(|| err_msg("Not a JSON object"))?;
 
-        let (mut release_time, mut yanked, mut downloads) = (None, None, None);
-
-        for version_data in versions {
-            let version_data = version_data
-                .as_object()
-                .ok_or_else(|| err_msg("Not a JSON object"))?;
-            let version_num = version_data
-                .get("num")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| err_msg("Not a JSON object"))?;
-
-            if Version::parse(version_num)?.to_string() == version {
-                let release_time_raw = version_data
-                    .get("created_at")
-                    .and_then(|c| c.as_str())
-                    .ok_or_else(|| err_msg("Not a JSON object"))?;
-
-                release_time = Some(
-                    DateTime::parse_from_str(release_time_raw, "%Y-%m-%dT%H:%M:%S%.f%:z")?
-                        .with_timezone(&Utc),
-                );
-
-                yanked = Some(
-                    version_data
-                        .get("yanked")
-                        .and_then(|c| c.as_bool())
-                        .ok_or_else(|| err_msg("Not a JSON object"))?,
-                );
-
-                downloads = Some(
-                    version_data
-                        .get("downloads")
-                        .and_then(|c| c.as_i64())
-                        .ok_or_else(|| err_msg("Not a JSON object"))? as i32,
-                );
-
-                break;
-            }
+        #[derive(Deserialize)]
+        struct Response {
+            versions: Vec<VersionData>,
         }
 
-        Ok((
-            release_time.unwrap_or_else(Utc::now),
-            yanked.unwrap_or(false),
-            downloads.unwrap_or(0),
-        ))
+        #[derive(Deserialize)]
+        struct VersionData {
+            num: Version,
+            #[serde(default = "Utc::now")]
+            created_at: DateTime<Utc>,
+            #[serde(default)]
+            yanked: bool,
+            #[serde(default)]
+            downloads: i32,
+        }
+
+        let response: Response = self.client.get(url).send()?.error_for_status()?.json()?;
+
+        let version = Version::parse(version)?;
+        let version = response
+            .versions
+            .into_iter()
+            .find(|data| data.num == version)
+            .ok_or_else(|| err_msg("Could not find version in response"))?;
+
+        Ok((version.created_at, version.yanked, version.downloads))
     }
 
     /// Fetch owners from the registry's API
     fn get_owners(&self, name: &str) -> Result<Vec<CrateOwner>> {
         let url = {
-            let mut url = self.api_base.clone();
+            let mut url = self.api_base()?;
             url.path_segments_mut()
                 .map_err(|()| err_msg("Invalid API url"))?
                 .extend(&["api", "v1", "crates", name, "owners"]);
             url
         };
-        // TODO: When reqwest is upgraded remove the `as_str` here
-        let mut res = self.client.get(url.as_str()).send()?;
-        // FIXME: There is probably better way to do this
-        //        and so many unwraps...
-        let mut body = String::new();
-        res.read_to_string(&mut body).unwrap();
-        let json: Value = serde_json::from_str(&body[..])?;
 
-        let owners = json
-            .as_object()
-            .and_then(|j| j.get("users"))
-            .and_then(|j| j.as_array());
+        #[derive(Deserialize)]
+        struct Response {
+            users: Vec<OwnerData>,
+        }
 
-        let result = if let Some(owners) = owners {
-            owners
-                .iter()
-                .filter_map(|owner| {
-                    fn extract<'a>(owner: &'a Value, field: &str) -> &'a str {
-                        owner
-                            .as_object()
-                            .and_then(|o| o.get(field))
-                            .and_then(|o| o.as_str())
-                            .unwrap_or_default()
-                    }
+        #[derive(Deserialize)]
+        struct OwnerData {
+            #[serde(default)]
+            avatar: String,
+            #[serde(default)]
+            email: String,
+            #[serde(default)]
+            login: String,
+            #[serde(default)]
+            name: String,
+        }
 
-                    let avatar = extract(owner, "avatar");
-                    let email = extract(owner, "email");
-                    let login = extract(owner, "login");
-                    let name = extract(owner, "name");
+        let response: Response = self.client.get(url).send()?.error_for_status()?.json()?;
 
-                    if login.is_empty() {
-                        return None;
-                    }
-
-                    Some(CrateOwner {
-                        avatar: avatar.to_string(),
-                        email: email.to_string(),
-                        login: login.to_string(),
-                        name: name.to_string(),
-                    })
-                })
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let result = response
+            .users
+            .into_iter()
+            .filter(|data| !data.login.is_empty())
+            .map(|data| CrateOwner {
+                avatar: data.avatar,
+                email: data.email,
+                login: data.login,
+                name: data.name,
+            })
+            .collect();
 
         Ok(result)
     }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1,6 +1,5 @@
 use std::path::{Path, PathBuf};
 
-use log::info;
 use url::Url;
 
 use self::api::Api;
@@ -11,7 +10,7 @@ pub(crate) mod api;
 pub(crate) struct Index {
     diff: crates_index_diff::Index,
     path: PathBuf,
-    api: Option<Api>,
+    api: Api,
 }
 
 #[derive(serde::Deserialize, Clone)]
@@ -44,12 +43,7 @@ impl Index {
         let path = path.as_ref().to_owned();
         let diff = crates_index_diff::Index::from_path_or_cloned(&path)?;
         let config = load_config(diff.repository())?;
-        let api = if let Some(api_base) = &config.api {
-            Some(Api::new(api_base)?)
-        } else {
-            info!("Cannot load registry data as index is missing an api base url");
-            None
-        };
+        let api = Api::new(config.api)?;
         Ok(Self { diff, path, api })
     }
 
@@ -57,8 +51,8 @@ impl Index {
         &self.diff
     }
 
-    pub(crate) fn api(&self) -> Option<&Api> {
-        self.api.as_ref()
+    pub(crate) fn api(&self) -> &Api {
+        &self.api
     }
 }
 

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1,1 +1,68 @@
+use std::path::{Path, PathBuf};
+
+use log::info;
+use url::Url;
+
+use self::api::Api;
+use crate::error::Result;
+
 pub(crate) mod api;
+
+pub(crate) struct Index {
+    diff: crates_index_diff::Index,
+    path: PathBuf,
+    config: IndexConfig,
+}
+
+#[derive(serde::Deserialize, Clone)]
+#[serde(rename_all = "kebab-case")]
+struct IndexConfig {
+    dl: String,
+    #[serde(default)]
+    api: Option<Url>,
+    #[serde(default)]
+    allowed_registries: Vec<String>,
+}
+
+/// Inspects the given repository to find the config as specified in [RFC 2141][], assumes that the
+/// repository has a remote called `origin` and that the branch `master` exists on it.
+///
+/// [RFC 2141]: https://rust-lang.github.io/rfcs/2141-alternative-registries.html
+fn load_config(repo: &git2::Repository) -> Result<IndexConfig> {
+    let tree = repo
+        .find_commit(repo.refname_to_id("refs/remotes/origin/master")?)?
+        .tree()?;
+    let file = tree
+        .get_name("config.json")
+        .ok_or_else(|| failure::format_err!("registry index missing config"))?;
+    let config = serde_json::from_slice(repo.find_blob(file.id())?.content())?;
+    Ok(config)
+}
+
+impl Index {
+    pub(crate) fn new(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref().to_owned();
+        let diff = crates_index_diff::Index::from_path_or_cloned(&path)?;
+        let config = load_config(diff.repository())?;
+        Ok(Self { diff, config, path })
+    }
+
+    pub(crate) fn diff(&self) -> &crates_index_diff::Index {
+        &self.diff
+    }
+
+    pub(crate) fn api(&self) -> Option<Api<'_>> {
+        if let Some(api_base) = &self.config.api {
+            Some(Api::new(api_base))
+        } else {
+            info!("Cannot load registry data as index is missing an api base url");
+            None
+        }
+    }
+}
+
+impl Clone for Index {
+    fn clone(&self) -> Self {
+        Self::new(&self.path).expect("we already loaded this registry successfully once")
+    }
+}

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -279,7 +279,7 @@ impl MatchSemver {
 /// been matched exactly, or if there has been a "correction" in the name that matched instead.
 fn match_version(conn: &Connection, name: &str, version: Option<&str>) -> Option<MatchVersion> {
     // version is an Option<&str> from router::Router::get, need to decode first
-    use url::percent_encoding::percent_decode;
+    use iron::url::percent_encoding::percent_decode;
 
     let req_version = version
         .and_then(|v| percent_decode(v.as_bytes()).decode_utf8().ok())

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -57,7 +57,7 @@ pub struct RustLangRedirector {
 
 impl RustLangRedirector {
     pub fn new(target: &'static str) -> Self {
-        let url = url::Url::parse("https://doc.rust-lang.org/stable/")
+        let url = iron::url::Url::parse("https://doc.rust-lang.org/stable/")
             .expect("failed to parse rust-lang.org base URL")
             .join(target)
             .expect("failed to append crate name to rust-lang.org base URL");
@@ -75,7 +75,7 @@ impl iron::Handler for RustLangRedirector {
 /// Handler called for `/:crate` and `/:crate/:version` URLs. Automatically redirects to the docs
 /// or crate details page based on whether the given crate version was successfully built.
 pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
-    use url::percent_encoding::percent_decode;
+    use iron::url::percent_encoding::percent_decode;
 
     fn redirect_to_doc(
         req: &Request,
@@ -520,7 +520,7 @@ pub fn badge_handler(req: &mut Request) -> IronResult<Response> {
 
         Some(MatchSemver::Semver((version, _))) => {
             let base_url = format!("{}/{}/badge.svg", redirect_base(req), name);
-            let url = ctry!(url::Url::parse_with_params(
+            let url = ctry!(iron::url::Url::parse_with_params(
                 &base_url,
                 &[("version", version)]
             ));


### PR DESCRIPTION
Another step on the way towards #767, removes hardcoded `https://crates.io/api` urls and determines what to use based on the config in the registry index. The API is optional for a registry, so if configured to use a registry without one it will just insert empty data when building crates.