### PR TITLE
Fixed docker test failure

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -13,8 +13,8 @@ FROM ubuntu:bionic AS build
 
 # Install packaged dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-  build-essential git curl cmake gcc g++ pkg-config libmagic-dev \
-  libssl-dev zlib1g-dev ca-certificates
+    build-essential git curl cmake gcc g++ pkg-config libmagic-dev \
+    libssl-dev zlib1g-dev ca-certificates
 
 # Install the stable toolchain with rustup
 RUN curl https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init >/tmp/rustup-init && \
@@ -74,7 +74,7 @@ RUN mkdir -p /opt/docsrs/prefix
 COPY --from=build /build/target/release/cratesfyi /usr/local/bin
 COPY static /opt/docsrs/prefix/public_html
 COPY templates /opt/docsrs/templates
-COPY docker/entrypoint.sh /opt/docsrs/
+COPY dockerfiles/entrypoint.sh /opt/docsrs/
 
 WORKDIR /opt/docsrs
 ENTRYPOINT ["/opt/docsrs/entrypoint.sh"]

--- a/dockerfiles/prometheus.yml
+++ b/dockerfiles/prometheus.yml
@@ -1,14 +1,14 @@
 global:
-  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+  scrape_interval: 15s # By default, scrape targets every 15 seconds.
 
   # Attach these labels to any time series or alerts when communicating with
   # external systems (federation, remote storage, Alertmanager).
   external_labels:
-    monitor: 'docs.rs-monitor'
+    monitor: "docs.rs-monitor"
 
 scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-  - job_name: 'docs.rs'
-    metrics_path: '/about/metrics'
+  - job_name: "docs.rs"
+    metrics_path: "/about/metrics"
     static_configs:
-      - targets: ['web:3000']
+      - targets: ["web:3000"]


### PR DESCRIPTION
Fixed a reference to the `docker` folder that hadn't been changed to the `dockerfiles` folder, causing CI failures. Introduced in #864

cc @jyn514 