### PR TITLE
Fix behavior on menu bar with focus and active

### DIFF
--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -39,16 +39,16 @@ div.nav-container {
         font-weight: 400;
         color: var(--color-navbar-standard);
 
-        &:hover {
-            color: var(--color-standard);
-            background-color: inherit;
-        }
-
         // Improves menu link readability when inverting the colors on focus.
         // Vendor do background-color #eee, looks weird on different theme.
         &:focus {
             color: var(--color-background);
             background-color: var(--color-doc-link-background);
+        }
+
+        &:hover {
+            color: var(--color-standard);
+            background-color: inherit;
         }
 
         &.crate-name {


### PR DESCRIPTION
Weird behavior is caused due to hover using color and focus
using background color as hover background-color is inherit,
so flipping will make both situation taking from focus, better.

Fix #1201