### PR TITLE
Fix contrast on pure-css menu link when hover

### DIFF
--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -44,6 +44,13 @@ div.nav-container {
             background-color: inherit;
         }
 
+        // Improves menu link readability when inverting the colors on focus.
+        // Vendor do background-color #eee, looks weird on different theme.
+        &:focus {
+            color: var(--color-background);
+            background-color: var(--color-doc-link-background);
+        }
+
         &.crate-name {
             text-overflow: ellipsis;
             overflow: hidden;


### PR DESCRIPTION
On `focus`

Before (any theme)

![image](https://user-images.githubusercontent.com/4687791/98235894-6fbe4880-1f9d-11eb-8dab-8c45661243ec.png)

After (Ayu)

![image](https://user-images.githubusercontent.com/4687791/98253145-a56f2b80-1fb5-11eb-9380-90242c06dacd.png)

After (Dark)

![image](https://user-images.githubusercontent.com/4687791/98253173-ac963980-1fb5-11eb-9fa8-aea59547e702.png)

After (Light)

![image](https://user-images.githubusercontent.com/4687791/98253220-b4ee7480-1fb5-11eb-9300-24acc30013f5.png)

Not tested after build, just from devtools.

Superseeds #1162