### PR TITLE
Don't keep the index repository open long term

### DIFF
--- a/src/docbuilder/queue.rs
+++ b/src/docbuilder/queue.rs
@@ -12,7 +12,8 @@ impl DocBuilder {
     /// Returns the number of crates added
     pub fn get_new_crates(&mut self) -> Result<usize> {
         let conn = connect_db()?;
-        let (mut changes, oid) = self.index.diff().peek_changes()?;
+        let diff = self.index.diff()?;
+        let (mut changes, oid) = diff.peek_changes()?;
         let mut crates_added = 0;
 
         // I believe this will fix ordering of queue if we get more than one crate from changes
@@ -58,7 +59,7 @@ impl DocBuilder {
             }
         }
 
-        self.index.diff().set_last_seen_reference(oid)?;
+        diff.set_last_seen_reference(oid)?;
 
         Ok(crates_added)
     }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -41,6 +41,8 @@ fn load_config(repo: &git2::Repository) -> Result<IndexConfig> {
 impl Index {
     pub(crate) fn new(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref().to_owned();
+        // This initializes the repository, then closes it afterwards to avoid leaking file descriptors.
+        // See https://github.com/rust-lang/docs.rs/pull/847
         let diff = crates_index_diff::Index::from_path_or_cloned(&path)
             .context("initialising registry index repository")?;
         let config = load_config(diff.repository()).context("loading registry config")?;


### PR DESCRIPTION
After deploying #813 there was a big change in the number of used file descriptors. This is likely a result of <https://github.com/libgit2/libgit2/issues/2758> given that #813 changed behaviour to keep the index repository open instead of just opening it when needed.

Given how long that `libgit2` issue and the PR fixing it have been open, it seems unlikely to be fixed soon. It would probably be ok to have all the packfiles open all the time, except based on [this comment](https://github.com/libgit2/libgit2/issues/2758#issuecomment-582610956) when running a concurrent `git gc` the garbage collected packfiles will not be closed, so there will be a constant slow fd leak until the service is restarted (which you can see in the graph below).

![image](https://user-images.githubusercontent.com/81079/85335330-22a17480-b4dd-11ea-8b4b-e05b38e4dcf0.png)

This PR changes behaviour back to match the old setup, only opening the repository when needed, and sticks some more context on related errors just in case.