### PR TITLE
Note that builds aren't immediate

### DIFF
--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -12,6 +12,9 @@
   Docs.rs automatically builds crates' documentation released on
   <a href="https://crates.io/">crates.io</a>
   using the nightly release of the Rust compiler.
+  Builds can take a while depending how many crates are in
+  <a href="/releases/queue">the queue</a>.
+
   {{#if content.rustc_version}}
   The current version of the Rust compiler in use is <code>{{content.rustc_version}}</code>.
   If you need a newer version of this compiler, check the


### PR DESCRIPTION
This (hopefully) avoids people being surprised when their docs aren't there, and also links them to the page that has a progress bar.