### PR TITLE
Improve the navbar resize when not on a crate documentation

### DIFF
--- a/templates/header/topbar_begin.html
+++ b/templates/header/topbar_begin.html
@@ -10,7 +10,7 @@
     <div class="container">
         <div class="pure-menu pure-menu-horizontal" role="navigation" aria-label="Main navigation">
             <form action="/releases/search" method="GET"
-                class="landing-search-form-nav {% if not is_latest_version %}not-latest{% endif %}">
+                class="landing-search-form-nav {% if is_latest_version is defined and not is_latest_version %}not-latest{% endif %}">
                 {# The search bar #}
                 <div id="search-input-nav" class="pure-menu-right">
                     <label for="nav-search">


### PR DESCRIPTION
It was having "not-latest" class way more often than it should have and therefore it required large screen size to be able to see the text.