### PR TITLE
Improve the styling of the coverage in the dropdown

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -668,14 +668,6 @@ mod test {
         node.select("#clipboard").unwrap().count() == 1
     }
 
-    fn check_doc_coverage_is_present_for_path(path: &str, web: &TestFrontend) -> bool {
-        let data = web.get(path).send().unwrap().text().unwrap();
-        let node = kuchiki::parse_html().one(data);
-        node.select(".pure-menu-heading")
-            .unwrap()
-            .any(|e| e.text_contents().contains("Coverage"))
-    }
-
     #[test]
     fn test_index_returns_success() {
         wrapper(|env| {
@@ -689,20 +681,27 @@ mod test {
     fn test_doc_coverage_for_crate_pages() {
         wrapper(|env| {
             env.fake_release()
-                .name("fake_crate")
+                .name("foo")
                 .version("0.0.1")
                 .source_file("test.rs", &[])
-                .create()
-                .unwrap();
+                .coverage(6, 10)
+                .create()?;
             let web = env.frontend();
-            assert!(check_doc_coverage_is_present_for_path(
-                "/crate/fake_crate/0.0.1",
-                web
-            ));
-            assert!(check_doc_coverage_is_present_for_path(
-                "/fake_crate/0.0.1/fake_crate",
-                web
-            ));
+
+            let foo_crate = kuchiki::parse_html().one(web.get("/crate/foo/0.0.1").send()?.text()?);
+            for value in &["60%", "6", "10"] {
+                assert!(foo_crate
+                    .select(".pure-menu-item b")
+                    .unwrap()
+                    .any(|e| e.text_contents().contains(value)));
+            }
+
+            let foo_doc = kuchiki::parse_html().one(web.get("/foo/0.0.1/foo").send()?.text()?);
+            assert!(foo_doc
+                .select(".pure-menu-link b")
+                .unwrap()
+                .any(|e| e.text_contents().contains("60%")));
+
             Ok(())
         });
     }

--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -19,7 +19,7 @@
                         {%- if details.documented_items and details.total_items -%}
                             {% set percent = details.documented_items * 100 / details.total_items %}
                             <li class="pure-menu-heading">Coverage</li>
-                            <li class="pure-menu-item" style="text-align:center;"><b>{{ percent | round(precision=2) }} %</b><br>
+                            <li class="pure-menu-item" style="text-align:center;"><b>{{ percent | round(precision=2) }}%</b><br>
                                 <span style="font-size: 13px;"><b>{{ details.documented_items }}</b> out of <b>{{ details.total_items }}</b> items documented</span>
                             </li>
                         {%- endif -%}

--- a/templates/rustdoc/body.html
+++ b/templates/rustdoc/body.html
@@ -117,21 +117,7 @@
                                 </div>
                             </div>
 
-                            {%- if krate.documented_items and krate.total_items -%}
-                                {% set percent = krate.documented_items * 100 / krate.total_items %}
-                                <div class="pure-g menu-item-divided">
-                                    <div class="pure-u-1">
-                                        <ul class="pure-menu-list">
-                                            <li class="pure-menu-heading">Coverage</li>
-                                            <li class="pure-menu-link"><b>{{ percent | round(precision=2) }} %</b><br>
-                                                <span><b>{{ krate.documented_items }}</b> out of <b>{{ krate.total_items }}</b> items documented</span>
-                                            </li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            {%- endif -%}
-
-                            <div class="pure-g">
+                            <div class="pure-g menu-item-divided">
                                 <div class="pure-u-1-2 right-border">
                                     <ul class="pure-menu-list">
                                         <li class="pure-menu-heading">Dependencies</li>
@@ -169,6 +155,21 @@
                                     </ul>
                                 </div>
                             </div>
+                            {%- if krate.documented_items and krate.total_items -%}
+                                {% set percent = krate.documented_items * 100 / krate.total_items %}
+                                <div class="pure-g">
+                                    <div class="pure-u-1">
+                                        <ul class="pure-menu-list">
+                                            <li>
+                                                <a href="{{ crate_url | safe }}" class="pure-menu-link">
+                                                    <b>{{ percent | round(precision=2) }}%</b>
+                                                    of the crate is documented
+                                                </a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            {%- endif -%}
                         </div>
                     </li>
 


### PR DESCRIPTION
New styling (the text is clickable and leads to the crate page):

![2020-08-12--23-24-00](https://user-images.githubusercontent.com/2299951/90069965-60f42c80-dcf3-11ea-9d65-d58858d360c1.png)

r? @GuillaumeGomez 
cc @yaahc @sunjay