### PR TITLE
Set environment variable `DOCS_RS` when building crates

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -516,6 +516,9 @@ impl RustwideBuilder {
                         .unwrap_or_default(),
                 )
                 .env("RUSTDOCFLAGS", rustdoc_flags.join(" "))
+                // For docs.rs detection from build script:
+                // https://github.com/rust-lang/docs.rs/issues/147
+                .env("DOCS_RS", "1")
                 .args(&cargo_args)
                 .run()
                 .is_ok()

--- a/tera-templates/core/about.html
+++ b/tera-templates/core/about.html
@@ -26,8 +26,10 @@
             <a href="{{ docsrs_repo }}/issues">issues page</a>
             and file a new issue if you don't see an existing request.
             {%- endif -%}
+        </p>
 
-            Docs.rs builds crates with environment variable `DOCS_RS` set to
+        <p>
+            Docs.rs builds crates with environment variable <code>DOCS_RS</code> set to
             `1`, which enables the crate to detect docs.rs and build the
             crate differently for docs.
         </p>

--- a/tera-templates/core/about.html
+++ b/tera-templates/core/about.html
@@ -26,6 +26,10 @@
             <a href="{{ docsrs_repo }}/issues">issues page</a>
             and file a new issue if you don't see an existing request.
             {%- endif -%}
+
+            Docs.rs builds crates with environment variable `DOCS_RS` set to
+            `1`, which enables the crate to detect docs.rs and build the
+            crate differently for docs.
         </p>
 
         <p>

--- a/tera-templates/core/about.html
+++ b/tera-templates/core/about.html
@@ -30,7 +30,7 @@
 
         <p>
             Docs.rs builds crates with environment variable <code>DOCS_RS</code> set to
-            `1`, which enables the crate to detect docs.rs and build the
+            <code>1</code>, which enables the crate to detect docs.rs and build the
             crate differently for docs.
         </p>
 


### PR DESCRIPTION
cc <https://github.com/rust-lang/docs.rs/issues/147#issuecomment-602049736>.

Fixes #147 .