### PR TITLE
Use procfs only on Linux builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ time = "0.1" # TODO: Remove once `iron` is removed
 version = "0.15"
 features = ["with-chrono", "with-serde_json"]
 
-[target.'cfg(linux)'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 # Process information
 procfs = "0.7"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ time = "0.1" # TODO: Remove once `iron` is removed
 version = "0.15"
 features = ["with-chrono", "with-serde_json"]
 
-[target.'cfg(not(windows))'.dependencies]
+[target.'cfg(linux)'.dependencies]
 # Process information
 procfs = "0.7"
 

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -128,7 +128,7 @@ pub fn metrics_handler(req: &mut Request) -> IronResult<Response> {
     PRIORITIZED_CRATES_COUNT.set(ctry!(queue.prioritized_count()) as i64);
     FAILED_CRATES_COUNT.set(ctry!(queue.failed_count()) as i64);
 
-    #[cfg(linux)]
+    #[cfg(target_os = "linux")]
     {
         use procfs::process::Process;
 

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -128,7 +128,7 @@ pub fn metrics_handler(req: &mut Request) -> IronResult<Response> {
     PRIORITIZED_CRATES_COUNT.set(ctry!(queue.prioritized_count()) as i64);
     FAILED_CRATES_COUNT.set(ctry!(queue.failed_count()) as i64);
 
-    #[cfg(not(windows))]
+    #[cfg(linux)]
     {
         use procfs::process::Process;
 


### PR DESCRIPTION
As we discussed on discord a few days ago, this fixes running the web service on macOS and freebsd machines as `procfs` is only available on Linux targets.