### PR TITLE
Switch GitHub updates to GraphQL, part 2

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -422,7 +422,7 @@ impl DatabaseSubcommand {
             }
 
             Self::UpdateGithubFields => {
-                docs_rs::utils::GithubUpdater::new(&*ctx.config()?, ctx.pool()?)?
+                docs_rs::utils::GithubUpdater::new(ctx.config()?, ctx.pool()?)?
                     .update_all_crates()?;
             }
 

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -374,6 +374,9 @@ enum DatabaseSubcommand {
     /// Updates github stats for crates.
     UpdateGithubFields,
 
+    /// Backfill GitHub stats for crates.
+    BackfillGithubStats,
+
     /// Updates info for a crate from the registry's API
     UpdateCrateRegistryFields {
         #[structopt(name = "CRATE")]
@@ -424,6 +427,11 @@ impl DatabaseSubcommand {
             Self::UpdateGithubFields => {
                 docs_rs::utils::GithubUpdater::new(ctx.config()?, ctx.pool()?)?
                     .update_all_crates()?;
+            }
+
+            Self::BackfillGithubStats => {
+                docs_rs::utils::GithubUpdater::new(ctx.config()?, ctx.pool()?)?
+                    .backfill_repositories()?;
             }
 
             Self::UpdateCrateRegistryFields { name } => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,7 @@ pub struct Config {
 
     // Github authentication
     pub(crate) github_accesstoken: Option<String>,
+    pub(crate) github_updater_min_rate_limit: u32,
 
     // Max size of the files served by the docs.rs frontend
     pub(crate) max_file_size: usize,
@@ -77,6 +78,7 @@ impl Config {
             s3_bucket_is_temporary: false,
 
             github_accesstoken: maybe_env("CRATESFYI_GITHUB_ACCESSTOKEN")?,
+            github_updater_min_rate_limit: env("DOCSRS_GITHUB_UPDATER_MIN_RATE_LIMIT", 2500)?,
 
             max_file_size: env("DOCSRS_MAX_FILE_SIZE", 50 * 1024 * 1024)?,
             max_file_size_html: env("DOCSRS_MAX_FILE_SIZE_HTML", 50 * 1024 * 1024)?,

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -37,6 +37,7 @@ pub(crate) fn add_package_into_database(
     has_docs: bool,
     has_examples: bool,
     compression_algorithms: std::collections::HashSet<CompressionAlgorithm>,
+    github_repo: Option<String>,
 ) -> Result<i32> {
     debug!("Adding package into database");
     let crate_id = initialize_package_in_database(conn, metadata_pkg)?;
@@ -54,12 +55,12 @@ pub(crate) fn add_package_into_database(
             homepage_url, description, description_long, readme,
             authors, keywords, have_examples, downloads, files,
             doc_targets, is_library, doc_rustc_version,
-            documentation_url, default_target, features
+            documentation_url, default_target, features, github_repo
          )
          VALUES (
             $1,  $2,  $3,  $4,  $5,  $6,  $7,  $8,  $9,
             $10, $11, $12, $13, $14, $15, $16, $17, $18,
-            $19, $20, $21, $22, $23, $24, $25, $26
+            $19, $20, $21, $22, $23, $24, $25, $26, $27
          )
          ON CONFLICT (crate_id, version) DO UPDATE
             SET release_time = $3,
@@ -85,7 +86,8 @@ pub(crate) fn add_package_into_database(
                 doc_rustc_version = $23,
                 documentation_url = $24,
                 default_target = $25,
-                features = $26
+                features = $26,
+                github_repo = $27
          RETURNING id",
         &[
             &crate_id,
@@ -114,6 +116,7 @@ pub(crate) fn add_package_into_database(
             &metadata_pkg.documentation,
             &default_target,
             &features,
+            &github_repo,
         ],
     )?;
 

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -300,6 +300,7 @@ impl<'a> FakeRelease<'a> {
             self.has_docs,
             self.has_examples,
             algs,
+            None,
         )?;
         crate::db::update_crate_data_in_database(
             &mut db.conn(),

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -97,7 +97,7 @@ pub fn start_daemon(context: &dyn Context, enable_registry_watcher: bool) -> Res
     if config.tmp_disable_github_updater {
         log::warn!("the github stats updater was disabled!");
     } else {
-        let github_updater = GithubUpdater::new(&config, context.pool()?)?;
+        let github_updater = GithubUpdater::new(config, context.pool()?)?;
         cron(
             "github stats updater",
             Duration::from_secs(60 * 60),

--- a/src/utils/github_updater.rs
+++ b/src/utils/github_updater.rs
@@ -1,8 +1,7 @@
 use crate::error::Result;
 use crate::{db::Pool, Config};
 use chrono::{DateTime, Utc};
-use failure::err_msg;
-use log::{debug, warn};
+use log::{info, trace, warn};
 use postgres::Client;
 use regex::Regex;
 use reqwest::{
@@ -10,6 +9,7 @@ use reqwest::{
     header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT},
 };
 use serde::Deserialize;
+use std::sync::Arc;
 
 const APP_USER_AGENT: &str = concat!(
     env!("CARGO_PKG_NAME"),
@@ -17,25 +17,35 @@ const APP_USER_AGENT: &str = concat!(
     include_str!(concat!(env!("OUT_DIR"), "/git_version"))
 );
 
-/// Fields we need in docs.rs
-#[derive(Debug)]
-struct GitHubFields {
-    node_id: String,
-    full_name: String,
-    description: String,
-    stars: i64,
-    forks: i64,
-    issues: i64,
-    last_commit: Option<DateTime<Utc>>,
-}
+const GRAPHQL_UPDATE: &str = "query($ids: [ID!]!) {
+    nodes(ids: $ids) {
+        ... on Repository {
+            id
+            nameWithOwner
+            pushedAt
+            description
+            stargazerCount
+            forkCount
+            issues { totalCount }
+        }
+    }
+    rateLimit {
+        remaining
+    }
+}";
+
+/// How many repositories to update in a single chunk. Values over 100 are probably going to be
+/// rejected by the GraphQL API.
+const UPDATE_CHUNK_SIZE: usize = 100;
 
 pub struct GithubUpdater {
     client: HttpClient,
     pool: Pool,
+    config: Arc<Config>,
 }
 
 impl GithubUpdater {
-    pub fn new(config: &Config, pool: Pool) -> Result<Self> {
+    pub fn new(config: Arc<Config>, pool: Pool) -> Result<Self> {
         let mut headers = HeaderMap::new();
         headers.insert(USER_AGENT, HeaderValue::from_static(APP_USER_AGENT));
         headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
@@ -51,81 +61,96 @@ impl GithubUpdater {
 
         let client = HttpClient::builder().default_headers(headers).build()?;
 
-        Ok(GithubUpdater { client, pool })
+        Ok(GithubUpdater {
+            client,
+            pool,
+            config,
+        })
     }
 
     /// Updates github fields in crates table
     pub fn update_all_crates(&self) -> Result<()> {
-        debug!("Starting update of all crates");
+        info!("started updating GitHub repository stats");
 
-        if self.is_rate_limited()? {
-            warn!("Skipping update because of rate limit");
+        let mut conn = self.pool.get()?;
+        let needs_update = conn
+            .query(
+                "SELECT id FROM github_repos WHERE updated_at < NOW() - INTERVAL '1 day';",
+                &[],
+            )?
+            .into_iter()
+            .map(|row| row.get(0))
+            .collect::<Vec<String>>();
+
+        if needs_update.is_empty() {
+            info!("no GitHub repository stats needed to be updated");
             return Ok(());
         }
 
-        let mut conn = self.pool.get()?;
-        // TODO: This query assumes repository field in Cargo.toml is
-        //       always the same across all versions of a crate
-        let rows = conn.query(
-            "SELECT DISTINCT ON (crates.name)
-                    crates.name,
-                    crates.id,
-                    releases.repository_url
-             FROM crates
-             INNER JOIN releases ON releases.crate_id = crates.id
-             WHERE releases.repository_url ~ '^https?://github.com' AND
-                   (crates.github_last_update < NOW() - INTERVAL '1 day' OR
-                    crates.github_last_update IS NULL)
-             ORDER BY crates.name, releases.release_time DESC",
-            &[],
-        )?;
-
-        for row in &rows {
-            let crate_name: String = row.get(0);
-            let crate_id: i32 = row.get(1);
-            let repository_url: String = row.get(2);
-
-            debug!("Updating {}", crate_name);
-            if let Err(err) = self.update_crate(&mut conn, crate_id, &repository_url) {
-                if self.is_rate_limited()? {
-                    warn!("Skipping remaining updates because of rate limit");
+        for chunk in needs_update.chunks(UPDATE_CHUNK_SIZE) {
+            if let Err(err) = self.update_repositories(&mut conn, &chunk) {
+                if err.downcast_ref::<RateLimitReached>().is_some() {
+                    warn!("rate limit reached, blocked the GitHub repository stats updater");
                     return Ok(());
                 }
-                warn!("Failed to update {}: {}", crate_name, err);
+                return Err(err);
             }
         }
 
-        debug!("Completed all updates");
+        info!("finished updating GitHub repository stats");
         Ok(())
     }
 
-    fn is_rate_limited(&self) -> Result<bool> {
-        #[derive(Deserialize)]
-        struct Response {
-            resources: Resources,
+    fn update_repositories(&self, conn: &mut Client, node_ids: &[String]) -> Result<()> {
+        let response: GraphResponse<GraphNodes<Option<GraphRepository>>> = self
+            .client
+            .post("https://api.github.com/graphql")
+            .json(&serde_json::json!({
+                "query": GRAPHQL_UPDATE,
+                "variables": {
+                    "ids": node_ids,
+                },
+            }))
+            .send()?
+            .error_for_status()?
+            .json()?;
+
+        // The error is returned *before* we reach the rate limit, to ensure we always have an
+        // amount of API calls we can make at any time.
+        trace!(
+            "GitHub GraphQL rate limit remaining: {}",
+            response.data.rate_limit.remaining
+        );
+        if response.data.rate_limit.remaining < self.config.github_updater_min_rate_limit {
+            return Err(RateLimitReached.into());
         }
 
-        #[derive(Deserialize)]
-        struct Resources {
-            core: Resource,
+        // When a node is missing (for example if the repository was deleted or made private) the
+        // GraphQL API will return *both* a `null` instead of the data in the nodes list and a
+        // `NOT_FOUND` error in the errors list.
+        for node in &response.data.nodes {
+            if let Some(node) = node {
+                self.store_repository(conn, &node)?;
+            }
+        }
+        for error in &response.errors {
+            use GraphErrorPath::*;
+            match (error.error_type.as_str(), error.path.as_slice()) {
+                ("NOT_FOUND", [Segment(nodes), Index(idx)]) if nodes == "nodes" => {
+                    self.delete_repository(conn, &node_ids[*idx as usize])?;
+                }
+                _ => failure::bail!("error updating repositories: {}", error.message),
+            }
         }
 
-        #[derive(Deserialize)]
-        struct Resource {
-            remaining: u64,
-        }
-
-        let url = "https://api.github.com/rate_limit";
-        let response: Response = self.client.get(url).send()?.error_for_status()?.json()?;
-
-        Ok(response.resources.core.remaining == 0)
+        Ok(())
     }
 
-    fn update_crate(&self, conn: &mut Client, crate_id: i32, repository_url: &str) -> Result<()> {
-        let path =
-            get_github_path(repository_url).ok_or_else(|| err_msg("Failed to get github path"))?;
-        let fields = self.get_github_fields(&path)?;
-
+    fn store_repository(&self, conn: &mut Client, repo: &GraphRepository) -> Result<()> {
+        trace!(
+            "storing GitHub repository stats for {}",
+            repo.name_with_owner
+        );
         conn.execute(
             "INSERT INTO github_repos (
                  id, name, description, last_commit, stars, forks, issues, updated_at
@@ -140,71 +165,22 @@ impl GithubUpdater {
                  issues = $7,
                  updated_at = NOW();",
             &[
-                &fields.node_id,
-                &fields.full_name,
-                &fields.description,
-                &fields.last_commit.as_ref().map(|lc| lc.naive_utc()),
-                &(fields.stars as i32),
-                &(fields.forks as i32),
-                &(fields.issues as i32),
+                &repo.id,
+                &repo.name_with_owner,
+                &repo.description,
+                &repo.pushed_at.naive_utc(),
+                &(repo.stargazer_count as i32),
+                &(repo.fork_count as i32),
+                &(repo.issues.total_count as i32),
             ],
         )?;
-
-        conn.execute(
-            "UPDATE crates
-             SET github_description = $1,
-                 github_stars = $2, github_forks = $3,
-                 github_issues = $4, github_last_commit = $5,
-                 github_last_update = NOW()
-             WHERE id = $6",
-            &[
-                &fields.description,
-                &(fields.stars as i32),
-                &(fields.forks as i32),
-                &(fields.issues as i32),
-                &fields.last_commit.as_ref().map(|lc| lc.naive_utc()),
-                &crate_id,
-            ],
-        )?;
-
-        // Temporary statement to migrate production data over to the new table. Will be removed by
-        // Pietro's next PR.
-        conn.execute(
-            "UPDATE releases SET github_repo = $1 WHERE crate_id = $2;",
-            &[&fields.node_id, &crate_id],
-        )?;
-
         Ok(())
     }
 
-    fn get_github_fields(&self, path: &str) -> Result<GitHubFields> {
-        #[derive(Deserialize)]
-        struct Response {
-            node_id: String,
-            full_name: String,
-            #[serde(default)]
-            description: Option<String>,
-            #[serde(default)]
-            stargazers_count: i64,
-            #[serde(default)]
-            forks_count: i64,
-            #[serde(default)]
-            open_issues: i64,
-            pushed_at: Option<DateTime<Utc>>,
-        }
-
-        let url = format!("https://api.github.com/repos/{}", path);
-        let response: Response = self.client.get(&url).send()?.error_for_status()?.json()?;
-
-        Ok(GitHubFields {
-            node_id: response.node_id,
-            full_name: response.full_name,
-            description: response.description.unwrap_or_default(),
-            stars: response.stargazers_count,
-            forks: response.forks_count,
-            issues: response.open_issues,
-            last_commit: response.pushed_at,
-        })
+    fn delete_repository(&self, conn: &mut Client, id: &str) -> Result<()> {
+        trace!("removing GitHub repository stats for ID {}", id);
+        conn.execute("DELETE FROM github_repos WHERE id = $1;", &[&id])?;
+        Ok(())
     }
 }
 
@@ -226,6 +202,62 @@ fn get_github_path(url: &str) -> Option<String> {
 
         None => None,
     }
+}
+
+#[derive(Debug, failure::Fail)]
+#[fail(display = "rate limit reached")]
+struct RateLimitReached;
+
+#[derive(Debug, Deserialize)]
+struct GraphResponse<T> {
+    data: T,
+    #[serde(default)]
+    errors: Vec<GraphError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphError {
+    #[serde(rename = "type")]
+    error_type: String,
+    path: Vec<GraphErrorPath>,
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum GraphErrorPath {
+    Segment(String),
+    Index(i64),
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphRateLimit {
+    remaining: u32,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GraphNodes<T> {
+    nodes: Vec<T>,
+    rate_limit: GraphRateLimit,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GraphRepository {
+    id: String,
+    name_with_owner: String,
+    pushed_at: DateTime<Utc>,
+    description: String,
+    stargazer_count: i64,
+    fork_count: i64,
+    issues: GraphIssues,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GraphIssues {
+    total_count: i64,
 }
 
 #[cfg(test)]

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -697,6 +697,40 @@ mod tests {
     use std::collections::HashSet;
 
     #[test]
+    fn releases_by_stars() {
+        wrapper(|env| {
+            let db = env.db();
+
+            env.fake_release()
+                .name("foo")
+                .version("1.0.0")
+                .github_stats("ghost/foo", 10, 10, 10)
+                .create()?;
+            env.fake_release()
+                .name("bar")
+                .version("1.0.0")
+                .github_stats("ghost/bar", 20, 20, 20)
+                .create()?;
+            env.fake_release().name("baz").version("1.0.0").create()?;
+
+            let releases = get_releases(&mut db.conn(), 1, 10, Order::GithubStars);
+            assert_eq!(
+                vec![
+                    "bar", // 20 stars
+                    "foo", // 10 stars
+                    "baz", // no stars (still included at the bottom)
+                ],
+                releases
+                    .iter()
+                    .map(|release| release.name.as_str())
+                    .collect::<Vec<_>>(),
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn database_search() {
         wrapper(|env| {
             let db = env.db();

--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -73,11 +73,11 @@
                                 <a href="{{ details.repository_url }}" class="pure-menu-link">
                                     {# If the repo link is for github, show some github stats #}
                                     {# TODO: add support for hosts besides github (#35) #}
-                                    {%- if details.github -%}
+                                    {%- if details.github_metadata -%}
                                         {{ "github" | fab(fw=true) }}
-                                        {{ "star" | fas(fw=true) }} {{ details.github_stars }}
-                                        {{ "code-branch" | fas(fw=true) }} {{ details.github_forks }}
-                                        {{ "exclamation-circle" | fas(fw=true) }} {{ details.github_issues }}
+                                        {{ "star" | fas(fw=true) }} {{ details.github_metadata.stars }}
+                                        {{ "code-branch" | fas(fw=true) }} {{ details.github_metadata.forks }}
+                                        {{ "exclamation-circle" | fas(fw=true) }} {{ details.github_metadata.issues }}
 
                                     {# If the repo link is unknown, just show a normal link #}
                                     {%- else -%}

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -59,13 +59,13 @@
                             {%- endif -%}
 
                             {# If the crate is hosted on GitHub, show some stats #}
-                            {%- if krate.github -%}
+                            {%- if krate.github_metadata -%}
                                 <li class="pure-menu-item">
                                     <a href="{{ krate.repository_url }}" class="pure-menu-link">
                                         {{ "github" | fab(fw=true) }}
-                                        {{ "star" | fas(fw=true) }} {{ krate.github_stars }}
-                                        {{ "code-branch" | fas(fw=true) }} {{ krate.github_forks }}
-                                        {{ "exclamation-circle" | fas(fw=true) }} {{ krate.github_issues }}
+                                        {{ "star" | fas(fw=true) }} {{ krate.github_metadata.stars }}
+                                        {{ "code-branch" | fas(fw=true) }} {{ krate.github_metadata.forks }}
+                                        {{ "exclamation-circle" | fas(fw=true) }} {{ krate.github_metadata.issues }}
                                     </a>
                                 </li>
 


### PR DESCRIPTION
This PR finishes the migration to GraphQL for fetching GitHub repository statistics started in #1208, and fixes #1176 in the process.

There are mainly four things changed by this PR:

* The code that periodically updates the GitHub metadata was changed to use GraphQL to fetch updates in batches, and to only update the new `github_repos` table. When a repository is deleted or made private the line in the `github_repos` table will be removed, preventing further updates to that repository.
* The documentation builder was changed to fetch the GitHub statistics for new releases right after the build (or to use already cached statistics). This means new crates will get their stats as soon as they're available, and there is no need to distinguish "crates that don't have a repository" vs "crates that were not scraped yet" in the schema.
* The command  `cratesfyi database backfill-github-stats` was added to manually try and gather stats for every crate that links to GitHub but doesn't have a repository attached. This will be useful during the migration to ensure we don't lose crates.
* The frontend was changed to fetch the stats from the new `github_repos` table, and the old data is dropped from the database.

Another notable change is that the daily updater now stops *before* the rate limit is reached (the threshold is configured through an environment variable). This was done both to avoid monitoring yelling that the rate limit was reached, and to leave room for the documentation builder to fetch statistics after builds. The default threshold is 2.5k requests, which will be able to update 250k repositories in one go.

The revised deployment plan for GraphQL is:

| # | Status | Task |
| --- | --- | --- |
| 1 | :green_circle: Done! | Land a code change that updates the old process to also store the node IDs in the database. |
| 2 | :green_circle: Done! | Keep that code change deployed for at least a day, to collect the node IDs of all the repositories we currently have. |
| 3 | :wave: This! | Land a code change that replaces the old updater code with the new one, based on GraphQL. |
| 4 | - | Before deploying that code change, disable automatic GitHub updates (to ensure we have API quota), lock the build queue (to ensure no more crates are being added) and manually call `cratesfyi database backfill-github-stats` to ensure newly built crates are also present in the new schema. |
| 5 | - | Deploy the changes landed in step 3! |

r? @jyn514 
This PR is best reviewed commit-by-commit.