### PR TITLE
Store build logs in S3

### DIFF
--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -175,17 +175,14 @@ pub(crate) fn add_build_into_database(
 ) -> Result<i32> {
     debug!("Adding build into database");
     let rows = conn.query(
-        "INSERT INTO builds (rid, rustc_version,
-                                                    cratesfyi_version,
-                                                    build_status, output)
-                                VALUES ($1, $2, $3, $4, $5)
-                                RETURNING id",
+        "INSERT INTO builds (rid, rustc_version, cratesfyi_version, build_status)
+        VALUES ($1, $2, $3, $4)
+        RETURNING id",
         &[
             &release_id,
             &res.rustc_version,
             &res.docsrs_version,
             &res.successful,
-            &res.build_log,
         ],
     )?;
     Ok(rows[0].get(0))

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -410,7 +410,7 @@ impl RustwideBuilder {
                     github_repo,
                 )?;
 
-                if let Some(doc_coverage) = res.result.doc_coverage {
+                if let Some(doc_coverage) = res.doc_coverage {
                     add_doc_coverage(&mut conn, release_id, doc_coverage)?;
                 }
 
@@ -560,8 +560,8 @@ impl RustwideBuilder {
                 rustc_version: self.rustc_version.clone(),
                 docsrs_version: format!("docsrs {}", crate::BUILD_VERSION),
                 successful,
-                doc_coverage,
             },
+            doc_coverage,
             cargo_metadata,
             target: target.to_string(),
         })
@@ -705,6 +705,7 @@ struct FullBuildResult {
     result: BuildResult,
     target: String,
     cargo_metadata: CargoMetadata,
+    doc_coverage: Option<DocCoverage>,
 }
 
 #[derive(Clone, Copy)]
@@ -726,5 +727,4 @@ pub(crate) struct BuildResult {
     pub(crate) docsrs_version: String,
     pub(crate) build_log: String,
     pub(crate) successful: bool,
-    pub(crate) doc_coverage: Option<DocCoverage>,
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,5 +1,6 @@
 mod fakes;
 
+pub(crate) use self::fakes::FakeBuild;
 use crate::db::{Pool, PoolClient};
 use crate::storage::{Storage, StorageKind};
 use crate::web::Server;

--- a/src/web/build_details.rs
+++ b/src/web/build_details.rs
@@ -1,7 +1,8 @@
 use crate::{
     db::Pool,
     impl_webpage,
-    web::{page::WebPage, MetaData, Nope},
+    web::{file::File, page::WebPage, MetaData, Nope},
+    Config, Storage,
 };
 use chrono::{DateTime, Utc};
 use iron::{IronResult, Request, Response};
@@ -29,6 +30,8 @@ impl_webpage! {
 }
 
 pub fn build_details_handler(req: &mut Request) -> IronResult<Response> {
+    let storage = extension!(req, Storage);
+    let config = extension!(req, Config);
     let router = extension!(req, Router);
     let name = cexpect!(req, router.find("name"));
     let version = cexpect!(req, router.find("version"));
@@ -44,7 +47,8 @@ pub fn build_details_handler(req: &mut Request) -> IronResult<Response> {
                 builds.cratesfyi_version,
                 builds.build_status,
                 builds.build_time,
-                builds.output
+                builds.output,
+                releases.default_target
              FROM builds
              INNER JOIN releases ON releases.id = builds.rid
              INNER JOIN crates ON releases.crate_id = crates.id
@@ -54,13 +58,21 @@ pub fn build_details_handler(req: &mut Request) -> IronResult<Response> {
     );
 
     let build_details = if let Some(row) = row {
+        let output = if let Some(output) = row.get("output") {
+            output
+        } else {
+            let target: String = row.get("default_target");
+            let path = format!("build-logs/{}/{}.txt", id, target);
+            let file = ctry!(req, File::from_path(&storage, &path, &config));
+            ctry!(req, String::from_utf8(file.0.content))
+        };
         BuildDetails {
             id,
             rustc_version: row.get("rustc_version"),
             docsrs_version: row.get("cratesfyi_version"),
             build_status: row.get("build_status"),
             build_time: row.get("build_time"),
-            output: row.get("output"),
+            output,
         }
     } else {
         return Err(Nope::BuildNotFound.into());
@@ -79,12 +91,14 @@ mod tests {
     use kuchiki::traits::TendrilSink;
 
     #[test]
-    fn build_logs() {
+    fn db_build_logs() {
         wrapper(|env| {
             env.fake_release()
                 .name("foo")
                 .version("0.1.0")
-                .builds(vec![FakeBuild::default().build_log("A build log")])
+                .builds(vec![FakeBuild::default()
+                    .no_s3_build_log()
+                    .db_build_log("A build log")])
                 .create()?;
 
             let page = kuchiki::parse_html().one(
@@ -103,6 +117,69 @@ mod tests {
             let log = page.select("pre").unwrap().next().unwrap().text_contents();
 
             assert!(log.contains("A build log"));
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn s3_build_logs() {
+        wrapper(|env| {
+            env.fake_release()
+                .name("foo")
+                .version("0.1.0")
+                .builds(vec![FakeBuild::default().s3_build_log("A build log")])
+                .create()?;
+
+            let page = kuchiki::parse_html().one(
+                env.frontend()
+                    .get("/crate/foo/0.1.0/builds")
+                    .send()?
+                    .text()?,
+            );
+
+            let node = page.select("ul > li a.release").unwrap().next().unwrap();
+            let attrs = node.attributes.borrow();
+            let url = attrs.get("href").unwrap();
+
+            let page = kuchiki::parse_html().one(env.frontend().get(url).send()?.text()?);
+
+            let log = page.select("pre").unwrap().next().unwrap().text_contents();
+
+            assert!(log.contains("A build log"));
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn both_build_logs() {
+        wrapper(|env| {
+            env.fake_release()
+                .name("foo")
+                .version("0.1.0")
+                .builds(vec![FakeBuild::default()
+                    .s3_build_log("A build log")
+                    .db_build_log("Another build log")])
+                .create()?;
+
+            let page = kuchiki::parse_html().one(
+                env.frontend()
+                    .get("/crate/foo/0.1.0/builds")
+                    .send()?
+                    .text()?,
+            );
+
+            let node = page.select("ul > li a.release").unwrap().next().unwrap();
+            let attrs = node.attributes.borrow();
+            let url = attrs.get("href").unwrap();
+
+            let page = kuchiki::parse_html().one(env.frontend().get(url).send()?.text()?);
+
+            let log = page.select("pre").unwrap().next().unwrap().text_contents();
+
+            // Relatively arbitrarily the DB is prioritised
+            assert!(log.contains("Another build log"));
 
             Ok(())
         });

--- a/src/web/build_details.rs
+++ b/src/web/build_details.rs
@@ -1,0 +1,124 @@
+use crate::{
+    db::Pool,
+    impl_webpage,
+    web::{page::WebPage, MetaData, Nope},
+};
+use chrono::{DateTime, Utc};
+use iron::{IronResult, Request, Response};
+use router::Router;
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct BuildDetails {
+    id: i32,
+    rustc_version: String,
+    docsrs_version: String,
+    build_status: bool,
+    build_time: DateTime<Utc>,
+    output: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct BuildDetailsPage {
+    metadata: MetaData,
+    build_details: BuildDetails,
+}
+
+impl_webpage! {
+    BuildDetailsPage = "crate/build_details.html",
+}
+
+pub fn build_details_handler(req: &mut Request) -> IronResult<Response> {
+    let router = extension!(req, Router);
+    let name = cexpect!(req, router.find("name"));
+    let version = cexpect!(req, router.find("version"));
+    let id: i32 = ctry!(req, cexpect!(req, router.find("id")).parse());
+
+    let mut conn = extension!(req, Pool).get()?;
+
+    let row = ctry!(
+        req,
+        conn.query_opt(
+            "SELECT
+                builds.rustc_version,
+                builds.cratesfyi_version,
+                builds.build_status,
+                builds.build_time,
+                builds.output
+             FROM builds
+             INNER JOIN releases ON releases.id = builds.rid
+             INNER JOIN crates ON releases.crate_id = crates.id
+             WHERE builds.id = $1 AND crates.name = $2 AND releases.version = $3",
+            &[&id, &name, &version]
+        )
+    );
+
+    let build_details = if let Some(row) = row {
+        BuildDetails {
+            id,
+            rustc_version: row.get("rustc_version"),
+            docsrs_version: row.get("cratesfyi_version"),
+            build_status: row.get("build_status"),
+            build_time: row.get("build_time"),
+            output: row.get("output"),
+        }
+    } else {
+        return Err(Nope::BuildNotFound.into());
+    };
+
+    BuildDetailsPage {
+        metadata: cexpect!(req, MetaData::from_crate(&mut conn, &name, &version)),
+        build_details,
+    }
+    .into_response(req)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::{wrapper, FakeBuild};
+    use kuchiki::traits::TendrilSink;
+
+    #[test]
+    fn build_logs() {
+        wrapper(|env| {
+            env.fake_release()
+                .name("foo")
+                .version("0.1.0")
+                .builds(vec![FakeBuild::default().build_log("A build log")])
+                .create()?;
+
+            let page = kuchiki::parse_html().one(
+                env.frontend()
+                    .get("/crate/foo/0.1.0/builds")
+                    .send()?
+                    .text()?,
+            );
+
+            let node = page.select("ul > li a.release").unwrap().next().unwrap();
+            let attrs = node.attributes.borrow();
+            let url = attrs.get("href").unwrap();
+
+            let page = kuchiki::parse_html().one(env.frontend().get(url).send()?.text()?);
+
+            let log = page.select("pre").unwrap().next().unwrap().text_contents();
+
+            assert!(log.contains("A build log"));
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn non_existing_build() {
+        wrapper(|env| {
+            env.fake_release().name("foo").version("0.1.0").create()?;
+
+            let res = env.frontend().get("/crate/foo/0.1.0/builds/42").send()?;
+            assert_eq!(res.status(), 404);
+            // TODO: blocked on https://github.com/rust-lang/docs.rs/issues/55
+            // assert!(res.text()?.contains("no such build"));
+
+            Ok(())
+        });
+    }
+}

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -361,7 +361,7 @@ mod tests {
             env.fake_release()
                 .name("foo")
                 .version("0.0.3")
-                .build_result_successful(false)
+                .build_result_failed()
                 .create()?;
             env.fake_release()
                 .name("foo")
@@ -371,7 +371,7 @@ mod tests {
             env.fake_release()
                 .name("foo")
                 .version("0.0.5")
-                .build_result_successful(false)
+                .build_result_failed()
                 .yanked(true)
                 .create()?;
 
@@ -392,12 +392,12 @@ mod tests {
             env.fake_release()
                 .name("foo")
                 .version("0.0.1")
-                .build_result_successful(false)
+                .build_result_failed()
                 .create()?;
             env.fake_release()
                 .name("foo")
                 .version("0.0.2")
-                .build_result_successful(false)
+                .build_result_failed()
                 .create()?;
             env.fake_release()
                 .name("foo")
@@ -421,7 +421,7 @@ mod tests {
             env.fake_release()
                 .name("foo")
                 .version("0.0.2")
-                .build_result_successful(false)
+                .build_result_failed()
                 .create()?;
             env.fake_release()
                 .name("foo")
@@ -449,7 +449,7 @@ mod tests {
             env.fake_release()
                 .name("foo")
                 .version("0.3.0")
-                .build_result_successful(false)
+                .build_result_failed()
                 .create()?;
             env.fake_release().name("foo").version("1.0.0").create()?;
             env.fake_release().name("foo").version("0.12.0").create()?;
@@ -465,7 +465,7 @@ mod tests {
             env.fake_release()
                 .name("foo")
                 .version("0.0.1")
-                .build_result_successful(false)
+                .build_result_failed()
                 .binary(true)
                 .create()?;
 

--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -9,6 +9,7 @@ use std::{error::Error, fmt};
 #[derive(Debug, Copy, Clone)]
 pub enum Nope {
     ResourceNotFound,
+    BuildNotFound,
     CrateNotFound,
     VersionNotFound,
     NoResults,
@@ -19,6 +20,7 @@ impl fmt::Display for Nope {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match *self {
             Nope::ResourceNotFound => "Requested resource not found",
+            Nope::BuildNotFound => "Requested build not found",
             Nope::CrateNotFound => "Requested crate not found",
             Nope::VersionNotFound => "Requested crate does not have specified version",
             Nope::NoResults => "Search yielded no results",
@@ -35,6 +37,7 @@ impl From<Nope> for IronError {
 
         let status = match err {
             Nope::ResourceNotFound
+            | Nope::BuildNotFound
             | Nope::CrateNotFound
             | Nope::VersionNotFound
             | Nope::NoResults => status::NotFound,
@@ -58,6 +61,13 @@ impl Handler for Nope {
                 }
                 .into_response(req)
             }
+
+            Nope::BuildNotFound => ErrorPage {
+                title: "The requested build does not exist",
+                message: Some("no such build".into()),
+                status: Status::NotFound,
+            }
+            .into_response(req),
 
             Nope::CrateNotFound => {
                 // user tried to navigate to a crate that doesn't exist

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -146,7 +146,7 @@ mod tests {
             env.fake_release()
                 .name("rcc")
                 .version("1.0.0")
-                .build_result_successful(false)
+                .build_result_failed()
                 .create()?;
             env.fake_release()
                 .name("hexponent")

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -77,6 +77,7 @@ macro_rules! extension {
     }};
 }
 
+mod build_details;
 mod builds;
 mod crate_details;
 mod error;

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -591,7 +591,7 @@ impl_webpage! {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{test::*, web::match_version};
+    use crate::{docbuilder::DocCoverage, test::*, web::match_version};
     use kuchiki::traits::TendrilSink;
     use serde_json::json;
 
@@ -643,7 +643,12 @@ mod test {
                 .name("foo")
                 .version("0.0.1")
                 .source_file("test.rs", &[])
-                .coverage(6, 10, 2, 1)
+                .doc_coverage(DocCoverage {
+                    total_items: 10,
+                    documented_items: 6,
+                    total_items_needing_examples: 2,
+                    items_with_examples: 1,
+                })
                 .create()?;
             let web = env.frontend();
 

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -750,7 +750,7 @@ mod tests {
             env.fake_release()
                 .name("fool")
                 .version("0.0.0")
-                .build_result_successful(false)
+                .build_result_failed()
                 .create()?;
             env.fake_release()
                 .name("freakin")
@@ -810,7 +810,7 @@ mod tests {
             env.fake_release()
                 .name("regex")
                 .version("0.0.0")
-                .build_result_successful(false)
+                .build_result_failed()
                 .create()?;
 
             let (num_results, results) = get_search_results(&mut db.conn(), "regex", 1, 100)?;
@@ -1076,7 +1076,7 @@ mod tests {
         env.fake_release()
             .name("crate_that_failed")
             .version("0.1.0")
-            .build_result_successful(false)
+            .build_result_failed()
             .create()?;
         let page = kuchiki::parse_html().one(env.frontend().get(path).send()?.text()?);
         let releases: Vec<_> = page.select("a.release").expect("missing heading").collect();
@@ -1151,7 +1151,7 @@ mod tests {
             env.fake_release().name("some_random_crate").create()?;
             env.fake_release()
                 .name("some_random_crate_that_failed")
-                .build_result_successful(false)
+                .build_result_failed()
                 .create()?;
             assert_success("/releases/feed", web)
         })

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -89,7 +89,7 @@ pub(super) fn build_routes() -> Routes {
     );
     routes.internal_page(
         "/crate/:name/:version/builds/:id",
-        super::builds::build_list_handler,
+        super::build_details::build_details_handler,
     );
     routes.internal_page(
         "/crate/:name/:version/features",

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -693,7 +693,6 @@ mod test {
             env.fake_release()
                 .name("buggy")
                 .version("0.1.0")
-                .build_result_successful(true)
                 .rustdoc_file("settings.html")
                 .rustdoc_file("directory_1/index.html")
                 .rustdoc_file("directory_2.html/index.html")
@@ -704,7 +703,7 @@ mod test {
             env.fake_release()
                 .name("buggy")
                 .version("0.2.0")
-                .build_result_successful(false)
+                .build_result_failed()
                 .create()?;
             let web = env.frontend();
             assert_success("/", web)?;
@@ -873,7 +872,7 @@ mod test {
             env.fake_release()
                 .name("dummy")
                 .version("0.2.0")
-                .build_result_successful(false)
+                .build_result_failed()
                 .create()?;
 
             let web = env.frontend();
@@ -1533,7 +1532,7 @@ mod test {
             env.fake_release()
                 .name("hexponent")
                 .version("0.2.0")
-                .build_result_successful(false)
+                .build_result_failed()
                 .create()?;
             let web = env.frontend();
 

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -193,7 +193,7 @@ mod tests {
             env.fake_release().name("some_random_crate").create()?;
             env.fake_release()
                 .name("some_random_crate_that_failed")
-                .build_result_successful(false)
+                .build_result_failed()
                 .create()?;
 
             // these fake crates appear only in the `s` sitemap

--- a/templates/crate/build_details.html
+++ b/templates/crate/build_details.html
@@ -1,0 +1,42 @@
+{%- extends "base.html" -%}
+{%- import "header/package_navigation.html" as navigation -%}
+
+{%- block title -%}
+    {{ macros::doc_title(name=metadata.name, version=metadata.version) }}
+{%- endblock title -%}
+
+{%- block topbar -%}
+  {%- set latest_version = "" -%}
+  {%- set latest_path = "" -%}
+  {%- set target = "" -%}
+  {%- set inner_path = metadata.target_name ~ "/index.html" -%}
+  {%- set is_latest_version = true -%}
+  {%- set is_prerelease = false -%}
+  {%- include "rustdoc/topbar.html" -%}
+{%- endblock topbar -%}
+
+{%- block header -%}
+    {{ navigation::package_navigation(metadata=metadata, active_tab="builds") }}
+{%- endblock header -%}
+
+{%- block body -%}
+    <div class="container">
+        <div class="recent-releases-container">
+            <div class="release">
+                <strong>Build #{{ build_details.id }} {{ build_details.build_time | date(format="%+") }}</strong>
+            </div>
+
+            {%- filter dedent -%}
+                <pre>
+                    # rustc version
+                    {{ build_details.rustc_version }}
+                    # docs.rs version
+                    {{ build_details.docsrs_version }}
+
+                    # build log
+                    {{ build_details.output }}
+                </pre>
+            {%- endfilter -%}
+        </div>
+    </div>
+{%- endblock body -%}

--- a/templates/crate/builds.html
+++ b/templates/crate/builds.html
@@ -22,26 +22,6 @@
 {%- block body -%}
     <div class="container">
         <div class="recent-releases-container">
-            {# If there is a build log then show it #}
-            {# TODO: When viewing a build log, show a back button or a hide button #}
-            {%- if build_details -%}
-                <div class="release">
-                    <strong>Build #{{ build_details.id }} {{ build_details.build_time | date(format="%+") }}</strong>
-                </div>
-
-                {%- filter dedent -%}
-                    <pre>
-                        # rustc version
-                        {{ build_details.rustc_version }}
-                        # docs.rs version
-                        {{ build_details.docsrs_version }}
-
-                        # build log
-                        {{ build_details.output }}
-                    </pre>
-                {%- endfilter -%}
-            {%- endif -%}
-
             <div class="release">
                 <strong>Builds</strong>
             </div>


### PR DESCRIPTION
This is a first step on the path to #787 

The first 4 commits are refactoring, adding tests for the builds list and build logs and splitting them into separate handlers and templates (I don't think there's much benefit to having the list of other builds below the log, and it makes the code simpler to reason about).

The last commit adds support for rendering the build log from either database or S3, and changes the build process to upload to S3.

The next step would be to migrate existing build logs from the database to S3 so we can delete the code checking for both. Then thread the build logs for other targets through and upload and render them all.

We could also consider bumping the max build log size up, which would allow reverting https://github.com/rust-lang/docs.rs/pull/1192 if having verbose logs would be useful.