### PR TITLE
Remove TEMPLATE_DATA static

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -90,9 +90,11 @@ impl CommandLine {
                 socket_addr,
                 reload_templates,
             } => {
-                Server::start(Some(&socket_addr), reload_templates, config);
+                Server::start(Some(&socket_addr), reload_templates, config)?;
             }
-            Self::Daemon { foreground } => cratesfyi::utils::start_daemon(!foreground, config),
+            Self::Daemon { foreground } => {
+                cratesfyi::utils::start_daemon(!foreground, config)?;
+            }
             Self::Database { subcommand } => subcommand.handle_args(),
             Self::Queue { subcommand } => subcommand.handle_args(),
         }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -212,7 +212,8 @@ pub(crate) struct TestFrontend {
 impl TestFrontend {
     fn new(db: &TestDatabase, config: Arc<Config>) -> Self {
         Self {
-            server: Server::start_test(db.conn.clone(), config),
+            server: Server::start_test(db.conn.clone(), config)
+                .expect("failed to start the server"),
             client: Client::new(),
         }
     }

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -8,6 +8,7 @@ use crate::{
     Config, DocBuilder, DocBuilderOptions,
 };
 use chrono::{Timelike, Utc};
+use failure::Error;
 use log::{debug, error, info, warn};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
@@ -18,7 +19,7 @@ use std::{env, thread};
 #[cfg(not(target_os = "windows"))]
 use ::{libc::fork, std::fs::File, std::io::Write, std::process::exit};
 
-pub fn start_daemon(background: bool, config: Arc<Config>) {
+pub fn start_daemon(background: bool, config: Arc<Config>) -> Result<(), Error> {
     const CRATE_VARIABLES: [&str; 3] = [
         "CRATESFYI_PREFIX",
         "CRATESFYI_GITHUB_USERNAME",
@@ -250,7 +251,8 @@ pub fn start_daemon(background: bool, config: Arc<Config>) {
     // at least start web server
     info!("Starting web server");
 
-    crate::Server::start(None, false, config);
+    crate::Server::start(None, false, config)?;
+    Ok(())
 }
 
 fn opts() -> DocBuilderOptions {

--- a/src/web/page/mod.rs
+++ b/src/web/page/mod.rs
@@ -8,11 +8,6 @@ pub(crate) use web_page::WebPage;
 
 use serde::Serialize;
 
-lazy_static::lazy_static! {
-    /// Holds all data relevant to templating
-    pub(crate) static ref TEMPLATE_DATA: TemplateData = TemplateData::new().expect("Failed to load template data");
-}
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct GlobalAlert {
     pub(crate) url: &'static str,

--- a/src/web/page/web_page.rs
+++ b/src/web/page/web_page.rs
@@ -1,5 +1,5 @@
-use super::TEMPLATE_DATA;
-use iron::{headers::ContentType, response::Response, status::Status, IronResult};
+use super::TemplateData;
+use iron::{headers::ContentType, response::Response, status::Status, IronResult, Request};
 use serde::Serialize;
 use tera::Context;
 
@@ -28,9 +28,13 @@ macro_rules! impl_webpage {
 pub trait WebPage: Serialize + Sized {
     /// Turn the current instance into a `Response`, ready to be served
     // TODO: We could cache similar pages using the `&Context`
-    fn into_response(self) -> IronResult<Response> {
+    fn into_response(self, req: &Request) -> IronResult<Response> {
         let ctx = Context::from_serialize(&self).unwrap();
-        let rendered = TEMPLATE_DATA
+
+        let rendered = req
+            .extensions
+            .get::<TemplateData>()
+            .expect("missing TemplateData from the request extensions")
             .templates
             .load()
             .render(Self::TEMPLATE, &ctx)

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -49,7 +49,7 @@ pub fn sitemap_handler(req: &mut Request) -> IronResult<Response> {
         })
         .collect::<Vec<(String, String)>>();
 
-    SitemapXml { releases }.into_response()
+    SitemapXml { releases }.into_response(req)
 }
 
 pub fn robots_txt_handler(_: &mut Request) -> IronResult<Response> {
@@ -83,5 +83,5 @@ pub fn about_handler(req: &mut Request) -> IronResult<Response> {
         rustc_version,
         limits: Limits::default(),
     }
-    .into_response()
+    .into_response(req)
 }


### PR DESCRIPTION
This PR removes the `TEMPLATE_DATA` static from the codebase, switching to a struct stored in the request extensions. This is a requirement for future refactorings. The PR can be reviewed commit-by-commit.

r? @Kixiron 