### PR TITLE
Release badge 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "badge"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -382,7 +382,7 @@ version = "0.6.0"
 dependencies = [
  "arc-swap 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.3.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "badge 0.2.0",
+ "badge 0.3.0",
  "base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "comrak 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
 name = "badge"
 version = "0.2.0"
 dependencies = [
- "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusttype 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/web/badge/CHANGELOG.md
+++ b/src/web/badge/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- `Badge::new()` will now return an error if the status or subject is empty
+- `Badge::new()` now caches `DejaVuSans.ttf` the first time it is loaded,
+  improving latency at a small memory cost.
+
+### Fixed
+
+- `rusttype` has been upgraded to `0.9`,
+  removing the dependency on the deprecated crate `stb_truetype`

--- a/src/web/badge/CHANGELOG.md
+++ b/src/web/badge/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] 2020-07-26
+
 ### Changed
 
 - `Badge::new()` will now return an error if the status or subject is empty

--- a/src/web/badge/CHANGELOG.md
+++ b/src/web/badge/CHANGELOG.md
@@ -15,3 +15,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `rusttype` has been upgraded to `0.9`,
   removing the dependency on the deprecated crate `stb_truetype`
+- `base64` has been upgraded to `0.12`

--- a/src/web/badge/Cargo.toml
+++ b/src/web/badge/Cargo.toml
@@ -9,6 +9,6 @@ documentation = "https://docs.rs/badge"
 edition = "2018"
 
 [dependencies]
-base64 = "0.9.0"
+base64 = "0.12"
 rusttype = "0.9"
 once_cell = "1"

--- a/src/web/badge/Cargo.toml
+++ b/src/web/badge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "badge"
-version = "0.2.0"
+version = "0.3.0"
 description = "Simple badge generator"
 authors = ["Onur Aslan <onur@onur.im>", "Joshua Nelson <jyn514@gmail.com>", "Chase Wilson <contact@chasewilson.dev>"]
 license-file = "LICENSE"

--- a/src/web/badge/Cargo.toml
+++ b/src/web/badge/Cargo.toml
@@ -2,7 +2,7 @@
 name = "badge"
 version = "0.2.0"
 description = "Simple badge generator"
-authors = ["Onur Aslan <onur@onur.im>"]
+authors = ["Onur Aslan <onur@onur.im>", "Joshua Nelson <jyn514@gmail.com>", "Chase Wilson <contact@chasewilson.dev>"]
 license-file = "LICENSE"
 repository = "https://github.com/rust-lang/docs.rs"
 documentation = "https://docs.rs/badge"

--- a/src/web/badge/src/lib.rs
+++ b/src/web/badge/src/lib.rs
@@ -63,7 +63,7 @@ impl Badge {
     pub fn to_svg_data_uri(&self) -> String {
         format!(
             "data:image/svg+xml;base64,{}",
-            Base64Display::standard(self.to_svg().as_bytes())
+            Base64Display::with_config(self.to_svg().as_bytes(), base64::STANDARD),
         )
     }
 


### PR DESCRIPTION
- Add myself and @Kixiron as authors
- Add a changelog
- Update `base64` dependency. This changes no dependencies in the docs.rs tree (because `iron` depended on 0.9 and we already depended directly on 0.12), but gets all the improvements from 0.9 to 0.12: https://github.com/marshallpierce/rust-base64/blob/master/RELEASE-NOTES.md

Closes https://github.com/rust-lang/docs.rs/issues/907

@vbrandl how does this look to you? Anything missing that you'd like to see in a new release?