### PR TITLE
Interpolate author login into releases url for pagination

### DIFF
--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -1223,10 +1223,9 @@ mod tests {
             }
             let page = kuchiki::parse_html().one(web.get("/releases/frankenstein").send()?.text()?);
             let button = page.select_first("a[href='/releases/frankenstein/2']");
-	    
-            eprintln!("{:?}", button);
+
             assert!(button.is_ok());
-	    
+
             Ok(())
         })
     }

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -461,7 +461,7 @@ pub fn author_handler(req: &mut Request) -> IronResult<Response> {
         show_next_page,
         show_previous_page,
         page_number,
-        author: Some(author_name),
+        author: Some(author.into()),
     }
     .into_response(req)
 }

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -1212,6 +1212,26 @@ mod tests {
     }
 
     #[test]
+    fn authors_pagination() {
+        wrapper(|env| {
+            let web = env.frontend();
+            for i in 0..RELEASES_IN_RELEASES {
+                env.fake_release()
+                    .name(&format!("some_random_crate_{}", i))
+                    .author("frankenstein <frankie@stein.com")
+                    .create()?;
+            }
+            let page = kuchiki::parse_html().one(web.get("/releases/frankenstein").send()?.text()?);
+            let button = page.select_first("a[href='/releases/frankenstein/2']");
+	    
+            eprintln!("{:?}", button);
+            assert!(button.is_ok());
+	    
+            Ok(())
+        })
+    }
+
+    #[test]
     fn home_page_links() {
         wrapper(|env| {
             let web = env.frontend();

--- a/templates/releases/releases.html
+++ b/templates/releases/releases.html
@@ -57,7 +57,11 @@
             </ul>
 
             <div class="pagination">
-                {%- set page_link = "/releases/" ~ release_type -%}
+                {%- if release_type == 'author' -%}
+                    {%- set page_link = "/releases/" ~ author -%}
+                {%- else -%}
+                    {%- set page_link = "/releases/" ~ release_type -%}
+                {%- endif -%}
                 {%- if release_type == 'search' -%}
                     {%- set query = "?search=" ~ search_query -%}
                 {%- endif -%}


### PR DESCRIPTION
The issue is as described in #1073
I mostly followed the schema suggested there. I also had to change the handler to add the author username to the template context rather than the author name, but this is safe because the value wasn't used before anyway.

Fixes rust-lang/docs.rs#1073