### PR TITLE
Run daemon without registry index watcher in local docker

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,3 @@
-CRATESFYI_GITHUB_USERNAME=
-CRATESFYI_GITHUB_ACCESSTOKEN=
 CRATESFYI_PREFIX=ignored/cratesfyi-prefix
 CRATESFYI_DATABASE_URL=postgresql://cratesfyi:password@localhost
 RUST_LOG=cratesfyi,rustwide=info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,7 @@ dependencies = [
  "slug 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "staticfile 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strum 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "systemstat 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tera 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3134,6 +3135,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "strum_macros 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "syn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4374,6 +4394,8 @@ dependencies = [
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "863246aaf5ddd0d6928dfeb1a9ca65f505599e4e1b399935ef7e75107516b4ef"
 "checksum structopt-derive 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
+"checksum strum 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b"
+"checksum strum_macros 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)" = "1425de3c33b0941002740a420b1a906a350b88d08b82b2c8a01035a3f9447bac"
 "checksum syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,7 @@ dependencies = [
  "arc-swap 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.3.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "badge 0.2.0",
+ "base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "comrak 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crates-index-diff 7.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ zstd = "0.5"
 git2 = { version = "0.13.6", default-features = false }
 path-slash = "0.1.3"
 once_cell = { version = "1.4.0", features = ["parking_lot"] }
+base64 = "0.12.1"
 
 # Data serialization and deserialization
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ git2 = { version = "0.13.6", default-features = false }
 path-slash = "0.1.3"
 once_cell = { version = "1.4.0", features = ["parking_lot"] }
 base64 = "0.12.1"
+strum = { version = "0.18.0", features = ["derive"] }
 
 # Data serialization and deserialization
 serde = { version = "1.0", features = ["derive"] }

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -79,4 +79,4 @@ COPY dockerfiles/entrypoint.sh /opt/docsrs/
 
 WORKDIR /opt/docsrs
 ENTRYPOINT ["/opt/docsrs/entrypoint.sh"]
-CMD ["start-web-server"]
+CMD ["daemon", "--disable-registry-watcher"]

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -79,4 +79,4 @@ COPY dockerfiles/entrypoint.sh /opt/docsrs/
 
 WORKDIR /opt/docsrs
 ENTRYPOINT ["/opt/docsrs/entrypoint.sh"]
-CMD ["daemon", "--disable-registry-watcher"]
+CMD ["daemon", "--registry-watcher=disabled"]

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -441,8 +441,8 @@ impl DatabaseSubcommand {
             }
 
             Self::UpdateGithubFields => {
-                cratesfyi::utils::github_updater(&*ctx.conn()?)
-                    .expect("Failed to update github fields");
+                cratesfyi::utils::GithubUpdater::new(&*ctx.config()?, ctx.pool()?)?
+                    .update_all_crates()?;
             }
 
             Self::AddDirectory { directory, prefix } => {

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -65,6 +65,9 @@ enum CommandLine {
         /// Deprecated. Run the server in the foreground instead of detaching a child
         #[structopt(name = "FOREGROUND", short = "f", long = "foreground")]
         foreground: bool,
+
+        #[structopt(long = "disable-registry-watcher")]
+        disable_registry_watcher: bool,
     },
 
     /// Database operations
@@ -98,12 +101,20 @@ impl CommandLine {
                     ctx.build_queue()?,
                 )?;
             }
-            Self::Daemon { foreground } => {
+            Self::Daemon {
+                foreground,
+                disable_registry_watcher,
+            } => {
                 if foreground {
                     log::warn!("--foreground was passed, but there is no need for it anymore");
                 }
 
-                cratesfyi::utils::start_daemon(ctx.config()?, ctx.pool()?, ctx.build_queue()?)?;
+                cratesfyi::utils::start_daemon(
+                    ctx.config()?,
+                    ctx.pool()?,
+                    ctx.build_queue()?,
+                    !disable_registry_watcher,
+                )?;
             }
             Self::Database { subcommand } => subcommand.handle_args(ctx)?,
             Self::Queue { subcommand } => subcommand.handle_args(ctx)?,

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -4,14 +4,12 @@
 
 use crate::{
     db::Pool,
-    docbuilder::RustwideBuilder,
-    utils::{github_updater, pubsubhubbub, update_release_activity},
+    utils::{github_updater, queue_builder, update_release_activity},
     BuildQueue, Config, DocBuilder, DocBuilderOptions,
 };
 use chrono::{Timelike, Utc};
 use failure::Error;
-use log::{debug, error, info, warn};
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use log::{debug, error, info};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -69,137 +67,16 @@ pub fn start_daemon(
         .unwrap();
 
     // build new crates every minute
-    // REFACTOR: Break this into smaller functions
     let cloned_db = db.clone();
     let cloned_build_queue = build_queue.clone();
-    thread::Builder::new().name("build queue reader".to_string()).spawn(move || {
-        let opts = opts();
-        let mut doc_builder = DocBuilder::new(opts, cloned_db.clone(), cloned_build_queue.clone());
-
-        /// Represents the current state of the builder thread.
-        enum BuilderState {
-            /// The builder thread has just started, and hasn't built any crates yet.
-            Fresh,
-            /// The builder has just seen an empty build queue.
-            EmptyQueue,
-            /// The builder has just seen the lock file.
-            Locked,
-            /// The builder has just finished building a crate. The enclosed count is the number of
-            /// crates built since the caches have been refreshed.
-            QueueInProgress(usize),
-        }
-
-        let mut builder = RustwideBuilder::init(cloned_db).unwrap();
-
-        let mut status = BuilderState::Fresh;
-
-        loop {
-            if !status.is_in_progress() {
-                thread::sleep(Duration::from_secs(60));
-            }
-
-            // check lock file
-            if doc_builder.is_locked() {
-                warn!("Lock file exits, skipping building new crates");
-                status = BuilderState::Locked;
-                continue;
-            }
-
-            if status.count() >= 10 {
-                // periodically, we need to flush our caches and ping the hubs
-                debug!("10 builds in a row; flushing caches");
-                status = BuilderState::QueueInProgress(0);
-
-                match pubsubhubbub::ping_hubs() {
-                    Err(e) => error!("Failed to ping hub: {}", e),
-                    Ok(n) => debug!("Succesfully pinged {} hubs", n)
-                }
-
-                if let Err(e) = doc_builder.load_cache() {
-                    error!("Failed to load cache: {}", e);
-                }
-
-                if let Err(e) = doc_builder.save_cache() {
-                    error!("Failed to save cache: {}", e);
-                }
-            }
-
-            // Only build crates if there are any to build
-            debug!("Checking build queue");
-            match cloned_build_queue.pending_count() {
-                Err(e) => {
-                    error!("Failed to read the number of crates in the queue: {}", e);
-                    continue;
-                }
-
-                Ok(0) => {
-                    if status.count() > 0 {
-                        // ping the hubs before continuing
-                        match pubsubhubbub::ping_hubs() {
-                            Err(e) => error!("Failed to ping hub: {}", e),
-                            Ok(n) => debug!("Succesfully pinged {} hubs", n)
-                        }
-
-                        if let Err(e) = doc_builder.save_cache() {
-                            error!("Failed to save cache: {}", e);
-                        }
-                    }
-                    debug!("Queue is empty, going back to sleep");
-                    status = BuilderState::EmptyQueue;
-                    continue;
-                }
-
-                Ok(queue_count) => {
-                    info!("Starting build with {} crates in queue (currently on a {} crate streak)",
-                          queue_count, status.count());
-                }
-            }
-
-            // if we're starting a new batch, reload our caches and sources
-            if !status.is_in_progress() {
-                if let Err(e) = doc_builder.load_cache() {
-                    error!("Failed to load cache: {}", e);
-                    continue;
-                }
-            }
-
-            // Run build_packages_queue under `catch_unwind` to catch panics
-            // This only panicked twice in the last 6 months but its just a better
-            // idea to do this.
-            let res = catch_unwind(AssertUnwindSafe(|| {
-                match doc_builder.build_next_queue_package(&mut builder) {
-                    Err(e) => error!("Failed to build crate from queue: {}", e),
-                    Ok(crate_built) => if crate_built {
-                        status.increment();
-                    }
-                }
-            }));
-
-            if let Err(e) = res {
-                error!("GRAVE ERROR Building new crates panicked: {:?}", e);
-            }
-        }
-
-        impl BuilderState {
-            fn count(&self) -> usize {
-                match *self {
-                    BuilderState::QueueInProgress(n) => n,
-                    _ => 0,
-                }
-            }
-
-            fn is_in_progress(&self) -> bool {
-                match *self {
-                    BuilderState::QueueInProgress(_) => true,
-                    _ => false,
-                }
-            }
-
-            fn increment(&mut self) {
-                *self = BuilderState::QueueInProgress(self.count() + 1);
-            }
-        }
-    }).unwrap();
+    thread::Builder::new()
+        .name("build queue reader".to_string())
+        .spawn(move || {
+            let doc_builder =
+                DocBuilder::new(opts(), cloned_db.clone(), cloned_build_queue.clone());
+            queue_builder(doc_builder, cloned_db, cloned_build_queue).unwrap();
+        })
+        .unwrap();
 
     // update release activity everyday at 23:55
     let cloned_db = db.clone();

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -19,6 +19,7 @@ pub fn start_daemon(
     config: Arc<Config>,
     db: Pool,
     build_queue: Arc<BuildQueue>,
+    enable_registry_watcher: bool,
 ) -> Result<(), Error> {
     const CRATE_VARIABLES: [&str; 3] = [
         "CRATESFYI_PREFIX",
@@ -38,33 +39,35 @@ pub fn start_daemon(
     // check paths once
     dbopts.check_paths().unwrap();
 
-    // check new crates every minute
-    let cloned_db = db.clone();
-    let cloned_build_queue = build_queue.clone();
-    thread::Builder::new()
-        .name("registry index reader".to_string())
-        .spawn(move || {
-            // space this out to prevent it from clashing against the queue-builder thread on launch
-            thread::sleep(Duration::from_secs(30));
-            loop {
-                let opts = opts();
-                let mut doc_builder =
-                    DocBuilder::new(opts, cloned_db.clone(), cloned_build_queue.clone());
+    if enable_registry_watcher {
+        // check new crates every minute
+        let cloned_db = db.clone();
+        let cloned_build_queue = build_queue.clone();
+        thread::Builder::new()
+            .name("registry index reader".to_string())
+            .spawn(move || {
+                // space this out to prevent it from clashing against the queue-builder thread on launch
+                thread::sleep(Duration::from_secs(30));
+                loop {
+                    let opts = opts();
+                    let mut doc_builder =
+                        DocBuilder::new(opts, cloned_db.clone(), cloned_build_queue.clone());
 
-                if doc_builder.is_locked() {
-                    debug!("Lock file exists, skipping checking new crates");
-                } else {
-                    debug!("Checking new crates");
-                    match doc_builder.get_new_crates() {
-                        Ok(n) => debug!("{} crates added to queue", n),
-                        Err(e) => error!("Failed to get new crates: {}", e),
+                    if doc_builder.is_locked() {
+                        debug!("Lock file exists, skipping checking new crates");
+                    } else {
+                        debug!("Checking new crates");
+                        match doc_builder.get_new_crates() {
+                            Ok(n) => debug!("{} crates added to queue", n),
+                            Err(e) => error!("Failed to get new crates: {}", e),
+                        }
                     }
-                }
 
-                thread::sleep(Duration::from_secs(60));
-            }
-        })
-        .unwrap();
+                    thread::sleep(Duration::from_secs(60));
+                }
+            })
+            .unwrap();
+    }
 
     // build new crates every minute
     let cloned_db = db.clone();

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,7 @@ pub use self::daemon::start_daemon;
 pub use self::github_updater::github_updater;
 pub use self::html::extract_head_and_body;
 pub use self::queue::{get_crate_priority, remove_crate_priority, set_crate_priority};
+pub use self::queue_builder::queue_builder;
 pub use self::release_activity_updater::update_release_activity;
 pub(crate) use self::rustc_version::parse_rustc_version;
 
@@ -19,6 +20,7 @@ mod github_updater;
 mod html;
 mod pubsubhubbub;
 mod queue;
+mod queue_builder;
 mod release_activity_updater;
 mod rustc_version;
 pub(crate) mod sized_buffer;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,7 +3,7 @@
 pub(crate) use self::cargo_metadata::{CargoMetadata, Package as MetadataPackage};
 pub(crate) use self::copy::copy_doc_dir;
 pub use self::daemon::start_daemon;
-pub use self::github_updater::github_updater;
+pub use self::github_updater::GithubUpdater;
 pub use self::html::extract_head_and_body;
 pub use self::queue::{get_crate_priority, remove_crate_priority, set_crate_priority};
 pub use self::queue_builder::queue_builder;

--- a/src/utils/queue_builder.rs
+++ b/src/utils/queue_builder.rs
@@ -7,7 +7,6 @@ use std::thread;
 use std::time::Duration;
 
 // TODO: change to `fn() -> Result<!, Error>` when never _finally_ stabilizes
-// REFACTOR: Break this into smaller functions
 pub fn queue_builder(
     mut doc_builder: DocBuilder,
     db: Pool,

--- a/src/utils/queue_builder.rs
+++ b/src/utils/queue_builder.rs
@@ -1,0 +1,144 @@
+use crate::{db::Pool, docbuilder::RustwideBuilder, utils::pubsubhubbub, BuildQueue, DocBuilder};
+use failure::Error;
+use log::{debug, error, info, warn};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+// TODO: change to `fn() -> Result<!, Error>` when never _finally_ stabilizes
+// REFACTOR: Break this into smaller functions
+pub fn queue_builder(
+    mut doc_builder: DocBuilder,
+    db: Pool,
+    build_queue: Arc<BuildQueue>,
+) -> Result<(), Error> {
+    /// Represents the current state of the builder thread.
+    enum BuilderState {
+        /// The builder thread has just started, and hasn't built any crates yet.
+        Fresh,
+        /// The builder has just seen an empty build queue.
+        EmptyQueue,
+        /// The builder has just seen the lock file.
+        Locked,
+        /// The builder has just finished building a crate. The enclosed count is the number of
+        /// crates built since the caches have been refreshed.
+        QueueInProgress(usize),
+    }
+
+    let mut builder = RustwideBuilder::init(db)?;
+
+    let mut status = BuilderState::Fresh;
+
+    loop {
+        if !status.is_in_progress() {
+            thread::sleep(Duration::from_secs(60));
+        }
+
+        // check lock file
+        if doc_builder.is_locked() {
+            warn!("Lock file exits, skipping building new crates");
+            status = BuilderState::Locked;
+            continue;
+        }
+
+        if status.count() >= 10 {
+            // periodically, we need to flush our caches and ping the hubs
+            debug!("10 builds in a row; flushing caches");
+            status = BuilderState::QueueInProgress(0);
+
+            match pubsubhubbub::ping_hubs() {
+                Err(e) => error!("Failed to ping hub: {}", e),
+                Ok(n) => debug!("Succesfully pinged {} hubs", n),
+            }
+
+            if let Err(e) = doc_builder.load_cache() {
+                error!("Failed to load cache: {}", e);
+            }
+
+            if let Err(e) = doc_builder.save_cache() {
+                error!("Failed to save cache: {}", e);
+            }
+        }
+
+        // Only build crates if there are any to build
+        debug!("Checking build queue");
+        match build_queue.pending_count() {
+            Err(e) => {
+                error!("Failed to read the number of crates in the queue: {}", e);
+                continue;
+            }
+
+            Ok(0) => {
+                if status.count() > 0 {
+                    // ping the hubs before continuing
+                    match pubsubhubbub::ping_hubs() {
+                        Err(e) => error!("Failed to ping hub: {}", e),
+                        Ok(n) => debug!("Succesfully pinged {} hubs", n),
+                    }
+
+                    if let Err(e) = doc_builder.save_cache() {
+                        error!("Failed to save cache: {}", e);
+                    }
+                }
+                debug!("Queue is empty, going back to sleep");
+                status = BuilderState::EmptyQueue;
+                continue;
+            }
+
+            Ok(queue_count) => {
+                info!(
+                    "Starting build with {} crates in queue (currently on a {} crate streak)",
+                    queue_count,
+                    status.count()
+                );
+            }
+        }
+
+        // if we're starting a new batch, reload our caches and sources
+        if !status.is_in_progress() {
+            if let Err(e) = doc_builder.load_cache() {
+                error!("Failed to load cache: {}", e);
+                continue;
+            }
+        }
+
+        // Run build_packages_queue under `catch_unwind` to catch panics
+        // This only panicked twice in the last 6 months but its just a better
+        // idea to do this.
+        let res = catch_unwind(AssertUnwindSafe(|| {
+            match doc_builder.build_next_queue_package(&mut builder) {
+                Err(e) => error!("Failed to build crate from queue: {}", e),
+                Ok(crate_built) => {
+                    if crate_built {
+                        status.increment();
+                    }
+                }
+            }
+        }));
+
+        if let Err(e) = res {
+            error!("GRAVE ERROR Building new crates panicked: {:?}", e);
+        }
+    }
+
+    impl BuilderState {
+        fn count(&self) -> usize {
+            match *self {
+                BuilderState::QueueInProgress(n) => n,
+                _ => 0,
+            }
+        }
+
+        fn is_in_progress(&self) -> bool {
+            match *self {
+                BuilderState::QueueInProgress(_) => true,
+                _ => false,
+            }
+        }
+
+        fn increment(&mut self) {
+            *self = BuilderState::QueueInProgress(self.count() + 1);
+        }
+    }
+}


### PR DESCRIPTION
Allows running all components of the daemon with the registry index watcher disabled in testing environments. This means that you can manually insert crates into the queue with `docker-compose run --rm web queue add serde 1.0.106` and the daemon will pick them up and build them like production. It also means the `github_updater` and `release_activity_updater` will run locally.