### PR TITLE
Fix panic on `ctry!` error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,7 @@ name = "cratesfyi"
 version = "0.6.0"
 dependencies = [
  "arc-swap 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "badge 0.2.0",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "comrak 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ r2d2_postgres = "0.14"
 # url@2 for other usecases
 url = { version = "2.1.1", features = ["serde"] }
 badge = { path = "src/web/badge" }
+backtrace = "0.3"
 failure = "0.1.3"
 comrak = { version = "0.3", default-features = false }
 toml = "0.5"

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -11,10 +11,11 @@ macro_rules! ctry {
         match $result {
             Ok(v) => v,
             Err(e) => {
-                return $crate::web::page::Page::new(format!("{:?}", e))
-                    .title("An error has occured")
+                log::error!("{}\n{:?}", e, backtrace::Backtrace::new());
+                return $crate::web::page::Page::new(format!("{}", e))
+                    .title("Internal Server Error")
                     .set_status(::iron::status::BadRequest)
-                    .to_resp("resp");
+                    .to_resp("error");
             }
         }
     };
@@ -27,10 +28,14 @@ macro_rules! cexpect {
         match $option {
             Some(v) => v,
             None => {
-                return $crate::web::page::Page::new("Resource not found".to_owned())
-                    .title("An error has occured")
+                log::error!(
+                    "called cexpect!() on a `None` value\n{:?}",
+                    backtrace::Backtrace::new()
+                );
+                return $crate::web::page::Page::new("Internal Server Error".to_owned())
+                    .title("Internal Server Error")
                     .set_status(::iron::status::BadRequest)
-                    .to_resp("resp");
+                    .to_resp("error");
             }
         }
     };

--- a/templates/error.hbs
+++ b/templates/error.hbs
@@ -1,2 +1,3 @@
 {{> header}}
+{{content}}
 {{> footer}}


### PR DESCRIPTION
## Before

### Website

![image](https://user-images.githubusercontent.com/23638587/85935482-5d315580-b8bf-11ea-9808-6e25f9b16797.png)

### Logs

```
Jun 28 01:45:10 docsrs cratesfyi[21043]: 2020/06/28 01:45:10 [ERROR] cratesfyi::web: internal server error: Template not found: resp
```

## After

### Website

![image](https://user-images.githubusercontent.com/23638587/85935494-88b44000-b8bf-11ea-9fe5-0fb29a905385.png)

### Logs

```
2020/06/27 21:42:48 [ERROR] cratesfyi::web::rustdoc: called cexpect!() on a `None` value
   0: cratesfyi::web::rustdoc::target_redirect_handler
             at src/web/rustdoc.rs:462
   1: core::ops::function::Fn::call
             at /home/joshua/.local/lib/rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libcore/ops/function.rs:72
   2: <F as iron::middleware::Handler>::handle
             at /home/joshua/.local/lib/cargo/registry/src/github.com-1ecc6299db9ec823/iron-0.5.1/src/middleware/mod.rs:312
   3: <alloc::boxed::Box<dyn iron::middleware::Handler> as iron::middleware::Handler>::handle
             at /home/joshua/.local/lib/cargo/registry/src/github.com-1ecc6299db9ec823/iron-0.5.1/src/middleware/mod.rs:318
   4: <cratesfyi::web::metrics::RequestRecorder as iron::middleware::Handler>::handle
             at src/web/metrics.rs:192
   5: <alloc::boxed::Box<dyn iron::middleware::Handler> as iron::middleware::Handler>::handle
             at /home/joshua/.local/lib/cargo/registry/src/github.com-1ecc6299db9ec823/iron-0.5.1/src/middleware/mod.rs:318
   6: <alloc::boxed::Box<dyn iron::middleware::Handler> as iron::middleware::Handler>::handle
             at /home/joshua/.local/lib/cargo/registry/src/github.com-1ecc6299db9ec823/iron-0.5.1/src/middleware/mod.rs:318
   7: router::router::Router::handle_method
             at /home/joshua/.local/lib/cargo/registry/src/github.com-1ecc6299db9ec823/router-0.5.1/src/router.rs:199
   8: <router::router::Router as iron::middleware::Handler>::handle
             at /home/joshua/.local/lib/cargo/registry/src/github.com-1ecc6299db9ec823/router-0.5.1/src/router.rs:212
   9: <alloc::boxed::Box<dyn iron::middleware::Handler> as iron::middleware::Handler>::handle
             at /home/joshua/.local/lib/cargo/registry/src/github.com-1ecc6299db9ec823/iron-0.5.1/src/middleware/mod.rs:318
  10: iron::middleware::Chain::continue_from_handler
             at /home/joshua/.local/lib/cargo/registry/src/github.com-1ecc6299db9ec823/iron-0.5.1/src/middleware/mod.rs:282
  11: iron::middleware::Chain::continue_from_before
             at /home/joshua/.local/lib/cargo/registry/src/github.com-1ecc6299db9ec823/iron-0.5.1/src/middleware/mod.rs:276
  12: <iron::middleware::Chain as iron::middleware::Handler>::handle
             at /home/joshua/.local/lib/cargo/registry/src/github.com-1ecc6299db9ec823/iron-0.5.1/src/middleware/mod.rs:200
  13: <alloc::boxed::Box<dyn iron::middleware::Handler> as iron::middleware::Handler>::handle
             at /home/joshua/.local/lib/cargo/registry/src/github.com-1ecc6299db9ec823/iron-0.5.1/src/middleware/mod.rs:318
  14: <cratesfyi::web::CratesfyiHandler as iron::middleware::Handler>::handle::{{closure}}::{{closure}}
             at src/web/mod.rs:171
  15: <cratesfyi::web::CratesfyiHandler as iron::middleware::Handler>::handle::if_404
             at src/web/mod.rs:161
  16: <cratesfyi::web::CratesfyiHandler as iron::middleware::Handler>::handle::{{closure}}
             at src/web/mod.rs:171
  17: core::result::Result<T,E>::or_else
             at /home/joshua/.local/lib/rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libcore/result.rs:799
  18: <cratesfyi::web::CratesfyiHandler as iron::middleware::Handler>::handle
             at src/web/mod.rs:169
  19: <iron::iron::RawHandler<H> as hyper::server::Handler>::handle
             at /home/joshua/.local/lib/cargo/registry/src/github.com-1ecc6299db9ec823/iron-0.5.1/src/iron.rs:176
  20: hyper::server::Worker<H>::keep_alive_loop
             at /home/joshua/.local/lib/cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.10.16/src/server/mod.rs:340
  21: hyper::server::Worker<H>::handle_connection
             at /home/joshua/.local/lib/cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.10.16/src/server/mod.rs:282
  22: hyper::server::handle::{{closure}}
             at /home/joshua/.local/lib/cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.10.16/src/server/mod.rs:242
  23: hyper::server::listener::spawn_with::{{closure}}
             at /home/joshua/.local/lib/cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.10.16/src/server/listener.rs:50
  24: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /home/joshua/.local/lib/rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/sys_common/backtrace.rs:130
  25: std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}
             at /home/joshua/.local/lib/rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/thread/mod.rs:475
  26: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /home/joshua/.local/lib/rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/panic.rs:318
  27: std::panicking::try::do_call
             at /home/joshua/.local/lib/rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/panicking.rs:331
  28: __rust_try
  29: std::panicking::try
             at /home/joshua/.local/lib/rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/panicking.rs:274
  30: std::panic::catch_unwind
             at /home/joshua/.local/lib/rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/panic.rs:394
  31: std::thread::Builder::spawn_unchecked::{{closure}}
             at /home/joshua/.local/lib/rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/thread/mod.rs:474
  32: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /home/joshua/.local/lib/rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libcore/ops/function.rs:232
  33: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/49cae55760da0a43428eba73abcb659bb70cf2e4/src/liballoc/boxed.rs:1008
      <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/49cae55760da0a43428eba73abcb659bb70cf2e4/src/liballoc/boxed.rs:1008
      std::sys::unix::thread::Thread::new::thread_start
             at /rustc/49cae55760da0a43428eba73abcb659bb70cf2e4/src/libstd/sys/unix/thread.rs:87
  34: start_thread
  35: clone
```

Note that we already have `backtrace` as a transitive dependency due to `failure`.

Closes https://github.com/rust-lang/docs.rs/issues/817