### PR TITLE
Transform "documentation" tab into button

### DIFF
--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -96,7 +96,6 @@ impl From<PoolError> for IronError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::test::wrapper;
     use kuchiki::traits::TendrilSink;
 

--- a/templates/about-base.html
+++ b/templates/about-base.html
@@ -1,32 +1,34 @@
 {% extends "base.html" %}
 
 {% block header %}
-	<div class="cratesfyi-package-container">
+    <div class="cratesfyi-package-container">
         <div class="container">
-            <h1 id="crate-title" class="no-description">Docs.rs documentation</h1>
-            <div class="pure-menu pure-menu-horizontal">
-                <ul class="pure-menu-list">
-                    {% set text = "info-circle" | fas(fw=true) %}
-                    {% set text = text ~ ' <span class="title">About</span>' %}
-                    {{ macros::active_link(expected="index", href="/about", text=text) }}
+            <div class="description-container">
+                <h1 id="crate-title" class="no-description">Docs.rs documentation</h1>
+                <div class="pure-menu pure-menu-horizontal">
+                    <ul class="pure-menu-list">
+                        {% set text = "info-circle" | fas(fw=true) %}
+                        {% set text = text ~ ' <span class="title">About</span>' %}
+                        {{ macros::active_link(expected="index", href="/about", text=text) }}
 
-                    {% set text = "fonticons" | fab(fw=true) %}
-                    {% set text = text ~ ' <span class="title">Badges</span>' %}
-                    {{ macros::active_link(expected="badges", href="/about/badges", text=text) }}
+                        {% set text = "fonticons" | fab(fw=true) %}
+                        {% set text = text ~ ' <span class="title">Badges</span>' %}
+                        {{ macros::active_link(expected="badges", href="/about/badges", text=text) }}
 
-                    {% set text = "cogs" | fas(fw=true) %}
-                    {% set text = text ~ ' <span class="title">Builds</span>' %}
-                    {{ macros::active_link(expected="builds", href="/about/builds", text=text) }}
+                        {% set text = "cogs" | fas(fw=true) %}
+                        {% set text = text ~ ' <span class="title">Builds</span>' %}
+                        {{ macros::active_link(expected="builds", href="/about/builds", text=text) }}
 
-                    {% set text = "table" | fas(fw=true) %}
-                    {% set text = text ~ ' <span class="title">Metadata</span>' %}
-                    {{ macros::active_link(expected="metadata", href="/about/metadata", text=text) }}
+                        {% set text = "table" | fas(fw=true) %}
+                        {% set text = text ~ ' <span class="title">Metadata</span>' %}
+                        {{ macros::active_link(expected="metadata", href="/about/metadata", text=text) }}
 
-                    {% set text = "road" | fas(fw=true) %}
-                    {% set text = text ~ ' <span class="title">Shorthand URLs</span>' %}
-                    {{ macros::active_link(expected="redirections", href="/about/redirections", text=text) }}
-                </ul>
+                        {% set text = "road" | fas(fw=true) %}
+                        {% set text = text ~ ' <span class="title">Shorthand URLs</span>' %}
+                        {{ macros::active_link(expected="redirections", href="/about/redirections", text=text) }}
+                    </ul>
+                </div>
             </div>
         </div>
-	</div>
+    </div>
 {% endblock %}

--- a/templates/header/package_navigation.html
+++ b/templates/header/package_navigation.html
@@ -15,85 +15,85 @@
 {% macro package_navigation(title=false, metadata, platforms=false, active_tab) %}
     <div class="cratesfyi-package-container">
         <div class="container">
-            {# Page title #}
-            <h1 id="crate-title">
-                {%- if title -%}
-                    {{ title }}
-                {%- else -%}
-                    {{ metadata.name }} {{ metadata.version }}
-                    {{ "copy" | far(id="clipboard", aria_label="Copy crate name and version information", fa=true) }}
-                {%- endif -%}
-            </h1>
+            <div class="description-container">
+                {# The partial path of the crate, `:name/:release` #}
+                {%- set crate_path = metadata.name ~ "/" ~ metadata.version -%}
 
-            {# Page description #}
-            <div class="description">
-                {%- if metadata.description -%}
-                    {{ metadata.description }}
-                {%- endif -%}
-            </div>
+                {# If docs are built, show a button for them #}
 
-            <div class="pure-menu pure-menu-horizontal">
-                {# If there are platforms, show a dropdown with them #}
-                {%- if platforms -%}
-                    <ul class="pure-menu-list platforms-menu">
-                        <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
-                            <a href="#" class="pure-menu-link">Platform</a>
-                            <ul class="pure-menu-children">
-                                {%- for platform in platforms -%}
-                                    <li class="pure-menu-item">
-                                        <a href="/{{ metadata.name }}/{{ metadata.version }}/{{ platform }}/{{ metadata.target_name }}/"
-                                            class="pure-menu-link">
-                                            {{ platform }}
-                                        </a>
-                                    </li>
-                                {%- endfor -%}
-                            </ul>
-                        </li>
-                    </ul>
-                {%- endif -%}
+                {# Page title #}
+                <h1 id="crate-title">
+                    {%- if title -%}
+                        {{ title }}
+                    {%- else -%}
+                        {{ metadata.name }} {{ metadata.version }}
+                        {{ "copy" | far(id="clipboard", aria_label="Copy crate name and version information", fa=true) }}
+                    {%- endif -%}
+                </h1>
 
-                <ul class="pure-menu-list">
-                    {# The partial path of the crate, `:name/:release` #}
-                    {%- set crate_path = metadata.name ~ "/" ~ metadata.version -%}
+                {# Page description #}
+                <div class="description">
+                    {%- if metadata.description -%}
+                        {{ metadata.description }}
+                    {%- endif -%}
+                </div>
 
-                    {# If docs are built, show a tab for them #}
-                    {%- if metadata.rustdoc_status -%}
-                        <li class="pure-menu-item">
-                            {# The docs tab redirects to the docs, so the tab will never be selected and seen #}
-                            <a href="/{{ crate_path | safe }}/{{ metadata.target_name }}/" class="pure-menu-link">
-                                {{ "book" | fas(fw=true) }}
-                                <span class="title"> Documentation</span>
-                            </a>
-                        </li>
+
+                <div class="pure-menu pure-menu-horizontal">
+                    {# If there are platforms, show a dropdown with them #}
+                    {%- if platforms -%}
+                        <ul class="pure-menu-list platforms-menu">
+                            <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
+                                <a href="#" class="pure-menu-link">Platform</a>
+                                <ul class="pure-menu-children">
+                                    {%- for platform in platforms -%}
+                                        <li class="pure-menu-item">
+                                            <a href="/{{ metadata.name }}/{{ metadata.version }}/{{ platform }}/{{ metadata.target_name }}/"
+                                                class="pure-menu-link">
+                                                {{ platform }}
+                                            </a>
+                                        </li>
+                                    {%- endfor -%}
+                                </ul>
+                            </li>
+                        </ul>
                     {%- endif -%}
 
-                    {# The crate information tab #}
-                    <li class="pure-menu-item"><a href="/crate/{{ crate_path | safe }}"
-                            class="pure-menu-link{% if active_tab == 'crate' %} pure-menu-active{% endif %}">
-                            {{ "cube" | fas(fw=true) }}
-                            <span class="title"> Crate</span>
-                        </a>
-                    </li>
+                    <ul class="pure-menu-list">
+                        {# The crate information tab #}
+                        <li class="pure-menu-item"><a href="/crate/{{ crate_path | safe }}"
+                                class="pure-menu-link{% if active_tab == 'crate' %} pure-menu-active{% endif %}">
+                                {{ "cube" | fas(fw=true) }}
+                                <span class="title"> Crate</span>
+                            </a>
+                        </li>
 
-                    {# The source view tab #}
-                    <li class="pure-menu-item">
-                        <a href="/crate/{{ crate_path | safe }}/source/"
-                            class="pure-menu-link{% if active_tab == 'source' %} pure-menu-active{% endif %}">
-                            {{ "folder-open" | far(fw=true) }}
-                            <span class="title"> Source</span>
-                        </a>
-                    </li>
+                        {# The source view tab #}
+                        <li class="pure-menu-item">
+                            <a href="/crate/{{ crate_path | safe }}/source/"
+                                class="pure-menu-link{% if active_tab == 'source' %} pure-menu-active{% endif %}">
+                                {{ "folder-open" | far(fw=true) }}
+                                <span class="title"> Source</span>
+                            </a>
+                        </li>
 
-                    {# The builds tab #}
-                    <li class="pure-menu-item">
-                        <a href="/crate/{{ crate_path | safe }}/builds"
-                            class="pure-menu-link{% if active_tab == 'builds' %} pure-menu-active{% endif %}">
-                            {{ "cogs" | fas }}
-                            <span class="title"> Builds</span>
-                        </a>
-                    </li>
-                </ul>
+                        {# The builds tab #}
+                        <li class="pure-menu-item">
+                            <a href="/crate/{{ crate_path | safe }}/builds"
+                                class="pure-menu-link{% if active_tab == 'builds' %} pure-menu-active{% endif %}">
+                                {{ "cogs" | fas }}
+                                <span class="title"> Builds</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
             </div>
+
+            {%- if metadata.rustdoc_status -%}
+                <a href="/{{ crate_path | safe }}/{{ metadata.target_name }}/" class="doc-link">
+                    {{ "book" | fas(fw=true) }} Documentation
+                </a>
+            {%- endif -%}
         </div>
     </div>
 {% endmacro package_navigation %}

--- a/templates/releases/header.html
+++ b/templates/releases/header.html
@@ -15,69 +15,71 @@
 {% macro header(title, description, tab, author=false) %}
     <div class="cratesfyi-package-container">
         <div class="container">
-            <h1 id="crate-title">{{ title }}</h1>
-            <div class="description">{{ description | default(value="") }}</div>
+            <div class="description-container">
+                <h1 id="crate-title">{{ title }}</h1>
+                <div class="description">{{ description | default(value="") }}</div>
 
-            {# This does double-duty as the search, so hide all tabs when we're searching something #}
-            {%- if tab != "search" -%}
-                <div class="pure-menu pure-menu-horizontal">
-                    <ul class="pure-menu-list">
-                        <li class="pure-menu-item">
-                            <a href="/releases" class="pure-menu-link{% if tab == 'recent' %} pure-menu-active{% endif %}">
-                                {{ "leaf" | fas(fw=true) }}
-                                <span class="title">Recent</span>
-                            </a>
-                        </li>
-
-                        <li class="pure-menu-item">
-                            <a href="/releases/stars" class="pure-menu-link{% if tab == 'stars' %} pure-menu-active{% endif %}">
-                                {{ "star" | fas(fw=true) }}
-                                <span class="title">Stars</span>
-                            </a>
-                        </li>
-
-                        <li class="pure-menu-item">
-                            <a href="/releases/recent-failures"
-                                class="pure-menu-link{% if tab == 'recent-failures' %} pure-menu-active{% endif %}">
-                                {{ "exclamation-triangle" | fas(fw=true) }}
-                                <span class="title">Recent Failures</span>
-                            </a>
-                        </li>
-
-                        <li class="pure-menu-item">
-                            <a href="/releases/failures"
-                                class="pure-menu-link{% if tab == 'failures' %} pure-menu-active{% endif %}">
-                                {{ "star" | far(fw=true) }}
-                                <span class="title">Failures By Stars</span>
-                            </a>
-                        </li>
-
-                        <li class="pure-menu-item">
-                            <a href="/releases/activity"
-                                class="pure-menu-link{% if tab == 'activity' %} pure-menu-active{% endif %}">
-                                {{ "chart-line" | fas(fw=true) }}
-                                <span class="title">Activity</span>
-                            </a>
-                        </li>
-
-                        <li class="pure-menu-item">
-                            <a href="/releases/queue" class="pure-menu-link{% if tab == 'queue' %} pure-menu-active{% endif %}">
-                                {{ "list" | fas(fw=true) }}
-                                <span class="title">Queue</span>
-                            </a>
-                        </li>
-
-                        {%- if author -%}
+                {# This does double-duty as the search, so hide all tabs when we're searching something #}
+                {%- if tab != "search" -%}
+                    <div class="pure-menu pure-menu-horizontal">
+                        <ul class="pure-menu-list">
                             <li class="pure-menu-item">
-                                <a href="#" class="pure-menu-link{% if tab == 'author' %} pure-menu-active{% endif %}">
-                                    {{ "user" | fas(fw=true) }}
-                                    <span class="title">{{ author }}</span>
+                                <a href="/releases" class="pure-menu-link{% if tab == 'recent' %} pure-menu-active{% endif %}">
+                                    {{ "leaf" | fas(fw=true) }}
+                                    <span class="title">Recent</span>
                                 </a>
                             </li>
-                        {%- endif -%}
-                    </ul>
-                </div>
-            {%- endif -%}
+
+                            <li class="pure-menu-item">
+                                <a href="/releases/stars" class="pure-menu-link{% if tab == 'stars' %} pure-menu-active{% endif %}">
+                                    {{ "star" | fas(fw=true) }}
+                                    <span class="title">Stars</span>
+                                </a>
+                            </li>
+
+                            <li class="pure-menu-item">
+                                <a href="/releases/recent-failures"
+                                    class="pure-menu-link{% if tab == 'recent-failures' %} pure-menu-active{% endif %}">
+                                    {{ "exclamation-triangle" | fas(fw=true) }}
+                                    <span class="title">Recent Failures</span>
+                                </a>
+                            </li>
+
+                            <li class="pure-menu-item">
+                                <a href="/releases/failures"
+                                    class="pure-menu-link{% if tab == 'failures' %} pure-menu-active{% endif %}">
+                                    {{ "star" | far(fw=true) }}
+                                    <span class="title">Failures By Stars</span>
+                                </a>
+                            </li>
+
+                            <li class="pure-menu-item">
+                                <a href="/releases/activity"
+                                    class="pure-menu-link{% if tab == 'activity' %} pure-menu-active{% endif %}">
+                                    {{ "chart-line" | fas(fw=true) }}
+                                    <span class="title">Activity</span>
+                                </a>
+                            </li>
+
+                            <li class="pure-menu-item">
+                                <a href="/releases/queue" class="pure-menu-link{% if tab == 'queue' %} pure-menu-active{% endif %}">
+                                    {{ "list" | fas(fw=true) }}
+                                    <span class="title">Queue</span>
+                                </a>
+                            </li>
+
+                            {%- if author -%}
+                                <li class="pure-menu-item">
+                                    <a href="#" class="pure-menu-link{% if tab == 'author' %} pure-menu-active{% endif %}">
+                                        {{ "user" | fas(fw=true) }}
+                                        <span class="title">{{ author }}</span>
+                                    </a>
+                                </li>
+                            {%- endif -%}
+                        </ul>
+                    </div>
+                {%- endif -%}
+            </div>
         </div>
     </div>
 {% endmacro header %}

--- a/templates/releases/header.html
+++ b/templates/releases/header.html
@@ -25,14 +25,14 @@
                         <li class="pure-menu-item">
                             <a href="/releases" class="pure-menu-link{% if tab == 'recent' %} pure-menu-active{% endif %}">
                                 {{ "leaf" | fas(fw=true) }}
-                                <span class="title"> Recent</span>
+                                <span class="title">Recent</span>
                             </a>
                         </li>
 
                         <li class="pure-menu-item">
                             <a href="/releases/stars" class="pure-menu-link{% if tab == 'stars' %} pure-menu-active{% endif %}">
                                 {{ "star" | fas(fw=true) }}
-                                <span class="title"> Stars</span>
+                                <span class="title">Stars</span>
                             </a>
                         </li>
 
@@ -40,7 +40,7 @@
                             <a href="/releases/recent-failures"
                                 class="pure-menu-link{% if tab == 'recent-failures' %} pure-menu-active{% endif %}">
                                 {{ "exclamation-triangle" | fas(fw=true) }}
-                                <span class="title"> Recent Failures</span>
+                                <span class="title">Recent Failures</span>
                             </a>
                         </li>
 
@@ -48,7 +48,7 @@
                             <a href="/releases/failures"
                                 class="pure-menu-link{% if tab == 'failures' %} pure-menu-active{% endif %}">
                                 {{ "star" | far(fw=true) }}
-                                <span class="title"> Failures By Stars</span>
+                                <span class="title">Failures By Stars</span>
                             </a>
                         </li>
 
@@ -56,14 +56,14 @@
                             <a href="/releases/activity"
                                 class="pure-menu-link{% if tab == 'activity' %} pure-menu-active{% endif %}">
                                 {{ "chart-line" | fas(fw=true) }}
-                                <span class="title"> Activity</span>
+                                <span class="title">Activity</span>
                             </a>
                         </li>
 
                         <li class="pure-menu-item">
                             <a href="/releases/queue" class="pure-menu-link{% if tab == 'queue' %} pure-menu-active{% endif %}">
                                 {{ "list" | fas(fw=true) }}
-                                <span class="title"> Queue</span>
+                                <span class="title">Queue</span>
                             </a>
                         </li>
 
@@ -71,7 +71,7 @@
                             <li class="pure-menu-item">
                                 <a href="#" class="pure-menu-link{% if tab == 'author' %} pure-menu-active{% endif %}">
                                     {{ "user" | fas(fw=true) }}
-                                    <span class="title"> {{ author }}</span>
+                                    <span class="title">{{ author }}</span>
                                 </a>
                             </li>
                         {%- endif -%}

--- a/templates/style/base.scss
+++ b/templates/style/base.scss
@@ -542,9 +542,10 @@ div.cratesfyi-package-container {
         .doc-link {
             margin: 0 10px;
             height: min-content;
-            background: #fff;
+            background: #333;
+            color: #fff;
             padding: 10px;
-            border: 1px solid #ccc;
+            border: 1px solid #333;
             border-radius: 5px;
             display: flex;
 
@@ -554,7 +555,7 @@ div.cratesfyi-package-container {
             }
 
             &:hover {
-                border-color: #81c5ee;
+                border-color: #3061f3;
             }
         }
     }

--- a/templates/style/base.scss
+++ b/templates/style/base.scss
@@ -444,87 +444,118 @@ div.cratesfyi-package-container {
     border-bottom: 1px solid $color-border;
     margin-bottom: 20px;
 
-    h1 {
-        margin: 0;
-        padding: 15px 0 0 14px;
+    .container {
+        display: flex;
+        align-items: center;
 
-        &.no-description {
-            padding-bottom: 15px;
-        }
-    }
+        .description-container {
+            flex-grow: 3;
 
-    div.description {
-        font-family: $font-family-serif;
-        margin: 0;
-        padding: 0 0 15px 14px;
+            h1 {
+                margin: 0;
+                padding: 15px 14px;
 
-        @media #{$media-sm} {
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-    }
+                @media #{$media-sm} {
+                    padding: 15px 0 0 14px;
+                }
 
-    div.description-in-rustdoc {
-        padding: 10px 0 10px 14px;
-    }
+                &.no-description {
+                    padding-bottom: 15px;
+                }
+            }
 
-    .pure-menu {
-        margin-bottom: -1px;
-        padding-left: 14px;
-
-        .pure-menu-link {
-            color: #666;
-            font-size: 14px;
-            padding: 0.4em 1em 0.3em 1em;
-
-            .title {
+            div.description {
                 display: none;
 
                 @media #{$media-sm} {
-                    display: inline;
+                    font-family: $font-family-serif;
+                    margin: 0;
+                    padding: 2px 0 14px 15px;
+                    display: block;
+                }
+            }
+
+            div.description-in-rustdoc {
+                padding: 10px 0 10px 14px;
+            }
+
+            .pure-menu {
+                margin-bottom: -1px;
+                padding-left: 14px;
+
+                .pure-menu-link {
+                    color: #666;
+                    font-size: 14px;
+                    padding: 0.4em 1em 0.3em 1em;
+
+                    .title {
+                        display: none;
+
+                        @media #{$media-sm} {
+                            display: inline;
+                        }
+                    }
+                }
+
+                .pure-menu-active {
+                    color: $color-standard;
+                    background-color: #fff;
+                    border-top: 1px solid $color-border;
+                    border-left: 1px solid $color-border;
+                    border-right: 1px solid $color-border;
+                    border-top-left-radius: 4px;
+                    border-top-right-radius: 4px;
+                    border-bottom: 2px solid #fff;
+                }
+
+                .pure-menu-active:hover {
+                    background-color: #fff !important;
+                }
+
+                .pure-menu-link:hover {
+                    color: #000;
+                    background-color: inherit;
+                }
+            }
+
+            ul.platforms-menu {
+                float: right;
+                display: none;
+
+                ul.pure-menu-children {
+                    left: auto;
+                    right: 0;
+                    border: 1px solid $color-border;
+                    border-radius: 2px;
+                }
+
+                .pure-menu-has-children > .pure-menu-link:after {
+                    font-size: 14px;
+                }
+
+                @media #{$media-sm} {
+                    display: inline-block;
                 }
             }
         }
 
-        .pure-menu-active {
-            color: $color-standard;
-            background-color: #fff;
-            border-top: 1px solid $color-border;
-            border-left: 1px solid $color-border;
-            border-right: 1px solid $color-border;
-            border-top-left-radius: 4px;
-            border-top-right-radius: 4px;
-            border-bottom: 2px solid #fff;
-        }
+        .doc-link {
+            margin: 0 10px;
+            height: min-content;
+            background: #fff;
+            padding: 10px;
+            border: 1px solid #ccc;
+            border-radius: 5px;
+            display: flex;
 
-        .pure-menu-active:hover {
-            background-color: #fff !important;
-        }
+            .fas {
+                margin-top: 2px;
+                margin-right: 6px;
+            }
 
-        .pure-menu-link:hover {
-            color: #000;
-            background-color: inherit;
-        }
-    }
-
-    ul.platforms-menu {
-        float: right;
-        display: none;
-
-        ul.pure-menu-children {
-            left: auto;
-            right: 0;
-            border: 1px solid $color-border;
-            border-radius: 2px;
-        }
-
-        .pure-menu-has-children > .pure-menu-link:after {
-            font-size: 14px;
-        }
-
-        @media #{$media-sm} {
-            display: inline-block;
+            &:hover {
+                border-color: #81c5ee;
+            }
         }
     }
 }


### PR DESCRIPTION
Same as before but with a fix for the 404 pages and a test to avoid regressions.

EDIT: Back to tab style but the "documentation" tab is now a button:

mobile:

![Screenshot from 2020-09-08 17-50-40](https://user-images.githubusercontent.com/3050060/92499385-171c3a80-f1fc-11ea-8189-4e542988801f.png)

"normal":

![Screenshot from 2020-09-08 17-50-37](https://user-images.githubusercontent.com/3050060/92499391-17b4d100-f1fc-11ea-9cd7-a7a52e2a3f9e.png)
