### PR TITLE
Ensure tests don't leak database connections

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -430,7 +430,11 @@ impl Server {
         context: &dyn Context,
     ) -> Result<Self, Error> {
         let cratesfyi = CratesfyiHandler::new(template_data, context)?;
-        let inner = Iron::new(cratesfyi)
+        let mut iron = Iron::new(cratesfyi);
+        if cfg!(test) {
+            iron.threads = 1;
+        }
+        let inner = iron
             .http(addr)
             .unwrap_or_else(|_| panic!("Failed to bind to socket on {}", addr));
 


### PR DESCRIPTION
Even if a pool instance is leaked (such as when the web server is leaked), internally drop the actual pool at the end of the test to ensure all connections are closed.
