### PR TITLE
Print a backtrace for crates which fail to build

### DIFF
--- a/src/docbuilder/queue.rs
+++ b/src/docbuilder/queue.rs
@@ -115,8 +115,11 @@ impl DocBuilder {
                     crate::web::metrics::TOTAL_BUILDS.inc();
                 }
                 error!(
-                    "Failed to build package {}-{} from queue: {}",
-                    name, version, e
+                    "Failed to build package {}-{} from queue: {}\nBacktrace: {}",
+                    name,
+                    version,
+                    e,
+                    e.backtrace()
                 )
             }
         }


### PR DESCRIPTION
Closes #821 

r? @pietroalbini 