### PR TITLE
Revert "Only show rustdoc styles on rustdoc pages"

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -11,6 +11,9 @@
 
         {# Docs.rs styles #}
         <link rel="stylesheet" href="/-/static/vendored.css?{{ docsrs_version() | slugify }}" type="text/css" media="all" />
+        <link rel="stylesheet" href="/normalize-{{ rustc_resource_suffix() }}.css" type="text/css" media="all" />
+        <link rel="stylesheet" href="/rustdoc-{{ rustc_resource_suffix() }}.css" type="text/css" media="all" />
+        <link rel="stylesheet" href="/light-{{ rustc_resource_suffix() }}.css" type="text/css" media="all" />
         <link rel="stylesheet" href="/-/static/style.css?{{ docsrs_version() | slugify }}" type="text/css" media="all" />
 
         {%- block css -%}{%- endblock css -%}

--- a/templates/rustdoc/head.html
+++ b/templates/rustdoc/head.html
@@ -1,7 +1,4 @@
 {%- import "macros.html" as macros -%}
         <link rel="stylesheet" href="/-/static/style.css?{{ docsrs_version() | slugify }}" type="text/css" media="all" />
-        <link rel="stylesheet" href="/normalize-{{ rustc_resource_suffix() }}.css" type="text/css" media="all" />
-        <link rel="stylesheet" href="/rustdoc-{{ rustc_resource_suffix() }}.css" type="text/css" media="all" />
-        <link rel="stylesheet" href="/light-{{ rustc_resource_suffix() }}.css" type="text/css" media="all" />
 
         <link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="Docs.rs">


### PR DESCRIPTION
Reverts rust-lang/docs.rs#1056

 This broke all styles other than the default light style (they just showed as light).