### PR TITLE
Remove daemonization code from docs.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,7 +378,6 @@ dependencies = [
  "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kuchiki 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.15 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,6 @@ chrono = { version = "0.4.11", features = ["serde"] }
 time = "0.1" # TODO: Remove once `iron` is removed
 
 [target.'cfg(not(windows))'.dependencies]
-libc = "0.2"
-
 # Process information
 procfs = "0.7"
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ docker-compose run web database blacklist remove <CRATE_NAME>
 # Run a persistent daemon which queues builds and starts a web server.
 # Warning: This will try to queue hundreds of packages on crates.io, only start it
 # if you have enough resources!
-docker-compose run -p 3000:3000 web daemon --foreground
+docker-compose run -p 3000:3000 web daemon
 ```
 
 ### Changing the build environment

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -62,7 +62,7 @@ enum CommandLine {
 
     /// Starts cratesfyi daemon
     Daemon {
-        /// Run the server in the foreground instead of detaching a child
+        /// Deprecated. Run the server in the foreground instead of detaching a child
         #[structopt(name = "FOREGROUND", short = "f", long = "foreground")]
         foreground: bool,
     },
@@ -93,7 +93,11 @@ impl CommandLine {
                 Server::start(Some(&socket_addr), reload_templates, config)?;
             }
             Self::Daemon { foreground } => {
-                cratesfyi::utils::start_daemon(!foreground, config)?;
+                if foreground {
+                    log::warn!("--foreground was passed, but there is no need for it anymore");
+                }
+
+                cratesfyi::utils::start_daemon(config)?;
             }
             Self::Database { subcommand } => subcommand.handle_args(),
             Self::Queue { subcommand } => subcommand.handle_args(),


### PR DESCRIPTION
This commit removes the forking code in the docs.rs daemon, forcing it to always run in the background. The rationale for the change is that forking adds complexity and sets extra constraint for development, while it's not needed anymore on modern infrastructure.

The --foreground flag is kept in the binary for compatibility, and it will only print a warning. Once this PR is deployed in production for a while, the flag can be removed.

r? @jyn514 