### PR TITLE
Revert "Unify crate pages rendering"

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -26,6 +26,8 @@
     <body>
         {%- include "header/topbar.html" -%}
 
+        {%- block header %}{% endblock header -%}
+
         {%- block body -%}{%- endblock body -%}
     </body>
 

--- a/templates/crate/builds.html
+++ b/templates/crate/builds.html
@@ -5,82 +5,78 @@
     {{ macros::doc_title(name=metadata.name, version=metadata.version) }}
 {%- endblock title -%}
 
+{%- block header -%}
+    {{ navigation::package_navigation(metadata=metadata, active_tab="builds") }}
+{%- endblock header -%}
+
 {%- block body -%}
     <div class="container">
-        <div class="pure-g">
-            <div class="pure-u-1 pure-u-sm-7-24 pure-u-md-5-24">
-                {%- block header -%}
-                    {# Set the active tab to the `crate` tab #}
-                    {{ navigation::package_navigation(show_description=false, metadata=metadata, active_tab="builds") }}
-                {%- endblock header -%}
+        <div class="recent-releases-container">
+            {# If there is a build log then show it #}
+            {# TODO: When viewing a build log, show a back button or a hide button #}
+            {%- if build_details -%}
+                <div class="release">
+                    <strong>Build #{{ build_details.id }} {{ build_details.build_time | date(format="%+") }}</strong>
+                </div>
+
+                {%- filter dedent -%}
+                    <pre>
+                        # rustc version
+                        {{ build_details.rustc_version }}
+                        # docs.rs version
+                        {{ build_details.docsrs_version }}
+
+                        # build log
+                        {{ build_details.output }}
+                    </pre>
+                {%- endfilter -%}
+            {%- endif -%}
+
+            <div class="release">
+                <strong>Builds</strong>
             </div>
-            <div class="pure-u-1 pure-u-sm-17-24 pure-u-md-19-24 recent-releases-container">
-                {# If there is a build log then show it #}
-                {# TODO: When viewing a build log, show a back button or a hide button #}
-                {%- if build_details -%}
-                    <div class="release">
-                        <strong>Build #{{ build_details.id }} {{ build_details.build_time | date(format="%+") }}</strong>
-                    </div>
 
-                    {%- filter dedent -%}
-                        <pre>
-                            # rustc version
-                            {{ build_details.rustc_version }}
-                            # docs.rs version
-                            {{ build_details.docsrs_version }}
+            <ul>
+                {%- for build in builds -%}
+                    <li>
+                        <a href="/crate/{{ metadata.name }}/{{ metadata.version }}/builds/{{ build.id }}" class="release">
+                            <div class="pure-g">
+                                <div class="pure-u-1 pure-u-sm-1-24 build">
+                                    {%- if build.build_status -%}
+                                        {{ "check" | fas }}
+                                    {%- else -%}
+                                        {{ "times" | fas }}
+                                    {%- endif -%}
+                                </div>
+                                <div class="pure-u-1 pure-u-sm-10-24">{{ build.rustc_version }}</div>
+                                <div class="pure-u-1 pure-u-sm-10-24">{{ build.docsrs_version }}</div>
+                                <div class="pure-u-1 pure-u-sm-3-24 date">{{ build.build_time | timeformat(relative=true) }}</div>
+                            </div>
+                        </a>
+                    </li>
+                {%- endfor -%}
+            </ul>
 
-                            # build log
-                            {{ build_details.output }}
-                        </pre>
-                    {%- endfilter -%}
+            <div class="about">
+                {# BuildsPage.metadata is an `Option<MetaData>`, so accessing it can fail #}
+                {%- if metadata -%}
+                    <h4>{{ metadata.name }}'s sandbox limits</h4>
+                {%- else -%}
+                    <h4>Sandbox limits</h4>
                 {%- endif -%}
 
-                <div class="release">
-                    <strong>Builds</strong>
-                </div>
+                <p>
+                    All the builds on docs.rs are executed inside a sandbox with limited
+                    resources. The limits for this crate are the following:
+                </p>
 
-                <ul>
-                    {%- for build in builds -%}
-                        <li>
-                            <a href="/crate/{{ metadata.name }}/{{ metadata.version }}/builds/{{ build.id }}" class="release">
-                                <div class="pure-g">
-                                    <div class="pure-u-1 pure-u-sm-1-24 build">
-                                        {%- if build.build_status -%}
-                                            {{ "check" | fas }}
-                                        {%- else -%}
-                                            {{ "times" | fas }}
-                                        {%- endif -%}
-                                    </div>
-                                    <div class="pure-u-1 pure-u-sm-10-24">{{ build.rustc_version }}</div>
-                                    <div class="pure-u-1 pure-u-sm-10-24">{{ build.docsrs_version }}</div>
-                                    <div class="pure-u-1 pure-u-sm-3-24 date">{{ build.build_time | timeformat(relative=true) }}</div>
-                                </div>
-                            </a>
-                        </li>
-                    {%- endfor -%}
-                </ul>
+                {{ macros::crate_limits(limits=limits) }}
 
-                <div class="about">
-                    {# BuildsPage.metadata is an `Option<MetaData>`, so accessing it can fail #}
-                    {%- if metadata -%}
-                        <h4>{{ metadata.name }}'s sandbox limits</h4>
-                    {%- else -%}
-                        <h4>Sandbox limits</h4>
-                    {%- endif -%}
-
-                    <p>
-                        All the builds on docs.rs are executed inside a sandbox with limited
-                        resources. The limits for this crate are the following:
-                    </p>
-
-                    {{ macros::crate_limits(limits=limits) }}
-
-                    <p>
-                        If a build fails because it hit one of those limits please
-                        <a href="https://github.com/rust-lang/docs.rs/issues/new/choose">open an issue</a>
-                        to get them increased.
-                    </p>
-                </div>
+                <p>
+                    If a build fails because it hit one of those limits please
+                    <a href="https://github.com/rust-lang/docs.rs/issues/new/choose">open an issue</a>
+                    to get them increased.
+                </p>
             </div>
         </div>
     </div>

--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -1,14 +1,19 @@
 {%- extends "base.html" -%}
 {%- import "header/package_navigation.html" as navigation -%}
 
+{%- block title -%}
+    {{ macros::doc_title(name=details.name, version=details.version) }}
+{%- endblock title -%}
+
+{%- block header -%}
+    {# Set the active tab to the `crate` tab #}
+    {{ navigation::package_navigation(metadata=details.metadata, active_tab="crate") }}
+{%- endblock header -%}
+
 {%- block body -%}
     <div class="container package-page-container">
         <div class="pure-g">
             <div class="pure-u-1 pure-u-sm-7-24 pure-u-md-5-24">
-                {%- block header -%}
-                    {# Set the active tab to the `crate` tab #}
-                    {{ navigation::package_navigation(show_description=false, metadata=details.metadata, active_tab="crate") }}
-                {%- endblock header -%}
                 <div class="pure-menu package-menu">
                     <ul class="pure-menu-list">
                         {%- if details.documented_items and details.total_items -%}
@@ -117,16 +122,6 @@
             </div>
 
             <div class="pure-u-1 pure-u-sm-17-24 pure-u-md-19-24 package-details" id="main">
-                <div class="cratesfyi-package-container">
-                    <div class="container">
-                        {# Page title #}
-                        <h1>{{ details.metadata.name }} {{ details.metadata.version }}</h1>
-                        {%- if details.metadata.description -%}
-                            <div class="description" style="white-space: initial;">{{ details.metadata.description }}</div>
-                        {%- endif -%}
-                    </div>
-                </div>
-
                 {# If the release is not a library #}
                 {%- if not details.is_library -%}
                     <div class="warning">

--- a/templates/crate/source.html
+++ b/templates/crate/source.html
@@ -5,14 +5,15 @@
     {{ macros::doc_title(name=file_list.metadata.name, version=file_list.metadata.version) }}
 {%- endblock title -%}
 
+{%- block header -%}
+    {# Set the active tab to the `source` tab #}
+    {{ navigation::package_navigation(metadata=file_list.metadata, active_tab="source") }}
+{%- endblock header -%}
+
 {%- block body -%}
     <div class="container package-page-container">
         <div class="pure-g">
-            <div class="pure-u-1 pure-u-sm-7-24 pure-u-md-5-24">
-                {%- block header -%}
-                    {# Set the active tab to the `source` tab #}
-                    {{ navigation::package_navigation(show_description=false, metadata=file_list.metadata, active_tab="source") }}
-                {%- endblock header -%}
+            <div class="pure-u-1 {% if file_content %}pure-u-sm-7-24 pure-u-md-5-24{% endif %}">
                 <div class="pure-menu package-menu">
                     <ul class="pure-menu-list">
                         {# If this isn't the root folder, show a 'back' button #}

--- a/templates/header/package_navigation.html
+++ b/templates/header/package_navigation.html
@@ -12,7 +12,7 @@
     Note: `false` here is acting as a pseudo-null value since you can't directly construct null values
            and tera requires all parameters without defaults to be filled
 #}
-{% macro package_navigation(title=false, metadata, show_description=true, platforms=false, active_tab) %}
+{% macro package_navigation(title=false, metadata, platforms=false, active_tab) %}
     <div class="cratesfyi-package-container">
         <div class="container">
             {# Page title #}
@@ -26,13 +26,13 @@
             </h1>
 
             {# Page description #}
-            {%- if metadata.description -%}
-                {%- if show_description -%}
-                    <div class="description">{{ metadata.description }}</div>
+            <div class="description">
+                {%- if metadata.description -%}
+                    {{ metadata.description }}
                 {%- endif -%}
-            {%- endif -%}
+            </div>
 
-            <div class="pure-menu" {% if active_tab %} style="margin-top: 13px;"{% endif %}>
+            <div class="pure-menu pure-menu-horizontal">
                 {# If there are platforms, show a dropdown with them #}
                 {%- if platforms -%}
                     <ul class="pure-menu-list platforms-menu">

--- a/templates/releases/header.html
+++ b/templates/releases/header.html
@@ -19,6 +19,65 @@
             <div class="description">{{ description | default(value="") }}</div>
 
             {# This does double-duty as the search, so hide all tabs when we're searching something #}
+            {%- if tab != "search" -%}
+                <div class="pure-menu pure-menu-horizontal">
+                    <ul class="pure-menu-list">
+                        <li class="pure-menu-item">
+                            <a href="/releases" class="pure-menu-link{% if tab == 'recent' %} pure-menu-active{% endif %}">
+                                {{ "leaf" | fas(fw=true) }}
+                                <span class="title"> Recent</span>
+                            </a>
+                        </li>
+
+                        <li class="pure-menu-item">
+                            <a href="/releases/stars" class="pure-menu-link{% if tab == 'stars' %} pure-menu-active{% endif %}">
+                                {{ "star" | fas(fw=true) }}
+                                <span class="title"> Stars</span>
+                            </a>
+                        </li>
+
+                        <li class="pure-menu-item">
+                            <a href="/releases/recent-failures"
+                                class="pure-menu-link{% if tab == 'recent-failures' %} pure-menu-active{% endif %}">
+                                {{ "exclamation-triangle" | fas(fw=true) }}
+                                <span class="title"> Recent Failures</span>
+                            </a>
+                        </li>
+
+                        <li class="pure-menu-item">
+                            <a href="/releases/failures"
+                                class="pure-menu-link{% if tab == 'failures' %} pure-menu-active{% endif %}">
+                                {{ "star" | far(fw=true) }}
+                                <span class="title"> Failures By Stars</span>
+                            </a>
+                        </li>
+
+                        <li class="pure-menu-item">
+                            <a href="/releases/activity"
+                                class="pure-menu-link{% if tab == 'activity' %} pure-menu-active{% endif %}">
+                                {{ "chart-line" | fas(fw=true) }}
+                                <span class="title"> Activity</span>
+                            </a>
+                        </li>
+
+                        <li class="pure-menu-item">
+                            <a href="/releases/queue" class="pure-menu-link{% if tab == 'queue' %} pure-menu-active{% endif %}">
+                                {{ "list" | fas(fw=true) }}
+                                <span class="title"> Queue</span>
+                            </a>
+                        </li>
+
+                        {%- if author -%}
+                            <li class="pure-menu-item">
+                                <a href="#" class="pure-menu-link{% if tab == 'author' %} pure-menu-active{% endif %}">
+                                    {{ "user" | fas(fw=true) }}
+                                    <span class="title"> {{ author }}</span>
+                                </a>
+                            </li>
+                        {%- endif -%}
+                    </ul>
+                </div>
+            {%- endif -%}
         </div>
     </div>
 {% endmacro header %}

--- a/templates/style/base.scss
+++ b/templates/style/base.scss
@@ -431,7 +431,6 @@ div.package-page-container {
     pre {
         background-color: inherit;
         padding: 0;
-        margin: 0;
 
         code {
             white-space: pre;
@@ -487,6 +486,12 @@ div.cratesfyi-package-container {
         .pure-menu-active {
             color: $color-standard;
             background-color: #fff;
+            border-top: 1px solid $color-border;
+            border-left: 1px solid $color-border;
+            border-right: 1px solid $color-border;
+            border-top-left-radius: 4px;
+            border-top-right-radius: 4px;
+            border-bottom: 2px solid #fff;
         }
 
         .pure-menu-active:hover {

--- a/templates/style/base.scss
+++ b/templates/style/base.scss
@@ -476,7 +476,11 @@ div.cratesfyi-package-container {
             padding: 0.4em 1em 0.3em 1em;
 
             .title {
-                display: inline;
+                display: none;
+
+                @media #{$media-sm} {
+                    display: inline;
+                }
             }
         }
 


### PR DESCRIPTION
Reverts rust-lang/docs.rs#1026, which has already been reverted in prod.
This caused 404 pages to break. We should test that before redeploying this PR.