### PR TITLE
Fix db health-check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
             # Use a non-standard port on the host to avoid conflicting with existing postgres servers
             - "15432:5432"
         healthcheck:
-            test: ["CMD", "pg_isready"]
+            test: ["CMD", "pg_isready", "--username", "cratesfyi"]
             interval: 10s
             timeout: 5s
             retries: 10


### PR DESCRIPTION
Stops continuous error logs every 10 seconds:

    db_1          | 2020-08-08 10:14:22.485 UTC [192065] FATAL:  role "root" does not exist