### PR TITLE
switch to empty-library to build essential files

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -60,8 +60,8 @@ const ESSENTIAL_FILES_UNVERSIONED: &[&str] = &[
     "SourceSerifPro-It.ttf.woff",
 ];
 
-const DUMMY_CRATE_NAME: &str = "acme-client";
-const DUMMY_CRATE_VERSION: &str = "0.0.0";
+const DUMMY_CRATE_NAME: &str = "empty-library";
+const DUMMY_CRATE_VERSION: &str = "1.0.0";
 
 pub struct RustwideBuilder {
     workspace: Workspace,
@@ -200,7 +200,7 @@ impl RustwideBuilder {
             .build_dir(&format!("essential-files-{}", rustc_version));
         build_dir.purge()?;
 
-        // acme-client-0.0.0 is an empty library crate and it will always build
+        // This is an empty library crate that is supposed to always build.
         let krate = Crate::crates_io(DUMMY_CRATE_NAME, DUMMY_CRATE_VERSION);
         krate.fetch(&self.workspace)?;
 


### PR DESCRIPTION
Before this commit docs.rs was using the acme-client 0.0.0 crate to generate the essential files for a nightly, but that crate actually contained some non-default values in it, which caused a breakage on 2020-06-12.

This commit switches that crate for empty-library 1.0.0, an empty library crate with the bare minimum information accepted by crates.io and with literally no code in it. The crate was just published by me.

r? @Nemo157 