### PR TITLE
Add .rustwide to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ target
 !vendor/**/*.css
 .sass-cache
 .vagrant
+.rustwide
 .rustwide-docker
 .workspace


### PR DESCRIPTION
This is the default directory when using `cargo run` instead of `docker-compose up`.