### PR TITLE
Revert "Support custom indexes"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,9 +2871,8 @@ dependencies = [
 
 [[package]]
 name = "rustwide"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17a9c66cf835ece6742443f3a2c2874df15db3dfc060ced53feeb210a463fd93"
+version = "0.10.0"
+source = "git+https://github.com/rust-lang/rustwide.git?rev=bcf19b84128c983d02257a0ae9b91e5a6772122b#bcf19b84128c983d02257a0ae9b91e5a6772122b"
 dependencies = [
  "base64 0.12.1",
  "failure",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "crates-index-diff"
-version = "7.1.2"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64af39a9a6805d715f8b72307d70815ed1ee38ef84e9de250fcdd56fe75a0e19"
+checksum = "2e6bb290b5bb11353fbb46ca4c68ad2e8f54ab6674e4ee6a94c102054fdaf00f"
 dependencies = [
  "git2",
  "serde",
@@ -1077,9 +1077,9 @@ checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 
 [[package]]
 name = "git2"
-version = "0.13.12"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6f1a0238d7f8f8fd5ee642f4ebac4dbc03e03d1f78fbe7a3ede35dcf7e2224"
+checksum = "11e4b2082980e751c4bf4273e9cbb4a02c655729c8ee8a79f66cad03c8f4d31e"
 dependencies = [
  "bitflags",
  "libc",
@@ -1509,9 +1509,9 @@ checksum = "3286f09f7d4926fc486334f28d8d2e6ebe4f7f9994494b6dab27ddfad2c9b11b"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.14+1.1.0"
+version = "0.12.6+1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f25af58e6495f7caf2919d08f212de550cfa3ed2f5e744988938ea292b9f549"
+checksum = "bf81b43f9b45ab07897a780c9b7b26b1504497e469c7a78162fc29e3b8b1c1b3"
 dependencies = [
  "cc",
  "libc",
@@ -1523,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.19"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca46220853ba1c512fc82826d0834d87b06bcd3c2a42241b7de72f3d2fe17056"
+checksum = "eafa907407504b0e683786d4aba47acf250f114d37357d56608333fd167dd0fc"
 dependencies = [
  "cc",
  "libc",
@@ -1537,9 +1537,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.2"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 dependencies = [
  "cc",
  "libc",
@@ -2872,7 +2872,8 @@ dependencies = [
 [[package]]
 name = "rustwide"
 version = "0.10.0"
-source = "git+https://github.com/rust-lang/rustwide.git?rev=bcf19b84128c983d02257a0ae9b91e5a6772122b#bcf19b84128c983d02257a0ae9b91e5a6772122b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417d578ebc7fa963bcd06f365f7987c091abeba70eac22dba94b7fd922a95c09"
 dependencies = [
  "base64 0.12.1",
  "failure",
@@ -2880,7 +2881,6 @@ dependencies = [
  "fs2",
  "futures-util",
  "getrandom",
- "git2",
  "lazy_static",
  "log 0.4.8",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4"
 regex = "1"
 structopt = "0.3"
 crates-index = "0.15.1"
-crates-index-diff = "7.1"
+crates-index-diff = "7"
 reqwest = { version = "0.10.6", features = ["blocking", "json"] } # TODO: Remove blocking when async is ready
 semver = { version = "0.9", features = ["serde"] }
 slug = "=0.1.1"
@@ -40,7 +40,7 @@ schemamama = "0.3"
 schemamama_postgres = "0.3"
 systemstat = "0.1.4"
 prometheus = { version = "0.10.0", default-features = false }
-rustwide = { git = "https://github.com/rust-lang/rustwide.git" , rev = "bcf19b84128c983d02257a0ae9b91e5a6772122b"}
+rustwide = "0.10.0"
 mime_guess = "2"
 dotenv = "0.15"
 zstd = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4"
 regex = "1"
 structopt = "0.3"
 crates-index = "0.15.1"
-crates-index-diff = "7.1.1"
+crates-index-diff = "7.1"
 reqwest = { version = "0.10.6", features = ["blocking", "json"] } # TODO: Remove blocking when async is ready
 semver = { version = "0.9", features = ["serde"] }
 slug = "=0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ schemamama = "0.3"
 schemamama_postgres = "0.3"
 systemstat = "0.1.4"
 prometheus = { version = "0.10.0", default-features = false }
-rustwide = "0.11"
+rustwide = { git = "https://github.com/rust-lang/rustwide.git" , rev = "bcf19b84128c983d02257a0ae9b91e5a6772122b"}
 mime_guess = "2"
 dotenv = "0.15"
 zstd = "0.5"

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -262,7 +262,11 @@ enum BuildSubcommand {
         crate_version: Option<String>,
 
         /// Build a crate at a specific path
-        #[structopt(short = "l", long = "local", conflicts_with_all(&["CRATE_NAME", "CRATE_VERSION"]))]
+        #[structopt(
+            short = "l",
+            long = "local",
+            conflicts_with_all(&["CRATE_NAME", "CRATE_VERSION", "CRATE_REGISTRY"])
+        )]
         local: Option<PathBuf>,
     },
 

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -170,12 +170,9 @@ impl QueueSubcommand {
                 crate_name,
                 crate_version,
                 build_priority,
-            } => ctx.build_queue()?.add_crate(
-                &crate_name,
-                &crate_version,
-                build_priority,
-                ctx.config()?.registry_url.as_deref(),
-            )?,
+            } => ctx
+                .build_queue()?
+                .add_crate(&crate_name, &crate_version, build_priority)?,
 
             Self::DefaultPriority { subcommand } => subcommand.handle_args(ctx)?,
         }

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -6,8 +6,7 @@ use std::sync::Arc;
 use docs_rs::db::{self, add_path_into_database, Pool, PoolClient};
 use docs_rs::utils::{remove_crate_priority, set_crate_priority};
 use docs_rs::{
-    BuildQueue, Config, Context, DocBuilder, Index, Metrics, PackageKind, RustwideBuilder, Server,
-    Storage,
+    BuildQueue, Config, Context, DocBuilder, Index, Metrics, RustwideBuilder, Server, Storage,
 };
 use failure::{err_msg, Error, ResultExt};
 use once_cell::sync::OnceCell;
@@ -258,16 +257,8 @@ enum BuildSubcommand {
         #[structopt(name = "CRATE_VERSION")]
         crate_version: Option<String>,
 
-        /// Url for registry different from cratesio
-        #[structopt(name = "CRATE_REGISTRY")]
-        crate_registry: Option<String>,
-
         /// Build a crate at a specific path
-        #[structopt(
-            short = "l",
-            long = "local",
-            conflicts_with_all(&["CRATE_NAME", "CRATE_VERSION", "CRATE_REGISTRY"])
-        )]
+        #[structopt(short = "l", long = "local", conflicts_with_all(&["CRATE_NAME", "CRATE_VERSION"]))]
         local: Option<PathBuf>,
     },
 
@@ -308,7 +299,6 @@ impl BuildSubcommand {
             Self::Crate {
                 crate_name,
                 crate_version,
-                crate_registry,
                 local,
             } => {
                 let mut builder = rustwide_builder()?;
@@ -323,10 +313,7 @@ impl BuildSubcommand {
                             &crate_name.ok_or_else(|| err_msg("must specify name if not local"))?,
                             &crate_version
                                 .ok_or_else(|| err_msg("must specify version if not local"))?,
-                            crate_registry
-                                .as_ref()
-                                .map(|s| PackageKind::Registry(s.as_str()))
-                                .unwrap_or(PackageKind::CratesIo),
+                            None,
                         )
                         .context("Building documentation failed")?;
                 }
@@ -606,16 +593,7 @@ impl Context for BinContext {
     fn index(&self) -> Result<Arc<Index>, Error> {
         Ok(self
             .index
-            .get_or_try_init::<_, Error>(|| {
-                let config = self.config()?;
-                Ok(Arc::new(
-                    if let Some(registry_url) = config.registry_url.clone() {
-                        Index::from_url(config.registry_index_path.clone(), registry_url)
-                    } else {
-                        Index::new(config.registry_index_path.clone())
-                    }?,
-                ))
-            })?
+            .get_or_try_init::<_, Error>(|| Ok(Arc::new(Index::new(&*self.config()?)?)))?
             .clone())
     }
 }

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -258,6 +258,10 @@ enum BuildSubcommand {
         #[structopt(name = "CRATE_VERSION")]
         crate_version: Option<String>,
 
+        /// Url for registry different from cratesio
+        #[structopt(name = "CRATE_REGISTRY")]
+        crate_registry: Option<String>,
+
         /// Build a crate at a specific path
         #[structopt(
             short = "l",
@@ -304,6 +308,7 @@ impl BuildSubcommand {
             Self::Crate {
                 crate_name,
                 crate_version,
+                crate_registry,
                 local,
             } => {
                 let mut builder = rustwide_builder()?;
@@ -313,13 +318,12 @@ impl BuildSubcommand {
                         .build_local_package(&path)
                         .context("Building documentation failed")?;
                 } else {
-                    let registry_url = ctx.config()?.registry_url.clone();
                     builder
                         .build_package(
                             &crate_name.ok_or_else(|| err_msg("must specify name if not local"))?,
                             &crate_version
                                 .ok_or_else(|| err_msg("must specify version if not local"))?,
-                            registry_url
+                            crate_registry
                                 .as_ref()
                                 .map(|s| PackageKind::Registry(s.as_str()))
                                 .unwrap_or(PackageKind::CratesIo),

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,6 @@ pub struct Config {
 
     pub prefix: PathBuf,
     pub registry_index_path: PathBuf,
-    pub registry_url: Option<String>,
 
     // Database connection params
     pub(crate) database_url: String,
@@ -57,7 +56,6 @@ impl Config {
 
             prefix: prefix.clone(),
             registry_index_path: env("REGISTRY_INDEX_PATH", prefix.join("crates.io-index"))?,
-            registry_url: maybe_env("REGISTRY_URL")?,
 
             database_url: require_env("CRATESFYI_DATABASE_URL")?,
             max_pool_size: env("DOCSRS_MAX_POOL_SIZE", 90)?,

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -475,20 +475,6 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> CratesfyiResult<(
                 DROP TYPE feature;                         
             "
         ),
-        migration!(
-            context,
-            20,
-            // description
-            "Support alternative registries",
-            // upgrade query
-            "
-                ALTER TABLE queue ADD COLUMN registry TEXT DEFAULT NULL;
-            ",
-            // downgrade query
-            "
-                ALTER TABLE queue DROP COLUMN registry;
-            "
-        )
     ];
 
     for migration in migrations {

--- a/src/docbuilder/mod.rs
+++ b/src/docbuilder/mod.rs
@@ -4,8 +4,8 @@ mod queue;
 mod rustwide_builder;
 
 pub(crate) use self::limits::Limits;
+pub use self::rustwide_builder::RustwideBuilder;
 pub(crate) use self::rustwide_builder::{BuildResult, DocCoverage};
-pub use self::rustwide_builder::{PackageKind, RustwideBuilder};
 
 use crate::db::Pool;
 use crate::error::Result;

--- a/src/docbuilder/queue.rs
+++ b/src/docbuilder/queue.rs
@@ -1,6 +1,6 @@
 //! Updates registry index and builds new packages
 
-use super::{DocBuilder, PackageKind, RustwideBuilder};
+use super::{DocBuilder, RustwideBuilder};
 use crate::error::Result;
 use crate::utils::get_crate_priority;
 use crate::Index;
@@ -79,7 +79,7 @@ impl DocBuilder {
         queue.process_next_crate(|krate| {
             processed = true;
 
-            builder.build_package(&krate.name, &krate.version, PackageKind::CratesIo)?;
+            builder.build_package(&krate.name, &krate.version, None)?;
             Ok(())
         })?;
 

--- a/src/docbuilder/queue.rs
+++ b/src/docbuilder/queue.rs
@@ -45,12 +45,10 @@ impl DocBuilder {
                 ChangeKind::Added => {
                     let priority = get_crate_priority(&mut conn, &krate.name)?;
 
-                    match self.build_queue.add_crate(
-                        &krate.name,
-                        &krate.version,
-                        priority,
-                        index.repository_url(),
-                    ) {
+                    match self
+                        .build_queue
+                        .add_crate(&krate.name, &krate.version, priority)
+                    {
                         Ok(()) => {
                             debug!("{}-{} added into build queue", krate.name, krate.version);
                             crates_added += 1;
@@ -81,13 +79,7 @@ impl DocBuilder {
         queue.process_next_crate(|krate| {
             processed = true;
 
-            let kind = krate
-                .registry
-                .as_ref()
-                .map(|r| PackageKind::Registry(r.as_str()))
-                .unwrap_or(PackageKind::CratesIo);
-
-            builder.build_package(&krate.name, &krate.version, kind)?;
+            builder.build_package(&krate.name, &krate.version, PackageKind::CratesIo)?;
             Ok(())
         })?;
 

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -113,8 +113,4 @@ impl Index {
             );
         }
     }
-
-    pub fn repository_url(&self) -> Option<&str> {
-        self.repository_url.as_deref()
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ pub use self::build_queue::BuildQueue;
 pub use self::config::Config;
 pub use self::context::Context;
 pub use self::docbuilder::DocBuilder;
-pub use self::docbuilder::PackageKind;
 pub use self::docbuilder::RustwideBuilder;
 pub use self::index::Index;
 pub use self::metrics::Metrics;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -197,10 +197,7 @@ impl TestEnvironment {
     pub(crate) fn index(&self) -> Arc<Index> {
         self.index
             .get_or_init(|| {
-                Arc::new(
-                    Index::new(self.config().registry_index_path.clone())
-                        .expect("failed to initialize the index"),
-                )
+                Arc::new(Index::new(&*self.config()).expect("failed to initialize the index"))
             })
             .clone()
     }

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -1126,9 +1126,9 @@ mod tests {
                 .expect("missing heading")
                 .any(|el| el.text_contents().contains("nothing")));
 
-            queue.add_crate("foo", "1.0.0", 0, None)?;
-            queue.add_crate("bar", "0.1.0", -10, None)?;
-            queue.add_crate("baz", "0.0.1", 10, None)?;
+            queue.add_crate("foo", "1.0.0", 0)?;
+            queue.add_crate("bar", "0.1.0", -10)?;
+            queue.add_crate("baz", "0.0.1", 10)?;
 
             let full = kuchiki::parse_html().one(web.get("/releases/queue").send()?.text()?);
             let items = full


### PR DESCRIPTION
Reverts rust-lang/docs.rs#1140

This caused a production outage:

```
Oct 30 15:42:52 docsrs cratesfyi[8350]: Error: initialising registry index repository
Oct 30 15:42:52 docsrs cratesfyi[8350]: Caused by:
Oct 30 15:42:52 docsrs cratesfyi[8350]:     Actual 'origin' remote url "https://github.com/rust-lang/crates.io-index.git" did not match desired one at "https://github.com/rust-lang/crates.io-index"
Oct 30 15:42:52 docsrs cratesfyi[8350]: Stack backtrace:
Oct 30 15:42:52 docsrs cratesfyi[8350]:    0: failure::backtrace::internal::InternalBacktrace::new
Oct 30 15:42:52 docsrs cratesfyi[8350]:    1: failure::backtrace::Backtrace::new
Oct 30 15:42:52 docsrs cratesfyi[8350]:    2: docs_rs::index::Index::new
Oct 30 15:42:52 docsrs cratesfyi[8350]:    3: once_cell::imp::OnceCell<T>::initialize
Oct 30 15:42:52 docsrs cratesfyi[8350]:    4: <cratesfyi::BinContext as docs_rs::context::Context>::index
Oct 30 15:42:52 docsrs cratesfyi[8350]:    5: docs_rs::utils::daemon::start_daemon
Oct 30 15:42:52 docsrs cratesfyi[8350]:    6: cratesfyi::CommandLine::handle_args
Oct 30 15:42:52 docsrs cratesfyi[8350]:    7: cratesfyi::main
Oct 30 15:42:52 docsrs cratesfyi[8350]:    8: std::rt::lang_start::{{closure}}
Oct 30 15:42:52 docsrs cratesfyi[8350]:    9: std::rt::lang_start_internal::{{closure}}
Oct 30 15:42:52 docsrs cratesfyi[8350]:              at /rustc/d3fb005a39e62501b8b0b356166e515ae24e2e54/src/libstd/rt.rs:52
Oct 30 15:42:52 docsrs cratesfyi[8350]:       std::panicking::try::do_call
Oct 30 15:42:52 docsrs cratesfyi[8350]:              at /rustc/d3fb005a39e62501b8b0b356166e515ae24e2e54/src/libstd/panicking.rs:297
Oct 30 15:42:52 docsrs cratesfyi[8350]:       std::panicking::try
Oct 30 15:42:52 docsrs cratesfyi[8350]:              at /rustc/d3fb005a39e62501b8b0b356166e515ae24e2e54/src/libstd/panicking.rs:274
Oct 30 15:42:52 docsrs cratesfyi[8350]:       std::panic::catch_unwind
Oct 30 15:42:52 docsrs cratesfyi[8350]:              at /rustc/d3fb005a39e62501b8b0b356166e515ae24e2e54/src/libstd/panic.rs:394
Oct 30 15:42:52 docsrs cratesfyi[8350]:       std::rt::lang_start_internal
Oct 30 15:42:52 docsrs cratesfyi[8350]:              at /rustc/d3fb005a39e62501b8b0b356166e515ae24e2e54/src/libstd/rt.rs:51
Oct 30 15:42:52 docsrs cratesfyi[8350]:   10: main
```

cc @l4l 