### PR TITLE
Added tooltips to the About and Releases links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.4"
 regex = "1"
 structopt = "0.3"
 crates-index-diff = "7"
-reqwest = { version = "0.10.6", features = ["blocking", "json"] }# TODO: Remove blocking when async is ready
+reqwest = { version = "0.10.6", features = ["blocking", "json"] } # TODO: Remove blocking when async is ready
 semver = { version = "0.9", features = ["serde"] }
 slug = "=0.1.1"
 env_logger = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.4"
 regex = "1"
 structopt = "0.3"
 crates-index-diff = "7"
-reqwest = { version = "0.10.6", features = ["blocking", "json"] } # TODO: Remove blocking when async is ready
+reqwest = { version = "0.10.6", features = ["blocking", "json"] }# TODO: Remove blocking when async is ready
 semver = { version = "0.9", features = ["serde"] }
 slug = "=0.1.1"
 env_logger = "0.7"
@@ -56,7 +56,7 @@ serde_json = "1.0"
 # iron dependencies
 iron = "0.5"
 router = "0.5"
-staticfile = { version = "0.4", features = [ "cache" ] }
+staticfile = { version = "0.4", features = ["cache"] }
 tempfile = "3.1.0"
 
 # Templating
@@ -84,6 +84,11 @@ criterion = "0.3"
 kuchiki = "0.8"
 rand = "0.7.3"
 
+[build-dependencies]
+time = "0.1"
+git2 = { version = "0.13", default-features = false }
+sass-rs = "0.2.2"
+
 [[bench]]
 name = "html_parsing"
 harness = false
@@ -91,11 +96,6 @@ harness = false
 [[bench]]
 name = "compression"
 harness = false
-
-[build-dependencies]
-time = "0.1"
-git2 = { version = "0.13", default-features = false }
-sass-rs = "0.2"
 
 [[bin]]
 name = "cratesfyi"

--- a/build.rs
+++ b/build.rs
@@ -28,7 +28,7 @@ fn main() {
 
     write_git_version();
     if let Err(sass_err) = compile_sass() {
-        panic!("Error compiling SASS: {}", sass_err);
+        panic!("Error compiling sass: {}", sass_err);
     }
     copy_js();
 }

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -47,7 +47,7 @@ COPY build.rs build.rs
 RUN touch build.rs
 COPY src src/
 RUN find src -name "*.rs" -exec touch {} \;
-COPY templates/style.scss templates/
+COPY templates/style templates/style
 COPY templates/index.js templates/
 COPY templates/menu.js templates/
 

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -64,9 +64,9 @@ impl TemplateData {
 
             while rx.recv().is_ok() {
                 if let Err(err) = reload(&template_data, &pool) {
-                    log::error!("Failed to reload templates:\n{}", err);
+                    log::error!("failed to reload templates: {}", err);
                 } else {
-                    log::info!("Reloaded templates");
+                    log::info!("reloaded templates");
                 }
             }
         });

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -54,7 +54,6 @@ impl TemplateData {
                 template_data
                     .templates
                     .swap(Arc::new(load_templates(&mut conn)?));
-                log::info!("Reloaded templates");
 
                 Ok(())
             }
@@ -65,7 +64,9 @@ impl TemplateData {
 
             while rx.recv().is_ok() {
                 if let Err(err) = reload(&template_data, &pool) {
-                    log::error!("failed to reload templates: {:?}", err);
+                    log::error!("Failed to reload templates:\n{}", err);
+                } else {
+                    log::info!("Reloaded templates");
                 }
             }
         });

--- a/templates/header/topbar.html
+++ b/templates/header/topbar.html
@@ -24,16 +24,28 @@
                 </a>
 
                 <ul class="pure-menu-list">
-                    <li class="pure-menu-item">
-                        <a href="/about" class="pure-menu-link">
+                    <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
+                        <a href="/about" class="pure-menu-link disable-menu-arrow">
                             About
                         </a>
+
+                        <ul class="pure-menu-children">
+                            <a href="/about" class="pure-menu-link">
+                                Documentation about builds, badges and more
+                            </a>
+                        </ul>
                     </li>
 
-                    <li class="pure-menu-item">
-                        <a href="/releases" class="pure-menu-link">
+                    <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
+                        <a href="/releases" class="pure-menu-link disable-menu-arrow">
                             Releases
                         </a>
+
+                        <ul class="pure-menu-children">
+                            <a href="/releases" class="pure-menu-link">
+                                Recent releases, the release queue and build failures
+                            </a>
+                        </ul>
                     </li>
 
                     {# The Rust dropdown menu #}

--- a/templates/header/topbar.html
+++ b/templates/header/topbar.html
@@ -25,26 +25,73 @@
 
                 <ul class="pure-menu-list">
                     <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
-                        <a href="/about" class="pure-menu-link disable-menu-arrow">
+                        <a href="/about" class="pure-menu-link">
                             About
                         </a>
 
                         <ul class="pure-menu-children">
-                            <a href="/about" class="pure-menu-link">
-                                Documentation about builds, badges and more
-                            </a>
+                            <li class="pure-menu-item">
+                                <a href="/about/badges" class="pure-menu-link">
+                                    Badges
+                                </a>
+                            </li>
+
+                            <li class="pure-menu-item">
+                                <a href="/about/builds" class="pure-menu-link">
+                                    Builds
+                                </a>
+                            </li>
+
+                            <li class="pure-menu-item">
+                                <a href="/about/metadata" class="pure-menu-link">
+                                    Metadata
+                                </a>
+                            </li>
+
+                            <li class="pure-menu-item">
+                                <a href="/about/redirections" class="pure-menu-link">
+                                    Shorthand URLs
+                                </a>
+                            </li>
                         </ul>
+
                     </li>
 
                     <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
-                        <a href="/releases" class="pure-menu-link disable-menu-arrow">
+                        <a href="/releases" class="pure-menu-link">
                             Releases
                         </a>
 
                         <ul class="pure-menu-children">
-                            <a href="/releases" class="pure-menu-link">
-                                Recent releases, the release queue and build failures
-                            </a>
+                            <li class="pure-menu-item">
+                                <a href="/releases/stars" class="pure-menu-link">
+                                    Releases by Stars
+                                </a>
+                            </li>
+
+                            <li class="pure-menu-item">
+                                <a href="/releases/recent-failures" class="pure-menu-link">
+                                    Recent Build Failures
+                                </a>
+                            </li>
+
+                            <ul class="pure-menu-children">
+                                <a href="/releases/failures" class="pure-menu-link">
+                                    Build Failures by Stars
+                                </a>
+                            </ul>
+
+                            <li class="pure-menu-item">
+                                <a href="/releases/failures" class="pure-menu-link">
+                                    Release Activity
+                                </a>
+                            </li>
+
+                            <li class="pure-menu-item">
+                                <a href="/releases/queue" class="pure-menu-link">
+                                    Build Queue
+                                </a>
+                            </li>
                         </ul>
                     </li>
 
@@ -101,7 +148,7 @@
 
                     {# The global alert, if there is one #}
                     {% include "header/global_alert.html" -%}
-                </ul>
+                    </li>
             </form>
         </div>
     </div>

--- a/templates/header/topbar.html
+++ b/templates/header/topbar.html
@@ -24,75 +24,16 @@
                 </a>
 
                 <ul class="pure-menu-list">
-                    <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
+                    <li class="pure-menu-item">
                         <a href="/about" class="pure-menu-link">
                             About
                         </a>
-
-                        <ul class="pure-menu-children">
-                            <li class="pure-menu-item">
-                                <a href="/about/badges" class="pure-menu-link">
-                                    Badges
-                                </a>
-                            </li>
-
-                            <li class="pure-menu-item">
-                                <a href="/about/builds" class="pure-menu-link">
-                                    Builds
-                                </a>
-                            </li>
-
-                            <li class="pure-menu-item">
-                                <a href="/about/metadata" class="pure-menu-link">
-                                    Metadata
-                                </a>
-                            </li>
-
-                            <li class="pure-menu-item">
-                                <a href="/about/redirections" class="pure-menu-link">
-                                    Shorthand URLs
-                                </a>
-                            </li>
-                        </ul>
-
                     </li>
 
-                    <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
+                    <li class="pure-menu-item">
                         <a href="/releases" class="pure-menu-link">
                             Releases
                         </a>
-
-                        <ul class="pure-menu-children">
-                            <li class="pure-menu-item">
-                                <a href="/releases/stars" class="pure-menu-link">
-                                    Releases by Stars
-                                </a>
-                            </li>
-
-                            <li class="pure-menu-item">
-                                <a href="/releases/recent-failures" class="pure-menu-link">
-                                    Recent Build Failures
-                                </a>
-                            </li>
-
-                            <ul class="pure-menu-children">
-                                <a href="/releases/failures" class="pure-menu-link">
-                                    Build Failures by Stars
-                                </a>
-                            </ul>
-
-                            <li class="pure-menu-item">
-                                <a href="/releases/failures" class="pure-menu-link">
-                                    Release Activity
-                                </a>
-                            </li>
-
-                            <li class="pure-menu-item">
-                                <a href="/releases/queue" class="pure-menu-link">
-                                    Build Queue
-                                </a>
-                            </li>
-                        </ul>
                     </li>
 
                     {# The Rust dropdown menu #}
@@ -148,7 +89,7 @@
 
                     {# The global alert, if there is one #}
                     {% include "header/global_alert.html" -%}
-                    </li>
+                </ul>
             </form>
         </div>
     </div>

--- a/templates/header/topbar.html
+++ b/templates/header/topbar.html
@@ -30,29 +30,10 @@
                         </a>
 
                         <ul class="pure-menu-children">
-                            <li class="pure-menu-item">
-                                <a href="/about/badges" class="pure-menu-link">
-                                    Badges
-                                </a>
-                            </li>
-
-                            <li class="pure-menu-item">
-                                <a href="/about/builds" class="pure-menu-link">
-                                    Builds
-                                </a>
-                            </li>
-
-                            <li class="pure-menu-item">
-                                <a href="/about/metadata" class="pure-menu-link">
-                                    Metadata
-                                </a>
-                            </li>
-
-                            <li class="pure-menu-item">
-                                <a href="/about/redirections" class="pure-menu-link">
-                                    Shorthand URLs
-                                </a>
-                            </li>
+                            {{ macros::menu_link(href="/about/badges", text="Badges") }}
+                            {{ macros::menu_link(href="/about/builds", text="Builds") }}
+                            {{ macros::menu_link(href="/about/metadata", text="Metadata") }}
+                            {{ macros::menu_link(href="/about/redirections", text="Shorthand URLs") }}
                         </ul>
                     </li>
 
@@ -62,35 +43,11 @@
                         </a>
 
                         <ul class="pure-menu-children">
-                            <li class="pure-menu-item">
-                                <a href="/releases/stars" class="pure-menu-link">
-                                    Releases by Stars
-                                </a>
-                            </li>
-
-                            <li class="pure-menu-item">
-                                <a href="/releases/recent-failures" class="pure-menu-link">
-                                    Recent Build Failures
-                                </a>
-                            </li>
-
-                            <ul class="pure-menu-children">
-                                <a href="/releases/failures" class="pure-menu-link">
-                                    Build Failures by Stars
-                                </a>
-                            </ul>
-
-                            <li class="pure-menu-item">
-                                <a href="/releases/failures" class="pure-menu-link">
-                                    Release Activity
-                                </a>
-                            </li>
-
-                            <li class="pure-menu-item">
-                                <a href="/releases/queue" class="pure-menu-link">
-                                    Build Queue
-                                </a>
-                            </li>
+                            {{ macros::menu_link(href="/releases/stars", text="Releases by Stars") }}
+                            {{ macros::menu_link(href="/releases/recent-failures", text="Recent Build Failures") }}
+                            {{ macros::menu_link(href="/releases/failures", text="Build Failures by Stars") }}
+                            {{ macros::menu_link(href="/releases/failures", text="Release Activity") }}
+                            {{ macros::menu_link(href="/releases/queue", text="Build Queue") }}
                         </ul>
                     </li>
 
@@ -99,49 +56,48 @@
                         <a href="#" class="pure-menu-link">Rust</a>
 
                         <ul class="pure-menu-children">
-                            <li class="pure-menu-item">
-                                <a href="https://www.rust-lang.org/" target="_blank" class="pure-menu-link">
-                                    The Rust Programming Language
-                                </a>
-                            </li>
+                            {{ macros::menu_link(
+                                href="https://www.rust-lang.org/",
+                                text="The Rust Programming Language",
+                                target="_blank"
+                            ) }}
 
-                            <li class="pure-menu-item">
-                                <a href="https://doc.rust-lang.org/book/" target="_blank" class="pure-menu-link">
-                                    The Book
-                                </a>
-                            </li>
+                            {{ macros::menu_link(
+                                href="https://doc.rust-lang.org/book/",
+                                text="The Book",
+                                target="_blank"
+                            ) }}
 
-                            <li class="pure-menu-item">
-                                <a href="https://doc.rust-lang.org/std/" target="_blank" class="pure-menu-link">
-                                    Standard Library API Reference
-                                </a>
-                            </li>
+                            {{ macros::menu_link(
+                                href="https://doc.rust-lang.org/std/",
+                                text="Standard Library API Reference",
+                                target="_blank"
+                            ) }}
 
-                            <li class="pure-menu-item">
-                                <a href="https://doc.rust-lang.org/rust-by-example/" target="_blank"
-                                    class="pure-menu-link">
-                                    Rust by Example
-                                </a>
-                            </li>
+                            {{ macros::menu_link(
+                                href="https://doc.rust-lang.org/rust-by-example/",
+                                text="Rust by Example",
+                                target="_blank"
+                            ) }}
 
-                            <li class="pure-menu-item menu-item-divided">
-                                <a href="https://rust-lang-nursery.github.io/rust-cookbook/" target="_blank"
-                                    class="pure-menu-link">
-                                    Rust Cookbook
-                                </a>
-                            </li>
+                            {{ macros::menu_link(
+                                href="https://rust-lang-nursery.github.io/rust-cookbook/",
+                                text="Rust Cookbook",
+                                target="_blank",
+                                extra_classes="menu-item-divided"
+                            ) }}
 
-                            <li class="pure-menu-item">
-                                <a href="https://crates.io" target="_blank" class="pure-menu-link">
-                                    Crates.io
-                                </a>
-                            </li>
+                            {{ macros::menu_link(
+                                href="https://crates.io",
+                                text="Crates.io",
+                                target="_blank"
+                            ) }}
 
-                            <li class="pure-menu-item menu-item-divided">
-                                <a href="http://doc.crates.io/guide.html" target="_blank" class="pure-menu-link">
-                                    The Cargo Guide
-                                </a>
-                            </li>
+                            {{ macros::menu_link(
+                                href="http://doc.crates.io/guide.html",
+                                text="The Cargo Guide",
+                                target="_blank"
+                            ) }}
                         </ul>
                     </li>
 

--- a/templates/header/topbar.html
+++ b/templates/header/topbar.html
@@ -46,7 +46,7 @@
                             {{ macros::menu_link(href="/releases/stars", text="Releases by Stars") }}
                             {{ macros::menu_link(href="/releases/recent-failures", text="Recent Build Failures") }}
                             {{ macros::menu_link(href="/releases/failures", text="Build Failures by Stars") }}
-                            {{ macros::menu_link(href="/releases/failures", text="Release Activity") }}
+                            {{ macros::menu_link(href="/releases/activity", text="Release Activity") }}
                             {{ macros::menu_link(href="/releases/queue", text="Build Queue") }}
                         </ul>
                     </li>

--- a/templates/header/topbar.html
+++ b/templates/header/topbar.html
@@ -24,16 +24,74 @@
                 </a>
 
                 <ul class="pure-menu-list">
-                    <li class="pure-menu-item">
+                    <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
                         <a href="/about" class="pure-menu-link">
                             About
                         </a>
+
+                        <ul class="pure-menu-children">
+                            <li class="pure-menu-item">
+                                <a href="/about/badges" class="pure-menu-link">
+                                    Badges
+                                </a>
+                            </li>
+
+                            <li class="pure-menu-item">
+                                <a href="/about/builds" class="pure-menu-link">
+                                    Builds
+                                </a>
+                            </li>
+
+                            <li class="pure-menu-item">
+                                <a href="/about/metadata" class="pure-menu-link">
+                                    Metadata
+                                </a>
+                            </li>
+
+                            <li class="pure-menu-item">
+                                <a href="/about/redirections" class="pure-menu-link">
+                                    Shorthand URLs
+                                </a>
+                            </li>
+                        </ul>
                     </li>
 
-                    <li class="pure-menu-item">
+                    <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
                         <a href="/releases" class="pure-menu-link">
                             Releases
                         </a>
+
+                        <ul class="pure-menu-children">
+                            <li class="pure-menu-item">
+                                <a href="/releases/stars" class="pure-menu-link">
+                                    Releases by Stars
+                                </a>
+                            </li>
+
+                            <li class="pure-menu-item">
+                                <a href="/releases/recent-failures" class="pure-menu-link">
+                                    Recent Build Failures
+                                </a>
+                            </li>
+
+                            <ul class="pure-menu-children">
+                                <a href="/releases/failures" class="pure-menu-link">
+                                    Build Failures by Stars
+                                </a>
+                            </ul>
+
+                            <li class="pure-menu-item">
+                                <a href="/releases/failures" class="pure-menu-link">
+                                    Release Activity
+                                </a>
+                            </li>
+
+                            <li class="pure-menu-item">
+                                <a href="/releases/queue" class="pure-menu-link">
+                                    Build Queue
+                                </a>
+                            </li>
+                        </ul>
                     </li>
 
                     {# The Rust dropdown menu #}

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -42,6 +42,21 @@
 {% endmacro active_link %}
 
 {#
+    Creates a list entry
+    * `href` A string used as the tab's link
+    * `text` A string used as the tab's text
+    * `target` An optional target
+    * `extra_classes` Optional extra css classes
+#}
+{% macro menu_link(href, text, target="", extra_classes="") %}
+    <li class="pure-menu-item">
+        <a class="pure-menu-link {{ extra_classes }}" href="{{ href }}" {% if target != "" -%} target="{{ target }}" {%- endif %}>
+            {{ text }}
+        </a>
+    </li>
+{% endmacro active_link %}
+
+{#
     Creates a formatted table showing the resource limits of a crate
     * `limits` A non-null `Limits` struct
 #}

--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -1,0 +1,148 @@
+// FIXME: Use modules
+@import "vars", "utils";
+
+div.nav-container {
+    // Nothing is supposed to be over or hovering the top navbar. Maybe add a few others '('? :)
+    z-index: 999;
+    height: $top-navbar-height;
+    border-bottom: 1px solid $color-border;
+    background-color: #fff;
+    left: 0;
+    right: 0;
+    top: 0;
+    position: fixed;
+
+    li {
+        border-left: 1px solid $color-border;
+    }
+
+    .pure-menu-has-children > .pure-menu-link:after {
+        font-size: 0.8em;
+    }
+
+    .pure-menu-link {
+        font-size: 0.8em;
+        font-weight: 400;
+
+        &:hover {
+            color: $color-standard;
+            background-color: inherit;
+        }
+    }
+
+    form.landing-search-form-nav {
+        max-width: 1200px;
+
+        #search-input-nav {
+            float: right;
+            max-width: 150px;
+            display: none;
+            border-left: 1px solid $color-border;
+
+            @media #{$media-sm} {
+                display: block;
+            }
+
+            @media #{$media-md} {
+                max-width: 200px;
+            }
+
+            label {
+                color: #777;
+                cursor: pointer;
+                padding-left: 0.5rem;
+                font-size: 0.8em;
+            }
+
+            input {
+                border: none;
+                margin: 0 1em 0 0;
+                font-size: 0.8em;
+                box-shadow: none;
+                background-color: #fff;
+                height: 31px;
+            }
+        }
+
+        input.search-input-nav:focus {
+            outline: unset;
+        }
+    }
+
+    .pure-menu-children {
+        border: 1px solid $color-border;
+        border-radius: 0 0 2px 2px;
+        margin-left: -1px;
+
+        li {
+            border-left: none;
+        }
+    }
+
+    // used for latest version warning
+    .warn,
+    .warn:hover {
+        color: $color-type;
+    }
+
+    a.warn:hover {
+        color: darken($color-type, 10%);
+    }
+
+    // used for global alerts
+    .error {
+        color: $color-red;
+
+        &:hover {
+            color: darken($color-red, 10%);
+        }
+    }
+
+    div.rustdoc-navigation {
+        span.title {
+            display: none;
+
+            @media #{$media-sm} {
+                display: inline;
+            }
+        }
+
+        div.package-details-menu {
+            width: 350px;
+
+            p.description {
+                font-family: $font-family-sans;
+                font-size: 0.8em;
+                color: #777; // color from pure
+                padding: 0.5em 1em;
+                margin: 0;
+            }
+
+            ul.pure-menu-list {
+                width: 100%;
+            }
+
+            div.right-border {
+                border-right: 1px solid $color-border;
+            }
+
+            a.pure-menu-link {
+                word-wrap: normal;
+                white-space: normal;
+            }
+
+            div.sub-menu {
+                max-height: 150px;
+                overflow-y: auto;
+
+                ul.pure-menu-list {
+                    border-top: none;
+                }
+
+                li.pure-menu-item:last-child {
+                    border-bottom: none;
+                }
+            }
+        }
+    }
+}

--- a/templates/style/_rustdoc.scss
+++ b/templates/style/_rustdoc.scss
@@ -1,0 +1,45 @@
+// FIXME: Use modules
+@import "vars";
+
+// rustdoc overrides
+div.rustdoc {
+    font-family: $font-family-serif;
+    padding: 10px 15px 20px 15px;
+    position: relative;
+
+    @media (max-width: 700px) {
+        padding-top: 0;
+    }
+
+    .sidebar {
+        @media (min-width: 701px) {
+            margin-top: $top-navbar-height;
+        }
+
+        .block > ul > li {
+            margin-right: -10px;
+        }
+
+        @media (max-width: 700px) {
+            &.mobile {
+                top: $top-navbar-height;
+
+                .sidebar-elems .show-it {
+                    top: 77px;
+                }
+
+                #sidebar-filler {
+                    top: $top-navbar-height;
+                }
+            }
+        }
+    }
+
+    #source-sidebar {
+        top: $top-navbar-height;
+    }
+
+    #sidebar-toggle {
+        top: 62px;
+    }
+}

--- a/templates/style/_utils.scss
+++ b/templates/style/_utils.scss
@@ -23,12 +23,3 @@ div {
         background-color: lighten($color-type, 45%);
     }
 }
-
-// Disable the dropdown arrow for pure menu items
-// It's a wonderful hack, but it allows us to hijack pure's dropdown menus to
-// make tooltips that appear when you hover over them that don't have the little
-// arrow on the link itself
-.disable-menu-arrow,
-.pure-menu-has-children > .disable-menu-arrow.pure-menu-link:after {
-    content: "" !important;
-}

--- a/templates/style/_utils.scss
+++ b/templates/style/_utils.scss
@@ -1,0 +1,34 @@
+// FIXME: Use modules
+@import "vars";
+
+// Info and warning notifications
+div {
+    .info {
+        font-family: $font-family-sans;
+        border-radius: 4px;
+        background-color: $color-background-code;
+        padding: 0.4em 1em;
+        text-align: center;
+        margin-bottom: 10px;
+
+        a {
+            color: $color-url;
+            text-decoration: underline;
+        }
+    }
+
+    .warning {
+        @extend .info;
+
+        background-color: lighten($color-type, 45%);
+    }
+}
+
+// Disable the dropdown arrow for pure menu items
+// It's a wonderful hack, but it allows us to hijack pure's dropdown menus to
+// make tooltips that appear when you hover over them that don't have the little
+// arrow on the link itself
+.disable-menu-arrow,
+.pure-menu-has-children > .disable-menu-arrow.pure-menu-link:after {
+    content: "" !important;
+}

--- a/templates/style/_vars.scss
+++ b/templates/style/_vars.scss
@@ -1,0 +1,33 @@
+// Stores all the style constants
+
+// Fonts
+$font-family-sans: "Fira Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+$font-family-serif: "Source Serif Pro", Georgia, Times, "Times New Roman", serif;
+$font-family-mono: "Source Code Pro", Menlo, Monaco, Consolas, "DejaVu Sans Mono", Inconsolata, monospace;
+
+// Colors
+$color-standard: #000;           // pure black
+$color-url: #4d76ae;             // blue
+$color-macro: #068000;           // green
+$color-struct: #df3600;          // red
+$color-enum: #5e9766;            // light green
+$color-type: #e57300;            // orange
+$color-keyword: #8959A8;         // purple
+$color-string: #718C00;          // greenish
+$color-macro-in-code: #3E999F;   // blueish
+$color-lifetime-incode: #B76514; // orangish
+$color-comment-in-code: #8E908C; // light gray
+$color-background-code: #F5F5F5; // lighter gray
+$color-border: #ddd;             // gray
+$color-red: #d93d3d;             // red
+
+// Sizes
+$top-navbar-height: 32px; // height of the floating top navbar
+
+// Pure compatible media queries
+// usage:
+// @media #{$media-sm} { ... }
+$media-sm: "screen and (min-width: 35.5em)";
+$media-md: "screen and (min-width: 48em)";
+$media-lg: "screen and (min-width: 64em)";
+$media-xl: "screen and (min-width: 80em)";

--- a/templates/style/base.scss
+++ b/templates/style/base.scss
@@ -1,34 +1,11 @@
-// FONTS
-$font-family-sans: "Fira Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-$font-family-serif: "Source Serif Pro",Georgia,Times,"Times New Roman",serif;
-$font-family-mono: "Source Code Pro", Menlo, Monaco, Consolas, "DejaVu Sans Mono", Inconsolata, monospace;
+// FIXME: Use modules
+@import "vars", "rustdoc", "utils", "navbar";
 
-// COLORS - Guess what?
-$color-standard: #000;             // pure black
-$color-url: #4d76ae;               // blue
-$color-macro: #068000;             // green
-$color-struct: #df3600;            // red
-$color-enum: #5e9766;              // light green
-$color-type: #e57300;              // orange
-$color-keyword: #8959A8;           // purple
-$color-string: #718C00;            // greenish
-$color-macro-in-code: #3E999F;     // blueish
-$color-lifetime-incode: #B76514;   // orangish
-$color-comment-in-code: #8E908C;   // light gray
-$color-background-code: #F5F5F5;   // lighter gray
-$color-border: #ddd;               // gray
-$color-red: #d93d3d;               // red
-$top-navbar-height: 32px;          // height of the floating top navbar
-
-// pure compatible media queries
-$media-sm: "screen and (min-width: 35.5em)";
-$media-md: "screen and (min-width: 48em)";
-$media-lg: "screen and (min-width: 64em)";
-$media-xl: "screen and (min-width: 80em)";
-// usage:
-// @media #{$media-sm} { ... }
-
-html, input, select, textarea, .pure-g [class *= "pure-u"] {
+html,
+input,
+select,
+textarea,
+.pure-g [class*="pure-u"] {
     font-family: $font-family-sans;
     color: $color-standard;
 }
@@ -43,60 +20,39 @@ html, input, select, textarea, .pure-g [class *= "pure-u"] {
     font-family: $font-family-serif;
 }
 
-// rustdoc overrides
-div.rustdoc {
-    font-family: $font-family-serif;
-    padding: 10px 15px 20px 15px;
-
-    @media (max-width: 700px) {
-        padding-top: 0;
-    }
-
-    .sidebar {
-        @media (min-width: 701px) {
-            margin-top: $top-navbar-height;
-        }
-
-        .block > ul > li {
-            margin-right: -10px;
-        }
-    }
-
-    #source-sidebar {
-        top: $top-navbar-height;
-    }
-
-    #sidebar-toggle {
-        top: 62px;
-    }
-
-    @media (max-width: 700px) {
-        .sidebar.mobile {
-            top: $top-navbar-height;
-
-            .sidebar-elems.show-it {
-                top: 77px;
-            }
-
-            #sidebar-filler {
-                top: $top-navbar-height;
-            }
-        }
-    }
-
-    position: relative;
-}
-
 body {
     padding: 0;
     margin: 0;
+
+    // rustdocs have 200px sidebar and
+    // max-width 960px main pane
+    // BUT I really want to make the website centered
+    text-align: center;
+    font: 16px/1.4 $font-family-sans;
+
     // Since top navbar is fixed, we need to add padding to the body content.
     padding-top: $top-navbar-height;
+
     // The scroll padding on the <body> is necessary for Chrome
     // browsers for now (see
     // https://css-tricks.com/fixed-headers-on-page-links-and-overlapping-content-oh-my/
     // for an explanation)
     scroll-padding-top: $top-navbar-height;
+
+    // this is a super nasty override for help dialog in rustdocs
+    // see #52 for details
+    .blur > :not(#help) {
+        filter: none;
+        -webkit-filter: none;
+    }
+
+    .blur > div.nav-container > *,
+    .blur > div.cratesfyi-package-container > *,
+    .blur > div.rustdoc > :not(#help) {
+        filter: blur(8px);
+        -webkit-filter: blur(8px);
+        opacity: 0.7;
+    }
 }
 
 html {
@@ -104,29 +60,6 @@ html {
     // overlap the top navigation bar (not supported on Desktop/Mobile
     // Safari yet):
     scroll-padding-top: $top-navbar-height;
-}
-
-// this is a super nasty override for help dialog in rustdocs
-// see #52 for details
-body.blur > :not(#help) {
-    filter: none;
-    -webkit-filter: none;
-}
-
-body.blur > div.nav-container > *,
-body.blur > div.cratesfyi-package-container > *,
-body.blur > div.rustdoc > :not(#help) {
-    filter: blur(8px);
-    -webkit-filter: blur(8px);
-    opacity: .7;
-}
-
-// rustdocs have 200px sidebar and
-// max-width 960px main pane
-// BUT I really want to make the website centered
-body {
-    text-align: center;
-    font: 16px/1.4 $font-family-sans;
 }
 
 pre {
@@ -143,151 +76,6 @@ div.container {
 
 div.container-rustdoc {
     text-align: left;
-}
-
-div.nav-container {
-    // Nothing is supposed to be over or hovering the top navbar. Maybe add a few others '('? :)
-    z-index: 999;
-    height: $top-navbar-height;
-    border-bottom: 1px solid $color-border;
-    background-color: #fff;
-    left: 0;
-    right: 0;
-    top: 0;
-    position: fixed;
-
-    li {
-        border-left: 1px solid $color-border;
-    }
-
-    .pure-menu-has-children>.pure-menu-link:after {
-        font-size: 0.8em;
-    }
-
-    .pure-menu-link {
-        font-size: 0.8em;
-        font-weight: 400;
-    }
-
-    .pure-menu-link:hover {
-        color: $color-standard;
-        background-color: inherit;
-    }
-
-    form.landing-search-form-nav {
-        max-width: 1200px;
-
-        #search-input-nav {
-            float: right;
-            max-width: 150px;
-            display: none;
-            border-left: 1px solid $color-border;
-
-            @media #{$media-sm} {
-                display: block;
-            }
-
-            @media #{$media-md} {
-                 max-width: 200px;
-            }
-
-            label {
-                 color: #777;
-                 cursor: pointer;
-                 padding-left: 0.5rem;
-                 font-size: 0.8em;
-            }
-
-            input {
-                 border: none;
-                 margin: 0 1em 0 0;
-                 font-size: 0.8em;
-                 box-shadow: none;
-                 background-color: #fff;
-                 height: 31px;
-            }
-        }
-
-        input.search-input-nav:focus {
-            outline: unset;
-        }
-    }
-
-    .pure-menu-children {
-        border: 1px solid $color-border;
-        border-radius: 0 0 2px 2px;
-        margin-left: -1px;
-
-        li {
-            border-left: none;
-        }
-    }
-
-    // used for latest version warning
-    .warn, .warn:hover {
-        color: $color-type;
-    }
-
-    a.warn:hover {
-        color: darken($color-type, 10%);
-    }
-
-    // used for global alerts
-    .error {
-        color: $color-red;
-
-        &:hover {
-            color: darken($color-red, 10%);
-        }
-    }
-
-    div.rustdoc-navigation {
-        span.title {
-            display: none;
-
-            @media #{$media-sm} {
-                display: inline;
-            }
-        }
-
-        div.package-details-menu {
-            width: 350px;
-
-            p.description {
-                font-family: $font-family-sans;
-                font-size: 0.8em;
-                color: #777;  // color from pure
-                padding: .5em 1em;
-                margin: 0;
-            }
-
-            ul.pure-menu-list {
-                width: 100%;
-            }
-
-            div.right-border {
-                border-right: 1px solid $color-border;
-            }
-
-            a.pure-menu-link {
-                word-wrap: normal;
-                white-space: normal;
-            }
-
-            div.sub-menu {
-                max-height: 150px;
-                overflow-y: auto;
-
-                ul.pure-menu-list {
-                    border-top: none;
-                }
-
-                li.pure-menu-item:last-child {
-                    border-bottom: none;
-                }
-            }
-        }
-    }
 }
 
 div.nav-container-rustdoc {
@@ -315,7 +103,7 @@ div.landing {
     form.landing-search-form {
         max-width: 500px;
         margin: 0 auto;
-        padding: .4em 1em;
+        padding: 0.4em 1em;
 
         div.buttons {
             margin-top: 30px;
@@ -331,7 +119,8 @@ div.recent-releases-container {
     text-align: left;
     margin-bottom: 50px;
 
-    ul, li {
+    ul,
+    li {
         list-style-type: none;
         margin: 0;
         padding: 0;
@@ -357,15 +146,16 @@ div.recent-releases-container {
     .release {
         display: block;
         border-bottom: 1px solid $color-border;
-        padding: .4em 1em;
+        padding: 0.4em 1em;
 
         @media #{$media-lg} {
-            padding: .4em 0;
+            padding: 0.4em 0;
             margin: 0 1em;
         }
     }
 
-    .release:hover, li.selected > .release {
+    .release:hover,
+    li.selected > .release {
         background-color: $color-background-code;
     }
 
@@ -452,7 +242,7 @@ div.recent-releases-container {
 
 div.package-container {
     background-color: $color-url;
-    color: $color-background-code;;
+    color: $color-background-code;
 
     h1 {
         margin: 0;
@@ -472,7 +262,7 @@ div.package-container {
             border-top-left-radius: 4px;
             border-top-right-radius: 4px;
             border-bottom: 2px solid $color-border;
-            padding: .4em 1em;
+            padding: 0.4em 1em;
         }
 
         .pure-menu-active {
@@ -492,7 +282,7 @@ div.package-sheet-container {
 
     .pure-menu-link {
         border-radius: 4px;
-        padding: .2em .8em;
+        padding: 0.2em 0.8em;
         font-weight: 400;
     }
 
@@ -580,7 +370,12 @@ div.package-page-container {
             text-decoration: underline;
         }
 
-        h1, h2, h3, h4, h5, h6 {
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
             font-family: $font-family-sans;
         }
 
@@ -601,7 +396,8 @@ div.package-page-container {
             border: 1px solid #cbcbcb;
             margin-bottom: 15px;
 
-            td, th {
+            td,
+            th {
                 border-left: 1px solid #cbcbcb;
                 border-width: 0 0 0 1px;
                 font-size: inherit;
@@ -676,7 +472,7 @@ div.cratesfyi-package-container {
         .pure-menu-link {
             color: #666;
             font-size: 14px;
-            padding: .4em 1em .3em 1em;
+            padding: 0.4em 1em 0.3em 1em;
 
             .title {
                 display: none;
@@ -719,7 +515,7 @@ div.cratesfyi-package-container {
             border-radius: 2px;
         }
 
-        .pure-menu-has-children>.pure-menu-link:after {
+        .pure-menu-has-children > .pure-menu-link:after {
             font-size: 14px;
         }
 
@@ -733,33 +529,14 @@ div.cratesfyi-package-container-rustdoc {
     margin-bottom: 10px;
 }
 
-div.info {
-    font-family: $font-family-sans;
-    border-radius: 4px;
-    background-color: $color-background-code;
-    padding: .4em 1em;
-    text-align: center;
-    margin-bottom: 10px;
-
-    a {
-        color: $color-url;
-        text-decoration: underline;
-    }
-}
-
-div.warning {
-    @extend div.info;
-    background-color: lighten($color-type, 45%);
-}
-
 div.search-page-search-form {
-    padding: .4em 1em;
+    padding: 0.4em 1em;
     text-align: center;
 
     input.search-input {
         display: inline-block;
         max-width: 300px;
-        padding: .4em 1em;
+        padding: 0.4em 1em;
     }
 }
 
@@ -776,13 +553,14 @@ div.search-page-search-form {
 
 .about {
     font-family: $font-family-serif;
-    padding: .4em 1em;
+    padding: 0.4em 1em;
 
     a {
         color: $color-url;
-    }
-    a:hover {
-        text-decoration: underline;
+
+        :hover {
+            text-decoration: underline;
+        }
     }
 
     table {
@@ -816,11 +594,12 @@ div.search-page-search-form {
 }
 
 i.dependencies.normal {
-  visibility: hidden;
-  display: none;
+    visibility: hidden;
+    display: none;
 }
 
 /* Don't put a newline after code fragments in headers */
-h3 > code, h4 > code {
-  display: inline-block;
+h3 > code,
+h4 > code {
+    display: inline-block;
 }


### PR DESCRIPTION
Before/Unhovered:
![image](https://user-images.githubusercontent.com/25047011/89593252-48c46f00-d814-11ea-8431-89c6e6eac9d2.png)

After/Hovered:
![image](https://user-images.githubusercontent.com/25047011/89604033-06a92680-d830-11ea-9198-aa4dc20c6ad1.png)
![image](https://user-images.githubusercontent.com/25047011/89604086-24768b80-d830-11ea-8a5e-3ebd49b0ee0e.png)

The tooltip text isn't final, I just couldn't think of better ones.

Engaged in a *minor* CSS splitting, no actual refactoring happened since it was just moved to separate files and then `@include`'d
