### PR TITLE
Detect theme changes on all docs.rs pages

### DIFF
--- a/static/storage-change-detection.html
+++ b/static/storage-change-detection.html
@@ -5,8 +5,8 @@
         <!--
             Only other windows get notified when we change local storage, so
             this is used in an invisible iframe to send a message to JS in
-            ../templates/rustdoc/body.html when local storage changes so we can
-            detect rustdoc changing the theme
+            ../templates/theme.js when rustdoc in the current window changes the
+            theme
         -->
         <script type="text/javascript">
             onstorage = function(ev) {

--- a/templates/rustdoc/body.html
+++ b/templates/rustdoc/body.html
@@ -29,16 +29,7 @@
       window.addEventListener("scroll", maybeFixupViewPortPosition, {"once": true});
     }
   }
-
-  window.addEventListener('message', function (ev) {
-    if (ev.data && ev.data.storage && ev.data.storage.key === 'rustdoc-theme') {
-      applyTheme(ev.data.storage.value);
-    }
-  });
 </script>
-<!--
-    Only other windows get notified when we change local storage, so we have an
-    invisible iframe that sends us a message when local storage changes so we
-    can detect rustdoc changing the theme
--->
+
+{# see comment in ../../static/storage-change-detection.html for details #}
 <iframe src="/-/static/storage-change-detection.html" width="0" height="0" style="display: none"></iframe>

--- a/templates/theme.js
+++ b/templates/theme.js
@@ -1,7 +1,18 @@
-// This is a global function also called from a script in ./rustdoc/body.html
-// which detects when the rustdoc theme is changed
 function applyTheme(theme) {
   document.documentElement.dataset.theme = theme;
 }
+
+window.addEventListener('storage', function (ev) {
+  if (ev.key === 'rustdoc-theme') {
+    applyTheme(ev.newValue);
+  }
+});
+
+// see ../static/storage-change-detection.html for details
+window.addEventListener('message', function (ev) {
+  if (ev.data && ev.data.storage && ev.data.storage.key === 'rustdoc-theme') {
+    applyTheme(ev.data.storage.value);
+  }
+});
 
 applyTheme(window.localStorage.getItem('rustdoc-theme'));


### PR DESCRIPTION
This allows us to change non-rustdoc pages if another open tab is looking at a rustdoc page and changes the theme.