### PR TITLE
Capture more metadata about crates and stop using json for dependencies

### DIFF
--- a/crates/metadata/build.rs
+++ b/crates/metadata/build.rs
@@ -4,6 +4,7 @@ fn main() {
         "cargo:rustc-env=DOCS_RS_METADATA_HOST_TARGET={}",
         std::env::var("TARGET").unwrap(),
     );
+
     // This only needs to be rerun if the TARGET changed, in which case cargo reruns it anyway.
     // See https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-env-changedname
     println!("cargo:rerun-if-changed=build.rs");

--- a/crates/metadata/lib.rs
+++ b/crates/metadata/lib.rs
@@ -51,6 +51,7 @@ use toml::Value;
 ///
 /// [`TARGET`]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
 pub const HOST_TARGET: &str = env!("DOCS_RS_METADATA_HOST_TARGET");
+
 /// The targets that are built if no `targets` section is specified.
 ///
 /// Currently, this is guaranteed to have only [tier one] targets.
@@ -88,17 +89,17 @@ pub enum MetadataError {
 /// name = "test"
 ///
 /// [package.metadata.docs.rs]
-/// features = [ "feature1", "feature2" ]
+/// features = ["feature1", "feature2"]
 /// all-features = true
 /// no-default-features = true
 /// default-target = "x86_64-unknown-linux-gnu"
-/// targets = [ "x86_64-apple-darwin", "x86_64-pc-windows-msvc" ]
-/// rustc-args = [ "--example-rustc-arg" ]
-/// rustdoc-args = [ "--example-rustdoc-arg" ]
+/// targets = ["x86_64-apple-darwin", "x86_64-pc-windows-msvc"]
+/// rustc-args = ["--example-rustc-arg"]
+/// rustdoc-args = ["--example-rustdoc-arg"]
 /// ```
 ///
 /// You can define one or more fields in your `Cargo.toml`.
-#[derive(Default, Deserialize)]
+#[derive(Default, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Metadata {
     /// List of features to pass on to `cargo`.
@@ -113,7 +114,7 @@ pub struct Metadata {
     /// Whether to pass `--no-default-features` to `cargo`.
     //
     /// By default, Docs.rs will build default features.
-    /// Set `no-default-fatures` to `true` if you want to build only certain features.
+    /// Set `no-default-features` to `true` if you want to build only certain features.
     #[serde(default)]
     no_default_features: bool,
 
@@ -249,7 +250,7 @@ impl Metadata {
     pub fn environment_variables(&self) -> HashMap<&'static str, String> {
         let joined = |v: &Option<Vec<_>>| v.as_ref().map(|args| args.join(" ")).unwrap_or_default();
 
-        let mut map = HashMap::new();
+        let mut map = HashMap::with_capacity(3);
         map.insert("RUSTFLAGS", joined(&self.rustc_args));
         map.insert("RUSTDOCFLAGS", self.rustdoc_args.join(" "));
         // For docs.rs detection from build scripts:

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -5,7 +5,10 @@ use crate::storage::Storage;
 use crate::utils::{Dependency, MetadataPackage, Target};
 use chrono::{DateTime, Utc};
 use failure::Error;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
+
+const DEFAULT_CONTENT: &[u8] =
+    b"<html><head></head><body>default content for test/fakes</body></html>";
 
 #[must_use = "FakeRelease does nothing until you call .create()"]
 pub(crate) struct FakeRelease<'a> {
@@ -27,9 +30,6 @@ pub(crate) struct FakeRelease<'a> {
     readme: Option<&'a str>,
 }
 
-const DEFAULT_CONTENT: &[u8] =
-    b"<html><head></head><body>default content for test/fakes</body></html>";
-
 impl<'a> FakeRelease<'a> {
     pub(super) fn new(db: &'a TestDatabase, storage: Arc<Storage>) -> Self {
         FakeRelease {
@@ -40,19 +40,29 @@ impl<'a> FakeRelease<'a> {
                 name: "fake-package".into(),
                 version: "1.0.0".into(),
                 license: Some("MIT".into()),
+                license_file: None,
                 repository: Some("https://git.example.com".into()),
                 homepage: Some("https://www.example.com".into()),
                 description: Some("Fake package".into()),
                 documentation: Some("https://docs.example.com".into()),
                 dependencies: vec![Dependency {
                     name: "fake-dependency".into(),
-                    req: "^1.0.0".into(),
+                    version_requirement: "^1.0.0".into(),
                     kind: None,
+                    rename: None,
+                    optional: false,
+                    default_features: true,
+                    features: Vec::new(),
+                    target: None,
                 }],
                 targets: vec![Target::dummy_lib("fake_package".into(), None)],
                 readme: None,
                 keywords: vec!["fake".into(), "package".into()],
                 authors: vec!["Fake Person <fake@example.com>".into()],
+                features: HashMap::new(),
+                categories: Vec::new(),
+                edition: "2018".to_owned(),
+                metadata: None,
             },
             build_result: BuildResult {
                 rustc_version: "rustc 2.0.0-nightly (000000000 1970-01-01)".into(),

--- a/src/utils/cargo_metadata.rs
+++ b/src/utils/cargo_metadata.rs
@@ -1,157 +1,255 @@
+#[cfg(test)]
+pub use raw::Target;
+pub use raw::{Dependency, Package};
+
 use crate::error::Result;
 use rustwide::{cmd::Command, Toolchain, Workspace};
-use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+};
 
-pub(crate) struct CargoMetadata {
+const CARGO_METADATA_ARGS: &[&str] = &["metadata", "--format-version", "1"];
+
+pub struct CargoMetadata {
     packages: HashMap<String, Package>,
-    deps_graph: HashMap<String, HashSet<String>>,
-    root_id: String,
+    dependency_graph: HashMap<String, HashSet<String>>,
+    root_package_id: String,
 }
 
 impl CargoMetadata {
-    pub(crate) fn load(
-        workspace: &Workspace,
-        toolchain: &Toolchain,
-        source_dir: &Path,
-    ) -> Result<Self> {
-        let res = Command::new(workspace, toolchain.cargo())
-            .args(&["metadata", "--format-version", "1"])
+    pub fn load(workspace: &Workspace, toolchain: &Toolchain, source_dir: &Path) -> Result<Self> {
+        let output = Command::new(workspace, toolchain.cargo())
+            .args(CARGO_METADATA_ARGS)
             .cd(source_dir)
             .log_output(false)
             .run_capture()?;
 
-        let mut iter = res.stdout_lines().iter();
-        let metadata = if let (Some(serialized), None) = (iter.next(), iter.next()) {
-            serde_json::from_str::<DeserializedMetadata>(serialized)?
-        } else {
-            return Err(::failure::err_msg(
-                "invalid output returned by `cargo metadata`",
-            ));
+        let metadata = {
+            let mut stdout = output.stdout_lines().iter();
+
+            if let (Some(serialized), None) = (stdout.next(), stdout.next()) {
+                serde_json::from_str::<raw::MetadataRoot>(serialized)?
+            } else {
+                return Err(::failure::err_msg(
+                    "invalid output returned by `cargo metadata`",
+                ));
+            }
         };
 
-        // Convert from Vecs to HashMaps and HashSets to get more efficient lookups
+        // Collect all packages into a map by their id
+        let packages = metadata
+            .packages
+            .into_iter()
+            .map(|pkg| (pkg.id.clone(), pkg))
+            .collect();
+
+        // Collect a dependency graph of package ids to the ids of packages they depend on
+        let dependency_graph = metadata
+            .resolve
+            .nodes
+            .into_iter()
+            .map(|node| {
+                let dependents = node
+                    .deps
+                    .into_iter()
+                    .map(|dependent| dependent.pkg)
+                    .collect();
+
+                (node.id, dependents)
+            })
+            .collect();
+
+        // Get the id of the root package, aka the one we're building
+        let root_package_id = metadata.resolve.root;
+
         Ok(CargoMetadata {
-            packages: metadata
-                .packages
-                .into_iter()
-                .map(|pkg| (pkg.id.clone(), pkg))
-                .collect(),
-            deps_graph: metadata
-                .resolve
-                .nodes
-                .into_iter()
-                .map(|node| (node.id, node.deps.into_iter().map(|d| d.pkg).collect()))
-                .collect(),
-            root_id: metadata.resolve.root,
+            packages,
+            dependency_graph,
+            root_package_id,
         })
     }
 
+    /// Get the root package
+    pub(crate) fn root(&self) -> &Package {
+        self.get_package(&self.root_package_id)
+            .expect("the root package does not exist within the given metadata")
+    }
+
+    pub(crate) fn get_package(&self, id: &str) -> Option<&Package> {
+        self.packages.get(id)
+    }
+
+    /// Get all direct dependencies of the root package
     pub(crate) fn root_dependencies(&self) -> Vec<&Package> {
-        let ids = &self.deps_graph[&self.root_id];
+        let ids = self
+            .dependency_graph
+            .get(&self.root_package_id)
+            .expect("the root package does not exist within the given metadata");
+
         self.packages
             .iter()
             .filter(|(id, _pkg)| ids.contains(id.as_str()))
             .map(|(_id, pkg)| pkg)
             .collect()
     }
-
-    pub(crate) fn root(&self) -> &Package {
-        &self.packages[&self.root_id]
-    }
 }
 
-#[derive(Deserialize, Serialize)]
-pub(crate) struct Package {
-    pub(crate) id: String,
-    pub(crate) name: String,
-    pub(crate) version: String,
-    pub(crate) license: Option<String>,
-    pub(crate) repository: Option<String>,
-    pub(crate) homepage: Option<String>,
-    pub(crate) description: Option<String>,
-    pub(crate) documentation: Option<String>,
-    pub(crate) dependencies: Vec<Dependency>,
-    pub(crate) targets: Vec<Target>,
-    pub(crate) readme: Option<String>,
-    pub(crate) keywords: Vec<String>,
-    pub(crate) authors: Vec<String>,
-}
+mod raw {
+    use serde::{Deserialize, Serialize};
+    use std::collections::HashMap;
 
-impl Package {
-    fn library_target(&self) -> Option<&Target> {
-        self.targets
-            .iter()
-            .find(|target| target.crate_types.iter().any(|kind| kind != "bin"))
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct MetadataRoot {
+        pub packages: Vec<Package>,
+        pub resolve: Resolve,
+        /// The members of the current workspace in the format of `{name} {version} ({path})`.
+        /// Used to resolve `path`-based dependencies
+        pub workspace_members: Vec<String>,
     }
 
-    pub(crate) fn is_library(&self) -> bool {
-        self.library_target().is_some()
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct Resolve {
+        pub nodes: Vec<Node>,
+        pub root: String,
     }
 
-    fn normalize_package_name(&self, name: &str) -> String {
-        name.replace('-', "_")
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct Node {
+        pub id: String,
+        pub dependencies: Vec<String>,
+        pub deps: Vec<Dep>,
+        pub features: Vec<String>,
     }
 
-    pub(crate) fn package_name(&self) -> String {
-        self.library_name()
-            .unwrap_or_else(|| self.normalize_package_name(&self.targets[0].name))
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct Dep {
+        pub name: String,
+        pub pkg: String,
+        pub dep_kinds: Vec<DepKind>,
     }
 
-    pub(crate) fn library_name(&self) -> Option<String> {
-        self.library_target()
-            .map(|target| self.normalize_package_name(&target.name))
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct DepKind {
+        pub kind: Option<String>,
+        pub target: Option<String>,
     }
-}
 
-#[derive(Deserialize, Serialize)]
-pub(crate) struct Target {
-    pub(crate) name: String,
-    #[cfg(not(test))]
-    crate_types: Vec<String>,
-    #[cfg(test)]
-    pub(crate) crate_types: Vec<String>,
-    pub(crate) src_path: Option<String>,
-}
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct Package {
+        pub name: String,
+        pub version: String,
+        /// The id of the package in the format of `{name} {version} ({path})`.
+        /// Use in conjunction with `workspace_members` to resolve `path`-based dependencies
+        pub id: String,
+        pub license: Option<String>,
+        pub license_file: Option<String>,
+        pub description: Option<String>,
+        pub dependencies: Vec<Dependency>,
+        pub targets: Vec<Target>,
+        pub features: HashMap<String, Vec<String>>,
+        pub authors: Vec<String>,
+        pub categories: Vec<String>,
+        pub keywords: Vec<String>,
+        pub readme: Option<String>,
+        pub repository: Option<String>,
+        pub homepage: Option<String>,
+        pub documentation: Option<String>,
+        pub edition: String,
+        pub metadata: Option<Metadata>,
+    }
 
-impl Target {
-    #[cfg(test)]
-    pub(crate) fn dummy_lib(name: String, src_path: Option<String>) -> Self {
-        Target {
-            name,
-            crate_types: vec!["lib".into()],
-            src_path,
+    impl Package {
+        fn library_target(&self) -> Option<&Target> {
+            self.targets
+                .iter()
+                .find(|target| target.crate_types.iter().any(|kind| kind != "bin"))
+        }
+
+        pub(crate) fn is_library(&self) -> bool {
+            self.library_target().is_some()
+        }
+
+        fn normalize_package_name(&self, name: &str) -> String {
+            name.replace('-', "_")
+        }
+
+        pub(crate) fn package_name(&self) -> String {
+            self.library_name()
+                .unwrap_or_else(|| self.normalize_package_name(&self.targets[0].name))
+        }
+
+        pub(crate) fn library_name(&self) -> Option<String> {
+            self.library_target()
+                .map(|target| self.normalize_package_name(&target.name))
         }
     }
-}
 
-#[derive(Deserialize, Serialize)]
-pub(crate) struct Dependency {
-    pub(crate) name: String,
-    pub(crate) req: String,
-    pub(crate) kind: Option<String>,
-}
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct Dependency {
+        pub name: String,
+        #[serde(rename = "req")]
+        pub version_requirement: String,
+        pub kind: Option<String>,
+        pub rename: Option<String>,
+        pub optional: bool,
+        #[serde(rename = "uses_default_features")]
+        pub default_features: bool,
+        pub features: Vec<String>,
+        pub target: Option<String>,
+    }
 
-#[derive(Deserialize, Serialize)]
-struct DeserializedMetadata {
-    packages: Vec<Package>,
-    resolve: DeserializedResolve,
-}
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+    #[serde(rename_all = "kebab-case")]
+    pub struct Target {
+        pub name: String,
+        pub kind: Vec<String>,
+        #[serde(rename = "crate_types")]
+        pub crate_types: Vec<String>,
+        pub src_path: Option<String>,
+        pub edition: String,
+        pub doctest: bool,
+        #[serde(default)]
+        pub required_features: Vec<String>,
+    }
 
-#[derive(Deserialize, Serialize)]
-struct DeserializedResolve {
-    root: String,
-    nodes: Vec<DeserializedResolveNode>,
-}
+    impl Target {
+        #[cfg(test)]
+        pub(crate) fn dummy_lib(name: String, src_path: Option<String>) -> Self {
+            Target {
+                name,
+                crate_types: vec!["lib".into()],
+                src_path,
+                kind: vec!["lib".to_owned()],
+                doctest: false,
+                edition: "2018".to_owned(),
+                required_features: Vec::new(),
+            }
+        }
+    }
 
-#[derive(Deserialize, Serialize)]
-struct DeserializedResolveNode {
-    id: String,
-    deps: Vec<DeserializedResolveDep>,
-}
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct Metadata {
+        pub docs: Option<Docs>,
+    }
 
-#[derive(Deserialize, Serialize)]
-struct DeserializedResolveDep {
-    pkg: String,
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct Docs {
+        pub rs: Rs,
+    }
+
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+    #[serde(rename_all = "kebab-case")]
+    pub struct Rs {
+        #[serde(default)]
+        pub targets: Vec<String>,
+        #[serde(default)]
+        pub features: Vec<String>,
+        pub all_features: Option<bool>,
+        pub default_target: Option<String>,
+        #[serde(default)]
+        pub rustdoc_args: Vec<String>,
+        pub no_default_features: Option<bool>,
+        pub rustc_args: Option<Vec<String>>,
+    }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,6 @@
 //! Various utilities for docs.rs
 
-pub(crate) use self::cargo_metadata::{CargoMetadata, Package as MetadataPackage};
+pub(crate) use self::cargo_metadata::{CargoMetadata, Dependency, Package as MetadataPackage};
 pub(crate) use self::copy::copy_doc_dir;
 pub use self::daemon::start_daemon;
 pub use self::github_updater::GithubUpdater;
@@ -11,7 +11,7 @@ pub use self::release_activity_updater::update_release_activity;
 pub(crate) use self::rustc_version::parse_rustc_version;
 
 #[cfg(test)]
-pub(crate) use self::cargo_metadata::{Dependency, Target};
+pub(crate) use self::cargo_metadata::Target;
 
 mod cargo_metadata;
 pub mod consistency;

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -1223,6 +1223,7 @@ mod tests {
                 let page = kuchiki::parse_html()
                     .one(env.frontend().get(url).send().unwrap().text().unwrap());
                 assert_eq!(page.select("#crate-title").unwrap().count(), 1);
+
                 let not_matching = page
                     .select(sel)
                     .unwrap()
@@ -1240,9 +1241,11 @@ mod tests {
                     )
                     .filter(|(a, b)| a.as_str() != **b)
                     .collect::<Vec<_>>();
-                if not_matching.len() > 0 {
+
+                if !not_matching.is_empty() {
                     let not_found = not_matching.iter().map(|(_, b)| b).collect::<Vec<_>>();
                     let found = not_matching.iter().map(|(a, _)| a).collect::<Vec<_>>();
+
                     assert!(
                         not_matching.is_empty(),
                         "Titles did not match for URL `{}`: not found: {:?}, found: {:?}",


### PR DESCRIPTION
The goals of this pr are simple: Get some more data about crates so that I can implement a features display, and stop using json to represent dependencies within the `releases` table.

The structs that parse out info from `cargo metadata`'s output got a little refactor and now get everything we need, so that part is done. The part I'm not having a fun time with is the database side of things, migrating the old json columns into the new table. There's also some only vaguely finished stuff (e.g. dependency versioning, the idea is that we'll have an enum on our side that tells us if it's the old and limited-in-data picture of the dependency or the new rich one, this is only actually mentioned in the migration query atm). The type-unsafe nature of our current database interactions is also a source of annoyance since I now have to manually hunt down points of interaction with the dependencies column, which as of now has not been done.