### PR TITLE
Improve executing tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,11 +409,12 @@ dependencies = [
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "systemstat 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tera 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tera 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zstd 0.5.2+zstd.1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3241,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4379,7 +4380,7 @@ dependencies = [
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum tendril 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "707feda9f2582d5d680d733e38755547a3e8fb471e7ba11452ecfd9ce93a5d3b"
-"checksum tera 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44567278e3f16c6f888f4a1426d1af33827e6bffbe3911fe24aec2c594f0dfcb"
+"checksum tera 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "55df25c7768a0fb9f165931366eb0f21587c407061e1e69c1f5c2b495adfd9bb"
 "checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thin-slice 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,8 @@ staticfile = { version = "0.4", features = [ "cache" ] }
 tempfile = "3.1.0"
 
 # Templating
-tera = { version = "1.3.0", features = ["builtins"] }
+tera = { version = "1.3.1", features = ["builtins"] }
+walkdir = "2"
 
 # Template hot-reloading
 arc-swap = "0.4.6"
@@ -67,16 +68,16 @@ notify = "4.0.15"
 chrono = { version = "0.4.11", features = ["serde"] }
 time = "0.1" # TODO: Remove once `iron` is removed
 
+[dependencies.postgres]
+version = "0.15"
+features = ["with-chrono", "with-serde_json"]
+
 [target.'cfg(not(windows))'.dependencies]
 # Process information
 procfs = "0.7"
 
 [target.'cfg(windows)'.dependencies]
 path-slash = "0.1.1"
-
-[dependencies.postgres]
-version = "0.15"
-features = ["with-chrono", "with-serde_json"]
 
 [dev-dependencies]
 once_cell = "1.2.0"

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -7,6 +7,9 @@ pub use self::file::add_path_into_database;
 pub use self::migrate::migrate;
 pub use self::pool::{Pool, PoolError};
 
+#[cfg(test)]
+pub(crate) use self::pool::PoolConnection;
+
 mod add_package;
 pub mod blacklist;
 mod delete_crate;

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -79,9 +79,6 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::{env, fmt, path::PathBuf, time::Duration};
 
-#[cfg(test)]
-use std::sync::Mutex;
-
 /// Duration of static files for staticfile and DatabaseFileHandler (in seconds)
 const STATIC_FILE_CACHE_DURATION: u64 = 60 * 60 * 24 * 30 * 12; // 12 months
 const STYLE_CSS: &str = include_str!(concat!(env!("OUT_DIR"), "/style.css"));
@@ -395,21 +392,6 @@ impl Server {
         let server = Self::start_inner(addr.unwrap_or(DEFAULT_BIND), db, config, template_data);
         info!("Running docs.rs web server on http://{}", server.addr());
         Ok(server)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn start_test(
-        conn: Arc<Mutex<Connection>>,
-        config: Arc<Config>,
-    ) -> Result<Self, Error> {
-        let templates = TemplateData::new(&conn.lock().unwrap())?;
-
-        Ok(Self::start_inner(
-            "127.0.0.1:0",
-            Pool::new_simple(conn.clone()),
-            config,
-            Arc::new(templates),
-        ))
     }
 
     fn start_inner(

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -97,6 +97,8 @@ pub(super) fn load_templates(conn: &Connection) -> Result<Tera> {
     // directory and matches them against the provided glob expression. Unfortunately this means
     // Tera will walk all the rustwide workspaces, the git repository and a bunch of other
     // unrelated data, slowing down the search a lot.
+    //
+    // TODO: remove this when https://github.com/Gilnaa/globwalk/issues/29 is fixed
     let mut tera = Tera::default();
     tera.add_template_files(find_templates_in_filesystem(TEMPLATES_DIRECTORY)?)?;
 


### PR DESCRIPTION
This PR makes two changes that will help executing tests:

* Moves tests to use a downsized connection pool instead of an `Arc<Mutex<Connection>>`
* Replaces Tera's template loading code with a custom function, making template loading instantaneous (it took 4 seconds on my NVMe before). See the comment in the code for why that was happening.