### PR TITLE
Introduced Nope::VersionNotFound error

### DIFF
--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -10,6 +10,7 @@ use std::{error::Error, fmt};
 pub enum Nope {
     ResourceNotFound,
     CrateNotFound,
+    VersionNotFound,
     NoResults,
     InternalServerError,
 }
@@ -19,6 +20,7 @@ impl fmt::Display for Nope {
         f.write_str(match *self {
             Nope::ResourceNotFound => "Requested resource not found",
             Nope::CrateNotFound => "Requested crate not found",
+            Nope::VersionNotFound => "Requested crate does not have specified version",
             Nope::NoResults => "Search yielded no results",
             Nope::InternalServerError => "Internal server error",
         })
@@ -47,6 +49,17 @@ impl Handler for Nope {
                 ErrorPage {
                     title: "The requested crate does not exist",
                     message: Some("no such crate".into()),
+                    status: Status::NotFound,
+                }
+                .into_response(req)
+            }
+
+            Nope::VersionNotFound => {
+                // user tried to navigate to a crate with a version that does not exist
+                // TODO: Display the attempted crate and version
+                ErrorPage {
+                    title: "The requested version does not exist",
+                    message: Some("no such version for this crate".into()),
                     status: Status::NotFound,
                 }
                 .into_response(req)

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -557,7 +557,7 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
             // since we never pass a version into `match_version` here, we'll never get
             // `MatchVersion::Exact`, so the distinction between `Exact` and `Semver` doesn't
             // matter
-            if let Some(matchver) = match_version(&mut conn, &query, None) {
+            if let Ok(matchver) = match_version(&mut conn, &query, None) {
                 let (version, id) = matchver.version.into_parts();
                 let query = matchver.corrected_name.unwrap_or_else(|| query.to_string());
 


### PR DESCRIPTION
Trying to reproduce the issue #55 revealed another bug: the order in which the different handlers were called in CratesfyiHandler::handle resulted in the more specific errors from the router_handler being dropped, due to them being 404 and the last handler being the static_handler which would just return a ResourceNotFound error.
It should be noted that the different execution order might affect the performance in production.