### PR TITLE
Remove --verbose when building with cargo

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -579,8 +579,6 @@ impl RustwideBuilder {
 
         // Add docs.rs specific arguments
         let mut cargo_args = Vec::new();
-        // Show the command line Rustdoc is invoked with
-        cargo_args.push("--verbose".into());
         // We know that `metadata` unconditionally passes `-Z rustdoc-map`.
         // Don't copy paste this, since that fact is not stable and may change in the future.
         cargo_args.push("-Zunstable-options".into());


### PR DESCRIPTION
This causes the logs to be too large and get truncated.

r? @Nemo157 