### PR TITLE
Add the Context trait and move Metrics out of the global state 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         run: cargo build --locked
 
       - name: Test
-        run: cargo test --locked -- --test-threads=1
+        run: cargo test --locked
 
       - name: Clean up the database
         run: docker-compose down --volumes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,7 @@ dependencies = [
  "path-slash 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.17.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "procfs 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prometheus 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2_postgres 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2079,14 +2079,14 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3930,7 +3930,7 @@ dependencies = [
 "checksum proc-macro2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639"
 "checksum procedural-masquerade 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1383dff4092fe903ac180e391a8d4121cc48f08ccf850614b0290c6673b69d"
 "checksum procfs 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c434e93ef69c216e68e4f417c927b4f31502c3560b72cfdb6827e2321c5c6b3e"
-"checksum prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5567486d5778e2c6455b1b90ff1c558f29e751fc018130fa182e15828e728af1"
+"checksum prometheus 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd0ced56dee39a6e960c15c74dc48849d614586db2eaada6497477af7c7811cd"
 "checksum quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 "checksum quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 "checksum r2d2 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1497e40855348e4a8a40767d8e55174bce1e445a3ac9254ad44ad468ee0485af"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ toml = "0.5"
 schemamama = "0.3"
 schemamama_postgres = "0.3"
 systemstat = "0.1.4"
-prometheus = { version = "0.7.0", default-features = false }
+prometheus = { version = "0.9.0", default-features = false }
 rustwide = "0.10.0"
 mime_guess = "2"
 dotenv = "0.15"

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -116,14 +116,7 @@ impl CommandLine {
                 socket_addr,
                 reload_templates,
             } => {
-                Server::start(
-                    Some(&socket_addr),
-                    reload_templates,
-                    ctx.pool()?,
-                    ctx.config()?,
-                    ctx.build_queue()?,
-                    ctx.storage()?,
-                )?;
+                Server::start(Some(&socket_addr), reload_templates, &ctx)?;
             }
             Self::Daemon {
                 foreground,
@@ -134,6 +127,7 @@ impl CommandLine {
                 }
 
                 cratesfyi::utils::start_daemon(
+                    &ctx,
                     ctx.config()?,
                     ctx.pool()?,
                     ctx.build_queue()?,

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use cratesfyi::db::{self, add_path_into_database, Pool};
+use cratesfyi::db::{self, add_path_into_database, Pool, PoolClient};
 use cratesfyi::index::Index;
 use cratesfyi::utils::{remove_crate_priority, set_crate_priority};
 use cratesfyi::{
@@ -565,12 +565,7 @@ impl BinContext {
         }
     }
 
-    fn conn(
-        &self,
-    ) -> Result<
-        r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager<postgres::NoTls>>,
-        Error,
-    > {
+    fn conn(&self) -> Result<PoolClient, Error> {
         Ok(self.pool()?.get()?)
     }
 }

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -126,14 +126,7 @@ impl CommandLine {
                     log::warn!("--foreground was passed, but there is no need for it anymore");
                 }
 
-                cratesfyi::utils::start_daemon(
-                    &ctx,
-                    ctx.config()?,
-                    ctx.pool()?,
-                    ctx.build_queue()?,
-                    ctx.storage()?,
-                    registry_watcher == Toggle::Enabled,
-                )?;
+                cratesfyi::utils::start_daemon(&ctx, registry_watcher == Toggle::Enabled)?;
             }
             Self::Database { subcommand } => subcommand.handle_args(ctx)?,
             Self::Queue { subcommand } => subcommand.handle_args(ctx)?,

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,5 @@
 use crate::db::Pool;
-use crate::{BuildQueue, Config, Storage};
+use crate::{BuildQueue, Config, Metrics, Storage};
 use failure::Error;
 use std::sync::Arc;
 
@@ -8,4 +8,5 @@ pub trait Context {
     fn build_queue(&self) -> Result<Arc<BuildQueue>, Error>;
     fn storage(&self) -> Result<Arc<Storage>, Error>;
     fn pool(&self) -> Result<Pool, Error>;
+    fn metrics(&self) -> Result<Arc<Metrics>, Error>;
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,11 @@
+use crate::db::Pool;
+use crate::{BuildQueue, Config, Storage};
+use failure::Error;
+use std::sync::Arc;
+
+pub trait Context {
+    fn config(&self) -> Result<Arc<Config>, Error>;
+    fn build_queue(&self) -> Result<Arc<BuildQueue>, Error>;
+    fn storage(&self) -> Result<Arc<Storage>, Error>;
+    fn pool(&self) -> Result<Pool, Error>;
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -7,8 +7,7 @@ pub(crate) use self::add_package::{
 pub use self::delete::{delete_crate, delete_version};
 pub use self::file::add_path_into_database;
 pub use self::migrate::migrate;
-pub(crate) use self::pool::PoolClient;
-pub use self::pool::{Pool, PoolError};
+pub use self::pool::{Pool, PoolClient, PoolError};
 
 mod add_package;
 pub mod blacklist;

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -4,7 +4,7 @@ use postgres::{Client, NoTls};
 use r2d2_postgres::PostgresConnectionManager;
 use std::sync::Arc;
 
-pub(crate) type PoolClient = r2d2::PooledConnection<PostgresConnectionManager<NoTls>>;
+pub type PoolClient = r2d2::PooledConnection<PostgresConnectionManager<NoTls>>;
 
 const DEFAULT_SCHEMA: &str = "public";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub use self::context::Context;
 pub use self::docbuilder::options::DocBuilderOptions;
 pub use self::docbuilder::DocBuilder;
 pub use self::docbuilder::RustwideBuilder;
+pub use self::metrics::Metrics;
 pub use self::storage::Storage;
 pub use self::web::Server;
 
@@ -18,6 +19,7 @@ pub mod db;
 mod docbuilder;
 mod error;
 pub mod index;
+mod metrics;
 pub mod storage;
 #[cfg(test)]
 mod test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub use self::build_queue::BuildQueue;
 pub use self::config::Config;
+pub use self::context::Context;
 pub use self::docbuilder::options::DocBuilderOptions;
 pub use self::docbuilder::DocBuilder;
 pub use self::docbuilder::RustwideBuilder;
@@ -12,6 +13,7 @@ pub use self::web::Server;
 
 mod build_queue;
 mod config;
+mod context;
 pub mod db;
 mod docbuilder;
 mod error;

--- a/src/metrics/macros.rs
+++ b/src/metrics/macros.rs
@@ -1,0 +1,65 @@
+pub(super) trait MetricFromOpts: Sized {
+    fn from_opts(opts: prometheus::Opts) -> Result<Self, prometheus::Error>;
+}
+
+#[macro_export]
+macro_rules! metrics {
+    (
+        $vis:vis struct $name:ident {
+            $(#[doc = $help:expr] $metric:ident: $ty:ty $([$($label:expr),*])?,)*
+        }
+        metrics visibility: $metric_vis:vis,
+        namespace: $namespace:expr,
+    ) => {
+        $vis struct $name {
+            registry: Registry,
+            $($metric_vis $metric: $ty,)*
+        }
+        impl $name {
+            $vis fn new() -> Result<Self, Error> {
+                let registry = Registry::new();
+                $(
+                    let $metric = <$ty>::from_opts(
+                        Opts::new(stringify!($metric), $help)
+                            .namespace($namespace)
+                            $(.variable_labels(vec![$($label.into()),*]))?
+                    )?;
+                    registry.register(Box::new($metric.clone()))?;
+                )*
+                Ok(Self { registry, $($metric,)* })
+            }
+        }
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, "{}", stringify!($name))
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! load_metric_type {
+    ($name:ident as single) => {
+        use prometheus::$name;
+        impl MetricFromOpts for $name {
+            fn from_opts(opts: Opts) -> Result<Self, prometheus::Error> {
+                $name::with_opts(opts)
+            }
+        }
+    };
+    ($name:ident as vec) => {
+        use prometheus::$name;
+        impl MetricFromOpts for $name {
+            fn from_opts(opts: Opts) -> Result<Self, prometheus::Error> {
+                $name::new(
+                    opts.clone().into(),
+                    opts.variable_labels
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .as_slice(),
+                )
+            }
+        }
+    };
+}

--- a/src/metrics/macros.rs
+++ b/src/metrics/macros.rs
@@ -8,10 +8,9 @@ macro_rules! metrics {
         $vis:vis struct $name:ident {
             $(
                 #[doc = $help:expr]
-                $metric:ident: $ty:ty $([$($label:expr),* $(,)?])?
+                $metric_vis:vis $metric:ident: $ty:ty $([$($label:expr),* $(,)?])?
             ),* $(,)?
         }
-        metrics visibility: $metric_vis:vis,
         namespace: $namespace:expr,
     ) => {
         $vis struct $name {

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -58,6 +58,10 @@ metrics! {
         pub(crate) html_rewrite_ooms: IntCounter,
     }
 
+    // The Rust prometheus library treats the namespace as the "prefix" of the metric name: a
+    // metric named `foo` with a prefix of `docsrs` will expose a metric called `docsrs_foo`.
+    //
+    // https://docs.rs/prometheus/0.9.0/prometheus/struct.Opts.html#structfield.namespace
     namespace: "docsrs",
 }
 

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -28,7 +28,7 @@ metrics! {
         /// The maximum number of database connections
         max_db_connections: IntGauge,
         /// Number of attempted and failed connections to the database
-        failed_db_connections: IntCounter,
+        pub(crate) failed_db_connections: IntCounter,
 
         /// The number of currently opened file descriptors
         open_file_descriptors: IntGauge,
@@ -36,29 +36,28 @@ metrics! {
         running_threads: IntGauge,
 
         /// The traffic of various docs.rs routes
-        routes_visited: IntCounterVec["route"],
+        pub(crate) routes_visited: IntCounterVec["route"],
         /// The response times of various docs.rs routes
-        response_time: HistogramVec["route"],
+        pub(crate) response_time: HistogramVec["route"],
         /// The time it takes to render a rustdoc page
-        rustdoc_rendering_times: HistogramVec["step"],
+        pub(crate) rustdoc_rendering_times: HistogramVec["step"],
 
         /// Number of crates built
-        total_builds: IntCounter,
+        pub(crate) total_builds: IntCounter,
         /// Number of builds that successfully generated docs
-        successful_builds: IntCounter,
+        pub(crate) successful_builds: IntCounter,
         /// Number of builds that generated a compiler error
-        failed_builds: IntCounter,
+        pub(crate) failed_builds: IntCounter,
         /// Number of builds that did not complete due to not being a library
-        non_library_builds: IntCounter,
+        pub(crate) non_library_builds: IntCounter,
 
         /// Number of files uploaded to the storage backend
-        uploaded_files_total: IntCounter,
+        pub(crate) uploaded_files_total: IntCounter,
 
         /// The number of attempted files that failed due to a memory limit
-        html_rewrite_ooms: IntCounter,
+        pub(crate) html_rewrite_ooms: IntCounter,
     }
 
-    metrics visibility: pub(crate),
     namespace: "docsrs",
 }
 

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -31,10 +31,10 @@ metrics! {
         pub(crate) failed_db_connections: IntCounter,
 
         /// The number of currently opened file descriptors
-        #[cfg(linux)]
+        #[cfg(target_os = "linux")]
         open_file_descriptors: IntGauge,
         /// The number of threads being used by docs.rs
-        #[cfg(linux)]
+        #[cfg(target_os = "linux")]
         running_threads: IntGauge,
 
         /// The traffic of various docs.rs routes
@@ -86,10 +86,10 @@ impl Metrics {
         Ok(self.registry.gather())
     }
 
-    #[cfg(not(linux))]
+    #[cfg(not(target_os = "linux"))]
     fn gather_system_performance(&self) {}
 
-    #[cfg(linux)]
+    #[cfg(target_os = "linux")]
     fn gather_system_performance(&self) {
         use procfs::process::Process;
 

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,0 +1,97 @@
+#[macro_use]
+mod macros;
+
+use self::macros::MetricFromOpts;
+use crate::db::Pool;
+use crate::BuildQueue;
+use failure::Error;
+use prometheus::{proto::MetricFamily, Opts, Registry};
+
+load_metric_type!(IntGauge as single);
+load_metric_type!(IntCounter as single);
+load_metric_type!(IntCounterVec as vec);
+load_metric_type!(HistogramVec as vec);
+
+metrics! {
+    pub struct Metrics {
+        /// Number of crates in the build queue
+        queued_crates_count: IntGauge,
+        /// Number of crates in the build queue that have a positive priority
+        prioritized_crates_count: IntGauge,
+        /// Number of crates that failed to build
+        failed_crates_count: IntGauge,
+
+        /// The number of idle database connections
+        idle_db_connections: IntGauge,
+        /// The number of used database connections
+        used_db_connections: IntGauge,
+        /// The maximum number of database connections
+        max_db_connections: IntGauge,
+        /// Number of attempted and failed connections to the database
+        failed_db_connections: IntCounter,
+
+        /// The number of currently opened file descriptors
+        open_file_descriptors: IntGauge,
+        /// The number of threads being used by docs.rs
+        running_threads: IntGauge,
+
+        /// The traffic of various docs.rs routes
+        routes_visited: IntCounterVec["route"],
+        /// The response times of various docs.rs routes
+        response_time: HistogramVec["route"],
+        /// The time it takes to render a rustdoc page
+        rustdoc_rendering_times: HistogramVec["step"],
+
+        /// Number of crates built
+        total_builds: IntCounter,
+        /// Number of builds that successfully generated docs
+        successful_builds: IntCounter,
+        /// Number of builds that generated a compiler error
+        failed_builds: IntCounter,
+        /// Number of builds that did not complete due to not being a library
+        non_library_builds: IntCounter,
+
+        /// Number of files uploaded to the storage backend
+        uploaded_files_total: IntCounter,
+
+        /// The number of attempted files that failed due to a memory limit
+        html_rewrite_ooms: IntCounter,
+    }
+
+    metrics visibility: pub(crate),
+    namespace: "docsrs",
+}
+
+impl Metrics {
+    pub(crate) fn gather(
+        &self,
+        pool: &Pool,
+        queue: &BuildQueue,
+    ) -> Result<Vec<MetricFamily>, Error> {
+        self.idle_db_connections.set(pool.idle_connections() as i64);
+        self.used_db_connections.set(pool.used_connections() as i64);
+        self.max_db_connections.set(pool.max_size() as i64);
+
+        self.queued_crates_count.set(queue.pending_count()? as i64);
+        self.prioritized_crates_count
+            .set(queue.prioritized_count()? as i64);
+        self.failed_crates_count.set(queue.failed_count()? as i64);
+
+        self.gather_system_performance();
+        Ok(self.registry.gather())
+    }
+
+    #[cfg(windows)]
+    fn gather_system_performance(&self) {}
+
+    #[cfg(not(windows))]
+    fn gather_system_performance(&self) {
+        use procfs::process::Process;
+
+        let process = Process::myself().unwrap();
+        self.open_file_descriptors
+            .set(process.fd().unwrap().len() as i64);
+        self.running_threads
+            .set(process.stat().unwrap().num_threads as i64);
+    }
+}

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -31,8 +31,10 @@ metrics! {
         pub(crate) failed_db_connections: IntCounter,
 
         /// The number of currently opened file descriptors
+        #[cfg(linux)]
         open_file_descriptors: IntGauge,
         /// The number of threads being used by docs.rs
+        #[cfg(linux)]
         running_threads: IntGauge,
 
         /// The traffic of various docs.rs routes
@@ -84,10 +86,10 @@ impl Metrics {
         Ok(self.registry.gather())
     }
 
-    #[cfg(windows)]
+    #[cfg(not(linux))]
     fn gather_system_performance(&self) {}
 
-    #[cfg(not(windows))]
+    #[cfg(linux)]
     fn gather_system_performance(&self) {
         use procfs::process::Process;
 

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -5,7 +5,7 @@ use self::macros::MetricFromOpts;
 use crate::db::Pool;
 use crate::BuildQueue;
 use failure::Error;
-use prometheus::{proto::MetricFamily, Opts, Registry};
+use prometheus::proto::MetricFamily;
 
 load_metric_type!(IntGauge as single);
 load_metric_type!(IntCounter as single);

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -3,8 +3,7 @@ mod fakes;
 use crate::db::{Pool, PoolClient};
 use crate::storage::Storage;
 use crate::web::Server;
-use crate::BuildQueue;
-use crate::Config;
+use crate::{BuildQueue, Config, Context};
 use failure::Error;
 use log::error;
 use once_cell::unsync::OnceCell;
@@ -215,6 +214,24 @@ impl TestEnvironment {
 
     pub(crate) fn fake_release(&self) -> fakes::FakeRelease {
         fakes::FakeRelease::new(self.db(), self.storage())
+    }
+}
+
+impl Context for TestEnvironment {
+    fn config(&self) -> Result<Arc<Config>, Error> {
+        Ok(TestEnvironment::config(self))
+    }
+
+    fn build_queue(&self) -> Result<Arc<BuildQueue>, Error> {
+        Ok(TestEnvironment::build_queue(self))
+    }
+
+    fn storage(&self) -> Result<Arc<Storage>, Error> {
+        Ok(TestEnvironment::storage(self))
+    }
+
+    fn pool(&self) -> Result<Pool, Error> {
+        Ok(self.db().pool())
     }
 }
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -185,9 +185,7 @@ impl TestEnvironment {
     }
 
     pub(crate) fn frontend(&self) -> &TestFrontend {
-        self.frontend.get_or_init(|| {
-            TestFrontend::new(self.db(), self.config(), self.build_queue(), self.storage())
-        })
+        self.frontend.get_or_init(|| TestFrontend::new(&*self))
     }
 
     pub(crate) fn s3(&self) -> Arc<Storage> {
@@ -314,22 +312,10 @@ pub(crate) struct TestFrontend {
 }
 
 impl TestFrontend {
-    fn new(
-        db: &TestDatabase,
-        config: Arc<Config>,
-        build_queue: Arc<BuildQueue>,
-        storage: Arc<Storage>,
-    ) -> Self {
+    fn new(context: &dyn Context) -> Self {
         Self {
-            server: Server::start(
-                Some("127.0.0.1:0"),
-                false,
-                db.pool.clone(),
-                config,
-                build_queue,
-                storage,
-            )
-            .expect("failed to start the web server"),
+            server: Server::start(Some("127.0.0.1:0"), false, context)
+                .expect("failed to start the web server"),
             client: Client::new(),
         }
     }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -218,7 +218,7 @@ impl TestEnvironment {
         self.storage_db
             .get_or_init(|| {
                 Arc::new(
-                    Storage::temp_new_db(self.db().pool())
+                    Storage::temp_new_db(self.db().pool(), self.metrics())
                         .expect("failed to initialize the storage"),
                 )
             })

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -21,7 +21,8 @@ fn start_registry_watcher(opts: DocBuilderOptions, context: &dyn Context) -> Res
             // space this out to prevent it from clashing against the queue-builder thread on launch
             thread::sleep(Duration::from_secs(30));
             loop {
-                let mut doc_builder = DocBuilder::new(opts.clone(), pool.clone(), build_queue.clone());
+                let mut doc_builder =
+                    DocBuilder::new(opts.clone(), pool.clone(), build_queue.clone());
 
                 if doc_builder.is_locked() {
                     debug!("Lock file exists, skipping checking new crates");
@@ -56,11 +57,12 @@ pub fn start_daemon(context: &dyn Context, enable_registry_watcher: bool) -> Res
     let pool = context.pool()?;
     let build_queue = context.build_queue()?;
     let storage = context.storage()?;
+    let metrics = context.metrics()?;
     thread::Builder::new()
         .name("build queue reader".to_string())
         .spawn(move || {
             let doc_builder = DocBuilder::new(dbopts.clone(), pool.clone(), build_queue.clone());
-            queue_builder(doc_builder, pool, build_queue, storage).unwrap();
+            queue_builder(doc_builder, pool, build_queue, metrics, storage).unwrap();
         })
         .unwrap();
 

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -6,7 +6,7 @@ use crate::{
     db::Pool,
     storage::Storage,
     utils::{queue_builder, update_release_activity, GithubUpdater},
-    BuildQueue, Config, DocBuilder, DocBuilderOptions,
+    Context, BuildQueue, Config, DocBuilder, DocBuilderOptions,
 };
 use chrono::{Timelike, Utc};
 use failure::Error;
@@ -47,6 +47,7 @@ fn start_registry_watcher(
 }
 
 pub fn start_daemon(
+    context: &dyn Context,
     config: Arc<Config>,
     db: Pool,
     build_queue: Arc<BuildQueue>,
@@ -110,7 +111,7 @@ pub fn start_daemon(
     // at least start web server
     info!("Starting web server");
 
-    crate::Server::start(None, false, db, config, build_queue, storage)?;
+    crate::Server::start(None, false, context)?;
     Ok(())
 }
 

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -3,31 +3,25 @@
 //! This daemon will start web server, track new packages and build them
 
 use crate::{
-    db::Pool,
-    storage::Storage,
     utils::{queue_builder, update_release_activity, GithubUpdater},
-    Context, BuildQueue, Config, DocBuilder, DocBuilderOptions,
+    Context, DocBuilder, DocBuilderOptions,
 };
 use chrono::{Timelike, Utc};
 use failure::Error;
 use log::{debug, error, info};
-use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-fn start_registry_watcher(
-    opts: DocBuilderOptions,
-    pool: Pool,
-    build_queue: Arc<BuildQueue>,
-) -> Result<(), Error> {
+fn start_registry_watcher(opts: DocBuilderOptions, context: &dyn Context) -> Result<(), Error> {
+    let pool = context.pool()?;
+    let build_queue = context.build_queue()?;
     thread::Builder::new()
         .name("registry index reader".to_string())
         .spawn(move || {
             // space this out to prevent it from clashing against the queue-builder thread on launch
             thread::sleep(Duration::from_secs(30));
             loop {
-                let mut doc_builder =
-                    DocBuilder::new(opts.clone(), pool.clone(), build_queue.clone());
+                let mut doc_builder = DocBuilder::new(opts.clone(), pool.clone(), build_queue.clone());
 
                 if doc_builder.is_locked() {
                     debug!("Lock file exists, skipping checking new crates");
@@ -46,14 +40,8 @@ fn start_registry_watcher(
     Ok(())
 }
 
-pub fn start_daemon(
-    context: &dyn Context,
-    config: Arc<Config>,
-    db: Pool,
-    build_queue: Arc<BuildQueue>,
-    storage: Arc<Storage>,
-    enable_registry_watcher: bool,
-) -> Result<(), Error> {
+pub fn start_daemon(context: &dyn Context, enable_registry_watcher: bool) -> Result<(), Error> {
+    let config = context.config()?;
     let dbopts = DocBuilderOptions::new(config.prefix.clone(), config.registry_index_path.clone());
 
     // check paths once
@@ -61,27 +49,23 @@ pub fn start_daemon(
 
     if enable_registry_watcher {
         // check new crates every minute
-        start_registry_watcher(dbopts.clone(), db.clone(), build_queue.clone())?;
+        start_registry_watcher(dbopts.clone(), context)?;
     }
 
     // build new crates every minute
-    let cloned_db = db.clone();
-    let cloned_build_queue = build_queue.clone();
-    let cloned_storage = storage.clone();
+    let pool = context.pool()?;
+    let build_queue = context.build_queue()?;
+    let storage = context.storage()?;
     thread::Builder::new()
         .name("build queue reader".to_string())
         .spawn(move || {
-            let doc_builder = DocBuilder::new(
-                dbopts.clone(),
-                cloned_db.clone(),
-                cloned_build_queue.clone(),
-            );
-            queue_builder(doc_builder, cloned_db, cloned_build_queue, cloned_storage).unwrap();
+            let doc_builder = DocBuilder::new(dbopts.clone(), pool.clone(), build_queue.clone());
+            queue_builder(doc_builder, pool, build_queue, storage).unwrap();
         })
         .unwrap();
 
     // update release activity everyday at 23:55
-    let cloned_db = db.clone();
+    let pool = context.pool()?;
     cron(
         "release activity updater",
         Duration::from_secs(60),
@@ -89,14 +73,14 @@ pub fn start_daemon(
             let now = Utc::now();
             if now.hour() == 23 && now.minute() == 55 {
                 info!("Updating release activity");
-                update_release_activity(&mut *cloned_db.get()?)?;
+                update_release_activity(&mut *pool.get()?)?;
             }
             Ok(())
         },
     )?;
 
     // update github stats every hour
-    let github_updater = GithubUpdater::new(&config, db.clone())?;
+    let github_updater = GithubUpdater::new(&config, context.pool()?)?;
     cron(
         "github stats updater",
         Duration::from_secs(60 * 60),
@@ -105,8 +89,6 @@ pub fn start_daemon(
             Ok(())
         },
     )?;
-
-    // TODO: update ssl certificate every 3 months
 
     // at least start web server
     info!("Starting web server");

--- a/src/utils/queue_builder.rs
+++ b/src/utils/queue_builder.rs
@@ -1,5 +1,6 @@
 use crate::{
-    db::Pool, docbuilder::RustwideBuilder, utils::pubsubhubbub, BuildQueue, DocBuilder, Storage,
+    db::Pool, docbuilder::RustwideBuilder, utils::pubsubhubbub, BuildQueue, DocBuilder, Metrics,
+    Storage,
 };
 use failure::Error;
 use log::{debug, error, info, warn};
@@ -13,6 +14,7 @@ pub fn queue_builder(
     mut doc_builder: DocBuilder,
     db: Pool,
     build_queue: Arc<BuildQueue>,
+    metrics: Arc<Metrics>,
     storage: Arc<Storage>,
 ) -> Result<(), Error> {
     /// Represents the current state of the builder thread.
@@ -28,7 +30,7 @@ pub fn queue_builder(
         QueueInProgress(usize),
     }
 
-    let mut builder = RustwideBuilder::init(db, storage)?;
+    let mut builder = RustwideBuilder::init(db, metrics, storage)?;
 
     let mut status = BuilderState::Fresh;
 

--- a/src/web/extensions.rs
+++ b/src/web/extensions.rs
@@ -1,5 +1,5 @@
 use crate::web::page::TemplateData;
-use crate::{db::Pool, BuildQueue, Config, Context, Storage};
+use crate::{db::Pool, BuildQueue, Config, Context, Metrics, Storage};
 use failure::Error;
 use iron::{BeforeMiddleware, IronResult, Request};
 use std::sync::Arc;
@@ -10,6 +10,7 @@ pub(super) struct InjectExtensions {
     pool: Pool,
     config: Arc<Config>,
     storage: Arc<Storage>,
+    metrics: Arc<Metrics>,
     template_data: Arc<TemplateData>,
 }
 
@@ -23,6 +24,7 @@ impl InjectExtensions {
             pool: context.pool()?,
             config: context.config()?,
             storage: context.storage()?,
+            metrics: context.metrics()?,
             template_data,
         })
     }
@@ -35,6 +37,7 @@ impl BeforeMiddleware for InjectExtensions {
         req.extensions.insert::<Pool>(self.pool.clone());
         req.extensions.insert::<Config>(self.config.clone());
         req.extensions.insert::<Storage>(self.storage.clone());
+        req.extensions.insert::<Metrics>(self.metrics.clone());
         req.extensions
             .insert::<TemplateData>(self.template_data.clone());
 
@@ -54,4 +57,5 @@ key!(BuildQueue => Arc<BuildQueue>);
 key!(Pool => Pool);
 key!(Config => Arc<Config>);
 key!(Storage => Arc<Storage>);
+key!(Metrics => Arc<Metrics>);
 key!(TemplateData => Arc<TemplateData>);

--- a/src/web/extensions.rs
+++ b/src/web/extensions.rs
@@ -1,18 +1,31 @@
-use crate::config::Config;
-use crate::db::Pool;
-use crate::storage::Storage;
 use crate::web::page::TemplateData;
-use crate::BuildQueue;
+use crate::{db::Pool, BuildQueue, Config, Context, Storage};
+use failure::Error;
 use iron::{BeforeMiddleware, IronResult, Request};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub(super) struct InjectExtensions {
-    pub(super) build_queue: Arc<BuildQueue>,
-    pub(super) pool: Pool,
-    pub(super) config: Arc<Config>,
-    pub(super) storage: Arc<Storage>,
-    pub(super) template_data: Arc<TemplateData>,
+    build_queue: Arc<BuildQueue>,
+    pool: Pool,
+    config: Arc<Config>,
+    storage: Arc<Storage>,
+    template_data: Arc<TemplateData>,
+}
+
+impl InjectExtensions {
+    pub(super) fn new(
+        context: &dyn Context,
+        template_data: Arc<TemplateData>,
+    ) -> Result<Self, Error> {
+        Ok(Self {
+            build_queue: context.build_queue()?,
+            pool: context.pool()?,
+            config: context.config()?,
+            storage: context.storage()?,
+            template_data,
+        })
+    }
 }
 
 impl BeforeMiddleware for InjectExtensions {

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -108,80 +108,32 @@ impl Drop for RenderingTimesRecorder<'_> {
 #[cfg(test)]
 mod tests {
     use crate::test::{assert_success, wrapper};
+    use std::collections::HashMap;
 
     #[test]
-    fn home_page() {
-        wrapper(|env| {
-            let frontend = env.frontend();
-            let metrics = env.metrics();
+    fn test_response_times_count_being_collected() {
+        const ROUTES: &[(&str, &str)] = &[
+            ("", "/"),
+            ("/", "/"),
+            ("/crate/hexponent/0.2.0", "/crate/:name/:version"),
+            ("/crate/rcc/0.0.0", "/crate/:name/:version"),
+            ("/index.js", "static resource"),
+            ("/menu.js", "static resource"),
+            ("/opensearch.xml", "static resource"),
+            ("/releases", "/releases"),
+            ("/releases/feed", "static resource"),
+            ("/releases/queue", "/releases/queue"),
+            ("/releases/recent-failures", "/releases/recent-failures"),
+            (
+                "/releases/recent-failures/1",
+                "/releases/recent-failures/:page",
+            ),
+            ("/releases/recent/1", "/releases/recent/:page"),
+            ("/robots.txt", "static resource"),
+            ("/sitemap.xml", "static resource"),
+            ("/style.css", "static resource"),
+        ];
 
-            frontend.get("/").send()?;
-            frontend.get("/").send()?;
-            assert_eq!(metrics.routes_visited.with_label_values(&["/"]).get(), 2);
-            assert_eq!(
-                metrics
-                    .response_time
-                    .with_label_values(&["/"])
-                    .get_sample_count(),
-                2
-            );
-
-            frontend.get("").send()?;
-            frontend.get("").send()?;
-            assert_eq!(metrics.routes_visited.with_label_values(&["/"]).get(), 4);
-            assert_eq!(
-                metrics
-                    .response_time
-                    .with_label_values(&["/"])
-                    .get_sample_count(),
-                4
-            );
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn resources() {
-        wrapper(|env| {
-            let frontend = env.frontend();
-            let metrics = env.metrics();
-
-            let routes = [
-                "/style.css",
-                "/index.js",
-                "/menu.js",
-                "/sitemap.xml",
-                "/opensearch.xml",
-                "/robots.txt",
-            ];
-
-            for route in routes.iter() {
-                frontend.get(route).send()?;
-                frontend.get(route).send()?;
-            }
-
-            assert_eq!(
-                metrics
-                    .routes_visited
-                    .with_label_values(&["static resource"])
-                    .get(),
-                12
-            );
-            assert_eq!(
-                metrics
-                    .response_time
-                    .with_label_values(&["static resource"])
-                    .get_sample_count(),
-                12
-            );
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn releases() {
         wrapper(|env| {
             env.fake_release()
                 .name("rcc")
@@ -193,47 +145,6 @@ mod tests {
                 .version("1.0.0")
                 .build_result_successful(false)
                 .create()?;
-
-            let frontend = env.frontend();
-            let metrics = env.metrics();
-
-            let routes = [
-                ("/releases", "/releases"),
-                ("/releases/recent/1", "/releases/recent/:page"),
-                ("/releases/feed", "static resource"),
-                ("/releases/queue", "/releases/queue"),
-                ("/releases/recent-failures", "/releases/recent-failures"),
-                (
-                    "/releases/recent-failures/1",
-                    "/releases/recent-failures/:page",
-                ),
-            ];
-
-            for (route, correct) in routes.iter() {
-                frontend.get(route).send()?;
-                frontend.get(route).send()?;
-
-                assert_eq!(
-                    metrics.routes_visited.with_label_values(&[*correct]).get(),
-                    2
-                );
-                assert_eq!(
-                    metrics
-                        .response_time
-                        .with_label_values(&[*correct])
-                        .get_sample_count(),
-                    2
-                );
-            }
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn crates() {
-        wrapper(|env| {
-            env.fake_release().name("rcc").version("0.0.0").create()?;
             env.fake_release()
                 .name("hexponent")
                 .version("0.2.0")
@@ -242,34 +153,37 @@ mod tests {
             let frontend = env.frontend();
             let metrics = env.metrics();
 
-            let routes = ["/crate/rcc/0.0.0", "/crate/hexponent/0.2.0"];
-
-            for route in routes.iter() {
+            for (route, _) in ROUTES.iter() {
                 frontend.get(route).send()?;
                 frontend.get(route).send()?;
             }
 
-            assert_eq!(
-                metrics
-                    .routes_visited
-                    .with_label_values(&["/crate/:name/:version"])
-                    .get(),
-                4
-            );
-            assert_eq!(
-                metrics
-                    .response_time
-                    .with_label_values(&["/crate/:name/:version"])
-                    .get_sample_count(),
-                4
-            );
+            let mut expected = HashMap::new();
+            for (_, correct) in ROUTES.iter() {
+                let entry = expected.entry(*correct).or_insert(0);
+                *entry += 2;
+            }
+
+            for (label, count) in expected.iter() {
+                assert_eq!(
+                    metrics.routes_visited.with_label_values(&[*label]).get(),
+                    *count
+                );
+                assert_eq!(
+                    metrics
+                        .response_time
+                        .with_label_values(&[*label])
+                        .get_sample_count(),
+                    *count as u64
+                );
+            }
 
             Ok(())
         })
     }
 
     #[test]
-    fn metrics() {
+    fn test_metrics_page_success() {
         wrapper(|env| {
             let web = env.frontend();
             assert_success("/about/metrics", web)

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -403,14 +403,6 @@ impl Server {
         template_data: Arc<TemplateData>,
         context: &dyn Context,
     ) -> Result<Self, Error> {
-        // poke all the metrics counters to instantiate and register them
-        metrics::TOTAL_BUILDS.inc_by(0);
-        metrics::SUCCESSFUL_BUILDS.inc_by(0);
-        metrics::FAILED_BUILDS.inc_by(0);
-        metrics::NON_LIBRARY_BUILDS.inc_by(0);
-        metrics::UPLOADED_FILES_TOTAL.inc_by(0);
-        metrics::FAILED_DB_CONNECTIONS.inc_by(0);
-
         let cratesfyi = CratesfyiHandler::new(template_data, context)?;
         let inner = Iron::new(cratesfyi)
             .http(addr)

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -77,7 +77,7 @@ mod rustdoc;
 mod sitemap;
 mod source;
 
-use crate::{config::Config, db::Pool, impl_webpage, BuildQueue, Storage};
+use crate::{impl_webpage, Context};
 use chrono::{DateTime, Utc};
 use extensions::InjectExtensions;
 use failure::Error;
@@ -123,19 +123,10 @@ impl CratesfyiHandler {
     }
 
     fn new(
-        pool: Pool,
-        config: Arc<Config>,
         template_data: Arc<TemplateData>,
-        build_queue: Arc<BuildQueue>,
-        storage: Arc<Storage>,
-    ) -> CratesfyiHandler {
-        let inject_extensions = InjectExtensions {
-            build_queue,
-            pool,
-            config,
-            storage,
-            template_data,
-        };
+        context: &dyn Context,
+    ) -> Result<CratesfyiHandler, Error> {
+        let inject_extensions = InjectExtensions::new(context, template_data)?;
 
         let routes = routes::build_routes();
         let blacklisted_prefixes = routes.page_prefixes();
@@ -151,7 +142,7 @@ impl CratesfyiHandler {
         let static_handler =
             Static::new(prefix).cache(Duration::from_secs(STATIC_FILE_CACHE_DURATION));
 
-        CratesfyiHandler {
+        Ok(CratesfyiHandler {
             shared_resource_handler: Box::new(shared_resources),
             router_handler: Box::new(router_chain),
             database_file_handler: Box::new(routes::BlockBlacklistedPrefixes::new(
@@ -160,7 +151,7 @@ impl CratesfyiHandler {
             )),
             static_handler: Box::new(static_handler),
             inject_extensions,
-        }
+        })
     }
 }
 
@@ -394,37 +385,24 @@ impl Server {
     pub fn start(
         addr: Option<&str>,
         reload_templates: bool,
-        db: Pool,
-        config: Arc<Config>,
-        build_queue: Arc<BuildQueue>,
-        storage: Arc<Storage>,
+        context: &dyn Context,
     ) -> Result<Self, Error> {
         // Initialize templates
-        let template_data = Arc::new(TemplateData::new(&mut *db.get()?)?);
+        let template_data = Arc::new(TemplateData::new(&mut *context.pool()?.get()?)?);
         if reload_templates {
-            TemplateData::start_template_reloading(template_data.clone(), db.clone());
+            TemplateData::start_template_reloading(template_data.clone(), context.pool()?);
         }
 
-        let server = Self::start_inner(
-            addr.unwrap_or(DEFAULT_BIND),
-            db,
-            config,
-            template_data,
-            build_queue,
-            storage,
-        );
+        let server = Self::start_inner(addr.unwrap_or(DEFAULT_BIND), template_data, context)?;
         info!("Running docs.rs web server on http://{}", server.addr());
         Ok(server)
     }
 
     fn start_inner(
         addr: &str,
-        pool: Pool,
-        config: Arc<Config>,
         template_data: Arc<TemplateData>,
-        build_queue: Arc<BuildQueue>,
-        storage: Arc<Storage>,
-    ) -> Self {
+        context: &dyn Context,
+    ) -> Result<Self, Error> {
         // poke all the metrics counters to instantiate and register them
         metrics::TOTAL_BUILDS.inc_by(0);
         metrics::SUCCESSFUL_BUILDS.inc_by(0);
@@ -433,12 +411,12 @@ impl Server {
         metrics::UPLOADED_FILES_TOTAL.inc_by(0);
         metrics::FAILED_DB_CONNECTIONS.inc_by(0);
 
-        let cratesfyi = CratesfyiHandler::new(pool, config, template_data, build_queue, storage);
+        let cratesfyi = CratesfyiHandler::new(template_data, context)?;
         let inner = Iron::new(cratesfyi)
             .http(addr)
             .unwrap_or_else(|_| panic!("Failed to bind to socket on {}", addr));
 
-        Server { inner }
+        Ok(Server { inner })
     }
 
     pub(crate) fn addr(&self) -> SocketAddr {


### PR DESCRIPTION
This PR does three things:

* Creates a `Context` trait, allowing to pass multiple "components" of docs.rs around without adding countless function params all around the codebase.
* Adds a new `Metrics` struct which replaces the lazy statics. This has the side effect of making `cargo test` work when running it in parallel :tada:, and allows testing that metrics are properly recorded.
* Adds a couple metrics tests around the codebase.

This PR is best reviewed commit-by-commit.