### PR TITLE
Make crates page closer to rustdoc pages.

### DIFF
--- a/templates/rustdoc/header.html
+++ b/templates/rustdoc/header.html
@@ -17,7 +17,7 @@
                 </div>
 
                 <a href="/" class="pure-menu-heading pure-menu-link">
-                    {{ "cube" | fas(fw=true) }} <span class="title">Docs.rs</span>
+                    {{ "cubes" | fas(fw=true) }} <span class="title">Docs.rs</span>
                 </a>
 
                 <ul class="pure-menu-list">

--- a/templates/style/base.scss
+++ b/templates/style/base.scss
@@ -70,7 +70,6 @@ pre {
 
 div.container {
     max-width: 1160px;
-    margin: 0 auto;
     text-align: left;
 }
 


### PR DESCRIPTION
- Align the whole page to the left, rather than center.
- Change the "Docs.rs" link on the rustdoc page to use three cubes,
  like other pages do.

Followup from #1077