### PR TITLE
Revert "metrics: fix docsrs_prioritized_crates_count"

### DIFF
--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -124,12 +124,9 @@ pub fn metrics_handler(req: &mut Request) -> IronResult<Response> {
                 .get(0),
         );
         PRIORITIZED_CRATES_COUNT.set(
-            ctry!(conn.query(
-                "SELECT COUNT(*) FROM queue WHERE attempts < 5 AND priority <= 0;",
-                &[]
-            ))
-            .get(0)
-            .get(0),
+            ctry!(conn.query("SELECT COUNT(*) FROM queue WHERE priority >= 0;", &[]))
+                .get(0)
+                .get(0),
         );
         FAILED_CRATES_COUNT.set(
             ctry!(conn.query("SELECT COUNT(*) FROM queue WHERE attempt >= 5;", &[]))


### PR DESCRIPTION
Reverts rust-lang/docs.rs#810

This caused /about/metrics to give 500 internal errors. Unfortunately, we don't know what those errors are because of #817.

cc @pietroalbini 