### PR TITLE
Fixed details dropdown

### DIFF
--- a/src/web/badge/src/lib.rs
+++ b/src/web/badge/src/lib.rs
@@ -1,8 +1,8 @@
 //! Simple badge generator
 
 use base64::display::Base64Display;
-use rusttype::{point, Font, Point, PositionedGlyph, Scale};
 use once_cell::sync::Lazy;
+use rusttype::{point, Font, Point, PositionedGlyph, Scale};
 
 const FONT_DATA: &[u8] = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/DejaVuSans.ttf"));
 const FONT_SIZE: f32 = 11.0;
@@ -35,9 +35,8 @@ pub struct Badge {
 
 impl Badge {
     pub fn new(options: BadgeOptions) -> Result<Badge, String> {
-        static FONT: Lazy<Font> = Lazy::new(|| {
-            Font::try_from_bytes(FONT_DATA).expect("Failed to parse FONT_DATA")
-        });
+        static FONT: Lazy<Font> =
+            Lazy::new(|| Font::try_from_bytes(FONT_DATA).expect("Failed to parse FONT_DATA"));
 
         let font = &*FONT;
         let scale = Scale {

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -253,17 +253,16 @@ fn map_to_release(conn: &Connection, crate_id: i32, version: String) -> Release 
         )
         .unwrap();
 
-    let (build_status, yanked, is_library) = if !rows.is_empty() {
-        let row = rows.get(0);
-
-        (
-            row.get("build_status"),
-            row.get("yanked"),
-            row.get("is_library"),
-        )
-    } else {
-        Default::default()
-    };
+    let (build_status, yanked, is_library) = rows.iter().next().map_or_else(
+        || Default::default(),
+        |row| {
+            (
+                row.get("build_status"),
+                row.get("yanked"),
+                row.get("is_library"),
+            )
+        },
+    );
 
     Release {
         version,

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -253,16 +253,14 @@ fn map_to_release(conn: &Connection, crate_id: i32, version: String) -> Release 
         )
         .unwrap();
 
-    let (build_status, yanked, is_library) = rows.iter().next().map_or_else(
-        || Default::default(),
-        |row| {
+    let (build_status, yanked, is_library) =
+        rows.iter().next().map_or_else(Default::default, |row| {
             (
                 row.get("build_status"),
                 row.get("yanked"),
                 row.get("is_library"),
             )
-        },
-    );
+        });
 
     Release {
         version,

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -83,6 +83,7 @@
         * `version` A string of the release's version
         * `yanked` A boolean of the release's yanked status
         * `build_status` A boolean of the crate's build status (true for built, false for failed build)
+        * `is_library` A boolean that's true if the crate is a library and false if it's a binary
 #}
 {% macro releases_list(name, releases) %}
     {%- for release in releases -%}
@@ -92,8 +93,14 @@
         {%- set release_name = name ~ "-" ~ release.version -%}
 
         <li class="pure-menu-item">
-            {# If the release is yanked but built, display an warning #}
-            {%- if release.yanked and release.build_status -%}
+            {# If the release isn't a library, then display that warning #}
+            {% if not release.is_library -%}
+                <a href="{{ release_url }}" class="pure-menu-link warn" title="{{ release_name }} is not a library">
+                    <i class="fa fa-fw fa-warning"></i> {{ release.version }}
+                </a>
+
+            {# If the release has been yanked and failed to build, display a warning #}
+            {%- elif release.yanked and release.build_status -%}
                 <a href="{{ release_url }}" class="pure-menu-link warn" title="{{ release_name }} is yanked">
                     <i class="fa fa-fw fa-warning"></i> {{ release.version }}
                 </a>
@@ -116,7 +123,7 @@
                 <a href="{{ release_url }}" class="pure-menu-link">
                     {{ release.version }}
                 </a>
-            {%- endif -%}
+            {%- endif %}
         </li>
     {%- endfor -%}
 {% endmacro releases_list %}


### PR DESCRIPTION
In the `Versions` lists any crate release that was not a library was incorrectly said to have failed to build when it should say that the crate isn't a library

Previous behavior:

![image](https://user-images.githubusercontent.com/25047011/87574872-a55cc000-c694-11ea-8aa2-ca28046d80ae.png)

Fixed behavior:

![image](https://user-images.githubusercontent.com/25047011/87574915-b60d3600-c694-11ea-9d05-02c8a43fc807.png)

I was also getting rustfmt errors from the `badges` crate, so I ran a quick fmt on that in the second commit