### PR TITLE
Don't crash if trying to move directories for a target that failed

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -532,7 +532,8 @@ impl RustwideBuilder {
         // cargo will put the output in `target/<target>/doc`.
         // However, if this is the default build, we don't want it there,
         // we want it in `target/doc`.
-        if target != HOST_TARGET && is_default_target {
+        // NOTE: don't rename this if the build failed, because `target/<target>/doc` won't exist.
+        if successful && target != HOST_TARGET && is_default_target {
             // mv target/$target/doc target/doc
             let target_dir = build.host_target_dir();
             let old_dir = target_dir.join(target).join("doc");


### PR DESCRIPTION
Fixes https://github.com/rust-lang/docs.rs/issues/1035.

Previously, if there was a build with
- a non-default target
- that failed to build

docs.rs would crash:
```
[DEBUG] cratesfyi::docbuilder::rustwide_builder: rename /home/cratesfyi/workspace/builds/stm32h7xx-hal-0.7.0/target/thumbv7em-none-eabihf/doc to /home/cratesfyi/workspace/builds/stm32h7xx-hal-0.7.0/target/doc
 2020/09/03 20:15:49 [ERROR] cratesfyi::build_queue: Failed to build package stm32h7xx-hal-0.7.0 from queue: No such file or directory (os error 2)
 Backtrace:    0: failure::backtrace::internal::InternalBacktrace::new
    1: <failure::backtrace::Backtrace as core::default::Default>::default
    2: cratesfyi::docbuilder::rustwide_builder::RustwideBuilder::execute_build
    3: rustwide::build::BuildBuilder::run
    4: cratesfyi::docbuilder::rustwide_builder::RustwideBuilder::build_package
    5: cratesfyi::build_queue::BuildQueue::process_next_crate
    6: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
    7: cratesfyi::utils::queue_builder::queue_builder
    8: std::sys_common::backtrace::__rust_begin_short_backtrace
    9: core::ops::function::FnOnce::call_once{{vtable.shim}}
   10: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
              at /rustc/d3fb005a39e62501b8b0b356166e515ae24e2e54/src/liballoc/boxed.rs:1076
       <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
              at /rustc/d3fb005a39e62501b8b0b356166e515ae24e2e54/src/liballoc/boxed.rs:1076
       std::sys::unix::thread::Thread::new::thread_start
              at /rustc/d3fb005a39e62501b8b0b356166e515ae24e2e54/src/libstd/sys/unix/thread.rs:87
   11: start_thread
   12: __clone
```

The issue is it was trying to rename a directory that didn't exist,
because the build failed. This no longer tries to rename the directory
unless the build succeeded.

r? @Nemo157  (and thanks for the help debugging!)