### PR TITLE
Make right-side menus onclick.

### DIFF
--- a/static/menu.js
+++ b/static/menu.js
@@ -49,6 +49,16 @@
         backdrop.style.display = "block";
     }
     function menuOnClick(e) {
+        // The "About", "Releases", and "Rust" menus act as menus on desktop,
+        // and links on mobile (due to pure-menu-opt-children). On desktop,
+        // we inhibit navigation events on click so the menu open action can
+        // take effect. Detect desktop by noticing that the second child
+        // is hidden.
+        console.log(this.children[1]);
+        console.log(window.getComputedStyle(this.children[1]).display);
+        if (this.children.length > 1 && window.getComputedStyle(this.children[1]).display != 'none') {
+            return false;
+        }
         if (this.getAttribute("href") != "#") {
             return;
         }

--- a/templates/header/package_navigation.html
+++ b/templates/header/package_navigation.html
@@ -43,7 +43,7 @@
                     {# If there are platforms, show a dropdown with them #}
                     {%- if platforms -%}
                         <ul class="pure-menu-list platforms-menu">
-                            <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
+                            <li class="pure-menu-item pure-menu-has-children">
                                 <a href="#" class="pure-menu-link">Platform</a>
                                 <ul class="pure-menu-children">
                                     {%- for platform in platforms -%}

--- a/templates/header/topbar_begin.html
+++ b/templates/header/topbar_begin.html
@@ -50,7 +50,7 @@
                         </a>
 
                         <ul class="pure-menu-children">
-                            {{ macros::menu_link(href="/releases", text="Releases by Recency") }}
+                            {{ macros::menu_link(href="/releases", text="Recent Releases") }}
                             {{ macros::menu_link(href="/releases/stars", text="Releases by Stars") }}
                             {{ macros::menu_link(href="/releases/recent-failures", text="Recent Build Failures") }}
                             {{ macros::menu_link(href="/releases/failures", text="Build Failures by Stars") }}
@@ -111,4 +111,3 @@
                         </ul>
                     </li>
                 </ul>
-

--- a/templates/header/topbar_begin.html
+++ b/templates/header/topbar_begin.html
@@ -29,7 +29,7 @@
 
                 <ul class="pure-menu-list pure-menu-right">
                     <li class="pure-menu-item pure-menu-has-children pure-menu-opt-children">
-                        <a href="#" class="pure-menu-link">
+                        <a href="/about" class="pure-menu-link">
                             <span title="About">{{ "info-circle" | fas }}</span>
                             <span class="title">About</span>
                         </a>
@@ -44,7 +44,7 @@
                     </li>{#
 
                     #}<li class="pure-menu-item pure-menu-has-children pure-menu-opt-children">
-                        <a href="#" class="pure-menu-link">
+                        <a href="/releases" class="pure-menu-link">
                             <span title="Releases">{{ "leaf" | fas }}</span>
                             <span class="title">Releases</span>
                         </a>
@@ -61,7 +61,7 @@
 
                     The Rust dropdown menu
                     #}<li class="pure-menu-item pure-menu-has-children pure-menu-opt">
-                        <a href="#" target="_blank" class="pure-menu-link">
+                        <a href="https://www.rust-lang.org/" target="_blank" class="pure-menu-link">
                             Rust
                         </a>
 

--- a/templates/header/topbar_begin.html
+++ b/templates/header/topbar_begin.html
@@ -68,7 +68,7 @@
                         <ul class="pure-menu-children">
                             {{ macros::menu_link(
                                 href="https://www.rust-lang.org/",
-                                text="Rust-Lang.org",
+                                text="The Rust Programming Language",
                                 target="_blank"
                             ) }}
 

--- a/templates/header/topbar_begin.html
+++ b/templates/header/topbar_begin.html
@@ -28,13 +28,14 @@
                 </a>
 
                 <ul class="pure-menu-list pure-menu-right">
-                    <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover pure-menu-opt-children">
-                        <a href="/about" class="pure-menu-link">
+                    <li class="pure-menu-item pure-menu-has-children pure-menu-opt-children">
+                        <a href="#" class="pure-menu-link">
                             <span title="About">{{ "info-circle" | fas }}</span>
                             <span class="title">About</span>
                         </a>
 
                         <ul class="pure-menu-children">
+                            {{ macros::menu_link(href="/about", text="About") }}
                             {{ macros::menu_link(href="/about/badges", text="Badges") }}
                             {{ macros::menu_link(href="/about/builds", text="Builds") }}
                             {{ macros::menu_link(href="/about/metadata", text="Metadata") }}
@@ -42,13 +43,14 @@
                         </ul>
                     </li>{#
 
-                    #}<li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover pure-menu-opt-children">
-                        <a href="/releases" class="pure-menu-link">
+                    #}<li class="pure-menu-item pure-menu-has-children pure-menu-opt-children">
+                        <a href="#" class="pure-menu-link">
                             <span title="Releases">{{ "leaf" | fas }}</span>
                             <span class="title">Releases</span>
                         </a>
 
                         <ul class="pure-menu-children">
+                            {{ macros::menu_link(href="/releases", text="Releases by Recency") }}
                             {{ macros::menu_link(href="/releases/stars", text="Releases by Stars") }}
                             {{ macros::menu_link(href="/releases/recent-failures", text="Recent Build Failures") }}
                             {{ macros::menu_link(href="/releases/failures", text="Build Failures by Stars") }}
@@ -58,12 +60,18 @@
                     </li>{#
 
                     The Rust dropdown menu
-                    #}<li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover pure-menu-opt">
-                        <a href="https://www.rust-lang.org/" target="_blank" class="pure-menu-link">
+                    #}<li class="pure-menu-item pure-menu-has-children pure-menu-opt">
+                        <a href="#" target="_blank" class="pure-menu-link">
                             Rust
                         </a>
 
                         <ul class="pure-menu-children">
+                            {{ macros::menu_link(
+                                href="https://www.rust-lang.org/",
+                                text="Rust-Lang.org",
+                                target="_blank"
+                            ) }}
+
                             {{ macros::menu_link(
                                 href="https://doc.rust-lang.org/book/",
                                 text="The Book",


### PR DESCRIPTION
This is followup from #1081 and #1077.

This takes the link that was the click action for each menu, and moves it to the first item in the menu.