### PR TITLE
Don't create a duplicate title on rustdoc pages

### DIFF
--- a/templates/rustdoc/head.html
+++ b/templates/rustdoc/head.html
@@ -7,5 +7,3 @@
         <link rel="stylesheet" href="/style.css?{{ docsrs_version() | slugify }}" type="text/css" media="all" />
 
         <link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="Docs.rs">
-
-        <title>{{ macros::doc_title(name=krate.name, version=krate.version) }}</title>


### PR DESCRIPTION
Since the LOL HTML rewrite, we show both the rustdoc title and the
docs.rs title. We should only show the rustdoc title.

Closes #971 
r? @Kixiron 