### PR TITLE
Revert left-alignment on div.container.

### DIFF
--- a/templates/style/base.scss
+++ b/templates/style/base.scss
@@ -72,6 +72,7 @@ pre {
 
 div.container {
     max-width: 1160px;
+    margin: 0 auto;
     text-align: left;
 }
 


### PR DESCRIPTION
Fixes #1084. I'll circle back around later with a change to left-align just the crate page.