### PR TITLE
Fix panics when building a crate from the queue

### DIFF
--- a/src/docbuilder/queue.rs
+++ b/src/docbuilder/queue.rs
@@ -79,7 +79,7 @@ impl DocBuilder {
     ) -> Result<bool> {
         // This is in a nested scope to drop the connection before build_package is called,
         // otherwise the borrow checker will complain.
-        let (id, name, version): (i64, String, String) = {
+        let (id, name, version): (i32, String, String) = {
             let conn = self.db.get()?;
 
             let query = conn.query(


### PR DESCRIPTION
This fixes the following panic found in production:

<details><summary>Backtrace</summary>

```
Jun 29 00:30:34 docsrs cratesfyi[14484]: 2020/06/29 00:30:34 [DEBUG] cratesfyi::utils::daemon: Checking build queue
Jun 29 00:30:34 docsrs cratesfyi[14484]: 2020/06/29 00:30:34 [INFO] cratesfyi::utils::daemon: Starting build with 102 crates in queue (currently on a 0 crate streak)
Jun 29 00:30:34 docsrs cratesfyi[14484]: 2020/06/29 00:30:34 [DEBUG] cratesfyi::docbuilder: Loading cache
Jun 29 00:30:34 docsrs cratesfyi[14484]: 2020/06/29 00:30:34 [DEBUG] cratesfyi::docbuilder: Loading database cache
Jun 29 00:30:34 docsrs cratesfyi[14484]: thread 'build queue reader' panicked at 'error retrieving column "id": Error(Conversion(WrongType(Type(Int4))))', /home/ubuntu/.carg
Jun 29 00:30:34 docsrs cratesfyi[14484]: stack backtrace:
Jun 29 00:30:34 docsrs cratesfyi[14484]:    0: backtrace::backtrace::libunwind::trace
Jun 29 00:30:34 docsrs cratesfyi[14484]:              at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.40/src/backtrace/libunwind.rs:88
Jun 29 00:30:34 docsrs cratesfyi[14484]:    1: backtrace::backtrace::trace_unsynchronized
Jun 29 00:30:34 docsrs cratesfyi[14484]:              at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.40/src/backtrace/mod.rs:66
Jun 29 00:30:34 docsrs cratesfyi[14484]:    2: std::sys_common::backtrace::_print_fmt
Jun 29 00:30:34 docsrs cratesfyi[14484]:              at src/libstd/sys_common/backtrace.rs:77
Jun 29 00:30:34 docsrs cratesfyi[14484]:    3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
Jun 29 00:30:34 docsrs cratesfyi[14484]:              at src/libstd/sys_common/backtrace.rs:61
Jun 29 00:30:34 docsrs cratesfyi[14484]:    4: core::fmt::write
Jun 29 00:30:34 docsrs cratesfyi[14484]:              at src/libcore/fmt/mod.rs:1028
Jun 29 00:30:34 docsrs cratesfyi[14484]:    5: std::io::Write::write_fmt
Jun 29 00:30:34 docsrs cratesfyi[14484]:              at src/libstd/io/mod.rs:1412
Jun 29 00:30:34 docsrs cratesfyi[14484]:    6: std::sys_common::backtrace::_print
Jun 29 00:30:34 docsrs cratesfyi[14484]:              at src/libstd/sys_common/backtrace.rs:65
Jun 29 00:30:34 docsrs cratesfyi[14484]:    7: std::sys_common::backtrace::print
Jun 29 00:30:34 docsrs cratesfyi[14484]:              at src/libstd/sys_common/backtrace.rs:50
Jun 29 00:30:34 docsrs cratesfyi[14484]:    8: std::panicking::default_hook::{{closure}}
Jun 29 00:30:34 docsrs cratesfyi[14484]:              at src/libstd/panicking.rs:188
Jun 29 00:30:34 docsrs cratesfyi[14484]:    9: std::panicking::default_hook
Jun 29 00:30:34 docsrs cratesfyi[14484]:              at src/libstd/panicking.rs:205
Jun 29 00:30:34 docsrs cratesfyi[14484]:   10: std::panicking::rust_panic_with_hook
Jun 29 00:30:34 docsrs cratesfyi[14484]:              at src/libstd/panicking.rs:464
Jun 29 00:30:34 docsrs cratesfyi[14484]:   11: std::panicking::continue_panic_fmt
Jun 29 00:30:34 docsrs cratesfyi[14484]:              at src/libstd/panicking.rs:373
Jun 29 00:30:34 docsrs cratesfyi[14484]:   12: std::panicking::begin_panic_fmt
Jun 29 00:30:34 docsrs cratesfyi[14484]:              at src/libstd/panicking.rs:328
Jun 29 00:30:34 docsrs cratesfyi[14484]:   13: postgres::rows::Row::get
Jun 29 00:30:34 docsrs cratesfyi[14484]:   14: cratesfyi::docbuilder::queue::<impl cratesfyi::docbuilder::DocBuilder>::build_next_queue_package
Jun 29 00:30:34 docsrs cratesfyi[14484]:   15: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
Jun 29 00:30:34 docsrs cratesfyi[14484]:   16: std::panicking::try::do_call
Jun 29 00:30:34 docsrs cratesfyi[14484]:   17: __rust_maybe_catch_panic
Jun 29 00:30:34 docsrs cratesfyi[14484]:              at src/libpanic_unwind/lib.rs:78
Jun 29 00:30:34 docsrs cratesfyi[14484]:   18: cratesfyi::utils::daemon::start_daemon::{{closure}}
Jun 29 00:30:34 docsrs cratesfyi[14484]: note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
Jun 29 00:30:34 docsrs cratesfyi[14484]: 2020/06/29 00:30:34 [ERROR] cratesfyi::utils::daemon: GRAVE ERROR Building new crates panicked: Any
Jun 29 00:30:43 docsrs cratesfyi[14484]: 2020/06/29 00:30:43 [DEBUG] cratesfyi::utils::daemon: Checking new crates
Jun 29 00:30:56 docsrs cratesfyi[14484]: 2020/06/29 00:30:56 [DEBUG] cratesfyi::utils::daemon: 0 crates added to queue
```

</details>

The regression was introduced by https://github.com/rust-lang/docs.rs/pull/843/files#diff-1db2810ea90cd4e7581b5a16ff760ea1R82.

r? @pietroalbini 