### PR TITLE
Remove CSS files that shouldn't be on rustdoc pages

### DIFF
--- a/templates/rustdoc/head.html
+++ b/templates/rustdoc/head.html
@@ -1,10 +1,4 @@
 {%- import "macros.html" as macros -%}
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/pure-min.css" type="text/css"
-            media="all" />
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/grids-responsive-min.css"
-            type="text/css" media="all" />
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css"
-            type="text/css" media="all" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/menus-min.css" type="text/css"
             media="all" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/grids-min.css" type="text/css"


### PR DESCRIPTION
These should only have been on the homepage. Not sure if this actually fixes the problem, my styles continue to be messed up locally. I'm not sure what else it could be though.

Addresses https://github.com/rust-lang/docs.rs/issues/945

r? @Kixiron 