### PR TITLE
Revert "Don't serve non-rustdoc resources from the shared resource handler"

### DIFF
--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -635,10 +635,6 @@ pub struct SharedResourceHandler;
 impl Handler for SharedResourceHandler {
     fn handle(&self, req: &mut Request) -> IronResult<Response> {
         let path = req.url.path();
-        if path.len() > 1 {
-            // All rustdoc shared resources are hosted at the root
-            return Err(Nope::ResourceNotFound.into());
-        }
         let filename = path.last().unwrap(); // unwrap is fine: vector is non-empty
         let suffix = filename.split('.').last().unwrap(); // unwrap is fine: split always works
         if ["js", "css", "woff", "svg"].contains(&suffix) {


### PR DESCRIPTION
This reverts commit d8caa1c4ca80cacbf2a72dac7faa981821a89ec9.

Workaround for #1181 

Can't easily be tested locally since it relies on the behaviour of docs built a long time ago.