### PR TITLE
Fix help blurring whole page

### DIFF
--- a/templates/style/base.scss
+++ b/templates/style/base.scss
@@ -41,17 +41,19 @@ body {
 
     // this is a super nasty override for help dialog in rustdocs
     // see #52 for details
-    .blur > :not(#help) {
-        filter: none;
-        -webkit-filter: none;
-    }
+    &.blur {
+        > :not(#help) {
+            filter: none;
+            -webkit-filter: none;
+        }
 
-    .blur > div.nav-container > *,
-    .blur > div.cratesfyi-package-container > *,
-    .blur > div.rustdoc > :not(#help) {
-        filter: blur(8px);
-        -webkit-filter: blur(8px);
-        opacity: 0.7;
+        > div.nav-container > *,
+        > div.cratesfyi-package-container > *,
+        > div.rustdoc > :not(#help) {
+            filter: blur(8px);
+            -webkit-filter: blur(8px);
+            opacity: 0.7;
+        }
     }
 }
 


### PR DESCRIPTION
Currently, when pressing the `?` key or the little `?` button next to the search bar that was recently added to rustdoc, the whole page is blurred. This makes the help unreadable.

This is caused by [doc.rs](doc.rs)'s "sandboxing"/"containerization" of rustdoc which messes up rustdoc's style. This was previously discussed in #52 and fixed in a8a3ece but a recent refactoring of the stylesheet in #943 messed up the fix.

From a cursory glance, it looks like all other changes in that PR were correct but the rule for `body.blur` was changed to `body { .blur { ... } }` in SASS which gets translated to `body .blur` (with a space in between, which has a different meaning).

This PR fixes this problem by changing the rule to `body { &.blur { ... } }` which SASS now again correctly translates to `body.blur { ... }`, therefore restoring the correct behavior of the previous fix, causing only the background to be blurred again.