### PR TITLE
Update owner details more fully during build and add CLI command to trigger it

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -467,7 +467,7 @@ impl DatabaseSubcommand {
                 db::update_crate_data_in_database(
                     &*ctx.conn()?,
                     &name,
-                    &index.api().get_crate_data(&name),
+                    &index.api().get_crate_data(&name)?,
                 )?;
             }
 

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -281,7 +281,9 @@ struct Build {
 impl Build {
     pub fn handle_args(self, ctx: Context) -> Result<(), Error> {
         let docbuilder = {
-            let mut doc_options = DocBuilderOptions::new(&*ctx.config()?);
+            let config = ctx.config()?;
+            let mut doc_options =
+                DocBuilderOptions::new(config.prefix.clone(), config.registry_index_path.clone());
 
             if let Some(registry_index_path) = self.registry_index_path {
                 log::warn!("Use of deprecated cli flag --registry-index-path");

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -249,6 +249,7 @@ struct Build {
     )]
     prefix: PathBuf,
 
+    /// DEPRECATED
     /// Sets the registry index path, where on disk the registry index will be cloned to
     #[structopt(
         name = "REGISTRY_INDEX_PATH",
@@ -280,9 +281,10 @@ struct Build {
 impl Build {
     pub fn handle_args(self, ctx: Context) -> Result<(), Error> {
         let docbuilder = {
-            let mut doc_options = DocBuilderOptions::from_prefix(self.prefix);
+            let mut doc_options = DocBuilderOptions::new(&*ctx.config()?);
 
             if let Some(registry_index_path) = self.registry_index_path {
+                log::warn!("Use of deprecated cli flag --registry-index-path");
                 doc_options.registry_index_path = registry_index_path;
             }
 

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -241,23 +241,6 @@ impl PrioritySubcommand {
 #[derive(Debug, Clone, PartialEq, Eq, StructOpt)]
 #[structopt(rename_all = "kebab-case")]
 struct Build {
-    #[structopt(
-        name = "PREFIX",
-        short = "P",
-        long = "prefix",
-        env = "CRATESFYI_PREFIX"
-    )]
-    prefix: PathBuf,
-
-    /// DEPRECATED
-    /// Sets the registry index path, where on disk the registry index will be cloned to
-    #[structopt(
-        name = "REGISTRY_INDEX_PATH",
-        long = "registry-index-path",
-        alias = "crates-io-index-path"
-    )]
-    registry_index_path: Option<PathBuf>,
-
     /// Skips building documentation if documentation exists
     #[structopt(name = "SKIP_IF_EXISTS", short = "s", long = "skip")]
     skip_if_exists: bool,
@@ -284,11 +267,6 @@ impl Build {
             let config = ctx.config()?;
             let mut doc_options =
                 DocBuilderOptions::new(config.prefix.clone(), config.registry_index_path.clone());
-
-            if let Some(registry_index_path) = self.registry_index_path {
-                log::warn!("Use of deprecated cli flag --registry-index-path");
-                doc_options.registry_index_path = registry_index_path;
-            }
 
             doc_options.skip_if_exists = self.skip_if_exists;
             doc_options.skip_if_log_exists = self.skip_if_log_exists;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,15 @@
 use failure::{bail, format_err, Error, Fail, ResultExt};
 use std::env::VarError;
+use std::path::PathBuf;
 use std::str::FromStr;
 
 #[derive(Debug)]
 pub struct Config {
     // Build params
     pub(crate) build_attempts: u16,
+
+    pub(crate) prefix: PathBuf,
+    pub(crate) registry_index_path: PathBuf,
 
     // Database connection params
     pub(crate) database_url: String,
@@ -23,8 +27,13 @@ pub struct Config {
 
 impl Config {
     pub fn from_env() -> Result<Self, Error> {
+        let prefix: PathBuf = require_env("CRATESFYI_PREFIX")?;
+
         Ok(Self {
             build_attempts: env("DOCSRS_BUILD_ATTEMPTS", 5)?,
+
+            prefix: prefix.clone(),
+            registry_index_path: env("REGISTRY_INDEX_PATH", prefix.join("crates.io-index"))?,
 
             database_url: require_env("CRATESFYI_DATABASE_URL")?,
             max_pool_size: env("DOCSRS_MAX_POOL_SIZE", 90)?,

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,8 +8,8 @@ pub struct Config {
     // Build params
     pub(crate) build_attempts: u16,
 
-    pub(crate) prefix: PathBuf,
-    pub(crate) registry_index_path: PathBuf,
+    pub prefix: PathBuf,
+    pub registry_index_path: PathBuf,
 
     // Database connection params
     pub(crate) database_url: String,

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -327,7 +327,7 @@ fn add_authors_into_database(
     Ok(())
 }
 
-pub(crate) fn update_crate_data_in_database(
+pub fn update_crate_data_in_database(
     conn: &Connection,
     name: &str,
     registry_data: &CrateData,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,8 +1,7 @@
 //! Database operations
 
-pub(crate) use self::add_package::{
-    add_build_into_database, add_package_into_database, update_crate_data_in_database,
-};
+pub use self::add_package::update_crate_data_in_database;
+pub(crate) use self::add_package::{add_build_into_database, add_package_into_database};
 pub use self::delete::{delete_crate, delete_version};
 pub use self::file::add_path_into_database;
 pub use self::migrate::migrate;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,7 +1,8 @@
 //! Database operations
 
-pub(crate) use self::add_package::add_build_into_database;
-pub(crate) use self::add_package::add_package_into_database;
+pub(crate) use self::add_package::{
+    add_build_into_database, add_package_into_database, update_crate_data_in_database,
+};
 pub use self::delete::{delete_crate, delete_version};
 pub use self::file::add_path_into_database;
 pub use self::migrate::migrate;

--- a/src/docbuilder/options.rs
+++ b/src/docbuilder/options.rs
@@ -1,4 +1,4 @@
-use crate::{config::Config, error::Result};
+use crate::error::Result;
 use std::path::PathBuf;
 
 #[derive(Clone, Debug)]
@@ -14,10 +14,10 @@ pub struct DocBuilderOptions {
 }
 
 impl DocBuilderOptions {
-    pub fn new(config: &Config) -> DocBuilderOptions {
+    pub fn new(prefix: PathBuf, registry_index_path: PathBuf) -> DocBuilderOptions {
         DocBuilderOptions {
-            prefix: config.prefix.clone(),
-            registry_index_path: config.registry_index_path.clone(),
+            prefix,
+            registry_index_path,
 
             keep_build_directory: false,
             skip_if_exists: false,

--- a/src/docbuilder/options.rs
+++ b/src/docbuilder/options.rs
@@ -1,8 +1,7 @@
-use crate::error::Result;
+use crate::{config::Config, error::Result};
 use std::path::PathBuf;
-use std::{env, fmt};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DocBuilderOptions {
     pub keep_build_directory: bool,
     pub prefix: PathBuf,
@@ -14,15 +13,11 @@ pub struct DocBuilderOptions {
     pub debug: bool,
 }
 
-impl Default for DocBuilderOptions {
-    fn default() -> DocBuilderOptions {
-        let cwd = env::current_dir().unwrap();
-
-        let (prefix, registry_index_path) = generate_paths(cwd);
-
+impl DocBuilderOptions {
+    pub fn new(config: &Config) -> DocBuilderOptions {
         DocBuilderOptions {
-            prefix,
-            registry_index_path,
+            prefix: config.prefix.clone(),
+            registry_index_path: config.registry_index_path.clone(),
 
             keep_build_directory: false,
             skip_if_exists: false,
@@ -30,36 +25,6 @@ impl Default for DocBuilderOptions {
             skip_oldest_versions: false,
             build_only_latest_version: false,
             debug: false,
-        }
-    }
-}
-
-impl fmt::Debug for DocBuilderOptions {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "DocBuilderOptions {{ \
-                registry_index_path: {:?}, \
-                keep_build_directory: {:?}, skip_if_exists: {:?}, \
-                skip_if_log_exists: {:?}, debug: {:?} }}",
-            self.registry_index_path,
-            self.keep_build_directory,
-            self.skip_if_exists,
-            self.skip_if_log_exists,
-            self.debug
-        )
-    }
-}
-
-impl DocBuilderOptions {
-    /// Creates new DocBuilderOptions from prefix
-    pub fn from_prefix(prefix: PathBuf) -> DocBuilderOptions {
-        let (prefix, registry_index_path) = generate_paths(prefix);
-
-        DocBuilderOptions {
-            prefix,
-            registry_index_path,
-            ..Default::default()
         }
     }
 
@@ -73,10 +38,4 @@ impl DocBuilderOptions {
 
         Ok(())
     }
-}
-
-fn generate_paths(prefix: PathBuf) -> (PathBuf, PathBuf) {
-    let registry_index_path = PathBuf::from(&prefix).join("crates.io-index");
-
-    (prefix, registry_index_path)
 }

--- a/src/index/api.rs
+++ b/src/index/api.rs
@@ -15,13 +15,13 @@ const APP_USER_AGENT: &str = concat!(
 );
 
 #[derive(Debug)]
-pub(crate) struct Api {
+pub struct Api {
     api_base: Option<Url>,
     client: reqwest::blocking::Client,
 }
 
 #[derive(Debug)]
-pub(crate) struct CrateData {
+pub struct CrateData {
     pub(crate) owners: Vec<CrateOwner>,
 }
 
@@ -33,7 +33,7 @@ pub(crate) struct ReleaseData {
 }
 
 #[derive(Debug)]
-pub(crate) struct CrateOwner {
+pub struct CrateOwner {
     pub(crate) avatar: String,
     pub(crate) email: String,
     pub(crate) login: String,
@@ -62,7 +62,7 @@ impl Api {
             .ok_or_else(|| err_msg("index is missing an api base url"))
     }
 
-    pub(crate) fn get_crate_data(&self, name: &str) -> CrateData {
+    pub fn get_crate_data(&self, name: &str) -> CrateData {
         let owners = self.get_owners(name).unwrap_or_else(|err| {
             warn!("Failed to get owners for {}: {}", name, err);
             Vec::new()

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -8,7 +8,7 @@ use failure::ResultExt;
 
 pub(crate) mod api;
 
-pub(crate) struct Index {
+pub struct Index {
     path: PathBuf,
     api: Api,
 }
@@ -39,7 +39,7 @@ fn load_config(repo: &git2::Repository) -> Result<IndexConfig> {
 }
 
 impl Index {
-    pub(crate) fn new(path: impl AsRef<Path>) -> Result<Self> {
+    pub fn new(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref().to_owned();
         // This initializes the repository, then closes it afterwards to avoid leaking file descriptors.
         // See https://github.com/rust-lang/docs.rs/pull/847
@@ -56,7 +56,7 @@ impl Index {
         Ok(diff)
     }
 
-    pub(crate) fn api(&self) -> &Api {
+    pub fn api(&self) -> &Api {
         &self.api
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod config;
 pub mod db;
 mod docbuilder;
 mod error;
-mod index;
+pub mod index;
 pub mod storage;
 #[cfg(test)]
 mod test;

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -1,6 +1,6 @@
 use super::TestDatabase;
 use crate::docbuilder::BuildResult;
-use crate::index::api::{CrateData, ReleaseData};
+use crate::index::api::{CrateData, CrateOwner, ReleaseData};
 use crate::storage::Storage;
 use crate::utils::{Dependency, MetadataPackage, Target};
 use chrono::{DateTime, Utc};
@@ -165,6 +165,11 @@ impl<'a> FakeRelease<'a> {
     pub(crate) fn readme(mut self, content: &'a str) -> Self {
         self.readme = Some(content);
         self.source_file("README.md", content.as_bytes())
+    }
+
+    pub(crate) fn add_owner(mut self, owner: CrateOwner) -> Self {
+        self.registry_crate_data.owners.push(owner);
+        self
     }
 
     /// Returns the release_id

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -53,7 +53,7 @@ pub fn start_daemon(
     storage: Arc<Storage>,
     enable_registry_watcher: bool,
 ) -> Result<(), Error> {
-    let dbopts = DocBuilderOptions::new(&config);
+    let dbopts = DocBuilderOptions::new(config.prefix.clone(), config.registry_index_path.clone());
 
     // check paths once
     dbopts.check_paths().unwrap();

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -681,7 +681,7 @@ mod tests {
                 vec![("barfoo".into(), "https://example.org/barfoo".into())]
             );
 
-            // Changing owner details on another of there crates applies too
+            // Changing owner details on another of their crates applies the change to both
             env.fake_release()
                 .name("bar")
                 .version("0.0.1")


### PR DESCRIPTION
First two commits improve handling of owner details during a build, if an owners mutable details have been changed since the last time we got them they will be updated in the database, and if an owner has been removed from a crate the relationship will be removed.

Next three commits are cherry-picked from #898, they standardise the prefix handling into the config so that it's easier to correctly load the registry details outside of the `DocBuilder`.

Final commit adds a CLI command to update the details for a specific crate from the registry API, so that we can solve requests like #158/#837 directly. New (renewed) and existing crates will be fixed automatically when they publish a new version, and doing a mass update of existing bad data should be part of #766, so this should be a temporary command just to solve the problem for users that request it.

fixes #900 