### PR TITLE
Move the rest of Storage over to Config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
         environment:
             CRATESFYI_RUSTWIDE_WORKSPACE: /opt/docsrs/rustwide
             CRATESFYI_DATABASE_URL: postgresql://cratesfyi:password@db
+            DOCSRS_STORAGE_BACKEND: s3
             S3_ENDPOINT: http://s3:9000
             AWS_ACCESS_KEY_ID: cratesfyi
             AWS_SECRET_ACCESS_KEY: secret_key

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::storage::StorageBackendKind;
 use failure::{bail, format_err, Error, Fail, ResultExt};
 use std::env::VarError;
 use std::path::PathBuf;
@@ -15,6 +16,9 @@ pub struct Config {
     pub(crate) database_url: String,
     pub(crate) max_pool_size: u32,
     pub(crate) min_pool_idle: u32,
+
+    // Storage params
+    pub(crate) storage_backend: StorageBackendKind,
 
     // S3 params
     pub(crate) s3_bucket: String,
@@ -47,6 +51,8 @@ impl Config {
             database_url: require_env("CRATESFYI_DATABASE_URL")?,
             max_pool_size: env("DOCSRS_MAX_POOL_SIZE", 90)?,
             min_pool_idle: env("DOCSRS_MIN_POOL_IDLE", 10)?,
+
+            storage_backend: env("DOCSRS_STORAGE_BACKEND", StorageBackendKind::Database)?,
 
             s3_bucket: env("DOCSRS_S3_BUCKET", "rust-docs-rs".to_string())?,
             // DO NOT CONFIGURE THIS THROUGH AN ENVIRONMENT VARIABLE!

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::storage::StorageBackendKind;
+use crate::storage::StorageKind;
 use failure::{bail, format_err, Error, Fail, ResultExt};
 use rusoto_core::Region;
 use std::env::VarError;
@@ -19,7 +19,7 @@ pub struct Config {
     pub(crate) min_pool_idle: u32,
 
     // Storage params
-    pub(crate) storage_backend: StorageBackendKind,
+    pub(crate) storage_backend: StorageKind,
 
     // S3 params
     pub(crate) s3_bucket: String,
@@ -55,7 +55,7 @@ impl Config {
             max_pool_size: env("DOCSRS_MAX_POOL_SIZE", 90)?,
             min_pool_idle: env("DOCSRS_MIN_POOL_IDLE", 10)?,
 
-            storage_backend: env("DOCSRS_STORAGE_BACKEND", StorageBackendKind::Database)?,
+            storage_backend: env("DOCSRS_STORAGE_BACKEND", StorageKind::Database)?,
 
             s3_bucket: env("DOCSRS_S3_BUCKET", "rust-docs-rs".to_string())?,
             s3_region: env("S3_REGION", Region::UsWest1)?,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use crate::storage::StorageBackendKind;
 use failure::{bail, format_err, Error, Fail, ResultExt};
+use rusoto_core::Region;
 use std::env::VarError;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -22,6 +23,8 @@ pub struct Config {
 
     // S3 params
     pub(crate) s3_bucket: String,
+    pub(crate) s3_region: Region,
+    pub(crate) s3_endpoint: Option<String>,
     #[cfg(test)]
     pub(crate) s3_bucket_is_temporary: bool,
 
@@ -55,6 +58,8 @@ impl Config {
             storage_backend: env("DOCSRS_STORAGE_BACKEND", StorageBackendKind::Database)?,
 
             s3_bucket: env("DOCSRS_S3_BUCKET", "rust-docs-rs".to_string())?,
+            s3_region: env("S3_REGION", Region::UsWest1)?,
+            s3_endpoint: maybe_env("S3_ENDPOINT")?,
             // DO NOT CONFIGURE THIS THROUGH AN ENVIRONMENT VARIABLE!
             // Accidentally turning this on outside of the test suite might cause data loss in the
             // production environment.

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -105,11 +105,9 @@ impl Storage {
                 StorageBackendKind::Database => {
                     StorageBackend::Database(DatabaseBackend::new(pool, metrics))
                 }
-                StorageBackendKind::S3 => StorageBackend::S3(Box::new(S3Backend::new(
-                    s3::s3_client().unwrap(),
-                    metrics,
-                    config,
-                )?)),
+                StorageBackendKind::S3 => {
+                    StorageBackend::S3(Box::new(S3Backend::new(metrics, config)?))
+                }
             },
         })
     }

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -262,7 +262,7 @@ impl<'a> StorageTransaction for S3StorageTransaction<'a> {
                     failure::bail!("deleting from s3 failed");
                 }
 
-                continuation_token = list.continuation_token;
+                continuation_token = list.next_continuation_token;
                 if continuation_token.is_none() {
                     return Ok(());
                 }

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -39,7 +39,7 @@ impl S3Backend {
                     name: config.s3_region.name().to_string(),
                     endpoint: endpoint.to_string(),
                 })
-                .unwrap_or(config.s3_region.clone()),
+                .unwrap_or_else(|| config.s3_region.clone()),
         );
 
         #[cfg(test)]

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -98,8 +98,6 @@ pub(crate) struct TestEnvironment {
     storage: OnceCell<Arc<Storage>>,
     metrics: OnceCell<Arc<Metrics>>,
     frontend: OnceCell<TestFrontend>,
-    s3: OnceCell<Arc<Storage>>,
-    storage_db: OnceCell<Arc<Storage>>,
 }
 
 pub(crate) fn init_logger() {
@@ -119,8 +117,6 @@ impl TestEnvironment {
             storage: OnceCell::new(),
             metrics: OnceCell::new(),
             frontend: OnceCell::new(),
-            s3: OnceCell::new(),
-            storage_db: OnceCell::new(),
         }
     }
 
@@ -201,28 +197,6 @@ impl TestEnvironment {
 
     pub(crate) fn frontend(&self) -> &TestFrontend {
         self.frontend.get_or_init(|| TestFrontend::new(&*self))
-    }
-
-    pub(crate) fn s3(&self) -> Arc<Storage> {
-        self.s3
-            .get_or_init(|| {
-                Arc::new(
-                    Storage::temp_new_s3(self.metrics(), &*self.config())
-                        .expect("failed to initialize the storage"),
-                )
-            })
-            .clone()
-    }
-
-    pub(crate) fn temp_storage_db(&self) -> Arc<Storage> {
-        self.storage_db
-            .get_or_init(|| {
-                Arc::new(
-                    Storage::temp_new_db(self.db().pool(), self.metrics())
-                        .expect("failed to initialize the storage"),
-                )
-            })
-            .clone()
     }
 
     pub(crate) fn fake_release(&self) -> fakes::FakeRelease {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,7 +1,7 @@
 mod fakes;
 
 use crate::db::{Pool, PoolClient};
-use crate::storage::Storage;
+use crate::storage::{Storage, StorageBackendKind};
 use crate::web::Server;
 use crate::{BuildQueue, Config, Context, Metrics};
 use failure::Error;
@@ -137,6 +137,9 @@ impl TestEnvironment {
         // Use less connections for each test compared to production.
         config.max_pool_size = 2;
         config.min_pool_idle = 0;
+
+        // Use the database for storage, as it's faster than S3.
+        config.storage_backend = StorageBackendKind::Database;
 
         // Use a temporary S3 bucket.
         config.s3_bucket = format!("docsrs-test-bucket-{}", rand::random::<u64>());

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,7 +1,7 @@
 mod fakes;
 
 use crate::db::{Pool, PoolClient};
-use crate::storage::{Storage, StorageBackendKind};
+use crate::storage::{Storage, StorageKind};
 use crate::web::Server;
 use crate::{BuildQueue, Config, Context, Metrics};
 use failure::Error;
@@ -139,7 +139,7 @@ impl TestEnvironment {
         config.min_pool_idle = 0;
 
         // Use the database for storage, as it's faster than S3.
-        config.storage_backend = StorageBackendKind::Database;
+        config.storage_backend = StorageKind::Database;
 
         // Use a temporary S3 bucket.
         config.s3_bucket = format!("docsrs-test-bucket-{}", rand::random::<u64>());


### PR DESCRIPTION
This PR moves the rest of the parameters of `Storage` over to `Config`: after this is done there is only one refactoring left before implementing build tests! Changes here:

* Instead of being detected automatically, the storage backend is now configured through the `DOCSRS_STORAGE_BACKEND` environment variable. If the variable is not present, the `database` backend will be used.
* During tests the `database` backend is hardcoded, even if the environment variable is set to `s3`: running tests with the database is faster, and the new unified storage tests are giving us the confidence that the two backends work the same way.
* `S3_REGION` and `S3_ENDPOINT` are moved to `Config`.

Note that `Config` won't contain the AWS credentials: it's better to rely on `DefaultCredentialsProvider`, as it also handle fetching credentials from other sources (for example, in production we use the EC2 Metadata Service to obtain temporary credentials for the `docsrs` AWS IAM Role).

**WARNING:** before deploying this to production, we'll need to add `DOCSRS_STORAGE_BACKEND=s3` to the environment variables.