### PR TITLE
Limit the size of served files

### DIFF
--- a/benches/compression.rs
+++ b/benches/compression.rs
@@ -1,5 +1,7 @@
-use cratesfyi::storage::{compress, decompress};
+use cratesfyi::storage::{compress, decompress, CompressionAlgorithm};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+const ALGORITHM: CompressionAlgorithm = CompressionAlgorithm::Zstd;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     // this isn't a great benchmark because it only tests on one file
@@ -7,11 +9,11 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let html = std::fs::read_to_string("benches/struct.CaptureMatches.html").unwrap();
     let html_slice = html.as_bytes();
     c.bench_function("compress regex html", |b| {
-        b.iter(|| compress(black_box(html_slice)))
+        b.iter(|| compress(black_box(html_slice, ALGORITHM)))
     });
-    let (compressed, alg) = compress(html_slice).unwrap();
+    let compressed = compress(html_slice, ALGORITHM).unwrap();
     c.bench_function("decompress regex html", |b| {
-        b.iter(|| decompress(black_box(compressed.as_slice()), alg))
+        b.iter(|| decompress(black_box(compressed.as_slice()), ALGORITHM))
     });
 }
 

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -13,8 +13,7 @@ pub fn main() -> Result<(), Error> {
     let _ = dotenv::dotenv();
     logger_init();
 
-    CommandLine::from_args().handle_args()?;
-    Ok(())
+    CommandLine::from_args().handle_args()
 }
 
 fn logger_init() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,37 @@
+use failure::{bail, Error, Fail, ResultExt};
+use std::env::VarError;
+use std::str::FromStr;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct Config {
+    pub(crate) max_file_size: usize,
+    pub(crate) max_file_size_html: usize,
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self, Error> {
+        Ok(Self {
+            max_file_size: env("DOCSRS_MAX_FILE_SIZE", 50 * 1024 * 1024)?,
+            max_file_size_html: env("DOCSRS_MAX_FILE_SIZE_HTML", 5 * 1024 * 1024)?,
+        })
+    }
+}
+
+impl iron::typemap::Key for Config {
+    type Value = Arc<Config>;
+}
+
+fn env<T>(var: &str, default: T) -> Result<T, Error>
+where
+    T: FromStr,
+    T::Err: Fail,
+{
+    match std::env::var(var) {
+        Ok(content) => Ok(content
+            .parse::<T>()
+            .with_context(|_| format!("failed to parse configuration variable {}", var))?),
+        Err(VarError::NotPresent) => Ok(default),
+        Err(VarError::NotUnicode(_)) => bail!("configuration variable {} is not UTF-8", var),
+    }
+}

--- a/src/db/file.rs
+++ b/src/db/file.rs
@@ -13,8 +13,8 @@ use std::path::{Path, PathBuf};
 
 pub(crate) use crate::storage::Blob;
 
-pub(crate) fn get_path(conn: &Connection, path: &str) -> Result<Blob> {
-    Storage::new(conn).get(path)
+pub(crate) fn get_path(conn: &Connection, path: &str, max_size: usize) -> Result<Blob> {
+    Storage::new(conn).get(path, max_size)
 }
 
 /// Store all files in a directory and return [[mimetype, filename]] as Json

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,3 +5,14 @@ use std::result::Result as StdResult;
 pub(crate) use failure::Error;
 
 pub type Result<T> = StdResult<T, Error>;
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct SizeLimitReached;
+
+impl std::error::Error for SizeLimitReached {}
+
+impl std::fmt::Display for SizeLimitReached {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "the size limit for the buffer was reached")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,13 @@
 //! documentation of crates for the Rust Programming Language.
 #![allow(clippy::cognitive_complexity)]
 
+pub use self::config::Config;
 pub use self::docbuilder::options::DocBuilderOptions;
 pub use self::docbuilder::DocBuilder;
 pub use self::docbuilder::RustwideBuilder;
 pub use self::web::Server;
 
+mod config;
 pub mod db;
 mod docbuilder;
 mod error;

--- a/src/storage/database.rs
+++ b/src/storage/database.rs
@@ -40,7 +40,7 @@ impl<'a> DatabaseBackend<'a> {
         } else {
             let row = rows.get(0);
 
-            if row.get::<_, bool>("is_too_big") {
+            if row.get("is_too_big") {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
                     crate::error::SizeLimitReached,

--- a/src/storage/database.rs
+++ b/src/storage/database.rs
@@ -16,18 +16,37 @@ impl<'a> DatabaseBackend<'a> {
         Self { conn }
     }
 
-    pub(super) fn get(&self, path: &str) -> Result<Blob, Error> {
+    pub(super) fn get(&self, path: &str, max_size: usize) -> Result<Blob, Error> {
         use std::convert::TryInto;
 
+        // The maximum size for a BYTEA (the type used for `content`) is 1GB, so this cast is safe:
+        // https://www.postgresql.org/message-id/162867790712200946i7ba8eb92v908ac595c0c35aee%40mail.gmail.com
+        let max_size = max_size.min(std::i32::MAX as usize) as i32;
+
+        // The size limit is checked at the database level, to avoid receiving data altogether if
+        // the limit is exceeded.
         let rows = self.conn.query(
             "SELECT path, mime, date_updated, content, compression
              FROM files
-             WHERE path = $1;",
-            &[&path],
+             WHERE path = $1 AND LENGTH(content) <= $2;",
+            &[&path, &(max_size)],
         )?;
 
         if rows.is_empty() {
-            Err(PathNotFoundError.into())
+            // This second query distinguishes between a path not found error and a size limit
+            // reached error, as the above query returns no result in either cases.
+            if self
+                .conn
+                .query("SELECT 0 FROM files WHERE path = $1;", &[&path])?
+                .is_empty()
+            {
+                Err(PathNotFoundError.into())
+            } else {
+                Err(
+                    std::io::Error::new(std::io::ErrorKind::Other, crate::error::SizeLimitReached)
+                        .into(),
+                )
+            }
         } else {
             let row = rows.get(0);
             let compression = row.get::<_, Option<i32>>("compression").map(|i| {
@@ -91,19 +110,66 @@ mod tests {
                     content: "Hello world!".bytes().collect(),
                     compression: None,
                 },
-                backend.get("dir/foo.txt")?
+                backend.get("dir/foo.txt", std::usize::MAX)?
             );
 
             // Test that other files are not returned
             assert!(backend
-                .get("dir/bar.txt")
+                .get("dir/bar.txt", std::usize::MAX)
                 .unwrap_err()
                 .downcast_ref::<PathNotFoundError>()
                 .is_some());
             assert!(backend
-                .get("foo.txt")
+                .get("foo.txt", std::usize::MAX)
                 .unwrap_err()
                 .downcast_ref::<PathNotFoundError>()
+                .is_some());
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_get_too_big() {
+        const MAX_SIZE: usize = 1024;
+
+        crate::test::wrapper(|env| {
+            let conn = env.db().conn();
+            let backend = DatabaseBackend::new(&conn);
+
+            let small_blob = Blob {
+                path: "small-blob.bin".into(),
+                mime: "text/plain".into(),
+                date_updated: Utc::now(),
+                content: vec![0; MAX_SIZE],
+                compression: None,
+            };
+            let big_blob = Blob {
+                path: "big-blob.bin".into(),
+                mime: "text/plain".into(),
+                date_updated: Utc::now(),
+                content: vec![0; MAX_SIZE * 2],
+                compression: None,
+            };
+
+            let transaction = conn.transaction()?;
+            backend
+                .store_batch(std::slice::from_ref(&small_blob), &transaction)
+                .unwrap();
+            backend
+                .store_batch(std::slice::from_ref(&big_blob), &transaction)
+                .unwrap();
+            transaction.commit()?;
+
+            let blob = backend.get("small-blob.bin", MAX_SIZE).unwrap();
+            assert_eq!(blob.content.len(), small_blob.content.len());
+
+            assert!(backend
+                .get("big-blob.bin", MAX_SIZE)
+                .unwrap_err()
+                .downcast_ref::<std::io::Error>()
+                .and_then(|io| io.get_ref())
+                .and_then(|err| err.downcast_ref::<crate::error::SizeLimitReached>())
                 .is_some());
 
             Ok(())

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -125,7 +125,7 @@ impl<'a> Storage<'a> {
     }
     pub(crate) fn get(&self, path: &str, max_size: usize) -> Result<Blob, Error> {
         let mut blob = match self {
-            Self::Database(db) => db.get(path),
+            Self::Database(db) => db.get(path, max_size),
             Self::S3(s3) => s3.get(path, max_size),
         }?;
         if let Some(alg) = blob.compression {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -414,27 +414,27 @@ mod test {
         let exact = &[b'A'; MAX_SIZE] as &[u8];
         let big = &[b'A'; MAX_SIZE * 2] as &[u8];
 
-        for alg in CompressionAlgorithm::AVAILABLE {
-            let compressed_small = compress(small, *alg).unwrap();
-            let compressed_exact = compress(exact, *alg).unwrap();
-            let compressed_big = compress(big, *alg).unwrap();
+        for &alg in CompressionAlgorithm::AVAILABLE {
+            let compressed_small = compress(small, alg).unwrap();
+            let compressed_exact = compress(exact, alg).unwrap();
+            let compressed_big = compress(big, alg).unwrap();
 
             // Ensure decompressing within the limit works.
             assert_eq!(
                 small.len(),
-                decompress(compressed_small.as_slice(), *alg, MAX_SIZE)
+                decompress(compressed_small.as_slice(), alg, MAX_SIZE)
                     .unwrap()
                     .len()
             );
             assert_eq!(
                 exact.len(),
-                decompress(compressed_exact.as_slice(), *alg, MAX_SIZE)
+                decompress(compressed_exact.as_slice(), alg, MAX_SIZE)
                     .unwrap()
                     .len()
             );
 
             // Ensure decompressing a file over the limit returns a SizeLimitReached error.
-            let err = decompress(compressed_big.as_slice(), *alg, MAX_SIZE).unwrap_err();
+            let err = decompress(compressed_big.as_slice(), alg, MAX_SIZE).unwrap_err();
             assert!(err
                 .downcast_ref::<std::io::Error>()
                 .and_then(|io| io.get_ref())

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -117,7 +117,7 @@ impl<'a> Storage<'a> {
             DatabaseBackend::new(conn).into()
         }
     }
-    pub(crate) fn get(&self, path: &str) -> Result<Blob, Error> {
+    pub(crate) fn get(&self, path: &str, max_size: usize) -> Result<Blob, Error> {
         let mut blob = match self {
             Self::Database(db) => db.get(path),
             Self::S3(s3) => s3.get(path),
@@ -282,7 +282,7 @@ mod test {
                 let name = Path::new(&blob.path);
                 assert!(stored_files.contains_key(name));
 
-                let actual = backend.get(&blob.path).unwrap();
+                let actual = backend.get(&blob.path, std::usize::MAX).unwrap();
                 assert_blob_eq(blob, &actual);
             }
 
@@ -324,12 +324,12 @@ mod test {
                 "text/rust"
             );
 
-            let file = backend.get("rustdoc/Cargo.toml").unwrap();
+            let file = backend.get("rustdoc/Cargo.toml", std::usize::MAX).unwrap();
             assert_eq!(file.content, b"data");
             assert_eq!(file.mime, "text/toml");
             assert_eq!(file.path, "rustdoc/Cargo.toml");
 
-            let file = backend.get("rustdoc/src/main.rs").unwrap();
+            let file = backend.get("rustdoc/src/main.rs", std::usize::MAX).unwrap();
             assert_eq!(file.content, b"data");
             assert_eq!(file.mime, "text/rust");
             assert_eq!(file.path, "rustdoc/src/main.rs");

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -126,7 +126,7 @@ impl<'a> Storage<'a> {
     pub(crate) fn get(&self, path: &str, max_size: usize) -> Result<Blob, Error> {
         let mut blob = match self {
             Self::Database(db) => db.get(path),
-            Self::S3(s3) => s3.get(path),
+            Self::S3(s3) => s3.get(path, max_size),
         }?;
         if let Some(alg) = blob.compression {
             blob.content = decompress(blob.content.as_slice(), alg, max_size)?;

--- a/src/storage/s3/test.rs
+++ b/src/storage/s3/test.rs
@@ -30,7 +30,7 @@ impl TestS3 {
         use rusoto_core::RusotoError;
         use rusoto_s3::GetObjectError;
 
-        let err = self.0.borrow().get(path).unwrap_err();
+        let err = self.0.borrow().get(path, std::usize::MAX).unwrap_err();
         match err
             .downcast_ref::<RusotoError<GetObjectError>>()
             .expect("wanted GetObject")
@@ -41,8 +41,12 @@ impl TestS3 {
         };
     }
     pub(crate) fn assert_blob(&self, blob: &Blob, path: &str) {
-        let actual = self.0.borrow().get(path).unwrap();
+        let actual = self.0.borrow().get(path, std::usize::MAX).unwrap();
         assert_blob_eq(blob, &actual);
+    }
+
+    pub(crate) fn with_client(&self, f: impl FnOnce(&mut S3Backend<'static>)) {
+        f(&mut self.0.borrow_mut())
     }
 }
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -122,17 +122,22 @@ impl TestEnvironment {
         }
     }
 
-    pub(crate) fn set_config(&self, config: Config) {
+    fn base_config(&self) -> Config {
+        Config::from_env().expect("failed to get base config")
+    }
+
+    pub(crate) fn override_config(&self, f: impl FnOnce(&mut Config)) {
+        let mut config = self.base_config();
+        f(&mut config);
+
         if self.config.set(Arc::new(config)).is_err() {
-            panic!("can't call set_config after the configuration is used!");
+            panic!("can't call override_config after the configuration is accessed!");
         }
     }
 
     pub(crate) fn config(&self) -> Arc<Config> {
         self.config
-            .get_or_init(|| {
-                Arc::new(Config::from_env().expect("failed to initialize the configuration"))
-            })
+            .get_or_init(|| Arc::new(self.base_config()))
             .clone()
     }
 

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -5,19 +5,20 @@
 use crate::{
     docbuilder::RustwideBuilder,
     utils::{github_updater, pubsubhubbub, update_release_activity},
-    DocBuilder, DocBuilderOptions,
+    Config, DocBuilder, DocBuilderOptions,
 };
 use chrono::{Timelike, Utc};
 use log::{debug, error, info, warn};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 use std::{env, thread};
 
 #[cfg(not(target_os = "windows"))]
 use ::{libc::fork, std::fs::File, std::io::Write, std::process::exit};
 
-pub fn start_daemon(background: bool) {
+pub fn start_daemon(background: bool, config: Arc<Config>) {
     const CRATE_VARIABLES: [&str; 3] = [
         "CRATESFYI_PREFIX",
         "CRATESFYI_GITHUB_USERNAME",
@@ -249,7 +250,7 @@ pub fn start_daemon(background: bool) {
     // at least start web server
     info!("Starting web server");
 
-    crate::Server::start(None, false);
+    crate::Server::start(None, false, config);
 }
 
 fn opts() -> DocBuilderOptions {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -23,3 +23,4 @@ mod pubsubhubbub;
 mod queue;
 mod release_activity_updater;
 mod rustc_version;
+pub(crate) mod sized_buffer;

--- a/src/utils/sized_buffer.rs
+++ b/src/utils/sized_buffer.rs
@@ -17,7 +17,7 @@ impl SizedBuffer {
         if self.inner.len() + amount > self.limit {
             self.inner.reserve_exact(self.limit - self.inner.len());
         } else {
-            self.inner.reserve_exact(amount);
+            self.inner.reserve(amount);
         }
     }
 

--- a/src/utils/sized_buffer.rs
+++ b/src/utils/sized_buffer.rs
@@ -1,0 +1,72 @@
+use std::io::{Error as IoError, ErrorKind, Write};
+
+pub(crate) struct SizedBuffer {
+    inner: Vec<u8>,
+    limit: usize,
+}
+
+impl SizedBuffer {
+    pub(crate) fn new(limit: usize) -> Self {
+        SizedBuffer {
+            inner: Vec::new(),
+            limit,
+        }
+    }
+
+    pub(crate) fn reserve(&mut self, amount: usize) {
+        if self.inner.len() + amount > self.limit {
+            self.inner.reserve_exact(self.limit - self.inner.len());
+        } else {
+            self.inner.reserve_exact(amount);
+        }
+    }
+
+    pub(crate) fn into_inner(self) -> Vec<u8> {
+        self.inner
+    }
+}
+
+impl Write for SizedBuffer {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, IoError> {
+        if self.inner.len() + buf.len() > self.limit {
+            Err(IoError::new(
+                ErrorKind::Other,
+                crate::error::SizeLimitReached,
+            ))
+        } else {
+            self.inner.write(buf)
+        }
+    }
+
+    fn flush(&mut self) -> Result<(), IoError> {
+        self.inner.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sized_buffer() {
+        let mut buffer = SizedBuffer::new(1024);
+
+        // Add two chunks of 500 bytes
+        assert_eq!(500, buffer.write(&[0; 500]).unwrap());
+        assert_eq!(500, buffer.write(&[0; 500]).unwrap());
+
+        // Ensure adding a third chunk fails
+        let error = buffer.write(&[0; 500]).unwrap_err();
+        assert!(error
+            .get_ref()
+            .unwrap()
+            .is::<crate::error::SizeLimitReached>());
+
+        // Ensure all the third chunk was discarded
+        assert_eq!(1000, buffer.inner.len());
+
+        // Ensure it's possible to reach the limit
+        assert_eq!(24, buffer.write(&[0; 24]).unwrap());
+        assert_eq!(1024, buffer.inner.len());
+    }
+}

--- a/src/web/file.rs
+++ b/src/web/file.rs
@@ -75,7 +75,6 @@ impl Handler for DatabaseFileHandler {
 mod tests {
     use super::*;
     use crate::test::wrapper;
-    use crate::Config;
     use chrono::Utc;
 
     #[test]
@@ -110,11 +109,10 @@ mod tests {
         const MAX_HTML_SIZE: usize = 128;
 
         wrapper(|env| {
-            // Ensure the enviornment is not overriding the configuration.
-            let mut config = Config::from_env().expect("failed to get base config");
-            config.max_file_size = MAX_SIZE;
-            config.max_file_size_html = MAX_HTML_SIZE;
-            env.set_config(config);
+            env.override_config(|config| {
+                config.max_file_size = MAX_SIZE;
+                config.max_file_size_html = MAX_HTML_SIZE;
+            });
 
             let db = env.db();
 

--- a/src/web/file.rs
+++ b/src/web/file.rs
@@ -5,14 +5,21 @@ use crate::{db, error::Result};
 use iron::{status, Handler, IronError, IronResult, Request, Response};
 use postgres::Connection;
 
-const MAX_FILE_SIZE: usize = 5 * 1024 * 1024; // 5MB
+const MAX_HTML_FILE_SIZE: usize = 5 * 1024 * 1024; // 5MB
+const MAX_FILE_SIZE: usize = 50 * 1024 * 1024; // 50MB
 
 pub(crate) struct File(pub(crate) db::file::Blob);
 
 impl File {
     /// Gets file from database
     pub fn from_path(conn: &Connection, path: &str) -> Result<File> {
-        Ok(File(db::file::get_path(conn, path, MAX_FILE_SIZE)?))
+        let max_size = if path.ends_with(".html") {
+            MAX_HTML_FILE_SIZE
+        } else {
+            MAX_FILE_SIZE
+        };
+
+        Ok(File(db::file::get_path(conn, path, max_size)?))
     }
 
     /// Consumes File and creates a iron response

--- a/src/web/file.rs
+++ b/src/web/file.rs
@@ -5,6 +5,7 @@ use crate::{db, error::Result, Config};
 use iron::{status, Handler, IronError, IronResult, Request, Response};
 use postgres::Connection;
 
+#[derive(Debug)]
 pub(crate) struct File(pub(crate) db::file::Blob);
 
 impl File {
@@ -74,6 +75,7 @@ impl Handler for DatabaseFileHandler {
 mod tests {
     use super::*;
     use crate::test::wrapper;
+    use crate::Config;
     use chrono::Utc;
 
     #[test]
@@ -100,5 +102,61 @@ mod tests {
 
             Ok(())
         });
+    }
+
+    #[test]
+    fn test_max_size() {
+        const MAX_SIZE: usize = 1024;
+        const MAX_HTML_SIZE: usize = 128;
+
+        wrapper(|env| {
+            // Ensure the enviornment is not overriding the configuration.
+            let mut config = Config::from_env().expect("failed to get base config");
+            config.max_file_size = MAX_SIZE;
+            config.max_file_size_html = MAX_HTML_SIZE;
+            env.set_config(config);
+
+            let db = env.db();
+
+            db.fake_release()
+                .name("dummy")
+                .version("0.1.0")
+                .rustdoc_file("small.html", &[b'A'; MAX_HTML_SIZE / 2] as &[u8])
+                .rustdoc_file("exact.html", &[b'A'; MAX_HTML_SIZE] as &[u8])
+                .rustdoc_file("big.html", &[b'A'; MAX_HTML_SIZE * 2] as &[u8])
+                .rustdoc_file("small.js", &[b'A'; MAX_SIZE / 2] as &[u8])
+                .rustdoc_file("exact.js", &[b'A'; MAX_SIZE] as &[u8])
+                .rustdoc_file("big.js", &[b'A'; MAX_SIZE * 2] as &[u8])
+                .create()?;
+
+            let file = |path| {
+                File::from_path(
+                    &db.conn(),
+                    &format!("rustdoc/dummy/0.1.0/{}", path),
+                    &env.config(),
+                )
+            };
+            let assert_len = |len, path| {
+                assert_eq!(len, file(path).unwrap().0.content.len());
+            };
+            let assert_too_big = |path| {
+                file(path)
+                    .unwrap_err()
+                    .downcast_ref::<std::io::Error>()
+                    .and_then(|io| io.get_ref())
+                    .and_then(|err| err.downcast_ref::<crate::error::SizeLimitReached>())
+                    .is_some()
+            };
+
+            assert_len(MAX_HTML_SIZE / 2, "small.html");
+            assert_len(MAX_HTML_SIZE, "exact.html");
+            assert_len(MAX_SIZE / 2, "small.js");
+            assert_len(MAX_SIZE, "exact.js");
+
+            assert_too_big("big.html");
+            assert_too_big("big.js");
+
+            Ok(())
+        })
     }
 }

--- a/src/web/file.rs
+++ b/src/web/file.rs
@@ -5,12 +5,14 @@ use crate::{db, error::Result};
 use iron::{status, Handler, IronError, IronResult, Request, Response};
 use postgres::Connection;
 
+const MAX_FILE_SIZE: usize = 5 * 1024 * 1024; // 5MB
+
 pub(crate) struct File(pub(crate) db::file::Blob);
 
 impl File {
     /// Gets file from database
     pub fn from_path(conn: &Connection, path: &str) -> Result<File> {
-        Ok(File(db::file::get_path(conn, path)?))
+        Ok(File(db::file::get_path(conn, path, MAX_FILE_SIZE)?))
     }
 
     /// Consumes File and creates a iron response

--- a/src/web/pool.rs
+++ b/src/web/pool.rs
@@ -1,5 +1,5 @@
 use crate::db::create_pool;
-use iron::{status::Status, typemap, BeforeMiddleware, IronError, IronResult, Request};
+use iron::{status::Status, typemap, IronError, IronResult};
 use postgres::Connection;
 use std::marker::PhantomData;
 
@@ -64,14 +64,6 @@ impl Pool {
 
 impl typemap::Key for Pool {
     type Value = Pool;
-}
-
-impl BeforeMiddleware for Pool {
-    fn before(&self, req: &mut Request) -> IronResult<()> {
-        req.extensions.insert::<Pool>(self.clone());
-
-        Ok(())
-    }
 }
 
 pub(crate) enum DerefConnection<'a> {

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -4,6 +4,7 @@ use super::file::File as DbFile;
 use super::page::Page;
 use super::pool::Pool;
 use super::MetaData;
+use crate::Config;
 use iron::prelude::*;
 use postgres::Connection;
 use router::Router;
@@ -211,11 +212,12 @@ pub fn source_browser_handler(req: &mut Request) -> IronResult<Response> {
     };
 
     let conn = extension!(req, Pool).get()?;
+    let config = extension!(req, Config);
 
     // try to get actual file first
     // skip if request is a directory
     let file = if !file_path.ends_with('/') {
-        DbFile::from_path(&conn, &file_path).ok()
+        DbFile::from_path(&conn, &file_path, &config).ok()
     } else {
         None
     };


### PR DESCRIPTION
This PR limits how big the files we serve from docs.rs are, to avoid OOMs. The current limit is 5MB, but that can be changed by tweaking a constant in the source code.

This PR adds limits when downloding the files from S3 and the database, and when decompressing previously downloaded files. For now the user will see a "resource not found" error page, but a dedicated page can be created in the future.

This PR also refactors compression a bit to better enable testing. It's best to review the PR commit-by-commit.

r? @jyn514 