### PR TITLE
Add rustfmt when installing a new toolchain

### DIFF
--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -89,7 +89,7 @@ pub enum PoolError {
     #[fail(display = "the provided database URL was not valid")]
     InvalidDatabaseUrl(#[fail(cause)] postgres::Error),
 
-    #[fail(display = "failed to create the connection pool")]
+    #[fail(display = "failed to create the database connection pool")]
     PoolCreationFailed(#[fail(cause)] r2d2::Error),
 
     #[fail(display = "failed to get a database connection")]

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -166,6 +166,9 @@ impl RustwideBuilder {
         for target in &targets_to_install {
             self.toolchain.add_target(&self.workspace, target)?;
         }
+        // NOTE: rustup will automatically refuse to update the toolchain
+        // if `rustfmt` is not available in the newer version
+        self.toolchain.add_component(&self.workspace, "rustfmt")?;
 
         self.rustc_version = self.detect_rustc_version()?;
         if old_version.as_deref() != Some(&self.rustc_version) {


### PR DESCRIPTION
Example build:

```
2020/07/26 20:02:52 [INFO] rustwide::toolchain: adding component rustfmt for toolchain nightly
2020/07/26 20:02:52 [INFO] rustwide::cmd: running `Command { std: "/home/joshua/src/rust/docs.rs/.rustwide/cargo-home/bin/rustup" "component" "add" "--toolchain" "nightly" "rustfmt", kill_on_drop: false }`
2020/07/26 20:02:53 [INFO] rustwide::cmd: [stderr] info: downloading component 'rustfmt'
2020/07/26 20:02:54 [INFO] rustwide::cmd: [stderr] info: installing component 'rustfmt'
```

This was tested by building `fermium 0.0.11` with the new changes. I made sure rustfmt was actually visible to the crate by looking at the generated source. Here is `/fermium/0.0.11/src/fermium/opt/rustwide/target/debug/build/fermium-d794f31f687205c6/out/bindings.rs.html#714-726`:

![image](https://user-images.githubusercontent.com/23638587/88492961-93282f00-cf7c-11ea-9a49-412e98df75a0.png)


I have not tested the upgrade behavior, so possibly this shouldn't be
merged until I do that.

Closes https://github.com/rust-lang/docs.rs/issues/357.

r? @pietroalbini 