### PR TITLE
Link to documentation, not to /crate on homepage

### DIFF
--- a/tera-templates/core/home.html
+++ b/tera-templates/core/home.html
@@ -34,7 +34,7 @@
 
             <ul>
                 {%- for release in recent_releases -%}
-                    {%- if rustdoc_status -%}
+                    {%- if release.rustdoc_status -%}
                         {%- set release_url = "/" ~ release.name ~ "/" ~ release.version ~ "/" ~ release.target_name -%}
                     {%- else -%}
                         {%- set release_url = "/crate/" ~ release.name ~ "/" ~ release.version -%}


### PR DESCRIPTION
Closes https://github.com/rust-lang/docs.rs/issues/880

r? @Kixiron 