### PR TITLE
Force the navbar to be left-aligned on rustdoc pages

### DIFF
--- a/src/utils/html.rs
+++ b/src/utils/html.rs
@@ -55,7 +55,7 @@ pub(crate) fn rewrite_lol(
         // Prepend the tera content
         rustdoc_body_class.prepend(&tera_body, ContentType::Html);
         // Wrap the tranformed body and topbar into a <body> element
-        rustdoc_body_class.before("<body>", ContentType::Html);
+        rustdoc_body_class.before(r#"<body class="rustdoc-page">"#, ContentType::Html);
         // Insert the topbar outside of the rustdoc div
         rustdoc_body_class.before(&tera_rustdoc_topbar, ContentType::Html);
         // Finalize body with </body>

--- a/templates/style/_rustdoc.scss
+++ b/templates/style/_rustdoc.scss
@@ -1,6 +1,15 @@
 // FIXME: Use modules
 @import "vars";
 
+// Force the navbar to be left-aligned on rustdoc pages
+body.rustdoc-page > .nav-container > .container {
+    margin-left: 0;
+}
+
+div.container-rustdoc {
+    text-align: left;
+}
+
 // rustdoc overrides
 div.rustdoc {
     font-family: $font-family-serif;
@@ -41,5 +50,9 @@ div.rustdoc {
 
     #sidebar-toggle {
         top: 62px;
+    }
+
+    &:focus {
+        outline: unset;
     }
 }

--- a/templates/style/base.scss
+++ b/templates/style/base.scss
@@ -76,22 +76,6 @@ div.container {
     text-align: left;
 }
 
-div.container-rustdoc {
-    text-align: left;
-}
-
-div.nav-container-rustdoc {
-    position: fixed;
-    left: 0;
-    right: 0;
-    top: 0;
-    z-index: 999;
-}
-
-.rustdoc:focus {
-    outline: unset;
-}
-
 div.landing {
     text-align: center;
     padding-top: 30px;
@@ -562,10 +546,6 @@ div.cratesfyi-package-container {
             }
         }
     }
-}
-
-div.cratesfyi-package-container-rustdoc {
-    margin-bottom: 10px;
 }
 
 div.search-page-search-form {


### PR DESCRIPTION
Rather than relying on a different navbar class, I added a `rustdoc-page` class to the body so the navbar style can be overridden. Also moved all the rustdoc overrides into the `_rustdoc.css` file (`.nav-container-rustdoc` is replaced by the `.rustdoc-page .nav-container > .container` style, `.cratesfyi-package-container-rustdoc` was unused).