### PR TITLE
Switch to one single runtime for S3 storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,7 @@ dependencies = [
  "notify 4.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "params 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "path-slash 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "procfs 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ path-slash = "0.1.3"
 once_cell = { version = "1.4.0", features = ["parking_lot"] }
 base64 = "0.12.1"
 strum = { version = "0.18.0", features = ["derive"] }
+parking_lot = "0.10.2"
 
 # Data serialization and deserialization
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
* Made `S3Backend::start_storage_transaction` stop creating a new `Runtime` on each call
* Added `parking_lot` as a direct dependency (was a transitive dependency)

This should allow updating `tokio` to v0.2 without the "fun little bugs" and hopefully allow async to actually be achievable 