### PR TITLE
Remove whitespace beside docs.rs text

### DIFF
--- a/templates/header/topbar_begin.html
+++ b/templates/header/topbar_begin.html
@@ -26,9 +26,9 @@
                 <a href="/" class="pure-menu-heading pure-menu-link" aria-label="Docs.rs">
                     <span title="Docs.rs">{{ "cubes" | fas }}</span>
                     <span class="title">Docs.rs</span>
-                </a>
+                </a>{#
 
-                <ul class="pure-menu-list pure-menu-right">
+                #}<ul class="pure-menu-list pure-menu-right">
                     <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover pure-menu-opt-children">
                         <a href="/about" class="pure-menu-link">
                             <span title="About">{{ "info-circle" | fas }}</span>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4687791/98204008-260b3900-1f70-11eb-94cf-ae660f8881bd.png)

See whitespace beside the docs.rs text which is focused. Next thing I want to fix is the weird focus which is set the title background to `#eee`, it still looks fine on light theme but works bad on dark theme.