### PR TITLE
Fix error handling for search

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -29,7 +29,7 @@ macro_rules! ctry {
                     message: ::std::option::Option::Some(::std::borrow::Cow::Owned(
                         ::std::format!("{}", error),
                     )),
-                    status: ::iron::status::BadRequest,
+                    status: ::iron::status::InternalServerError,
                 };
 
                 return $crate::web::page::WebPage::into_response(error, request);
@@ -58,7 +58,7 @@ macro_rules! cexpect {
                 let error = $crate::web::ErrorPage {
                     title: "Internal Server Error",
                     message: None,
-                    status: ::iron::status::BadRequest,
+                    status: ::iron::status::InternalServerError,
                 };
 
                 return $crate::web::page::WebPage::into_response(error, request);


### PR DESCRIPTION
- Return 500, not 400, for internal errors
- Return an error for internal errors in search instead of 'not found'

Found while working on https://github.com/rust-lang/docs.rs/issues/1101.

r? @Kixiron 