### PR TITLE
Add link to the Rust Cookbook to the topbar

### DIFF
--- a/templates/header/topbar.html
+++ b/templates/header/topbar.html
@@ -53,10 +53,17 @@
                                 </a>
                             </li>
 
-                            <li class="pure-menu-item menu-item-divided">
+                            <li class="pure-menu-item">
                                 <a href="https://doc.rust-lang.org/rust-by-example/" target="_blank"
                                     class="pure-menu-link">
                                     Rust by Example
+                                </a>
+                            </li>
+
+                            <li class="pure-menu-item menu-item-divided">
+                                <a href="https://rust-lang-nursery.github.io/rust-cookbook/" target="_blank"
+                                    class="pure-menu-link">
+                                    Rust Cookbook
                                 </a>
                             </li>
 


### PR DESCRIPTION
Fixes #137

<img width="745" alt="Screen Shot 2020-07-26 at 8 03 14 PM" src="https://user-images.githubusercontent.com/107097/88499558-12b4fe80-cf7b-11ea-8bde-c3b60bacdd7e.png">
