### PR TITLE
Fix tabbing through the giant crate menu

### DIFF
--- a/static/menu.js
+++ b/static/menu.js
@@ -187,7 +187,7 @@
                 case "pageup":
                     // page up: jump five items up, stopping at the top
                     // the number 5 is used so that we go one page in the
-                    // inner-scrolled Depedencies and Versions fields
+                    // inner-scrolled Dependencies and Versions fields
                     switchTo = currentLink;
                     for (var n = 0; n < 5 && switchTo; ++n) {
                         switchTo = previous(allItems, switchTo);

--- a/static/menu.js
+++ b/static/menu.js
@@ -188,24 +188,22 @@
                     // page up: jump five items up, stopping at the top
                     // the number 5 is used so that we go one page in the
                     // inner-scrolled Dependencies and Versions fields
-                    switchTo = currentLink;
-                    for (var n = 0; n < 5 && switchTo; ++n) {
-                        switchTo = previous(allItems, switchTo);
-                    }
-                    if (!switchTo) {
-                        switchTo = allItems[0];
+                    switchTo = currentItem || allItems[0];
+                    for (var n = 0; n < 5; ++n) {
+                        if (switchTo.previousElementSibling && switchTo.previousElementSibling.className == 'pure-menu-item') {
+                            switchTo = switchTo.previousElementSibling;
+                        }
                     }
                     break;
                 case "pagedown":
                     // page down: jump five items down, stopping at the bottom
                     // the number 5 is used so that we go one page in the
-                    // inner-scrolled Depedencies and Versions fields
-                    switchTo = currentLink;
-                    for (var n = 0; n < 5 && switchTo; ++n) {
-                        switchTo = next(allItems, switchTo);
-                    }
-                    if (!switchTo) {
-                        switchTo = last(allItems);
+                    // inner-scrolled Dependencies and Versions fields
+                    switchTo = currentItem || last(allItems);
+                    for (var n = 0; n < 5; ++n) {
+                        if (switchTo.nextElementSibling && switchTo.nextElementSibling.className == 'pure-menu-item') {
+                            switchTo = switchTo.nextElementSibling;
+                        }
                     }
                     break;
             }

--- a/static/menu.js
+++ b/static/menu.js
@@ -171,7 +171,6 @@
                     e.stopPropagation();
                     break;
                 case "home":
-                case "pageup":
                     // home: focus first menu item.
                     // This is the behavior of WAI, while GitHub scrolls,
                     // but it's unlikely that a user will try to scroll the page while the menu is open,
@@ -179,12 +178,35 @@
                     switchTo = allItems[0];
                     break;
                 case "end":
-                case "pagedown":
                     // end: focus last menu item.
                     // This is the behavior of WAI, while GitHub scrolls,
                     // but it's unlikely that a user will try to scroll the page while the menu is open,
                     // so they won't do it on accident.
                     switchTo = last(allItems);
+                    break;
+                case "pageup":
+                    // page up: jump five items up, stopping at the top
+                    // the number 5 is used so that we go one page in the
+                    // inner-scrolled Depedencies and Versions fields
+                    switchTo = currentLink;
+                    for (var n = 0; n < 5 && switchTo; ++n) {
+                        switchTo = previous(allItems, switchTo);
+                    }
+                    if (!switchTo) {
+                        switchTo = allItems[0];
+                    }
+                    break;
+                case "pagedown":
+                    // page down: jump five items down, stopping at the bottom
+                    // the number 5 is used so that we go one page in the
+                    // inner-scrolled Depedencies and Versions fields
+                    switchTo = currentLink;
+                    for (var n = 0; n < 5 && switchTo; ++n) {
+                        switchTo = next(allItems, switchTo);
+                    }
+                    if (!switchTo) {
+                        switchTo = last(allItems);
+                    }
                     break;
             }
             if (switchTo) {

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -113,7 +113,7 @@
 
                             {# Display all dependencies that the crate has #}
                             <li class="pure-menu-item">
-                                <div class="pure-menu pure-menu-scrollable sub-menu">
+                                <div class="pure-menu pure-menu-scrollable sub-menu" tabindex="-1">
                                     <ul class="pure-menu-list">
                                         {%- for dep in krate.dependencies -%}
                                             <li class="pure-menu-item">
@@ -134,7 +134,7 @@
                             <li class="pure-menu-heading">Versions</li>
 
                             <li class="pure-menu-item">
-                                <div class="pure-menu pure-menu-scrollable sub-menu">
+                                <div class="pure-menu pure-menu-scrollable sub-menu" tabindex="-1">
                                     <ul class="pure-menu-list">
                                         {# Display all releases of this crate #}
                                         {{ macros::releases_list(name=krate.name, releases=krate.releases, target=target, inner_path=inner_path) }}

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -82,7 +82,9 @@
                                 <a href="https://crates.io/crates/{{ krate.name }}" class="pure-menu-link" title="See {{ krate.name }} in crates.io">
                                     {{ "cube" | fas(fw=true) }} Crates.io
                                 </a>
+                            </li>
 
+                            <li class="pure-menu-item">
                                 <a href="{{ crate_url | safe }}" class="pure-menu-link" title="See {{ krate.name }} in docs.rs">
                                     {{ "cube" | fas(fw=true) }} More information
                                 </a>


### PR DESCRIPTION
Without this tabindex attribute, the scroll view itself gets selected.

With this attribute added, focus jumps straight to the menu item within, which is what we want, since it contains nothing but menu items, and most of the keyboard shortcuts you would use to interact with the scroll view are trapped by JavaScript anyway.
