### PR TITLE
Switch most of the side services to async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "mime_guess 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "path-slash 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.17.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "procfs 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ once_cell = { version = "1.4.0", features = ["parking_lot"] }
 base64 = "0.12.1"
 strum = { version = "0.18.0", features = ["derive"] }
 lol_html = "0.2"
+parking_lot = "0.10.2"
 
 # Async
 tokio = { version = "0.2.22", features = ["rt-threaded", "io-util", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ strum = { version = "0.18.0", features = ["derive"] }
 lol_html = "0.2"
 
 # Async
-tokio = { version = "0.2.22", features = ["rt-threaded"] }
+tokio = { version = "0.2.22", features = ["rt-threaded", "io-util", "macros"] }
 futures-util = "0.3.5"
 rusoto_s3 = "0.45.0"
 rusoto_core = "0.45.0"

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -409,8 +409,8 @@ impl BuildSubcommand {
                     .context("failed to add essential files")?;
             }
 
-            Self::Lock => docbuilder.lock().context("Failed to lock")?,
-            Self::Unlock => docbuilder.unlock().context("Failed to unlock")?,
+            Self::Lock => docbuilder.lock().await.context("Failed to lock")?,
+            Self::Unlock => docbuilder.unlock().await.context("Failed to unlock")?,
             Self::PrintOptions => println!("{:?}", docbuilder.options()),
         }
 

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -31,6 +31,7 @@ impl BuildQueue {
             "INSERT INTO queue (name, version, priority) VALUES ($1, $2, $3);",
             &[&name, &version, &priority],
         )?;
+
         Ok(())
     }
 
@@ -39,6 +40,7 @@ impl BuildQueue {
             "SELECT COUNT(*) FROM queue WHERE attempt < $1;",
             &[&self.max_attempts],
         )?;
+
         Ok(res[0].get::<_, i64>(0) as usize)
     }
 

--- a/src/docbuilder/mod.rs
+++ b/src/docbuilder/mod.rs
@@ -76,7 +76,7 @@ impl DocBuilder {
         let db = self.db.clone();
         // FIXME: When DB ops are async, remove the `spawn_blocking` and directly insert into the cache
         let cache = task::spawn_blocking(move || {
-            let conn = db.get()?;
+            let mut conn = db.get()?;
             let query = conn.query(
                 "SELECT name, version FROM crates, releases \
                  WHERE crates.id = releases.crate_id",

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -11,42 +11,40 @@ use crate::{
 use chrono::{Timelike, Utc};
 use failure::Error;
 use log::{debug, error, info};
-use std::sync::Arc;
-use std::thread;
-use std::time::Duration;
+use std::{env, path::PathBuf, sync::Arc};
+use tokio::{
+    task::{self, JoinHandle},
+    time::{self, Duration, Instant},
+};
 
-fn start_registry_watcher(
+async fn start_registry_watcher(
     opts: DocBuilderOptions,
     pool: Pool,
     build_queue: Arc<BuildQueue>,
-) -> Result<(), Error> {
-    thread::Builder::new()
-        .name("registry index reader".to_string())
-        .spawn(move || {
-            // space this out to prevent it from clashing against the queue-builder thread on launch
-            thread::sleep(Duration::from_secs(30));
-            loop {
-                let mut doc_builder =
-                    DocBuilder::new(opts.clone(), pool.clone(), build_queue.clone());
+) -> JoinHandle<()> {
+    task::spawn(async move {
+        let mut interval = time::interval(Duration::from_secs(60));
 
-                if doc_builder.is_locked() {
-                    debug!("Lock file exists, skipping checking new crates");
-                } else {
-                    debug!("Checking new crates");
-                    match doc_builder.get_new_crates() {
-                        Ok(n) => debug!("{} crates added to queue", n),
-                        Err(e) => error!("Failed to get new crates: {}", e),
-                    }
+        let mut doc_builder = DocBuilder::new(opts.clone(), pool.clone(), build_queue.clone());
+
+        loop {
+            interval.tick().await;
+
+            if doc_builder.is_locked() {
+                debug!("Lock file exists, skipping checking new crates");
+            } else {
+                debug!("Checking new crates");
+
+                match doc_builder.get_new_crates() {
+                    Ok(n) => debug!("{} crates added to queue", n),
+                    Err(e) => error!("Failed to get new crates: {}", e),
                 }
-
-                thread::sleep(Duration::from_secs(60));
             }
-        })?;
-
-    Ok(())
+        }
+    })
 }
 
-pub fn start_daemon(
+pub async fn start_daemon(
     config: Arc<Config>,
     db: Pool,
     build_queue: Arc<BuildQueue>,
@@ -60,50 +58,71 @@ pub fn start_daemon(
 
     if enable_registry_watcher {
         // check new crates every minute
-        start_registry_watcher(dbopts.clone(), db.clone(), build_queue.clone())?;
+        start_registry_watcher(dbopts.clone(), db.clone(), build_queue.clone()).await;
     }
 
     // build new crates every minute
     let cloned_db = db.clone();
     let cloned_build_queue = build_queue.clone();
     let cloned_storage = storage.clone();
-    thread::Builder::new()
-        .name("build queue reader".to_string())
-        .spawn(move || {
-            let doc_builder = DocBuilder::new(
-                dbopts.clone(),
-                cloned_db.clone(),
-                cloned_build_queue.clone(),
-            );
-            queue_builder(doc_builder, cloned_db, cloned_build_queue, cloned_storage).unwrap();
-        })
-        .unwrap();
+
+    task::spawn(async {
+        let doc_builder = DocBuilder::new(
+            dbopts.clone(),
+            cloned_db.clone(),
+            cloned_build_queue.clone(),
+        );
+
+        queue_builder(doc_builder, cloned_db, cloned_build_queue, cloned_storage)
+            .await
+            .unwrap();
+    });
 
     // update release activity everyday at 23:55
     let cloned_db = db.clone();
-    cron(
-        "release activity updater",
-        Duration::from_secs(60),
-        move || {
-            let now = Utc::now();
-            if now.hour() == 23 && now.minute() == 55 {
-                info!("Updating release activity");
-                update_release_activity(&mut *cloned_db.get()?)?;
+    task::spawn(async move {
+        // Calculate the Duration until 23:55
+        let now = Utc::now();
+        let until_midnight =
+            Duration::from_secs(((23 - now.hour() as u64) * 60) + (55 - now.minute() as u64));
+        let mut interval = time::interval_at(
+            Instant::now() + until_midnight,
+            Duration::from_secs(24 * 60 * 60),
+        );
+
+        loop {
+            interval.tick().await;
+
+            info!("Updating release activity");
+            if let Err(err) = cloned_db
+                .get()
+                .map_err(Into::into)
+                .and_then(|pool| update_release_activity(&mut *pool))
+            {
+                error!(
+                    "failed to run scheduled task 'release activity updater': {:?}",
+                    err
+                );
             }
-            Ok(())
-        },
-    )?;
+        }
+    });
 
     // update github stats every hour
     let github_updater = GithubUpdater::new(&config, db.clone())?;
-    cron(
-        "github stats updater",
-        Duration::from_secs(60 * 60),
-        move || {
-            github_updater.update_all_crates()?;
-            Ok(())
-        },
-    )?;
+    task::spawn(async move {
+        let mut interval = time::interval(Duration::from_secs(60 * 60));
+
+        loop {
+            interval.tick().await;
+
+            if let Err(err) = github_updater.update_all_crates().await {
+                error!(
+                    "failed to run scheduled task 'github stats updater': {:?}",
+                    err,
+                );
+            }
+        }
+    });
 
     // TODO: update ssl certificate every 3 months
 
@@ -114,17 +133,9 @@ pub fn start_daemon(
     Ok(())
 }
 
-fn cron<F>(name: &'static str, interval: Duration, exec: F) -> Result<(), Error>
-where
-    F: Fn() -> Result<(), Error> + Send + 'static,
-{
-    thread::Builder::new()
-        .name(name.into())
-        .spawn(move || loop {
-            thread::sleep(interval);
-            if let Err(err) = exec() {
-                error!("failed to run scheduled task '{}': {:?}", name, err);
-            }
-        })?;
-    Ok(())
+fn opts() -> DocBuilderOptions {
+    let prefix = PathBuf::from(
+        env::var("CRATESFYI_PREFIX").expect("CRATESFYI_PREFIX environment variable not found"),
+    );
+    DocBuilderOptions::from_prefix(prefix)
 }

--- a/src/utils/pubsubhubbub.rs
+++ b/src/utils/pubsubhubbub.rs
@@ -1,27 +1,25 @@
-use reqwest::{
-    blocking::{Client, Response},
-    Result,
-};
+use reqwest::{Client, Response, Result};
 use std::collections::HashMap;
 
-fn ping_hub(url: &str) -> Result<Response> {
+const PING_HUBS: &[&str] = &[
+    "https://pubsubhubbub.appspot.com",
+    "https://pubsubhubbub.superfeedr.com",
+];
+
+async fn ping_hub(url: &str) -> Result<Response> {
     let mut params = HashMap::with_capacity(2);
     params.insert("hub.mode", "publish");
     params.insert("hub.url", "https://docs.rs/releases/feed");
 
     let client = Client::new();
-    client.post(url).form(&params).send()
+    client.post(url).form(&params).send().await
 }
 
-/// Ping the two predefined hubs. Return either the number of successfully
-/// pinged hubs, or the first error.
-pub fn ping_hubs() -> Result<usize> {
-    vec![
-        "https://pubsubhubbub.appspot.com",
-        "https://pubsubhubbub.superfeedr.com",
-    ]
-    .into_iter()
-    .map(ping_hub)
-    .collect::<Result<Vec<_>>>()
-    .map(|v| v.len())
+/// Ping the predefined hubs. Return either the number of successfully pinged hubs or the first error.
+pub async fn ping_hubs() -> Result<usize> {
+    for hub in PING_HUBS {
+        ping_hub(hub).await?;
+    }
+
+    Ok(PING_HUBS.len())
 }

--- a/src/utils/pubsubhubbub.rs
+++ b/src/utils/pubsubhubbub.rs
@@ -1,25 +1,43 @@
-use reqwest::{Client, Response, Result};
-use std::collections::HashMap;
+use futures_util::stream::{self, TryStreamExt};
+use reqwest::{Client, Result};
+use std::{collections::HashMap, sync::Arc};
 
-const PING_HUBS: &[&str] = &[
+/// The maximum of concurrent pings, `None` for no limit
+const MAX_CONCURRENT_PINGS: Option<usize> = None;
+const HUBS: &[&str] = &[
     "https://pubsubhubbub.appspot.com",
     "https://pubsubhubbub.superfeedr.com",
 ];
 
-async fn ping_hub(url: &str) -> Result<Response> {
-    let mut params = HashMap::with_capacity(2);
-    params.insert("hub.mode", "publish");
-    params.insert("hub.url", "https://docs.rs/releases/feed");
-
-    let client = Client::new();
-    client.post(url).form(&params).send().await
+#[derive(Debug)]
+pub struct HubPinger {
+    params: Arc<HashMap<&'static str, &'static str>>,
+    client: Arc<Client>,
 }
 
-/// Ping the predefined hubs. Return either the number of successfully pinged hubs or the first error.
-pub async fn ping_hubs() -> Result<usize> {
-    for hub in PING_HUBS {
-        ping_hub(hub).await?;
+impl HubPinger {
+    pub fn new() -> Self {
+        let client = Arc::new(Client::new());
+        let params = {
+            let mut params = HashMap::with_capacity(2);
+            params.insert("hub.mode", "publish");
+            params.insert("hub.url", "https://docs.rs/releases/feed");
+
+            Arc::new(params)
+        };
+
+        Self { params, client }
     }
 
-    Ok(PING_HUBS.len())
+    /// Ping the predefined hubs. Return either the number of successfully pinged hubs or the first error.
+    pub async fn ping_hubs(&self) -> Result<usize> {
+        stream::iter(HUBS.iter().map(Ok))
+            .try_for_each_concurrent(MAX_CONCURRENT_PINGS, |&url| {
+                let (client, params) = (Arc::clone(&self.client), Arc::clone(&self.params));
+                async move { client.post(url).form(&*params).send().await.map(drop) }
+            })
+            .await?;
+
+        Ok(HUBS.len())
+    }
 }

--- a/src/utils/queue_builder.rs
+++ b/src/utils/queue_builder.rs
@@ -4,9 +4,7 @@ use crate::{
 };
 use failure::Error;
 use log::{debug, error, info, warn};
-use std::panic;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{panic, sync::Arc, time::Duration};
 use tokio::{runtime::Handle, sync::Mutex, task, time};
 
 /// This is the core of the documentation building, within the inner loop we should never panic in any way

--- a/src/utils/queue_builder.rs
+++ b/src/utils/queue_builder.rs
@@ -1,91 +1,87 @@
 use crate::{
-    db::Pool, docbuilder::RustwideBuilder, utils::pubsubhubbub, BuildQueue, DocBuilder, Storage,
+    db::Pool, docbuilder::RustwideBuilder, utils::pubsubhubbub::HubPinger, BuildQueue, DocBuilder,
+    Storage,
 };
 use failure::Error;
 use log::{debug, error, info, warn};
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::panic;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::time;
+use tokio::{runtime::Handle, sync::Mutex, task, time};
 
+/// This is the core of the documentation building, within the inner loop we should never panic in any way
 // TODO: change to `fn() -> Result<!, Error>` when never _finally_ stabilizes
 pub async fn queue_builder(
-    mut doc_builder: DocBuilder,
+    doc_builder: DocBuilder,
     db: Pool,
     build_queue: Arc<BuildQueue>,
     storage: Arc<Storage>,
 ) -> Result<(), Error> {
-    /// Represents the current state of the builder thread.
-    enum BuilderState {
-        /// The builder thread has just started, and hasn't built any crates yet.
-        Fresh,
-        /// The builder has just seen an empty build queue.
-        EmptyQueue,
-        /// The builder has just seen the lock file.
-        Locked,
-        /// The builder has just finished building a crate. The enclosed count is the number of
-        /// crates built since the caches have been refreshed.
-        QueueInProgress(usize),
-    }
-
-    let mut builder = RustwideBuilder::init(db, storage)?;
-    let mut status = BuilderState::Fresh;
+    // These are all locked up due to the cross-thread sharing currently involved, it may be able to be removed after the
+    // build pipeline is async
+    let doc_builder = Arc::new(Mutex::new(doc_builder));
+    let builder = Arc::new(Mutex::new(
+        task::spawn_blocking(|| RustwideBuilder::init(db, storage)).await??,
+    ));
+    let status = Arc::new(Mutex::new(BuilderState::Fresh));
+    let hub_pinger = HubPinger::new();
 
     loop {
-        if !status.is_in_progress() {
+        if !status.lock().await.is_in_progress() {
             time::delay_for(Duration::from_secs(60)).await;
         }
 
         // check lock file
-        if doc_builder.is_locked() {
+        if doc_builder.lock().await.is_locked() {
             warn!("Lock file exits, skipping building new crates");
-            status = BuilderState::Locked;
+            *status.lock().await = BuilderState::Locked;
 
             continue;
         }
 
-        if status.count() >= 10 {
+        if status.lock().await.count() >= 10 {
             // periodically, we need to flush our caches and ping the hubs
             debug!("10 builds in a row; flushing caches");
-            status = BuilderState::QueueInProgress(0);
+            *status.lock().await = BuilderState::QueueInProgress(0);
 
-            match pubsubhubbub::ping_hubs().await {
+            match hub_pinger.ping_hubs().await {
                 Err(e) => error!("Failed to ping hub: {}", e),
-                Ok(n) => debug!("Succesfully pinged {} hubs", n),
+                Ok(n) => debug!("Successfully pinged {} hubs", n),
             }
 
-            if let Err(e) = doc_builder.load_cache().await {
+            if let Err(e) = doc_builder.lock().await.load_cache().await {
                 error!("Failed to load cache: {}", e);
             }
 
-            if let Err(e) = doc_builder.save_cache().await {
+            if let Err(e) = doc_builder.lock().await.save_cache().await {
                 error!("Failed to save cache: {}", e);
             }
         }
 
         // Only build crates if there are any to build
         debug!("Checking build queue");
-        match build_queue.pending_count() {
+        let queue = Arc::clone(&build_queue);
+        match task::spawn_blocking(move || queue.pending_count()).await? {
             Err(e) => {
                 error!("Failed to read the number of crates in the queue: {}", e);
                 continue;
             }
 
             Ok(0) => {
-                if status.count() > 0 {
+                if status.lock().await.count() > 0 {
                     // ping the hubs before continuing
-                    match pubsubhubbub::ping_hubs().await {
+                    match hub_pinger.ping_hubs().await {
                         Err(e) => error!("Failed to ping hub: {}", e),
                         Ok(n) => debug!("Succesfully pinged {} hubs", n),
                     }
 
-                    if let Err(e) = doc_builder.save_cache().await {
+                    if let Err(e) = doc_builder.lock().await.save_cache().await {
                         error!("Failed to save cache: {}", e);
                     }
                 }
 
                 debug!("Queue is empty, going back to sleep");
-                status = BuilderState::EmptyQueue;
+                *status.lock().await = BuilderState::EmptyQueue;
 
                 continue;
             }
@@ -94,14 +90,14 @@ pub async fn queue_builder(
                 info!(
                     "Starting build with {} crates in queue (currently on a {} crate streak)",
                     queue_count,
-                    status.count()
+                    status.lock().await.count()
                 );
             }
         }
 
         // if we're starting a new batch, reload our caches and sources
-        if !status.is_in_progress() {
-            if let Err(e) = doc_builder.load_cache().await {
+        if !status.lock().await.is_in_progress() {
+            if let Err(e) = doc_builder.lock().await.load_cache().await {
                 error!("Failed to load cache: {}", e);
 
                 continue;
@@ -111,39 +107,69 @@ pub async fn queue_builder(
         // Run build_packages_queue under `catch_unwind` to catch panics
         // This only panicked twice in the last 6 months but its just a better
         // idea to do this.
-        let res = catch_unwind(AssertUnwindSafe(|| {
-            match doc_builder.build_next_queue_package(&mut builder) {
-                Err(e) => error!("Failed to build crate from queue: {}", e),
-                Ok(crate_built) => {
-                    if crate_built {
-                        status.increment();
+        let (doc_builder, status, builder) = (
+            Arc::clone(&doc_builder),
+            Arc::clone(&status),
+            Arc::clone(&builder),
+        );
+        let res = task::spawn_blocking(move || {
+            panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                match Handle::current()
+                    .block_on(doc_builder.lock())
+                    .build_next_queue_package(&mut *Handle::current().block_on(builder.lock()))
+                {
+                    Err(e) => error!("Failed to build crate from queue: {}", e),
+                    Ok(crate_built) => {
+                        if crate_built {
+                            Handle::current().block_on(status.lock()).increment();
+                        }
                     }
                 }
-            }
-        }));
+            }))
+        })
+        .await;
 
-        if let Err(e) = res {
-            error!("GRAVE ERROR Building new crates panicked: {:?}", e);
+        match res {
+            Ok(Err(err)) => {
+                error!("GRAVE ERROR Building new crates panicked: {:?}", err);
+            }
+            Err(err) => {
+                error!("GRAVE ERROR Building new crates panicked: {:?}", err);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Represents the current state of the builder thread.
+enum BuilderState {
+    /// The builder thread has just started, and hasn't built any crates yet.
+    Fresh,
+    /// The builder has just seen an empty build queue.
+    EmptyQueue,
+    /// The builder has just seen the lock file.
+    Locked,
+    /// The builder has just finished building a crate. The enclosed count is the number of
+    /// crates built since the caches have been refreshed.
+    QueueInProgress(usize),
+}
+
+impl BuilderState {
+    fn count(&self) -> usize {
+        match *self {
+            BuilderState::QueueInProgress(n) => n,
+            _ => 0,
         }
     }
 
-    impl BuilderState {
-        fn count(&self) -> usize {
-            match *self {
-                BuilderState::QueueInProgress(n) => n,
-                _ => 0,
-            }
+    fn is_in_progress(&self) -> bool {
+        match *self {
+            BuilderState::QueueInProgress(_) => true,
+            _ => false,
         }
+    }
 
-        fn is_in_progress(&self) -> bool {
-            match *self {
-                BuilderState::QueueInProgress(_) => true,
-                _ => false,
-            }
-        }
-
-        fn increment(&mut self) {
-            *self = BuilderState::QueueInProgress(self.count() + 1);
-        }
+    fn increment(&mut self) {
+        *self = BuilderState::QueueInProgress(self.count() + 1);
     }
 }


### PR DESCRIPTION
Moves most of the side services to asyncronous code, decreasing the number of constantly running threads and hopefully allowing some better perf

* Pubsubhubbub now uses async requests
* Github updater now uses async requests
* The build queue now uses async for file IO and calling the sub hub
* The daemon now spawns off async tasks instead of full on threads
* The registry watcher uses async
* The release activity updater uses async

The spawned tasks use tokio's `Interval`s for timed execution which allows for more efficient use of CPU time

More could have been done in this PR, but that would need `rustwide` to make some more async-centric changes first (which will also help us tons since it'll mean that we remove 2 tokio runtimes, one from `rustwide` and one from `S3Backend`)