### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Please file bugs for any trouble you have running docs.rs!
 
 ### Running tests
 
-Tests are only supported via cargo, not docker-compose.
+Tests are only supported via cargo and do not work in docker-compose
 
 ```
 cargo test


### PR DESCRIPTION
- Point users to the /about page
- Recommend `cargo run` over `docker-compose up`
- Document native dependencies
- Suggest `--registry-watcher disabled` for the daemon

Closes https://github.com/rust-lang/docs.rs/issues/888