### PR TITLE
Add metrics tracking number of recently loaded crates/versions/platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,6 +709,8 @@ dependencies = [
  "serde",
  "serde_json",
  "slug",
+ "string_cache",
+ "string_cache_codegen",
  "structopt",
  "strum",
  "systemstat",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +335,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
+dependencies = [
+ "getrandom",
+ "proc-macro-hack",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +594,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "3.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f260e2fc850179ef410018660006951c1b55b79e8087e87111a2c388994b9b5"
+dependencies = [
+ "ahash",
+ "cfg-if",
+ "num_cpus",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +673,7 @@ dependencies = [
  "crates-index",
  "crates-index-diff",
  "criterion",
+ "dashmap",
  "docsrs-metadata",
  "dotenv",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ base64 = "0.12.1"
 strum = { version = "0.18.0", features = ["derive"] }
 lol_html = "0.2"
 font-awesome-as-a-crate = { path = "crates/font-awesome-as-a-crate" }
+dashmap = "3.11.10"
 
 # Async
 tokio = { version = "0.2.22", features = ["rt-threaded"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ strum = { version = "0.18.0", features = ["derive"] }
 lol_html = "0.2"
 font-awesome-as-a-crate = { path = "crates/font-awesome-as-a-crate" }
 dashmap = "3.11.10"
+string_cache = "0.8.0"
 
 # Async
 tokio = { version = "0.2.22", features = ["rt-threaded"] }
@@ -98,6 +99,7 @@ rand = "0.7.3"
 time = "0.1"
 git2 = { version = "0.13", default-features = false }
 sass-rs = "0.2.2"
+string_cache_codegen = "0.5.1"
 
 [[bench]]
 name = "html_parsing"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,13 @@ mod test;
 pub mod utils;
 mod web;
 
+#[allow(dead_code)]
+mod target {
+    //! [`crate::target::TargetAtom`] is an interned string type for rustc targets, such as
+    //! `x86_64-unknown-linux-gnu`. See the [`string_cache`] docs for usage examples.
+    include!(concat!(env!("OUT_DIR"), "/target_atom.rs"));
+}
+
 use web::page::GlobalAlert;
 
 // Warning message shown in the navigation bar of every page. Set to `None` to hide it.

--- a/src/metrics/macros.rs
+++ b/src/metrics/macros.rs
@@ -20,7 +20,7 @@ macro_rules! metrics {
                 $(#[$meta])*
                 $metric_vis $metric: $ty,
             )*
-            pub(crate) recent_releases: RecentReleases,
+            pub(crate) recently_accessed_releases: RecentlyAccessedReleases,
         }
         impl $name {
             $vis fn new() -> Result<Self, prometheus::Error> {
@@ -37,7 +37,7 @@ macro_rules! metrics {
                 )*
                 Ok(Self {
                     registry,
-                    recent_releases: RecentReleases::new(),
+                    recently_accessed_releases: RecentlyAccessedReleases::new(),
                     $(
                         $(#[$meta])*
                         $metric,

--- a/src/metrics/macros.rs
+++ b/src/metrics/macros.rs
@@ -20,6 +20,7 @@ macro_rules! metrics {
                 $(#[$meta])*
                 $metric_vis $metric: $ty,
             )*
+            pub(crate) recent_releases: RecentReleases,
         }
         impl $name {
             $vis fn new() -> Result<Self, prometheus::Error> {
@@ -36,6 +37,7 @@ macro_rules! metrics {
                 )*
                 Ok(Self {
                     registry,
+                    recent_releases: RecentReleases::new(),
                     $(
                         $(#[$meta])*
                         $metric,

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -48,7 +48,7 @@ metrics! {
         pub(crate) rustdoc_rendering_times: HistogramVec["step"],
 
         /// Count of recently accessed crates
-        pub(crate) recent_krates: IntGaugeVec["duration"],
+        pub(crate) recent_crates: IntGaugeVec["duration"],
         /// Count of recently accessed versions of crates
         pub(crate) recent_versions: IntGaugeVec["duration"],
         /// Count of recently accessed platforms of versions of crates
@@ -130,7 +130,7 @@ impl RecentReleases {
                 .set(five_minute_count);
         }
 
-        inner(&self.krates, &metrics.recent_krates);
+        inner(&self.krates, &metrics.recent_crates);
         inner(&self.versions, &metrics.recent_versions);
         inner(&self.platforms, &metrics.recent_platforms);
     }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -3,6 +3,7 @@ mod macros;
 
 use self::macros::MetricFromOpts;
 use crate::db::Pool;
+use crate::target::TargetAtom;
 use crate::BuildQueue;
 use dashmap::DashMap;
 use failure::Error;
@@ -81,7 +82,7 @@ metrics! {
 pub(crate) struct RecentlyAccessedReleases {
     krates: DashMap<i32, Instant>,
     versions: DashMap<i32, Instant>,
-    platforms: DashMap<(i32, String), Instant>,
+    platforms: DashMap<(i32, TargetAtom), Instant>,
 }
 
 impl RecentlyAccessedReleases {
@@ -93,7 +94,7 @@ impl RecentlyAccessedReleases {
         self.krates.insert(krate, Instant::now());
         self.versions.insert(version, Instant::now());
         self.platforms
-            .insert((version, target.to_owned()), Instant::now());
+            .insert((version, TargetAtom::from(target)), Instant::now());
     }
 
     pub(crate) fn gather(&self, metrics: &Metrics) {

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -91,10 +91,11 @@ impl RecentlyAccessedReleases {
     }
 
     pub(crate) fn record(&self, krate: i32, version: i32, target: &str) {
-        self.crates.insert(krate, Instant::now());
-        self.versions.insert(version, Instant::now());
+        let now = Instant::now();
+        self.crates.insert(krate, now);
+        self.versions.insert(version, now);
         self.platforms
-            .insert((version, TargetAtom::from(target)), Instant::now());
+            .insert((version, TargetAtom::from(target)), now);
     }
 
     pub(crate) fn gather(&self, metrics: &Metrics) {
@@ -116,7 +117,7 @@ impl RecentlyAccessedReleases {
                 }
 
                 // Only retain items accessed within the last hour
-                return elapsed < Duration::from_secs(60 * 60);
+                elapsed < Duration::from_secs(60 * 60)
             });
 
             metric.with_label_values(&["one hour"]).set(hour_count);

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -80,7 +80,7 @@ metrics! {
 
 #[derive(Debug, Default)]
 pub(crate) struct RecentlyAccessedReleases {
-    krates: DashMap<i32, Instant>,
+    crates: DashMap<i32, Instant>,
     versions: DashMap<i32, Instant>,
     platforms: DashMap<(i32, TargetAtom), Instant>,
 }
@@ -91,7 +91,7 @@ impl RecentlyAccessedReleases {
     }
 
     pub(crate) fn record(&self, krate: i32, version: i32, target: &str) {
-        self.krates.insert(krate, Instant::now());
+        self.crates.insert(krate, Instant::now());
         self.versions.insert(version, Instant::now());
         self.platforms
             .insert((version, TargetAtom::from(target)), Instant::now());
@@ -130,7 +130,7 @@ impl RecentlyAccessedReleases {
                 .set(five_minute_count);
         }
 
-        inner(&self.krates, &metrics.recent_crates);
+        inner(&self.crates, &metrics.recent_crates);
         inner(&self.versions, &metrics.recent_versions);
         inner(&self.platforms, &metrics.recent_platforms);
     }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -104,19 +104,19 @@ impl RecentlyAccessedReleases {
             let mut five_minute_count = 0;
             map.retain(|_, instant| {
                 let elapsed = instant.elapsed();
-                if elapsed > Duration::from_secs(60 * 60) {
-                    return false;
+
+                if elapsed < Duration::from_secs(60 * 60) {
+                    hour_count += 1;
                 }
-                hour_count += 1;
-                if elapsed > Duration::from_secs(30 * 60) {
-                    return true;
+                if elapsed < Duration::from_secs(30 * 60) {
+                    half_hour_count += 1;
                 }
-                half_hour_count += 1;
-                if elapsed > Duration::from_secs(5 * 60) {
-                    return true;
+                if elapsed < Duration::from_secs(5 * 60) {
+                    five_minute_count += 1;
                 }
-                five_minute_count += 1;
-                true
+
+                // Only retain items accessed within the last hour
+                return elapsed < Duration::from_secs(60 * 60);
             });
 
             metric.with_label_values(&["one hour"]).set(hour_count);

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -91,6 +91,11 @@ impl RecentlyAccessedReleases {
     }
 
     pub(crate) fn record(&self, krate: i32, version: i32, target: &str) {
+        if self.platforms.len() > 100_000 {
+            // Avoid filling the maps _too_ much, we should never get anywhere near this limit
+            return;
+        }
+
         let now = Instant::now();
         self.crates.insert(krate, now);
         self.versions.insert(version, now);

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -78,13 +78,13 @@ metrics! {
 }
 
 #[derive(Debug, Default)]
-pub(crate) struct RecentReleases {
+pub(crate) struct RecentlyAccessedReleases {
     krates: DashMap<String, Instant>,
     versions: DashMap<String, Instant>,
     platforms: DashMap<String, Instant>,
 }
 
-impl RecentReleases {
+impl RecentlyAccessedReleases {
     pub(crate) fn new() -> Self {
         Self::default()
     }
@@ -151,7 +151,7 @@ impl Metrics {
             .set(queue.prioritized_count()? as i64);
         self.failed_crates_count.set(queue.failed_count()? as i64);
 
-        self.recent_releases.gather(self);
+        self.recently_accessed_releases.gather(self);
         self.gather_system_performance();
         Ok(self.registry.gather())
     }

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -45,6 +45,10 @@ pub struct CrateDetails {
     documented_items: Option<f32>,
     total_items_needing_examples: Option<f32>,
     items_with_examples: Option<f32>,
+    /// Database id for this crate
+    pub(crate) crate_id: i32,
+    /// Database id for this release
+    pub(crate) release_id: i32,
 }
 
 fn optional_markdown<S>(markdown: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
@@ -183,6 +187,8 @@ impl CrateDetails {
             total_items: total_items.map(|v| v as f32),
             total_items_needing_examples: total_items_needing_examples.map(|v| v as f32),
             items_with_examples: items_with_examples.map(|v| v as f32),
+            crate_id,
+            release_id,
         };
 
         if let Some(repository_url) = crate_details.repository_url.clone() {

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -423,7 +423,9 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
         (target, inner_path.join("/"))
     };
 
-    metrics.recent_releases.record(&name, &version, target);
+    metrics
+        .recently_accessed_releases
+        .record(&name, &version, target);
 
     let target = if target == "" {
         String::new()

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -415,14 +415,20 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
                 .iter()
                 .any(|s| s == inner_path[0])
         {
-            let mut target = inner_path.remove(0).to_string();
-            target.push('/');
-            target
+            inner_path.remove(0)
         } else {
-            String::new()
+            ""
         };
 
         (target, inner_path.join("/"))
+    };
+
+    metrics.recent_releases.record(&name, &version, target);
+
+    let target = if target == "" {
+        String::new()
+    } else {
+        format!("{}/", target)
     };
 
     rendering_time.step("rewrite html");

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -425,7 +425,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
 
     metrics
         .recently_accessed_releases
-        .record(&name, &version, target);
+        .record(krate.crate_id, krate.release_id, target);
 
     let target = if target == "" {
         String::new()


### PR DESCRIPTION
These metrics are intended to be useful for evaluating changes for #1004. Knowing how many different crates get accessed over short timespans could help us know things like the potential memory cost of keeping cached indexes around short term.

I'm not sure what the performance impact of these might be in production. The most likely issue would be a large memory usage if the number of different platforms requested per-hour is very high, leading to a lot of small strings kept around to track these.

(based on #1017, so to review the lockfile changes look at the last commit in isolation)