### PR TITLE
Switch GitHub updates to GraphQL, part 3

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -426,11 +426,13 @@ impl DatabaseSubcommand {
 
             Self::UpdateGithubFields => {
                 docs_rs::utils::GithubUpdater::new(ctx.config()?, ctx.pool()?)?
+                    .ok_or_else(|| failure::format_err!("missing GitHub token"))?
                     .update_all_crates()?;
             }
 
             Self::BackfillGithubStats => {
                 docs_rs::utils::GithubUpdater::new(ctx.config()?, ctx.pool()?)?
+                    .ok_or_else(|| failure::format_err!("missing GitHub token"))?
                     .backfill_repositories()?;
             }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,9 +46,6 @@ pub struct Config {
     pub(crate) toolchain: String,
     pub(crate) build_cpu_limit: Option<u32>,
     pub(crate) include_default_targets: bool,
-
-    // Temporary flags
-    pub(crate) tmp_disable_github_updater: bool,
 }
 
 impl Config {
@@ -93,8 +90,6 @@ impl Config {
             toolchain: env("CRATESFYI_TOOLCHAIN", "nightly".to_string())?,
             build_cpu_limit: maybe_env("DOCS_RS_BUILD_CPU_LIMIT")?,
             include_default_targets: env("DOCSRS_INCLUDE_DEFAULT_TARGETS", true)?,
-
-            tmp_disable_github_updater: env("DOCSRS_TMP_DISABLE_GITHUB_UPDATER", false)?,
         })
     }
 }

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -529,7 +529,33 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> CratesfyiResult<(
                 ALTER TABLE releases DROP COLUMN github_repo;
                 DROP TABLE github_repos;
             "
-        )
+        ),
+        migration!(
+            context,
+            23,
+            // description
+            "Delete old GitHub stats",
+            // upgrade query
+            "
+                ALTER TABLE crates
+                    DROP COLUMN github_description,
+                    DROP COLUMN github_stars,
+                    DROP COLUMN github_forks,
+                    DROP COLUMN github_issues,
+                    DROP COLUMN github_last_commit,
+                    DROP COLUMN github_last_update;
+            ",
+            // downgrade query
+            "
+                ALTER TABLE crates
+                    ADD COLUMN github_description VARCHAR(1024),
+                    ADD COLUMN github_stars INTEGER NOT NULL DEFAULT 0,
+                    ADD COLUMN github_forks INTEGER DEFAULT 0,
+                    ADD COLUMN github_issues INTEGER DEFAULT 0,
+                    ADD COLUMN github_last_commit TIMESTAMP,
+                    ADD COLUMN github_last_update TIMESTAMP;
+            "
+        ),
     ];
 
     for migration in migrations {

--- a/src/utils/github_updater.rs
+++ b/src/utils/github_updater.rs
@@ -59,6 +59,8 @@ pub struct GithubUpdater {
 }
 
 impl GithubUpdater {
+    /// Returns `Err` if the access token has invalid syntax (but *not* if it isn't authorized).
+    /// Returns `Ok(None)` if there is no access token.
     pub fn new(config: Arc<Config>, pool: Pool) -> Result<Option<Self>> {
         let mut headers = HeaderMap::new();
         headers.insert(USER_AGENT, HeaderValue::from_static(APP_USER_AGENT));

--- a/src/utils/github_updater.rs
+++ b/src/utils/github_updater.rs
@@ -59,7 +59,7 @@ pub struct GithubUpdater {
 }
 
 impl GithubUpdater {
-    pub fn new(config: Arc<Config>, pool: Pool) -> Result<Self> {
+    pub fn new(config: Arc<Config>, pool: Pool) -> Result<Option<Self>> {
         let mut headers = HeaderMap::new();
         headers.insert(USER_AGENT, HeaderValue::from_static(APP_USER_AGENT));
         headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
@@ -70,16 +70,16 @@ impl GithubUpdater {
                 HeaderValue::from_str(&format!("token {}", token))?,
             );
         } else {
-            warn!("No GitHub authorization specified, will be working with very low rate limits");
+            return Ok(None);
         }
 
         let client = HttpClient::builder().default_headers(headers).build()?;
 
-        Ok(GithubUpdater {
+        Ok(Some(GithubUpdater {
             client,
             pool,
             config,
-        })
+        }))
     }
 
     pub fn backfill_repositories(&self) -> Result<()> {


### PR DESCRIPTION
*Episode 3 of our beloved serie of "let's not hammer the GitHub API anymore". You can find previous episodes here: https://github.com/rust-lang/docs.rs/pull/1208 https://github.com/rust-lang/docs.rs/pull/1209*

This PR finishes the work of switching GitHub updates over to GraphQL:

* It's not possible anymore to use the updater without a GitHub token, as the GraphQL API straight up rejects unauthenticated requests. Warnings will be emitted instead, both at the start of the daemon and every time the builder tries to load stats.
* The temporary flag to disable the updater has been removed.
* The old database columns have been removed.

This PR is best reviewed commit-by-commit.
r? @jyn514 