### PR TITLE
Retain crate details padding on mobile screens

### DIFF
--- a/templates/style/base.scss
+++ b/templates/style/base.scss
@@ -359,7 +359,7 @@ div.package-page-container {
     }
 
     div.package-details {
-        padding: 0 1em;
+        padding: 0 1em !important;
         font-family: $font-family-serif;
 
         a {


### PR DESCRIPTION
On mobile screens, package-details padding was being overriden. This resulted in the README section of crate details having 0 padding.

![css_pr](https://user-images.githubusercontent.com/10987380/90216157-d29fa980-ddcb-11ea-83d8-5946e2c5c755.gif)


Closes #962 