### PR TITLE
Fix links for releases page

### DIFF
--- a/tera-templates/releases/feed.xml
+++ b/tera-templates/releases/feed.xml
@@ -14,7 +14,7 @@
     {%- for release in recent_releases -%}
         {%- set name = release.name | escape_xml -%}
         {%- set version = release.version | escape_xml -%}
-        {%- if rustdoc_status -%}
+        {%- if release.rustdoc_status -%}
             {%- set link = "/" ~ release.name ~ "/" ~ release.version ~ "/" ~ release.target_name -%}
         {%- else -%}
             {%- set link = "/crate/" ~ release.name ~ "/" ~ version -%}

--- a/tera-templates/releases/releases.html
+++ b/tera-templates/releases/releases.html
@@ -21,7 +21,7 @@
             <ul>
                 {# TODO: If there are no releases, then display a message that says so #}
                 {%- for release in releases -%}
-                    {%- if rustdoc_status -%}
+                    {%- if release.rustdoc_status -%}
                         {% set link = "/" ~ release.name ~ "/" ~ release.version ~ "/" ~ release.target_name -%}
                     {%- else -%}
                         {% set link = "/crate/" ~ release.name ~ "/" ~ release.version -%}


### PR DESCRIPTION
Closes https://github.com/rust-lang/docs.rs/issues/880 for real this time. The fix is the same as before but in more places. Most of the changes are refactoring tests.

r? @Kixiron 