### PR TITLE
Improve logging & cexpect BuildPage.metadata

### DIFF
--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -26,7 +26,7 @@ pub(crate) struct Build {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct BuildsPage {
-    metadata: Option<MetaData>,
+    metadata: MetaData,
     builds: Vec<Build>,
     build_details: Option<Build>,
     limits: Limits,
@@ -59,11 +59,11 @@ pub fn build_list_handler(req: &mut Request) -> IronResult<Response> {
                 builds.build_status,
                 builds.build_time,
                 builds.output
-         FROM builds
-         INNER JOIN releases ON releases.id = builds.rid
-         INNER JOIN crates ON releases.crate_id = crates.id
-         WHERE crates.name = $1 AND releases.version = $2
-         ORDER BY id DESC",
+             FROM builds
+             INNER JOIN releases ON releases.id = builds.rid
+             INNER JOIN crates ON releases.crate_id = crates.id
+             WHERE crates.name = $1 AND releases.version = $2
+             ORDER BY id DESC",
             &[&name, &version]
         )
     );
@@ -111,7 +111,7 @@ pub fn build_list_handler(req: &mut Request) -> IronResult<Response> {
         Ok(resp)
     } else {
         BuildsPage {
-            metadata: MetaData::from_crate(&mut conn, &name, &version),
+            metadata: cexpect!(req, MetaData::from_crate(&mut conn, &name, &version)),
             builds,
             build_details,
             limits,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -6,12 +6,23 @@ use log::{debug, info};
 
 /// ctry! (cratesfyitry) is extremely similar to try! and itry!
 /// except it returns an error page response instead of plain Err.
+#[macro_export]
 macro_rules! ctry {
     ($req:expr, $result:expr $(,)?) => {
         match $result {
             Ok(success) => success,
             Err(error) => {
-                ::log::error!("{}\n{:?}", error, ::backtrace::Backtrace::new());
+                let request: &::iron::Request = $req;
+
+                ::log::error!(
+                    "called ctry!() on an `Err` value in {}:{}:{}: {}\nclient attempted to fetch the route {:?}\n{:?}",
+                    file!(),
+                    line!(),
+                    column!(),
+                    error,
+                    request.url,
+                    ::backtrace::Backtrace::new(),
+                );
 
                 // This is very ugly, but it makes it impossible to get a type inference error
                 // from this macro
@@ -23,7 +34,7 @@ macro_rules! ctry {
                     status: ::iron::status::BadRequest,
                 };
 
-                return $crate::web::page::WebPage::into_response(error, $req);
+                return $crate::web::page::WebPage::into_response(error, request);
             }
         }
     };
@@ -36,8 +47,14 @@ macro_rules! cexpect {
         match $option {
             Some(success) => success,
             None => {
+                let request: &::iron::Request = $req;
+
                 ::log::error!(
-                    "called cexpect!() on a `None` value\n{:?}",
+                    "called cexpect!() on a `None` value in {}:{}:{}\nclient attempted to fetch the route {:?}\n{:?}",
+                    file!(),
+                    line!(),
+                    column!(),
+                    request.url,
                     ::backtrace::Backtrace::new(),
                 );
 
@@ -49,7 +66,7 @@ macro_rules! cexpect {
                     status: ::iron::status::BadRequest,
                 };
 
-                return $crate::web::page::WebPage::into_response(error, $req);
+                return $crate::web::page::WebPage::into_response(error, request);
             }
         }
     };

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -15,7 +15,7 @@ macro_rules! ctry {
                 let request: &::iron::Request = $req;
 
                 ::log::error!(
-                    "called ctry!() on an `Err` value while attempting to fetch the route {:?}\n{:?}",
+                    "called ctry!() on an `Err` value: {}\nnote: while attempting to fetch the route {:?}\n{:?}",
                     error,
                     request.url,
                     ::backtrace::Backtrace::new(),

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -15,10 +15,7 @@ macro_rules! ctry {
                 let request: &::iron::Request = $req;
 
                 ::log::error!(
-                    "called ctry!() on an `Err` value in {}:{}:{}: {}\nclient attempted to fetch the route {:?}\n{:?}",
-                    file!(),
-                    line!(),
-                    column!(),
+                    "called ctry!() on an `Err` value while attempting to fetch the route {:?}\n{:?}",
                     error,
                     request.url,
                     ::backtrace::Backtrace::new(),
@@ -50,10 +47,7 @@ macro_rules! cexpect {
                 let request: &::iron::Request = $req;
 
                 ::log::error!(
-                    "called cexpect!() on a `None` value in {}:{}:{}\nclient attempted to fetch the route {:?}\n{:?}",
-                    file!(),
-                    line!(),
-                    column!(),
+                    "called cexpect!() on a `None` value while attempting to fetch the route {:?}\n{:?}",
                     request.url,
                     ::backtrace::Backtrace::new(),
                 );


### PR DESCRIPTION
Fixes random panics with build pages, changes `WebPage::into_response` to use `cexpect` instead of `.unwrap()` and adds file locations and the requested route to `ctry`/`cexpect` logging

Closes #969