### PR TITLE
Use walkdir to ensure all style files trigger rebuilding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ time = "0.1"
 git2 = { version = "0.13", default-features = false }
 sass-rs = "0.2.2"
 string_cache_codegen = "0.5.1"
+walkdir = "2"
 
 [[bench]]
 name = "html_parsing"


### PR DESCRIPTION
No more manually updating the file list, just assume that all files within the `include_paths` might affect the output.