### PR TITLE
Fix platform handling

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -790,6 +790,36 @@ mod test {
     }
 
     #[test]
+    fn platform_dropdown_not_shown_with_no_targets() {
+        wrapper(|env| {
+            release("0.1.0", env);
+            let web = env.frontend();
+            let text = web.get("/foo/0.1.0/foo").send()?.text()?;
+            let platform = kuchiki::parse_html()
+                .one(text)
+                .select(r#"ul > li > a[aria-label="Platform"]"#)
+                .unwrap()
+                .count();
+            assert_eq!(platform, 0);
+
+            // sanity check the test is doing something
+            env.fake_release()
+                .name("foo")
+                .version("0.2.0")
+                .add_platform("x86_64-unknown-linux-musl")
+                .create()?;
+            let text = web.get("/foo/0.2.0/foo").send()?.text()?;
+            let platform = kuchiki::parse_html()
+                .one(text)
+                .select(r#"ul > li > a[aria-label="Platform"]"#)
+                .unwrap()
+                .count();
+            assert_eq!(platform, 1);
+            Ok(())
+        });
+    }
+
+    #[test]
     // https://github.com/rust-lang/docs.rs/issues/221
     fn yanked_crates_are_not_considered() {
         wrapper(|env| {

--- a/templates/header/package_navigation.html
+++ b/templates/header/package_navigation.html
@@ -3,7 +3,6 @@
 
     * `title` A possibly-null string. If it is null, `metadata.name metadata.version` will be used as the title
     * `metadata` A non-null instance of the MetaData struct
-    * `platforms` A possibly-null vector of strings
     * `active_tab` A string with one of the following values:
         * `crate`
         * `source`
@@ -13,7 +12,7 @@
     Note: `false` here is acting as a pseudo-null value since you can't directly construct null values
            and tera requires all parameters without defaults to be filled
 #}
-{% macro package_navigation(title=false, metadata, platforms=false, active_tab) %}
+{% macro package_navigation(title=false, metadata, active_tab) %}
     <div class="cratesfyi-package-container">
         <div class="container">
             <div class="description-container">
@@ -41,25 +40,6 @@
 
 
                 <div class="pure-menu pure-menu-horizontal">
-                    {# If there are platforms, show a dropdown with them #}
-                    {%- if platforms -%}
-                        <ul class="pure-menu-list platforms-menu">
-                            <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
-                                <a href="#" class="pure-menu-link">Platform</a>
-                                <ul class="pure-menu-children">
-                                    {%- for platform in platforms -%}
-                                        <li class="pure-menu-item">
-                                            <a href="/{{ metadata.name }}/{{ metadata.version }}/{{ platform }}/{{ metadata.target_name }}/"
-                                                class="pure-menu-link">
-                                                {{ platform }}
-                                            </a>
-                                        </li>
-                                    {%- endfor -%}
-                                </ul>
-                            </li>
-                        </ul>
-                    {%- endif -%}
-
                     <ul class="pure-menu-list">
                         {# The crate information tab #}
                         <li class="pure-menu-item"><a href="/crate/{{ crate_path | safe }}"

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -213,7 +213,9 @@
     </li>{#
 
     Display the platforms that the release has been built for
-    #}<li class="pure-menu-item pure-menu-has-children">
+    #}
+    {% if metadata.doc_targets %}
+    <li class="pure-menu-item pure-menu-has-children">
         <a href="#" class="pure-menu-link" aria-label="Platform">
             {{ "cogs" | fas }}
             <span class="title">Platform</span>
@@ -238,6 +240,7 @@
             <span class="title">Feature flags</span>
         </a>
     </li>
+    {% endif %}
 </ul>
 
 {%- include "header/topbar_end.html" -%}


### PR DESCRIPTION
- Remove unused platforms tab on /crate page. We always show platforms, even on rustdoc pages.
- Don't show the platform dropdown if it's empty.
- Add a test

Fixes https://github.com/rust-lang/docs.rs/issues/1111.