### PR TITLE
Revert onclick menus.

### DIFF
--- a/static/menu.js
+++ b/static/menu.js
@@ -62,6 +62,17 @@
         e.preventDefault();
         e.stopPropagation();
     };
+    function menuMouseOver(e) {	
+        if (currentMenu) {	
+            if (e.target.className.indexOf("pure-menu-link") !== -1) {	
+                e.target.focus();	
+                if (e.target.parentNode.className.indexOf("pure-menu-has-children") !== -1 && e.target.parentNode !== currentMenu) {	
+                  closeMenu();	
+                  openMenu(e.target.parentNode);	
+                }	
+            }	
+        }	
+    }
     function menuKeyDown(e) {
         if (currentMenu) {
             var children = currentMenu.querySelector(".pure-menu-children");
@@ -187,4 +198,5 @@
         menu.firstElementChild.addEventListener("click", menuOnClick);
     }
     document.documentElement.addEventListener("keydown", menuKeyDown);
+    menu.addEventListener("mouseover", menuMouseOver);
 })();

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -7,8 +7,8 @@
 
 <ul class="pure-menu-list">
     {% if 'krate' in __tera_context %}
-        <li class="pure-menu-item pure-menu-has-children">
-            <a href="#" class="pure-menu-link" title="{{ krate.description }}">
+        <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
+            <a href="{{ crate_url | safe }}" class="pure-menu-link" title="{{ krate.description }}">
                 {{ "cube" | fas }}
                 <span class="title">{{ krate.name }}-{{ krate.version }}</span>
             </a>
@@ -210,7 +210,7 @@
     </li>{#
 
     Display the platforms that the release has been built for
-    #}<li class="pure-menu-item pure-menu-has-children">
+    #}<li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
         <a href="#" class="pure-menu-link" aria-label="Platform">
             {{ "cogs" | fas }}
             <span class="title">Platform</span>


### PR DESCRIPTION
This reverts the changes in #1081 and #1097.

As reported in #1103, those changes broke navigation to the crate page with JavaScript turned off.