### PR TITLE
Use `-Z rustdoc-map` instead of rewriting it

### DIFF
--- a/crates/metadata/lib.rs
+++ b/crates/metadata/lib.rs
@@ -522,7 +522,12 @@ mod test_calculations {
     use super::*;
 
     fn default_cargo_args() -> Vec<String> {
-        vec!["rustdoc".into(), "--lib".into(), "--".into()]
+        vec![
+            "rustdoc".into(),
+            "--lib".into(),
+            "-Zrustdoc-map".into(),
+            "--".into(),
+        ]
     }
 
     #[test]
@@ -575,6 +580,7 @@ mod test_calculations {
         let expected_args = vec![
             "rustdoc".into(),
             "--lib".into(),
+            "-Zrustdoc-map".into(),
             "--features".into(),
             String::new(),
             "--".into(),
@@ -589,6 +595,7 @@ mod test_calculations {
         let expected_args = vec![
             String::from("rustdoc"),
             "--lib".into(),
+            "-Zrustdoc-map".into(),
             "--features".into(),
             "some_feature".into(),
             "--".into(),
@@ -603,6 +610,7 @@ mod test_calculations {
         let expected_args = vec![
             String::from("rustdoc"),
             "--lib".into(),
+            "-Zrustdoc-map".into(),
             "--features".into(),
             "feature1 feature2".into(),
             "--".into(),
@@ -624,6 +632,7 @@ mod test_calculations {
         let expected_args = vec![
             String::from("rustdoc"),
             "--lib".into(),
+            "-Zrustdoc-map".into(),
             "--".into(),
             "-Z".into(),
             "unstable-options".into(),
@@ -642,6 +651,7 @@ mod test_calculations {
         let expected_args = vec![
             String::from("rustdoc"),
             "--lib".into(),
+            "-Zrustdoc-map".into(),
             "-Z".into(),
             "unstable-options".into(),
             "--config".into(),

--- a/crates/metadata/lib.rs
+++ b/crates/metadata/lib.rs
@@ -229,7 +229,8 @@ impl Metadata {
     /// For example, the links may point somewhere different than they would on docs.rs.
     /// However, rustdoc will see exactly the same code as it would on docs.rs, even counting `cfg`s.
     pub fn cargo_args(&self, additional_args: &[String], rustdoc_args: &[String]) -> Vec<String> {
-        let mut cargo_args: Vec<String> = vec!["rustdoc".into(), "--lib".into()];
+        let mut cargo_args: Vec<String> =
+            vec!["rustdoc".into(), "--lib".into(), "-Zrustdoc-map".into()];
 
         if let Some(features) = &self.features {
             cargo_args.push("--features".into());

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -583,7 +583,7 @@ impl RustwideBuilder {
         cargo_args.push("--verbose".into());
         // We know that `metadata` unconditionally passes `-Z rustdoc-map`.
         // Don't copy paste this, since that fact is not stable and may change in the future.
-        // Normally we would need -Z unstable-options, but we currently pass that too.
+        cargo_args.push("-Zunstable-options".into());
         cargo_args.push(r#"--config=doc.extern-map.registries.crates-io="https://docs.rs""#.into());
         if let Some(cpu_limit) = self.config.build_cpu_limit {
             cargo_args.push(format!("-j{}", cpu_limit));

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -518,16 +518,6 @@ impl RustwideBuilder {
 
         let mut rustdoc_flags = Vec::new();
 
-        for dep in &cargo_metadata.root_dependencies() {
-            rustdoc_flags.push("--extern-html-root-url".to_string());
-            rustdoc_flags.push(format!(
-                "{}=https://docs.rs/{}/{}",
-                dep.name.replace("-", "_"),
-                dep.name,
-                dep.version
-            ));
-        }
-
         rustdoc_flags.extend(vec![
             "--resource-suffix".to_string(),
             format!("-{}", parse_rustc_version(&self.rustc_version)?),

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -579,6 +579,12 @@ impl RustwideBuilder {
 
         // Add docs.rs specific arguments
         let mut cargo_args = Vec::new();
+        // Show the command line Rustdoc is invoked with
+        cargo_args.push("--verbose".into());
+        // We know that `metadata` unconditionally passes `-Z rustdoc-map`.
+        // Don't copy paste this, since that fact is not stable and may change in the future.
+        // Normally we would need -Z unstable-options, but we currently pass that too.
+        cargo_args.push(r#"--config=doc.extern-map.registries.crates-io="https://docs.rs""#.into());
         if let Some(cpu_limit) = self.config.build_cpu_limit {
             cargo_args.push(format!("-j{}", cpu_limit));
         }


### PR DESCRIPTION
Closes https://github.com/rust-lang/docs.rs/issues/1177, closes https://github.com/rust-lang/docs.rs/issues/1165. Fixes https://github.com/rust-lang/docs.rs/issues/1166.