### PR TITLE
Upload sources even for binaries and failed builds

### DIFF
--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -30,7 +30,7 @@ pub(crate) fn add_package_into_database(
     source_dir: &Path,
     res: &BuildResult,
     default_target: &str,
-    source_files: Option<Value>,
+    source_files: Value,
     doc_targets: Vec<String>,
     registry_data: &ReleaseData,
     has_docs: bool,


### PR DESCRIPTION
Closes https://github.com/rust-lang/docs.rs/issues/607. Makes https://github.com/rust-lang/docs.rs/issues/520 much less of an issue (since it will only happen for crates built before this PR).

Tested with:
- notcurses 1.6.10, a library that failed to build
- bat 0.12.1, a binary
- hexponent 0.3.0, a library that built successfully