### PR TITLE
Improve CLI errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ r2d2_postgres = "0.14"
 url = { version = "2.1.1", features = ["serde"] }
 badge = { path = "src/web/badge" }
 backtrace = "0.3"
-failure = "0.1.3"
+failure = { version = "0.1.3", features = ["backtrace"] }
 comrak = { version = "0.3", default-features = false }
 toml = "0.5"
 kuchiki = "0.8"

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::fmt::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -10,11 +11,21 @@ use once_cell::sync::OnceCell;
 use structopt::StructOpt;
 use strum::VariantNames;
 
-pub fn main() -> Result<(), Error> {
+pub fn main() {
     let _ = dotenv::dotenv();
     logger_init();
 
-    CommandLine::from_args().handle_args()
+    if let Err(err) = CommandLine::from_args().handle_args() {
+        let mut msg = format!("Error: {}", err);
+        for cause in err.iter_causes() {
+            write!(msg, "\n\nCaused by:\n    {}", cause).unwrap();
+        }
+        eprintln!("{}", msg);
+        if !err.backtrace().is_empty() {
+            eprintln!("\nStack backtrace:\n{}", err.backtrace());
+        }
+        std::process::exit(1);
+    }
 }
 
 fn logger_init() {


### PR DESCRIPTION
As a test I added an extra constraint to the database:

```sql
ALTER TABLE queue ADD CHECK (name != 'foo');
```

Then, the old failure displays as:

```console
> cratesfyi queue add foo 1.0.0
Error: Error(Db(DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState("23514"), message: "new row for relation \"queue\" violates check constraint \"queue_name_check\"", de
tail: Some("Failing row contains (23, foo, 1.0.0, 0, 2020-07-16 22:03:44.774961, 5)."), hint: None, position: None, where_: None, schema: Some("public"), table: Some("queue"), column: None, da
tatype: None, constraint: Some("queue_name_check"), file: Some("execMain.c"), line: Some(2009), routine: Some("ExecConstraints") }))

   0: failure::backtrace::internal::InternalBacktrace::new
             at /home/nemo157/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.8/src/backtrace/internal.rs:46
   1: failure::backtrace::Backtrace::new
             at /home/nemo157/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.8/src/backtrace/mod.rs:121
   2: <failure::error::error_impl::ErrorImpl as core::convert::From<F>>::from
             at /home/nemo157/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.8/src/error/error_impl.rs:19
   3: <failure::error::Error as core::convert::From<F>>::from
             at /home/nemo157/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.8/src/error/mod.rs:36
   4: cratesfyi::build_queue::BuildQueue::add_crate
             at src/build_queue.rs:33
   5: cratesfyi::QueueSubcommand::handle_args
             at src/bin/cratesfyi.rs:174
   6: cratesfyi::CommandLine::handle_args
             at src/bin/cratesfyi.rs:133
   7: cratesfyi::main
             at src/bin/cratesfyi.rs:17
   8: std::rt::lang_start::{{closure}}
             at /home/nemo157/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/rt.rs:67
   9: std::rt::lang_start_internal::{{closure}}
             at /rustc/ff5b446d2fdbd898bc97a751f2f72858de185cf1/src/libstd/rt.rs:52
      std::panicking::try::do_call
             at /rustc/ff5b446d2fdbd898bc97a751f2f72858de185cf1/src/libstd/panicking.rs:296
      std::panicking::try
             at /rustc/ff5b446d2fdbd898bc97a751f2f72858de185cf1/src/libstd/panicking.rs:273
      std::panic::catch_unwind
             at /rustc/ff5b446d2fdbd898bc97a751f2f72858de185cf1/src/libstd/panic.rs:394
      std::rt::lang_start_internal
             at /rustc/ff5b446d2fdbd898bc97a751f2f72858de185cf1/src/libstd/rt.rs:51
  10: std::rt::lang_start
             at /home/nemo157/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/rt.rs:67
  11: main
  12: __libc_start_main
  13: _start
```

While the new failure looks like:

```console
> target/debug/cratesfyi queue add foo 1.0.0
Error: database error: ERROR: new row for relation "queue" violates check constraint "queue_name_check"

Stack backtrace:
   0: failure::backtrace::internal::InternalBacktrace::new
             at /home/nemo157/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.8/src/backtrace/internal.rs:46
   1: failure::backtrace::Backtrace::new
             at /home/nemo157/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.8/src/backtrace/mod.rs:121
   2: <failure::error::error_impl::ErrorImpl as core::convert::From<F>>::from
             at /home/nemo157/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.8/src/error/error_impl.rs:19
   3: <failure::error::Error as core::convert::From<F>>::from
             at /home/nemo157/.cargo/registry/src/github.com-1ecc6299db9ec823/failure-0.1.8/src/error/mod.rs:36
   4: cratesfyi::build_queue::BuildQueue::add_crate
             at src/build_queue.rs:33
   5: cratesfyi::QueueSubcommand::handle_args
             at src/bin/cratesfyi.rs:185
   6: cratesfyi::CommandLine::handle_args
             at src/bin/cratesfyi.rs:144
   7: cratesfyi::main
             at src/bin/cratesfyi.rs:18
   8: std::rt::lang_start::{{closure}}
             at /home/nemo157/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/rt.rs:67
   9: std::rt::lang_start_internal::{{closure}}
             at /rustc/ff5b446d2fdbd898bc97a751f2f72858de185cf1/src/libstd/rt.rs:52
      std::panicking::try::do_call
             at /rustc/ff5b446d2fdbd898bc97a751f2f72858de185cf1/src/libstd/panicking.rs:296
      std::panicking::try
             at /rustc/ff5b446d2fdbd898bc97a751f2f72858de185cf1/src/libstd/panicking.rs:273
      std::panic::catch_unwind
             at /rustc/ff5b446d2fdbd898bc97a751f2f72858de185cf1/src/libstd/panic.rs:394
      std::rt::lang_start_internal
             at /rustc/ff5b446d2fdbd898bc97a751f2f72858de185cf1/src/libstd/rt.rs:51
  10: std::rt::lang_start
             at /home/nemo157/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/rt.rs:67
  11: main
  12: __libc_start_main
  13: _start
```

And an example of the cause chain when injecting an error within a function (not yet in master) that has a good chain of `.context()` calls up to the cli:

```console
> cargo database synchronize --dry-run
Error: Loading crate data from index for consistency check

Caused by:
    Loading crate details from 'a'

Caused by:
    tarnations

Stack backtrace:
  ︙
```