### PR TITLE
Allow the site to load even if the external CSS does not

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -9,20 +9,11 @@
         <meta name="generator" content="docs.rs {{ docsrs_version() }}">
         {%- block meta -%}{%- endblock meta -%}
 
-        {# External styles #}
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/pure-min.css" type="text/css"
-            media="all" />
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/grids-responsive-min.css"
-            type="text/css" media="all" />
-        <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.14.0/css/all.css" />
-
         {# Docs.rs styles #}
         <link rel="stylesheet" href="/normalize-{{ rustc_resource_suffix() }}.css" type="text/css" media="all" />
         <link rel="stylesheet" href="/rustdoc-{{ rustc_resource_suffix() }}.css" type="text/css" media="all" />
         <link rel="stylesheet" href="/light-{{ rustc_resource_suffix() }}.css" type="text/css" media="all" />
         <link rel="stylesheet" href="/style.css?{{ docsrs_version() | slugify }}" type="text/css" media="all" />
-
-        {%- block css -%}{%- endblock css -%}
 
         <link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="Docs.rs">
 
@@ -30,16 +21,20 @@
     </head>
 
     <body>
+        {# External styles, loaded in the body so the site will be available even if these don't load #}
+        {%- block css -%}{%- endblock css -%}
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/pure-min.css" type="text/css"
+            media="all" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/grids-responsive-min.css"
+            type="text/css" media="all" />
+        <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.14.0/css/all.css" />
+
         {%- include "header/topbar.html" -%}
-
         {%- block header %}{% endblock header -%}
-
         {%- block body -%}{%- endblock body -%}
+
+        <script type="text/javascript" src="/menu.js?{{ docsrs_version() | slugify }}"></script>
+        <script type="text/javascript" src="/index.js?{{ docsrs_version() | slugify }}"></script>
+        {%- block javascript -%}{%- endblock javascript -%}
     </body>
-
-    <script type="text/javascript" src="/menu.js?{{ docsrs_version() | slugify }}"></script>
-    <script type="text/javascript" src="/index.js?{{ docsrs_version() | slugify }}"></script>
-
-    {%- block javascript -%}{%- endblock javascript -%}
-
 </html>

--- a/templates/rustdoc/body.html
+++ b/templates/rustdoc/body.html
@@ -3,6 +3,13 @@
 {# The url of the current release, `/crate/:name/:version` #}
 {%- set crate_url = "/crate/" ~ krate.name ~ "/" ~ krate.version -%}
 
+{# Load CSS in the body, not the head, so that pages will still be visible even if the external provider goes down #}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/menus-min.css" type="text/css"
+    media="all" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/grids-min.css" type="text/css"
+    media="all" />
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.14.0/css/all.css" />
+
 <div class="nav-container nav-container-rustdoc">
     <div class="container-rustdoc rustdoc-navigation">
         <div class="pure-menu pure-menu-horizontal">

--- a/templates/rustdoc/head.html
+++ b/templates/rustdoc/head.html
@@ -1,9 +1,3 @@
 {%- import "macros.html" as macros -%}
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/menus-min.css" type="text/css"
-            media="all" />
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/grids-min.css" type="text/css"
-            media="all" />
-        <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.14.0/css/all.css" />
         <link rel="stylesheet" href="/style.css?{{ docsrs_version() | slugify }}" type="text/css" media="all" />
-
         <link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="Docs.rs">


### PR DESCRIPTION
Our external CSS is only used for the header bar and a few other things - the site will look ugly without, but the rustdoc pages should still be usable.

This also changes several `<script>` tags to be inside the body, since
it's invalid for them to come after: 
![script](https://user-images.githubusercontent.com/23638587/90335396-c752a680-dfa2-11ea-8ad8-d9832d64cc3c.png)

Partially addresses #979, cc @Byron. I can set up a staging server in a little bit so you can verify this actually helps.