### PR TITLE
Redirect to documentation in the version link

### DIFF
--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -103,7 +103,7 @@
                             <div class="pure-menu pure-menu-scrollable sub-menu">
                                 <ul class="pure-menu-list">
                                     {# Display all releases of this crate #}
-                                    {{ macros::releases_list(name=details.name, releases=details.releases) }}
+                                    {{ macros::releases_list(name=details.name, releases=details.releases, target="", inner_path="") }}
                                 </ul>
                             </div>
                         </li>

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -114,11 +114,18 @@
         * `yanked` A boolean of the release's yanked status
         * `build_status` A boolean of the crate's build status (true for built, false for failed build)
         * `is_library` A boolean that's true if the crate is a library and false if it's a binary
+    * `target` The target platform (empty string if the default or a `/crate` page)
+    * `inner_path` The current rustdoc page (empty string if a `/crate` page)
 #}
-{% macro releases_list(name, releases) %}
+{% macro releases_list(name, releases, target, inner_path) %}
     {%- for release in releases -%}
         {# The url for the release, `/crate/:name/:version` #}
-        {%- set release_url = "/crate/" ~ name ~ "/" ~ release.version -%}
+        {# NOTE: `/` is part of target if it exists (to avoid `target-direct//path`) #}
+        {% if inner_path == "" %} {# /crate #}
+            {%- set release_url = "/crate/" ~ name ~ "/" ~ release.version -%}
+        {% else %}
+            {%- set release_url = "/crate/" ~ name ~ "/" ~ release.version ~ "/target-redirect/" ~ target ~ inner_path -%}
+        {% endif %}
         {# The release's name and version, `:name-:version` #}
         {%- set release_name = name ~ "-" ~ release.version -%}
 

--- a/templates/rustdoc/header.html
+++ b/templates/rustdoc/header.html
@@ -147,7 +147,7 @@
                                             <div class="pure-menu pure-menu-scrollable sub-menu">
                                                 <ul class="pure-menu-list">
                                                     {# Display all releases of this crate #}
-                                                    {{ macros::releases_list(name=krate.name, releases=krate.releases) }}
+                                                    {{ macros::releases_list(name=krate.name, releases=krate.releases, target=target, inner_path=inner_path) }}
                                                 </ul>
                                             </div>
                                         </li>


### PR DESCRIPTION
Previously it would redirect to /crate, which no one wanted to look at.

Closes https://github.com/rust-lang/docs.rs/issues/488.
r? @nemo157