### PR TITLE
frontend: Show feature flags in topbar and separate page

### DIFF
--- a/src/db/types.rs
+++ b/src/db/types.rs
@@ -1,7 +1,7 @@
 use postgres_types::{FromSql, ToSql};
 use serde::Serialize;
 
-#[derive(Debug, Clone, PartialEq, Serialize, FromSql, ToSql)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, FromSql, ToSql)]
 #[postgres(name = "feature")]
 pub struct Feature {
     name: String,
@@ -11,5 +11,9 @@ pub struct Feature {
 impl Feature {
     pub fn new(name: String, subfeatures: Vec<String>) -> Self {
         Feature { name, subfeatures }
+    }
+
+    pub fn is_private(&self) -> bool {
+        self.name.starts_with('_')
     }
 }

--- a/src/db/types.rs
+++ b/src/db/types.rs
@@ -4,8 +4,8 @@ use serde::Serialize;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, FromSql, ToSql)]
 #[postgres(name = "feature")]
 pub struct Feature {
-    name: String,
-    subfeatures: Vec<String>,
+    pub(crate) name: String,
+    pub(crate) subfeatures: Vec<String>,
 }
 
 impl Feature {

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -210,6 +210,15 @@ impl<'a> FakeRelease<'a> {
         self
     }
 
+    pub(crate) fn features(mut self, opt_features: Option<HashMap<String, Vec<String>>>) -> Self {
+        if let Some(features) = opt_features {
+            self.package.features = features;
+        } else {
+            self.package.features = HashMap::new();
+        }
+        self
+    }
+
     /// Returns the release_id
     pub(crate) fn create(self) -> Result<i32, Error> {
         use std::fs;

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -210,12 +210,8 @@ impl<'a> FakeRelease<'a> {
         self
     }
 
-    pub(crate) fn features(mut self, opt_features: Option<HashMap<String, Vec<String>>>) -> Self {
-        if let Some(features) = opt_features {
-            self.package.features = features;
-        } else {
-            self.package.features = HashMap::new();
-        }
+    pub(crate) fn features(mut self, features: HashMap<String, Vec<String>>) -> Self {
+        self.package.features = features;
         self
     }
 

--- a/src/web/features.rs
+++ b/src/web/features.rs
@@ -1,0 +1,30 @@
+use crate::{
+    db::Pool,
+    impl_webpage,
+    web::{page::WebPage, MetaData},
+};
+use iron::{IronResult, Request, Response};
+use router::Router;
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct FeaturesPage {
+    metadata: MetaData,
+}
+
+impl_webpage! {
+    FeaturesPage = "crate/features.html",
+}
+
+pub fn build_features_handler(req: &mut Request) -> IronResult<Response> {
+    let router = extension!(req, Router);
+    let name = cexpect!(req, router.find("name"));
+    let version = cexpect!(req, router.find("version"));
+
+    let mut conn = extension!(req, Pool).get()?;
+
+    FeaturesPage {
+        metadata: cexpect!(req, MetaData::from_crate(&mut conn, &name, &version)),
+    }
+    .into_response(req)
+}

--- a/src/web/features.rs
+++ b/src/web/features.rs
@@ -9,6 +9,8 @@ use router::Router;
 use serde::Serialize;
 use std::collections::{HashMap, VecDeque};
 
+const DEFAULT_NAME: &str = "default";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct FeaturesPage {
     metadata: MetaData,
@@ -38,28 +40,14 @@ pub fn build_features_handler(req: &mut Request) -> IronResult<Response> {
 
     let row = cexpect!(req, rows.get(0));
 
+    let mut features = None;
     let mut default_len = 0;
-    let features = row
-        .get::<'_, usize, Option<Vec<Feature>>>(0)
-        .map(|raw| {
-            raw.into_iter()
-                .filter(|feature| !feature.is_private())
-                .map(|feature| (feature.name.clone(), feature))
-                .collect::<HashMap<String, Feature>>()
-        })
-        .map(|mut feature_map| {
-            let mut features = get_tree_structure_from_default(&mut feature_map);
-            let mut remaining = feature_map
-                .into_iter()
-                .map(|(_, feature)| feature)
-                .collect::<Vec<Feature>>();
-            remaining.sort_by_key(|feature| feature.subfeatures.len());
 
-            default_len = features.len();
-
-            features.extend(remaining.into_iter().rev());
-            features
-        });
+    if let Some(raw) = row.get(0) {
+        let result = order_features_and_count_default_len(raw);
+        features = Some(result.0);
+        default_len = result.1;
+    }
 
     FeaturesPage {
         metadata: cexpect!(req, MetaData::from_crate(&mut conn, &name, &version)),
@@ -69,11 +57,26 @@ pub fn build_features_handler(req: &mut Request) -> IronResult<Response> {
     .into_response(req)
 }
 
+fn order_features_and_count_default_len(raw: Vec<Feature>) -> (Vec<Feature>, usize) {
+    let mut feature_map = get_feature_map(raw);
+    let mut features = get_tree_structure_from_default(&mut feature_map);
+    let mut remaining: Vec<_> = feature_map
+        .into_iter()
+        .map(|(_, feature)| feature)
+        .collect();
+    remaining.sort_by_key(|feature| feature.subfeatures.len());
+
+    let default_len = features.len();
+
+    features.extend(remaining.into_iter().rev());
+    (features, default_len)
+}
+
 fn get_tree_structure_from_default(feature_map: &mut HashMap<String, Feature>) -> Vec<Feature> {
     let mut features = Vec::new();
     let mut queue: VecDeque<String> = VecDeque::new();
 
-    queue.push_back("default".into());
+    queue.push_back(DEFAULT_NAME.into());
     while !queue.is_empty() {
         let name = queue.pop_front().unwrap();
         if let Some(feature) = feature_map.remove(&name) {
@@ -85,4 +88,133 @@ fn get_tree_structure_from_default(feature_map: &mut HashMap<String, Feature>) -
         }
     }
     features
+}
+
+fn get_feature_map(raw: Vec<Feature>) -> HashMap<String, Feature> {
+    raw.into_iter()
+        .filter(|feature| !feature.is_private())
+        .map(|feature| (feature.name.clone(), feature))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::types::Feature;
+    use crate::web::features::{
+        get_feature_map, get_tree_structure_from_default, order_features_and_count_default_len,
+        DEFAULT_NAME,
+    };
+
+    #[test]
+    fn test_feature_map_filters_private() {
+        let private1 = Feature::new("_private1".into(), vec!["feature1".into()]);
+        let feature2 = Feature::new("feature2".into(), Vec::new());
+
+        let raw = vec![private1.clone(), feature2.clone()];
+        let feature_map = get_feature_map(raw);
+
+        assert_eq!(feature_map.len(), 1);
+        assert!(feature_map.contains_key(&feature2.name));
+        assert!(!feature_map.contains_key(&private1.name));
+    }
+
+    #[test]
+    fn test_default_tree_structure_with_nested_default() {
+        let default = Feature::new(DEFAULT_NAME.into(), vec!["feature1".into()]);
+        let non_default = Feature::new("non-default".into(), Vec::new());
+        let feature1 = Feature::new(
+            "feature1".into(),
+            vec!["feature2".into(), "feature3".into()],
+        );
+        let feature2 = Feature::new("feature2".into(), Vec::new());
+        let feature3 = Feature::new("feature3".into(), Vec::new());
+
+        let raw = vec![
+            default.clone(),
+            non_default.clone(),
+            feature3.clone(),
+            feature2.clone(),
+            feature1.clone(),
+        ];
+        let mut feature_map = get_feature_map(raw);
+        let default_tree = get_tree_structure_from_default(&mut feature_map);
+
+        assert_eq!(feature_map.len(), 1);
+        assert_eq!(default_tree.len(), 4);
+        assert!(feature_map.contains_key(&non_default.name));
+        assert!(!feature_map.contains_key(&default.name));
+        assert_eq!(default_tree[0], default);
+        assert_eq!(default_tree[1], feature1);
+        assert_eq!(default_tree[2], feature2);
+        assert_eq!(default_tree[3], feature3);
+    }
+
+    #[test]
+    fn test_default_tree_structure_without_default() {
+        let feature1 = Feature::new(
+            "feature1".into(),
+            vec!["feature2".into(), "feature3".into()],
+        );
+        let feature2 = Feature::new("feature2".into(), Vec::new());
+        let feature3 = Feature::new("feature3".into(), Vec::new());
+
+        let raw = vec![feature3.clone(), feature2.clone(), feature1.clone()];
+        let mut feature_map = get_feature_map(raw);
+        let default_tree = get_tree_structure_from_default(&mut feature_map);
+
+        assert_eq!(feature_map.len(), 3);
+        assert_eq!(default_tree.len(), 0);
+        assert!(feature_map.contains_key(&feature1.name));
+        assert!(feature_map.contains_key(&feature2.name));
+        assert!(feature_map.contains_key(&feature3.name));
+    }
+
+    #[test]
+    fn test_default_tree_structure_single_default() {
+        let default = Feature::new(DEFAULT_NAME.into(), Vec::new());
+        let non_default = Feature::new("non-default".into(), Vec::new());
+
+        let raw = vec![default.clone(), non_default.clone()];
+        let mut feature_map = get_feature_map(raw);
+        let default_tree = get_tree_structure_from_default(&mut feature_map);
+
+        assert_eq!(feature_map.len(), 1);
+        assert_eq!(default_tree.len(), 1);
+        assert!(feature_map.contains_key(&non_default.name));
+        assert!(!feature_map.contains_key(&default.name));
+        assert_eq!(default_tree[0], default);
+    }
+
+    #[test]
+    fn test_order_features_and_get_len_without_default() {
+        let feature1 = Feature::new(
+            "feature1".into(),
+            vec!["feature10".into(), "feature11".into()],
+        );
+        let feature2 = Feature::new("feature2".into(), vec!["feature20".into()]);
+        let feature3 = Feature::new("feature3".into(), Vec::new());
+
+        let raw = vec![feature3.clone(), feature2.clone(), feature1.clone()];
+        let (features, default_len) = order_features_and_count_default_len(raw);
+
+        assert_eq!(features.len(), 3);
+        assert_eq!(default_len, 0);
+        assert_eq!(features[0], feature1);
+        assert_eq!(features[1], feature2);
+        assert_eq!(features[2], feature3);
+    }
+
+    #[test]
+    fn test_order_features_and_get_len_single_default() {
+        let default = Feature::new(DEFAULT_NAME.into(), Vec::new());
+        let non_default = Feature::new("non-default".into(), Vec::new());
+
+        let raw = vec![default.clone(), non_default.clone()];
+        let (features, default_len) = order_features_and_count_default_len(raw);
+
+        assert_eq!(features.len(), 2);
+        assert_eq!(default_len, 1);
+        assert_eq!(features[0], default);
+        assert_eq!(features[1], non_default);
+    }
 }

--- a/src/web/features.rs
+++ b/src/web/features.rs
@@ -1,3 +1,4 @@
+use crate::db::types::Feature;
 use crate::{
     db::Pool,
     impl_webpage,
@@ -6,10 +7,13 @@ use crate::{
 use iron::{IronResult, Request, Response};
 use router::Router;
 use serde::Serialize;
+use std::collections::{HashMap, VecDeque};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct FeaturesPage {
     metadata: MetaData,
+    features: Option<Vec<Feature>>,
+    default_len: usize,
 }
 
 impl_webpage! {
@@ -22,9 +26,63 @@ pub fn build_features_handler(req: &mut Request) -> IronResult<Response> {
     let version = cexpect!(req, router.find("version"));
 
     let mut conn = extension!(req, Pool).get()?;
+    let rows = ctry!(
+        req,
+        conn.query(
+            "SELECT releases.features FROM releases
+            INNER JOIN crates ON crates.id = releases.crate_id
+            WHERE crates.name = $1 AND releases.version = $2",
+            &[&name, &version]
+        )
+    );
+
+    let row = cexpect!(req, rows.get(0));
+
+    let mut default_len = 0;
+    let features = row
+        .get::<'_, usize, Option<Vec<Feature>>>(0)
+        .map(|raw| {
+            raw.into_iter()
+                .filter(|feature| !feature.is_private())
+                .map(|feature| (feature.name.clone(), feature))
+                .collect::<HashMap<String, Feature>>()
+        })
+        .map(|mut feature_map| {
+            let mut features = get_tree_structure_from_default(&mut feature_map);
+            let mut remaining = feature_map
+                .into_iter()
+                .map(|(_, feature)| feature)
+                .collect::<Vec<Feature>>();
+            remaining.sort_by_key(|feature| feature.subfeatures.len());
+
+            default_len = features.len();
+
+            features.extend(remaining.into_iter().rev());
+            features
+        });
 
     FeaturesPage {
         metadata: cexpect!(req, MetaData::from_crate(&mut conn, &name, &version)),
+        features,
+        default_len,
     }
     .into_response(req)
+}
+
+fn get_tree_structure_from_default(feature_map: &mut HashMap<String, Feature>) -> Vec<Feature> {
+    let mut features = Vec::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+
+    queue.push_back("default".into());
+    while !queue.is_empty() {
+        let name = queue.pop_front().unwrap();
+        if let Some(feature) = feature_map.remove(&name) {
+            feature
+                .subfeatures
+                .iter()
+                .for_each(|sub| queue.push_back(sub.clone()));
+            features.push(feature);
+        }
+    }
+    features
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -91,7 +91,6 @@ mod sitemap;
 mod source;
 mod statics;
 
-use crate::db::types::Feature;
 use crate::{impl_webpage, Context};
 use chrono::{DateTime, Utc};
 use error::Nope;
@@ -522,7 +521,6 @@ pub(crate) struct MetaData {
     pub(crate) default_target: String,
     pub(crate) doc_targets: Vec<String>,
     pub(crate) yanked: bool,
-    pub(crate) features: Option<Vec<Feature>>,
 }
 
 impl MetaData {
@@ -536,8 +534,7 @@ impl MetaData {
                        releases.rustdoc_status,
                        releases.default_target,
                        releases.doc_targets,
-                       releases.yanked,
-                       releases.features
+                       releases.yanked
                 FROM releases
                 INNER JOIN crates ON crates.id = releases.crate_id
                 WHERE crates.name = $1 AND releases.version = $2",
@@ -556,7 +553,6 @@ impl MetaData {
             default_target: row.get(5),
             doc_targets: MetaData::parse_doc_targets(row.get(6)),
             yanked: row.get(7),
-            features: MetaData::parse_features(row.get(8)),
         })
     }
 
@@ -570,14 +566,6 @@ impl MetaData {
                     .collect()
             })
             .unwrap_or_else(Vec::new)
-    }
-
-    pub(crate) fn parse_features(features: Option<Vec<Feature>>) -> Option<Vec<Feature>> {
-        features.map(|vec| {
-            vec.into_iter()
-                .filter(|feature| !feature.is_private())
-                .collect()
-        })
     }
 }
 
@@ -857,7 +845,6 @@ mod test {
                 "arm64-unknown-linux-gnu".to_string(),
             ],
             yanked: false,
-            features: None,
         };
 
         let correct_json = json!({
@@ -872,7 +859,6 @@ mod test {
                 "arm64-unknown-linux-gnu",
             ],
             "yanked": false,
-            "features": null
         });
 
         assert_eq!(correct_json, serde_json::to_value(&metadata).unwrap());
@@ -890,7 +876,6 @@ mod test {
                 "arm64-unknown-linux-gnu",
             ],
             "yanked": false,
-            "features": null,
         });
 
         assert_eq!(correct_json, serde_json::to_value(&metadata).unwrap());
@@ -908,7 +893,6 @@ mod test {
                 "arm64-unknown-linux-gnu",
             ],
             "yanked": false,
-            "features": null,
         });
 
         assert_eq!(correct_json, serde_json::to_value(&metadata).unwrap());

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -88,6 +88,10 @@ pub(super) fn build_routes() -> Routes {
         super::builds::build_list_handler,
     );
     routes.internal_page(
+        "/crate/:name/:version/features",
+        super::features::build_features_handler,
+    );
+    routes.internal_page(
         "/crate/:name/:version/source",
         SimpleRedirect::new(|url| url.set_path(&format!("{}/", url.path()))),
     );

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -58,8 +58,7 @@ impl FileList {
                         releases.files,
                         releases.default_target,
                         releases.doc_targets,
-                        releases.yanked,
-                        releases.features
+                        releases.yanked
                 FROM releases
                 LEFT OUTER JOIN crates ON crates.id = releases.crate_id
                 WHERE crates.name = $1 AND releases.version = $2",
@@ -138,7 +137,6 @@ impl FileList {
                     default_target: rows[0].get(6),
                     doc_targets: MetaData::parse_doc_targets(rows[0].get(7)),
                     yanked: rows[0].get(8),
-                    features: MetaData::parse_features(rows[0].get(9)),
                 },
                 files: file_list,
             })

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -58,7 +58,8 @@ impl FileList {
                         releases.files,
                         releases.default_target,
                         releases.doc_targets,
-                        releases.yanked
+                        releases.yanked,
+                        releases.features
                 FROM releases
                 LEFT OUTER JOIN crates ON crates.id = releases.crate_id
                 WHERE crates.name = $1 AND releases.version = $2",
@@ -137,6 +138,7 @@ impl FileList {
                     default_target: rows[0].get(6),
                     doc_targets: MetaData::parse_doc_targets(rows[0].get(7)),
                     yanked: rows[0].get(8),
+                    features: MetaData::parse_features(rows[0].get(9)),
                 },
                 files: file_list,
             })

--- a/templates/crate/features.html
+++ b/templates/crate/features.html
@@ -34,9 +34,13 @@
                                     </a>
                                 </li>
                             {%- endfor -%}
+                        {%- elif metadata.features is iterable -%}
+                            <li class="pure-menu-item">
+                                <span style="font-size: 13px;">This release does not have any feature flags.</span>
+                            </li>
                         {%- else -%}
                             <li class="pure-menu-item">
-                                <span style="font-size: 13px;">Feature flags are not available for this version.</span>
+                                <span style="font-size: 13px;">Feature flags data are not available for this release.</span>
                             </li>
                         {%- endif -%}
                     </ul>
@@ -52,7 +56,7 @@
                         {%- else -%}
                             0
                         {%- endif -%}
-                    </b> of them being enabled by <b>default</b>.</p>
+                    </b> of them enabled by <b>default</b>.</p>
                     {%- for feature in metadata.features -%}
                         <h3 id="{{ feature.name }}">{{ feature.name }}</h3>
                         <ul class="pure-menu-list">
@@ -67,8 +71,10 @@
                             {%- endif -%}
                         </ul>
                     {%- endfor -%}
+                {%- elif metadata.features is iterable  -%}
+                    <p data-id="empty-features">This release does not have any feature flags.</p>
                 {%- else -%}
-                    <p data-id="empty-features">Feature flags are not available for this release.</p>
+                    <p data-id="null-features">Feature flags data are not available for this release.</p>
                 {%- endif -%}
             </div>
         </div>

--- a/templates/crate/features.html
+++ b/templates/crate/features.html
@@ -1,0 +1,76 @@
+{%- extends "base.html" -%}
+{%- import "header/package_navigation.html" as navigation -%}
+
+{%- block title -%}
+    {{ macros::doc_title(name=metadata.name, version=metadata.version) }}
+{%- endblock title -%}
+
+{%- block topbar -%}
+  {%- set latest_version = "" -%}
+  {%- set latest_path = "" -%}
+  {%- set target = "" -%}
+  {%- set inner_path = metadata.target_name ~ "/index.html" -%}
+  {%- set is_latest_version = true -%}
+  {%- set is_prerelease = false -%}
+  {%- include "rustdoc/topbar.html" -%}
+{%- endblock topbar -%}
+
+{%- block header -%}
+    {{ navigation::package_navigation(metadata=metadata, active_tab="features") }}
+{%- endblock header -%}
+
+{%- block body -%}
+    <div class="container package-page-container">
+        <div class="pure-g">
+            <div class="pure-u-1 pure-u-sm-7-24 pure-u-md-5-24">
+                <div class="pure-menu package-menu">
+                    <ul class="pure-menu-list">
+                        <li class="pure-menu-heading">Feature flags</li>
+                        {%- if metadata.features -%}
+                            {%- for feature in metadata.features -%}
+                                <li class="pure-menu-item">
+                                    <a href="#{{ feature.name }}" class="pure-menu-link" style="text-align:center;">
+                                        {{ feature.name }}
+                                    </a>
+                                </li>
+                            {%- endfor -%}
+                        {%- else -%}
+                            <li class="pure-menu-item">
+                                <span style="font-size: 13px;">Feature flags are not available for this version.</span>
+                            </li>
+                        {%- endif -%}
+                    </ul>
+                </div>
+            </div>
+
+            <div class="pure-u-1 pure-u-sm-17-24 pure-u-md-19-24 package-details" id="main">
+                <h1>{{ metadata.name }}</h1>
+                {%- if metadata.features -%}
+                    <p>This version has <b>{{ metadata.features | length }}</b> feature flags, <b data-id="default-feature-len">
+                        {%- if metadata.features[0].name == 'default' -%}
+                            {{ metadata.features[0].subfeatures | length }}
+                        {%- else -%}
+                            0
+                        {%- endif -%}
+                    </b> of them being enabled by <b>default</b>.</p>
+                    {%- for feature in metadata.features -%}
+                        <h3 id="{{ feature.name }}">{{ feature.name }}</h3>
+                        <ul class="pure-menu-list">
+                            {%- if feature.subfeatures -%}
+                                {%- for subfeature in feature.subfeatures -%}
+                                    <li class="pure-menu-item">
+                                        <span>{{ subfeature }}</span>
+                                    </li>
+                                {%- endfor -%}
+                            {%- else -%}
+                                <p>This feature flag does not enable additional features.</p>
+                            {%- endif -%}
+                        </ul>
+                    {%- endfor -%}
+                {%- else -%}
+                    <p data-id="empty-features">Feature flags are not available for this release.</p>
+                {%- endif -%}
+            </div>
+        </div>
+    </div>
+{%- endblock body -%}

--- a/templates/crate/features.html
+++ b/templates/crate/features.html
@@ -26,15 +26,15 @@
                 <div class="pure-menu package-menu">
                     <ul class="pure-menu-list">
                         <li class="pure-menu-heading">Feature flags</li>
-                        {%- if metadata.features -%}
-                            {%- for feature in metadata.features -%}
+                        {%- if features -%}
+                            {%- for feature in features -%}
                                 <li class="pure-menu-item">
                                     <a href="#{{ feature.name }}" class="pure-menu-link" style="text-align:center;">
                                         {{ feature.name }}
                                     </a>
                                 </li>
                             {%- endfor -%}
-                        {%- elif metadata.features is iterable -%}
+                        {%- elif features is iterable -%}
                             <li class="pure-menu-item">
                                 <span style="font-size: 13px;">This release does not have any feature flags.</span>
                             </li>
@@ -49,15 +49,9 @@
 
             <div class="pure-u-1 pure-u-sm-17-24 pure-u-md-19-24 package-details" id="main">
                 <h1>{{ metadata.name }}</h1>
-                {%- if metadata.features -%}
-                    <p>This version has <b>{{ metadata.features | length }}</b> feature flags, <b data-id="default-feature-len">
-                        {%- if metadata.features[0].name == 'default' -%}
-                            {{ metadata.features[0].subfeatures | length }}
-                        {%- else -%}
-                            0
-                        {%- endif -%}
-                    </b> of them enabled by <b>default</b>.</p>
-                    {%- for feature in metadata.features -%}
+                {%- if features -%}
+                    <p>This version has <b>{{ features | length }}</b> feature flags, <b data-id="default-feature-len">{{ default_len }}</b> of them enabled by <b>default</b>.</p>
+                    {%- for feature in features -%}
                         <h3 id="{{ feature.name }}">{{ feature.name }}</h3>
                         <ul class="pure-menu-list">
                             {%- if feature.subfeatures -%}
@@ -71,7 +65,7 @@
                             {%- endif -%}
                         </ul>
                     {%- endfor -%}
-                {%- elif metadata.features is iterable  -%}
+                {%- elif features is iterable  -%}
                     <p data-id="empty-features">This release does not have any feature flags.</p>
                 {%- else -%}
                     <p data-id="null-features">Feature flags data are not available for this release.</p>

--- a/templates/header/package_navigation.html
+++ b/templates/header/package_navigation.html
@@ -8,6 +8,7 @@
         * `crate`
         * `source`
         * `builds`
+        * `features`
 
     Note: `false` here is acting as a pseudo-null value since you can't directly construct null values
            and tera requires all parameters without defaults to be filled
@@ -83,6 +84,15 @@
                                 class="pure-menu-link{% if active_tab == 'builds' %} pure-menu-active{% endif %}">
                                 {{ "cogs" | fas }}
                                 <span class="title"> Builds</span>
+                            </a>
+                        </li>
+
+                        {# The features tab #}
+                        <li class="pure-menu-item">
+                            <a href="/crate/{{ crate_path | safe }}/features"
+                               class="pure-menu-link{% if active_tab == 'features' %} pure-menu-active{% endif %}">
+                                {{ "flag" | fas }}
+                                <span class="title">Feature flags</span>
                             </a>
                         </li>
                     </ul>

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -229,6 +229,14 @@
                 </li>
             {%- endfor -%}
         </ul>
+    </li>{#
+    Display the features available in current build
+    #}
+    <li class="pure-menu-item">
+        <a href="{{ crate_url | safe }}/features" title="Browse available feature flags of {{ metadata.name }}-{{ metadata.version }}" class="pure-menu-link">
+            {{ "flag" | fas }}
+            <span class="title">Feature flags</span>
+        </a>
     </li>
 </ul>
 


### PR DESCRIPTION
As discussed in #1129. Opening the frontend part for discussion. 

Current implementation look:
![Feature flags](https://user-images.githubusercontent.com/30824037/97670137-e59a4f80-1a85-11eb-8f53-9bd910dba3f8.png)

