### PR TITLE
Add `impl From<Nope> for IronError` and use it across the codebase

### DIFF
--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -29,6 +29,22 @@ impl fmt::Display for Nope {
 
 impl Error for Nope {}
 
+impl From<Nope> for IronError {
+    fn from(err: Nope) -> IronError {
+        use iron::status;
+
+        let status = match err {
+            Nope::ResourceNotFound
+            | Nope::CrateNotFound
+            | Nope::VersionNotFound
+            | Nope::NoResults => status::NotFound,
+            Nope::InternalServerError => status::InternalServerError,
+        };
+
+        IronError::new(err, status)
+    }
+}
+
 impl Handler for Nope {
     fn handle(&self, req: &mut Request) -> IronResult<Response> {
         match *self {

--- a/src/web/file.rs
+++ b/src/web/file.rs
@@ -2,7 +2,7 @@
 
 use crate::storage::{Blob, Storage};
 use crate::{error::Result, Config};
-use iron::{status, Handler, IronError, IronResult, Request, Response};
+use iron::{status, Handler, IronResult, Request, Response};
 
 #[derive(Debug)]
 pub(crate) struct File(pub(crate) Blob);
@@ -62,10 +62,7 @@ impl Handler for DatabaseFileHandler {
         if let Ok(file) = File::from_path(&storage, &path, &config) {
             Ok(file.serve())
         } else {
-            Err(IronError::new(
-                super::error::Nope::CrateNotFound,
-                status::NotFound,
-            ))
+            Err(super::error::Nope::CrateNotFound.into())
         }
     }
 }

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -12,7 +12,7 @@ use iron::{
     headers::{ContentType, Expires, HttpDate},
     mime::{Mime, SubLevel, TopLevel},
     modifiers::Redirect,
-    status, IronError, IronResult, Request, Response, Url,
+    status, IronResult, Request, Response, Url,
 };
 use postgres::Client;
 use router::Router;
@@ -420,7 +420,7 @@ pub fn author_handler(req: &mut Request) -> IronResult<Response> {
     let author = router
         .find("author")
         // TODO: Accurate error here, the author wasn't provided
-        .ok_or_else(|| IronError::new(Nope::CrateNotFound, status::NotFound))?;
+        .ok_or(Nope::CrateNotFound)?;
 
     let (author_name, releases) = {
         let mut conn = extension!(req, Pool).get()?;
@@ -442,7 +442,7 @@ pub fn author_handler(req: &mut Request) -> IronResult<Response> {
 
     if releases.is_empty() {
         // TODO: Accurate error here, the author wasn't found
-        return Err(IronError::new(Nope::CrateNotFound, status::NotFound));
+        return Err(Nope::CrateNotFound.into());
     }
 
     // Show next and previous page buttons
@@ -621,7 +621,7 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
         }
         .into_response(req)
     } else {
-        Err(IronError::new(Nope::NoResults, status::NotFound))
+        Err(Nope::NoResults.into())
     }
 }
 

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -284,10 +284,7 @@ impl Handler for BlockBlacklistedPrefixes {
     fn handle(&self, req: &mut iron::Request) -> iron::IronResult<iron::Response> {
         if let Some(prefix) = req.url.path().get(0) {
             if self.blacklist.contains(*prefix) {
-                return Err(iron::IronError::new(
-                    super::error::Nope::CrateNotFound,
-                    iron::status::NotFound,
-                ));
+                return Err(super::error::Nope::CrateNotFound.into());
             }
         }
         self.handler.handle(req)

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -12,7 +12,7 @@ use crate::{
 use iron::{
     headers::{CacheControl, CacheDirective, Expires, HttpDate},
     modifiers::Redirect,
-    status, Handler, IronError, IronResult, Request, Response, Url,
+    status, Handler, IronResult, Request, Response, Url,
 };
 use lol_html::errors::RewritingError;
 use router::Router;
@@ -110,10 +110,10 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
 
             let path = req.url.path();
             let path = path.join("/");
-            match File::from_path(&storage, &path, &config) {
-                Ok(f) => return Ok(f.serve()),
-                Err(..) => return Err(IronError::new(Nope::ResourceNotFound, status::NotFound)),
-            }
+            return match File::from_path(&storage, &path, &config) {
+                Ok(f) => Ok(f.serve()),
+                Err(..) => Err(Nope::ResourceNotFound.into()),
+            };
         }
     } else if req
         .url
@@ -142,19 +142,13 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
 
     // it doesn't matter if the version that was given was exact or not, since we're redirecting
     // anyway
-    let (version, id) = match match_version(&mut conn, &crate_name, req_version) {
-        Ok(v) => {
-            if let Some(new_name) = v.corrected_name {
-                // `match_version` checked against -/_ typos, so if we have a name here we should
-                // use that instead
-                crate_name = new_name;
-            }
-            v.version.into_parts()
-        }
-        Err(err) => {
-            return Err(IronError::new(err, status::NotFound));
-        }
-    };
+    let v = match_version(&mut conn, &crate_name, req_version)?;
+    if let Some(new_name) = v.corrected_name {
+        // `match_version` checked against -/_ typos, so if we have a name here we should
+        // use that instead
+        crate_name = new_name;
+    }
+    let (version, id) = v.version.into_parts();
 
     // get target name and whether it has docs
     // FIXME: This is a bit inefficient but allowing us to use less code in general
@@ -287,8 +281,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
     // * If both the name and the version are an exact match, return the version of the crate.
     // * If there is an exact match, but the requested crate name was corrected (dashes vs. underscores), redirect to the corrected name.
     // * If there is a semver (but not exact) match, redirect to the exact version.
-    let release_found = match_version(&mut conn, &name, url_version)
-        .map_err(|err| IronError::new(err, status::NotFound))?;
+    let release_found = match_version(&mut conn, &name, url_version)?;
 
     let version = match release_found.version {
         MatchSemver::Exact((version, _)) => {
@@ -348,7 +341,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
             return if ctry!(req, storage.exists(&path)) {
                 redirect(&name, &version, &req_path[3..])
             } else {
-                Err(IronError::new(Nope::ResourceNotFound, status::NotFound))
+                Err(Nope::ResourceNotFound.into())
             };
         }
     };
@@ -474,7 +467,7 @@ pub fn target_redirect_handler(req: &mut Request) -> IronResult<Response> {
 
     let crate_details = match CrateDetails::new(&mut conn, &name, &version) {
         Some(krate) => krate,
-        None => return Err(IronError::new(Nope::ResourceNotFound, status::NotFound)),
+        None => return Err(Nope::ResourceNotFound.into()),
     };
 
     //   [crate, :name, :version, target-redirect, :target, *path]
@@ -608,7 +601,7 @@ impl Handler for SharedResourceHandler {
         }
 
         // Just always return a 404 here - the main handler will then try the other handlers
-        Err(IronError::new(Nope::ResourceNotFound, status::NotFound))
+        Err(Nope::ResourceNotFound.into())
     }
 }
 

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -6,7 +6,7 @@ use crate::{
     web::{error::Nope, file::File as DbFile, page::WebPage, MetaData},
     Config, Storage,
 };
-use iron::{status::Status, IronError, IronResult, Request, Response};
+use iron::{IronResult, Request, Response};
 use postgres::Client;
 use router::Router;
 use serde::Serialize;
@@ -213,8 +213,8 @@ pub fn source_browser_handler(req: &mut Request) -> IronResult<Response> {
         (None, false)
     };
 
-    let file_list = FileList::from_path(&mut conn, &name, &version, &req_path)
-        .ok_or_else(|| IronError::new(Nope::NoResults, Status::NotFound))?;
+    let file_list =
+        FileList::from_path(&mut conn, &name, &version, &req_path).ok_or(Nope::NoResults)?;
 
     SourcePage {
         file_list,


### PR DESCRIPTION
This cleans things up quite a bit. It also makes the eventual transition
to hyper easier, since we can modify the `From` impl instead of changing
each line one at a time.

Helps with https://github.com/rust-lang/docs.rs/issues/860.
r? @Nemo157