### PR TITLE
Removed all usages of lazy_static and replaced them with once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,6 @@ dependencies = [
  "handlebars-iron 0.25.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kuchiki 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1816,6 +1815,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "once_cell"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "oorandom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,14 +37,13 @@ futures = "0.1"
 tokio = "0.1"
 systemstat = "0.1.4"
 prometheus = { version = "0.7.0", default-features = false }
-lazy_static = "1.0.0"
 rustwide = "0.7.1"
 mime_guess = "2"
 dotenv = "0.15"
 zstd = "0.5"
 git2 = { version = "0.13.6", default-features = false }
-once_cell = "1.4.0"
 path-slash = "0.1.3"
+once_cell = { version = "1.4.0", features = ["parking_lot"] }
 
 # Data serialization and deserialization
 serde = { version = "1.0", features = ["derive"] }

--- a/src/web/badge/test.svg
+++ b/src/web/badge/test.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="91" height="20">
+              <linearGradient id="smooth" x2="0" y2="100%">
+                <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+                <stop offset="1" stop-opacity=".1"/>
+              </linearGradient>
+                    
+              <mask id="round">
+                <rect width="91" height="20" rx="3" fill="#fff"/>
+              </mask>
+                    
+              <g mask="url(#round)">
+                <rect width="37" height="20" fill="#555"/>
+                <rect x="37" width="54" height="20" fill="#4c1"/>
+                <rect width="91" height="20" fill="url(#smooth)"/>
+              </g>
+                    
+              <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+                <text x="18" y="15" fill="#010101" fill-opacity=".3">build</text>
+                <text x="18" y="14">build</text>
+                <text x="64" y="15" fill="#010101" fill-opacity=".3">passing</text>
+                <text x="64" y="14">passing</text>
+              </g>
+            </svg>

--- a/src/web/page/handlebars.rs
+++ b/src/web/page/handlebars.rs
@@ -3,6 +3,7 @@
 use handlebars_iron::Template;
 use iron::response::Response;
 use iron::{status, IronResult, Set};
+use once_cell::sync::Lazy;
 use serde::{
     ser::{SerializeStruct, Serializer},
     Serialize,
@@ -10,10 +11,8 @@ use serde::{
 use serde_json::Value;
 use std::collections::BTreeMap;
 
-lazy_static::lazy_static! {
-    static ref RUSTC_RESOURCE_SUFFIX: String = load_rustc_resource_suffix()
-        .unwrap_or_else(|_| "???".into());
-}
+static RUSTC_RESOURCE_SUFFIX: Lazy<String> =
+    Lazy::new(|| load_rustc_resource_suffix().unwrap_or_else(|_| "???".into()));
 
 fn load_rustc_resource_suffix() -> Result<String, failure::Error> {
     // New instances of the configuration or the connection pool shouldn't be created inside the

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -77,6 +77,7 @@ fn load_rustc_resource_suffix(conn: &Connection) -> Result<String> {
         "SELECT value FROM config WHERE name = 'rustc_version';",
         &[],
     )?;
+
     if res.is_empty() {
         failure::bail!("missing rustc version");
     }


### PR DESCRIPTION
* Replaced `lazy_static` with `once_cell` (using the `parking_lot` feature for smaller, faster and non-poisoning locks)
* ~~Tweaked `load_rustc_resource_suffix`, it now substitutes a dummy rustc version for tests when one isn't found. This fixed a lot of intermittent (and essentially false) test failures for me, I can remove it if it's uneeded~~