### PR TITLE
Extend coverage feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ To rebuild the site, run `docker-compose build`.
 Note that docker-compose caches the build even if you change the source code,
 so this will be necessary anytime you make changes.
 
+If you want to completely clean up the database, don't forget to remove the volumes too:
+
+```
+$ docker-compose down --volumes
+```
+
 #### FAQ
 
 ##### I keep getting the error `standard_init_linux.go:211: exec user process caused "no such file or directory"` when I use docker-compose.

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -137,17 +137,24 @@ pub(crate) fn add_doc_coverage(
 ) -> Result<i32> {
     debug!("Adding doc coverage into database");
     let rows = conn.query(
-        "INSERT INTO doc_coverage (release_id, total_items, documented_items)
-            VALUES ($1, $2, $3)
+        "INSERT INTO doc_coverage (
+            release_id, total_items, documented_items,
+            total_items_needing_examples, items_with_examples
+        )
+            VALUES ($1, $2, $3, $4, $5)
             ON CONFLICT (release_id) DO UPDATE
                 SET
                     total_items = $2,
-                    documented_items = $3
+                    documented_items = $3,
+                    total_items_needing_examples = $4,
+                    items_with_examples = $5
             RETURNING release_id",
         &[
             &release_id,
             &doc_coverage.total_items,
             &doc_coverage.documented_items,
+            &doc_coverage.total_items_needing_examples,
+            &doc_coverage.items_with_examples,
         ],
     )?;
     Ok(rows[0].get(0))

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -438,6 +438,25 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> CratesfyiResult<(
             ALTER TABLE owners ALTER COLUMN name DROP NOT NULL;
             ALTER TABLE crates ALTER COLUMN github_stars DROP NOT NULL;
             "
+        ),
+        migration!(
+            context,
+            // version
+            18,
+            // description
+            "Add more information into doc coverage",
+            // upgrade query
+            "
+            ALTER TABLE doc_coverage
+                ADD COLUMN total_items_needing_examples INT,
+                ADD COLUMN items_with_examples INT;
+            ",
+            // downgrade query
+            "
+            ALTER TABLE doc_coverage
+                DROP COLUMN total_items_needing_examples,
+                DROP COLUMN items_with_examples;
+            "
         )
     ];
 

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -455,11 +455,15 @@ impl RustwideBuilder {
         struct FileCoverage {
             total: i32,
             with_docs: i32,
+            total_examples: i32,
+            with_examples: i32,
         }
 
         let mut coverage = DocCoverage {
             total_items: 0,
             documented_items: 0,
+            total_items_needing_examples: 0,
+            items_with_examples: 0,
         };
 
         self.prepare_command(build, target, metadata, limits, rustdoc_flags)?
@@ -472,6 +476,8 @@ impl RustwideBuilder {
                     for file in parsed.values() {
                         coverage.total_items += file.total;
                         coverage.documented_items += file.with_docs;
+                        coverage.total_items_needing_examples += file.total_examples;
+                        coverage.items_with_examples += file.with_examples;
                     }
                 }
             })
@@ -670,6 +676,11 @@ pub(crate) struct DocCoverage {
     pub(crate) total_items: i32,
     /// The items of the crate that are documented, used to calculate documentation coverage.
     pub(crate) documented_items: i32,
+    /// The total items that could have code examples in the current crate, used to calculate
+    /// documentation coverage.
+    pub(crate) total_items_needing_examples: i32,
+    /// The items of the crate that have a code example, used to calculate documentation coverage.
+    pub(crate) items_with_examples: i32,
 }
 
 pub(crate) struct BuildResult {

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -183,10 +183,18 @@ impl<'a> FakeRelease<'a> {
         self
     }
 
-    pub(crate) fn coverage(mut self, documented_items: i32, total_items: i32) -> Self {
+    pub(crate) fn coverage(
+        mut self,
+        documented_items: i32,
+        total_items: i32,
+        total_items_needing_examples: i32,
+        items_with_examples: i32,
+    ) -> Self {
         self.build_result.doc_coverage = Some(DocCoverage {
             total_items,
             documented_items,
+            total_items_needing_examples,
+            items_with_examples,
         });
         self
     }

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -45,6 +45,8 @@ pub struct CrateDetails {
     documentation_url: Option<String>,
     total_items: Option<f32>,
     documented_items: Option<f32>,
+    total_items_needing_examples: Option<f32>,
+    items_with_examples: Option<f32>,
 }
 
 fn optional_markdown<S>(markdown: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
@@ -100,7 +102,9 @@ impl CrateDetails {
                 releases.documentation_url,
                 releases.default_target,
                 doc_coverage.total_items,
-                doc_coverage.documented_items
+                doc_coverage.documented_items,
+                doc_coverage.total_items_needing_examples,
+                doc_coverage.items_with_examples
             FROM releases
             INNER JOIN crates ON releases.crate_id = crates.id
             LEFT JOIN doc_coverage ON doc_coverage.release_id = releases.id
@@ -156,6 +160,8 @@ impl CrateDetails {
 
         let documented_items: Option<i32> = krate.get("documented_items");
         let total_items: Option<i32> = krate.get("total_items");
+        let total_items_needing_examples: Option<i32> = krate.get("total_items_needing_examples");
+        let items_with_examples: Option<i32> = krate.get("items_with_examples");
 
         let mut crate_details = CrateDetails {
             name: krate.get("name"),
@@ -189,6 +195,8 @@ impl CrateDetails {
             documentation_url: krate.get("documentation_url"),
             documented_items: documented_items.map(|v| v as f32),
             total_items: total_items.map(|v| v as f32),
+            total_items_needing_examples: total_items_needing_examples.map(|v| v as f32),
+            items_with_examples: items_with_examples.map(|v| v as f32),
         };
 
         if let Some(repository_url) = crate_details.repository_url.clone() {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -644,12 +644,12 @@ mod test {
                 .name("foo")
                 .version("0.0.1")
                 .source_file("test.rs", &[])
-                .coverage(6, 10)
+                .coverage(6, 10, 2, 1)
                 .create()?;
             let web = env.frontend();
 
             let foo_crate = kuchiki::parse_html().one(web.get("/crate/foo/0.0.1").send()?.text()?);
-            for value in &["60%", "6", "10"] {
+            for value in &["60%", "6", "10", "2", "1"] {
                 assert!(foo_crate
                     .select(".pure-menu-item b")
                     .unwrap()

--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -20,7 +20,10 @@
                             {% set percent = details.documented_items * 100 / details.total_items %}
                             <li class="pure-menu-heading">Coverage</li>
                             <li class="pure-menu-item" style="text-align:center;"><b>{{ percent | round(precision=2) }}%</b><br>
-                                <span style="font-size: 13px;"><b>{{ details.documented_items }}</b> out of <b>{{ details.total_items }}</b> items documented</span>
+                                <span class="documented-info"><b>{{ details.documented_items }}</b> out of <b>{{ details.total_items }}</b> items documented</span>
+                                {%- if details.total_items_needing_examples and details.items_with_examples -%}
+                                    <span style="font-size: 13px;"><b>{{ details.items_with_examples }}</b> out of <b>{{ details.total_items_needing_examples }}</b> items with examples</span>
+                                {%- endif -%}
                             </li>
                         {%- endif -%}
                         {# List the release author's names and a link to their docs.rs profile #}

--- a/templates/style/base.scss
+++ b/templates/style/base.scss
@@ -311,6 +311,12 @@ div.package-page-container {
             margin: 20px 5px 15px 5px;
         }
 
+        li.pure-menu-item > .documented-info {
+            font-size: 13px;
+            display: block;
+            width: 100%;
+        }
+
         li.pure-menu-heading:first-child {
             margin-top: 0;
         }


### PR DESCRIPTION
Like we talked about some time ago, the doc examples have been added to rustdoc so we can now use them on docs.rs as well!

<s>For information, I decided to go for this computation: the documentation itself is worth 80% of the rating, the doc examples is the remaining 20%.</s>

After debate, for now it won't be taken into account in the percentage computation.

Here is what it looks like:

![Screenshot from 2020-10-01 16-06-23](https://user-images.githubusercontent.com/3050060/94820048-4a6b7700-0400-11eb-97c2-c13d70fb58ce.png)
