### PR TITLE
Rust dropdown now directly links to rust-lang.org (#959)

### DIFF
--- a/templates/header/topbar.html
+++ b/templates/header/topbar.html
@@ -53,15 +53,9 @@
 
                     {# The Rust dropdown menu #}
                     <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
-                        <a href="#" class="pure-menu-link">Rust</a>
+                        <a href="https://www.rust-lang.org/" target="_blank" class="pure-menu-link">Rust</a>
 
                         <ul class="pure-menu-children">
-                            {{ macros::menu_link(
-                                href="https://www.rust-lang.org/",
-                                text="The Rust Programming Language",
-                                target="_blank"
-                            ) }}
-
                             {{ macros::menu_link(
                                 href="https://doc.rust-lang.org/book/",
                                 text="The Book",


### PR DESCRIPTION
* Rust topbar dropdown now directly links to https://www.rust-lang.org/
* Removed "The Rust Programming Language" link 

![dropdown_rs](https://user-images.githubusercontent.com/10987380/90158917-a64d4400-dd5d-11ea-8041-1577f3aeb5d9.gif)

Closes #959 