### PR TITLE
Add a way to not build tier one targets by default

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,3 +4,4 @@ DOCSRS_LOG=docs_rs,rustwide=info
 AWS_ACCESS_KEY_ID=cratesfyi
 AWS_SECRET_ACCESS_KEY=secret_key
 S3_ENDPOINT=http://localhost:9000
+DOCSRS_INCLUDE_DEFAULT_TARGETS=false

--- a/crates/metadata/lib.rs
+++ b/crates/metadata/lib.rs
@@ -20,7 +20,7 @@
 //! let metadata = Metadata::from_crate_root(&source_root)?;
 //!
 //! // Next, learn what arguments we need to pass to `cargo`.
-//! let targets = metadata.targets();
+//! let targets = metadata.targets(/* include_default_targets: */ true);
 //! let mut cargo_args = metadata.cargo_args(&[], &[]);
 //! cargo_args.push(targets.default_target.into());
 //!
@@ -190,7 +190,10 @@ impl Metadata {
     /// Return the targets that should be built.
     ///
     /// The `default_target` will never be one of the `other_targets`.
-    pub fn targets(&self) -> BuildTargets<'_> {
+    /// If `include_default_targets` is `true` and `targets` is unset, this also includes
+    /// [`DEFAULT_TARGETS`]. Otherwise, if `include_default_targets` is `false` and `targets`
+    /// is unset, `other_targets` will be empty.
+    pub fn targets(&self, include_default_targets: bool) -> BuildTargets<'_> {
         let default_target = self
             .default_target
             .as_deref()
@@ -202,12 +205,16 @@ impl Metadata {
             })
             .unwrap_or(HOST_TARGET);
 
-        // Let people opt-in to only having specific targets
-        let mut targets: HashSet<_> = self
+        let crate_targets = self
             .targets
             .as_ref()
-            .map(|targets| targets.iter().map(String::as_str).collect())
-            .unwrap_or_else(|| DEFAULT_TARGETS.iter().copied().collect());
+            .map(|targets| targets.iter().map(String::as_str).collect());
+        // Let people opt-in to only having specific targets
+        let mut targets: HashSet<_> = if include_default_targets {
+            crate_targets.unwrap_or_else(|| DEFAULT_TARGETS.iter().copied().collect())
+        } else {
+            crate_targets.unwrap_or_default()
+        };
 
         targets.remove(&default_target);
         BuildTargets {
@@ -411,7 +418,7 @@ mod test_targets {
         let BuildTargets {
             default_target: default,
             other_targets: tier_one,
-        } = metadata.targets();
+        } = metadata.targets(true);
         assert_eq!(default, HOST_TARGET);
 
         // should be equal to TARGETS \ {HOST_TARGET}
@@ -433,7 +440,7 @@ mod test_targets {
         let BuildTargets {
             default_target: default,
             other_targets: others,
-        } = metadata.targets();
+        } = metadata.targets(true);
 
         assert_eq!(default, HOST_TARGET);
         assert!(others.is_empty());
@@ -447,7 +454,7 @@ mod test_targets {
         let BuildTargets {
             default_target: default,
             other_targets: others,
-        } = metadata.targets();
+        } = metadata.targets(true);
 
         assert_eq!(default, "i686-pc-windows-msvc");
         assert_eq!(others.len(), 1);
@@ -458,7 +465,7 @@ mod test_targets {
         let BuildTargets {
             default_target: default,
             other_targets: others,
-        } = metadata.targets();
+        } = metadata.targets(true);
 
         assert_eq!(default, HOST_TARGET);
         assert!(others.is_empty());
@@ -472,7 +479,7 @@ mod test_targets {
         let BuildTargets {
             default_target: default,
             other_targets: others,
-        } = metadata.targets();
+        } = metadata.targets(true);
 
         assert_eq!(default, "i686-pc-windows-msvc");
         assert!(others.is_empty());
@@ -482,7 +489,7 @@ mod test_targets {
         let BuildTargets {
             default_target: default,
             other_targets: others,
-        } = metadata.targets();
+        } = metadata.targets(true);
 
         assert_eq!(default, "i686-apple-darwin");
         assert_eq!(others.len(), 1);
@@ -493,7 +500,7 @@ mod test_targets {
         let BuildTargets {
             default_target: default,
             other_targets: others,
-        } = metadata.targets();
+        } = metadata.targets(true);
 
         assert_eq!(default, "i686-apple-darwin");
         assert!(others.is_empty());
@@ -503,7 +510,7 @@ mod test_targets {
         let BuildTargets {
             default_target: default,
             other_targets: others,
-        } = metadata.targets();
+        } = metadata.targets(true);
 
         assert_eq!(default, "i686-apple-darwin");
         let tier_one_targets_no_default = DEFAULT_TARGETS
@@ -513,6 +520,17 @@ mod test_targets {
             .collect();
 
         assert_eq!(others, tier_one_targets_no_default);
+    }
+
+    #[test]
+    fn no_default_targets() {
+        // if `targets` is unset, `other_targets` should be empty
+        let metadata = Metadata::default();
+        let BuildTargets {
+            other_targets: others,
+            ..
+        } = metadata.targets(false);
+        assert!(others.is_empty(), "{:?}", others);
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,9 +7,6 @@ use std::str::FromStr;
 
 #[derive(Debug)]
 pub struct Config {
-    // Build params
-    pub(crate) build_attempts: u16,
-
     pub prefix: PathBuf,
     pub registry_index_path: PathBuf,
     pub registry_url: Option<String>,
@@ -41,11 +38,14 @@ pub struct Config {
     // Time between 'git gc --auto' calls in seconds
     pub(crate) registry_gc_interval: u64,
 
+    // Build params
+    pub(crate) build_attempts: u16,
     pub(crate) rustwide_workspace: PathBuf,
     pub(crate) inside_docker: bool,
     pub(crate) local_docker_image: Option<String>,
     pub(crate) toolchain: String,
     pub(crate) build_cpu_limit: Option<u32>,
+    pub(crate) include_default_targets: bool,
 }
 
 impl Config {
@@ -89,6 +89,7 @@ impl Config {
             local_docker_image: maybe_env("DOCS_RS_LOCAL_DOCKER_IMAGE")?,
             toolchain: env("CRATESFYI_TOOLCHAIN", "nightly".to_string())?,
             build_cpu_limit: maybe_env("DOCS_RS_BUILD_CPU_LIMIT")?,
+            include_default_targets: env("DOCSRS_INCLUDE_DEFAULT_TARGETS", true)?,
         })
     }
 

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -333,7 +333,7 @@ impl RustwideBuilder {
                 let BuildTargets {
                     default_target,
                     other_targets,
-                } = metadata.targets();
+                } = metadata.targets(self.config.include_default_targets);
 
                 // Perform an initial build
                 let res = self.execute_build(default_target, true, &build, &limits, &metadata)?;


### PR DESCRIPTION
This is still opt-in and off by default. However, it's useful for local
development and custom registries.

This is all of https://github.com/rust-lang/docs.rs/pull/532 except for actually switching it on. It does turn it on for local development, so that builds will be faster.

r? @pietroalbini 
cc @l4l