### PR TITLE
Add favicon to essential files

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 const USER_AGENT: &str = "docs.rs builder (https://github.com/rust-lang/docs.rs)";
 const ESSENTIAL_FILES_VERSIONED: &[&str] = &[
     "brush.svg",
+    "favicon.svg",
     "wheel.svg",
     "down-arrow.svg",
     "dark.css",


### PR DESCRIPTION
This can be tested with `cargo run build add-essential-files && cargo build chrono 0.4.18`.

Closes https://github.com/rust-lang/docs.rs/issues/1070.

r? @Nemo157 