### PR TITLE
Switch GitHub updates to GraphQL, part 1

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,6 @@ pub struct Config {
     pub(crate) s3_bucket_is_temporary: bool,
 
     // Github authentication
-    pub(crate) github_username: Option<String>,
     pub(crate) github_accesstoken: Option<String>,
 
     // Max size of the files served by the docs.rs frontend
@@ -74,7 +73,6 @@ impl Config {
             #[cfg(test)]
             s3_bucket_is_temporary: false,
 
-            github_username: maybe_env("CRATESFYI_GITHUB_USERNAME")?,
             github_accesstoken: maybe_env("CRATESFYI_GITHUB_ACCESSTOKEN")?,
 
             max_file_size: env("DOCSRS_MAX_FILE_SIZE", 50 * 1024 * 1024)?,
@@ -91,13 +89,6 @@ impl Config {
             build_cpu_limit: maybe_env("DOCS_RS_BUILD_CPU_LIMIT")?,
             include_default_targets: env("DOCSRS_INCLUDE_DEFAULT_TARGETS", true)?,
         })
-    }
-
-    pub fn github_auth(&self) -> Option<(&str, &str)> {
-        Some((
-            self.github_username.as_deref()?,
-            self.github_accesstoken.as_deref()?,
-        ))
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,9 @@ pub struct Config {
     pub(crate) toolchain: String,
     pub(crate) build_cpu_limit: Option<u32>,
     pub(crate) include_default_targets: bool,
+
+    // Temporary flags
+    pub(crate) tmp_disable_github_updater: bool,
 }
 
 impl Config {
@@ -88,6 +91,8 @@ impl Config {
             toolchain: env("CRATESFYI_TOOLCHAIN", "nightly".to_string())?,
             build_cpu_limit: maybe_env("DOCS_RS_BUILD_CPU_LIMIT")?,
             include_default_targets: env("DOCSRS_INCLUDE_DEFAULT_TARGETS", true)?,
+
+            tmp_disable_github_updater: env("DOCSRS_TMP_DISABLE_GITHUB_UPDATER", false)?,
         })
     }
 }

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -502,6 +502,33 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> CratesfyiResult<(
             "
                  ALTER TYPE feature DROP ATTRIBUTE optional_dependency;
             "
+        ),
+        migration!(
+            context,
+            22,
+            // description
+            "Add the github_repositories table to contain GitHub information",
+            // upgrade query
+            "
+                CREATE TABLE github_repos (
+                    id VARCHAR PRIMARY KEY NOT NULL,
+                    name VARCHAR NOT NULL,
+                    description VARCHAR,
+                    last_commit TIMESTAMP,
+                    stars INT NOT NULL,
+                    forks INT NOT NULL,
+                    issues INT NOT NULL,
+                    updated_at TIMESTAMP NOT NULL
+                );
+
+                ALTER TABLE releases ADD COLUMN github_repo VARCHAR
+                    REFERENCES github_repos(id) ON DELETE SET NULL;
+            ",
+            // downgrade query
+            "
+                ALTER TABLE releases DROP COLUMN github_repo;
+                DROP TABLE github_repos;
+            "
         )
     ];
 

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -94,15 +94,19 @@ pub fn start_daemon(context: &dyn Context, enable_registry_watcher: bool) -> Res
     )?;
 
     // update github stats every hour
-    let github_updater = GithubUpdater::new(&config, context.pool()?)?;
-    cron(
-        "github stats updater",
-        Duration::from_secs(60 * 60),
-        move || {
-            github_updater.update_all_crates()?;
-            Ok(())
-        },
-    )?;
+    if config.tmp_disable_github_updater {
+        log::warn!("the github stats updater was disabled!");
+    } else {
+        let github_updater = GithubUpdater::new(&config, context.pool()?)?;
+        cron(
+            "github stats updater",
+            Duration::from_secs(60 * 60),
+            move || {
+                github_updater.update_all_crates()?;
+                Ok(())
+            },
+        )?;
+    }
 
     // Never returns; `server` blocks indefinitely when dropped
     // NOTE: if a failure occurred earlier in `start_daemon`, the server will _not_ be joined -

--- a/src/utils/github_updater.rs
+++ b/src/utils/github_updater.rs
@@ -34,18 +34,15 @@ pub struct GithubUpdater {
 
 impl GithubUpdater {
     pub fn new(config: &Config, pool: Pool) -> Result<Self> {
-        let github_auth = config.github_auth();
-
-        let mut headers = HeaderMap::with_capacity(2 + github_auth.is_some() as usize);
+        let mut headers = HeaderMap::new();
         headers.insert(USER_AGENT, HeaderValue::from_static(APP_USER_AGENT));
         headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
 
-        if let Some((username, accesstoken)) = github_auth {
-            let basicauth = format!(
-                "Basic {}",
-                base64::encode(format!("{}:{}", username, accesstoken))
+        if let Some(token) = &config.github_accesstoken {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("token {}", token))?,
             );
-            headers.insert(AUTHORIZATION, HeaderValue::from_str(&basicauth).unwrap());
         } else {
             warn!("No GitHub authorization specified, will be working with very low rate limits");
         }

--- a/src/utils/github_updater.rs
+++ b/src/utils/github_updater.rs
@@ -26,7 +26,7 @@ struct GitHubFields {
     stars: i64,
     forks: i64,
     issues: i64,
-    last_commit: DateTime<Utc>,
+    last_commit: Option<DateTime<Utc>>,
 }
 
 pub struct GithubUpdater {
@@ -143,7 +143,7 @@ impl GithubUpdater {
                 &fields.node_id,
                 &fields.full_name,
                 &fields.description,
-                &fields.last_commit.naive_utc(),
+                &fields.last_commit.as_ref().map(|lc| lc.naive_utc()),
                 &(fields.stars as i32),
                 &(fields.forks as i32),
                 &(fields.issues as i32),
@@ -162,7 +162,7 @@ impl GithubUpdater {
                 &(fields.stars as i32),
                 &(fields.forks as i32),
                 &(fields.issues as i32),
-                &fields.last_commit.naive_utc(),
+                &fields.last_commit.as_ref().map(|lc| lc.naive_utc()),
                 &crate_id,
             ],
         )?;
@@ -190,8 +190,7 @@ impl GithubUpdater {
             forks_count: i64,
             #[serde(default)]
             open_issues: i64,
-            #[serde(default = "Utc::now")]
-            pushed_at: DateTime<Utc>,
+            pushed_at: Option<DateTime<Utc>>,
         }
 
         let url = format!("https://api.github.com/repos/{}", path);


### PR DESCRIPTION
This PR is the first of two PRs that are going to switch our GitHub updater to use GitHub's GraphQL API, reducing the amount of API requests docs.rs makes to GitHub and fixing https://github.com/rust-lang/docs.rs/issues/1176.

We can't just switch the current code to use GraphQL, as the GraphQL API relies on "node IDs" (for example `MDEwOlJlcG9zaXRvcnkyMzg1MzQ4Mg==`) to query multiple items at once. Because of that we'll need to have a transition period where we use the old code but also collect the node IDs we'll use in the future to query the new information in batches. The plan is the following:

1. **<We're here!>** Land a code change that updates the old process to also store the node IDs in the database.
2. Keep that code change deployed for at least a day, to collect the node IDs of all the repositories we currently have.
3. Land a code change that replaces the old updater code with the new one, based on GraphQL.
4. Before deploying that code change, disable automatic GitHub updates (to ensure we have API quota), lock the build queue (to ensure no more crates are being added) and manually call `cratesfyi database update-github-fields` to ensure newly built crates are also present in the new schema.
5. Deploy the changes landed in step 3!

Since we needed to change the database schema to also store node IDs, I took this opportunity to define a new schema for storing the GitHub information: there will be a `github_repos` table keyed by the repository node ID which contains the information, and each release will have a field called `github_repo` pointing to the right row in the `github_repos` table. This will have a few really nice side-effects:

* It will be easy to handle deleted repos: when GitHub returns a 404 on a repository we'll just need to delete the row from `github_repos`, and the foreign key will set all the affected releases's `github_repo` to `NULL`.
* It will be easy to handle renamed repositories; since the node ID stays the same across renames, we only need to update the name when we get a response from the API.
* We will only fetch the stats for each repository once, even if multiple crates are pointing to the same repositories.
* We will support different releases pointing to different repositories.

This PR includes the code to store information fetched during the update on both the old `crates` table and the new `github_repos` one, and to link each release with the right repository. The rest of the changes will be done in a followup PR. There are also two vaguely related changes in this PR:

* The `CRATESFYI_GITHUB_USERNAME` environment variable has been removed, as that was not really useful.
* I added a **temporary** environment variable to disable the github updater, used for step 4 above. I'll remove it in the next PR.