### PR TITLE
Use `clip-path` instead of `mask` to make round corners

### DIFF
--- a/crates/badge/src/lib.rs
+++ b/crates/badge/src/lib.rs
@@ -78,11 +78,11 @@ impl Badge {
                 <stop offset="1" stop-opacity=".1"/>
               </linearGradient>
 
-              <mask id="round">
+              <clipPath id="round">
                 <rect width="{badge_width}" height="20" rx="3" fill="#fff"/>
-              </mask>
+              </clipPath>
 
-              <g mask="url(#round)">
+              <g clip-path="url(#round)">
                 <rect width="{left_width}" height="20" fill="#555"/>
                 <rect x="{left_width}" width="{right_width}" height="20" fill="{color}"/>
                 <rect width="{badge_width}" height="20" fill="url(#smooth)"/>

--- a/crates/badge/test_badge.svg
+++ b/crates/badge/test_badge.svg
@@ -5,11 +5,11 @@
         <stop offset="1" stop-opacity=".1"/>
     </linearGradient>
 
-    <mask id="round">
+    <clipPath id="round">
         <rect width="73" height="20" rx="3" fill="#fff"/>
-    </mask>
+    </clipPath>
 
-    <g mask="url(#round)">
+    <g clip-path="url(#round)">
         <rect width="34" height="20" fill="#555"/>
         <rect x="34" width="39" height="20" fill="#4d76ae"/>
         <rect width="73" height="20" fill="url(#smooth)"/>


### PR DESCRIPTION
Before and after:

![image](https://user-images.githubusercontent.com/2662758/102852106-72470580-4458-11eb-8ba0-54762b821c4c.png)

Fixes #1212