### PR TITLE
Use a custom environment variable to configure logging

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 CRATESFYI_PREFIX=ignored/cratesfyi-prefix
 CRATESFYI_DATABASE_URL=postgresql://cratesfyi:password@localhost:15432
-RUST_LOG=cratesfyi,rustwide=info
+DOCSRS_LOG=cratesfyi,rustwide=info
 AWS_ACCESS_KEY_ID=cratesfyi
 AWS_SECRET_ACCESS_KEY=secret_key
 S3_ENDPOINT=http://localhost:9000

--- a/dockerfiles/entrypoint.sh
+++ b/dockerfiles/entrypoint.sh
@@ -4,7 +4,7 @@ set -euv
 
 export CRATESFYI_PREFIX=/opt/docsrs/prefix
 export DOCS_RS_DOCKER=true
-export RUST_LOG=${RUST_LOG-cratesfyi,rustwide=info}
+export DOCSRS_LOG=${DOCSRS_LOG-cratesfyi,rustwide=info}
 export PATH="$PATH:/build/target/release"
 
 # Try migrating the database multiple times if it fails

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -33,25 +33,21 @@ pub fn main() {
 fn logger_init() {
     use std::io::Write;
 
-    let mut builder = env_logger::Builder::new();
-    builder.format(|buf, record| {
-        writeln!(
-            buf,
-            "{} [{}] {}: {}",
-            time::now().strftime("%Y/%m/%d %H:%M:%S").unwrap(),
-            record.level(),
-            record.target(),
-            record.args()
-        )
-    });
-    builder.parse_filters(
-        env::var("RUST_LOG")
-            .ok()
-            .as_deref()
-            .unwrap_or("cratesfyi=info"),
-    );
+    let env = env_logger::Env::default().filter_or("DOCSRS_LOG", "cratesfyi=info");
+    let logger = env_logger::from_env(env)
+        .format(|buf, record| {
+            writeln!(
+                buf,
+                "{} [{}] {}: {}",
+                time::now().strftime("%Y/%m/%d %H:%M:%S").unwrap(),
+                record.level(),
+                record.target(),
+                record.args()
+            )
+        })
+        .build();
 
-    rustwide::logging::init_with(builder.build());
+    rustwide::logging::init_with(logger);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumString, strum::EnumVariantNames)]

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -104,7 +104,9 @@ pub(crate) struct TestEnvironment {
 
 pub(crate) fn init_logger() {
     // If this fails it's probably already initialized
-    let _ = env_logger::builder().is_test(true).try_init();
+    let _ = env_logger::from_env(env_logger::Env::default().filter("DOCSRS_LOG"))
+        .is_test(true)
+        .try_init();
 }
 
 impl TestEnvironment {


### PR DESCRIPTION
Using `RUST_LOG` leads to issues with accidentally configuring logging for unrelated utilities when overriding it. The biggest one I notice is that setting `RUST_LOG=debug` temporarily to debug stuff results in `sccache` logging extra details during `cargo run` (which I've also opened an issue about moving to a custom variable, but in general I don't think using a single variable for all projects written in Rust makes sense).