### PR TITLE
Split single sitemap into index and sub-sitemaps by starting letter in crate-name

### DIFF
--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -16,7 +16,11 @@ pub(super) fn build_routes() -> Routes {
     //   https://support.google.com/webmasters/answer/183668?hl=en
     routes.static_resource("/robots.txt", PermanentRedirect("/-/static/robots.txt"));
     routes.static_resource("/favicon.ico", PermanentRedirect("/-/static/favicon.ico"));
-    routes.static_resource("/sitemap.xml", super::sitemap::sitemap_handler);
+    routes.static_resource("/sitemap.xml", super::sitemap::sitemapindex_handler);
+    routes.static_resource(
+        "/-/sitemap/:which/sitemap.xml",
+        super::sitemap::sitemap_handler,
+    );
 
     // This should not need to be served from the root as we reference the inner path in links,
     // but clients might have cached the url and need to update it.

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -18,7 +18,7 @@ pub(super) fn build_routes() -> Routes {
     routes.static_resource("/favicon.ico", PermanentRedirect("/-/static/favicon.ico"));
     routes.static_resource("/sitemap.xml", super::sitemap::sitemapindex_handler);
     routes.static_resource(
-        "/-/sitemap/:which/sitemap.xml",
+        "/-/sitemap/:letter/sitemap.xml",
         super::sitemap::sitemap_handler,
     );
 

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -59,21 +59,10 @@ pub fn sitemap_handler(req: &mut Request) -> IronResult<Response> {
              INNER JOIN releases ON releases.crate_id = crates.id
              WHERE 
                 rustdoc_status = true AND 
-                ( 
-                    crates.name like $1 OR 
-                    crates.name like $2
-                )
+                crates.name ILIKE $1 
              GROUP BY crates.name
              ",
-            &[
-                // postgres can use the normal BTREE index on `name`
-                // for LIKE queries, if they are anchored to the
-                // beginning of the string.
-                // This does not work for ILIKE and alphabetic
-                // characters, hence the OR.
-                &format!("{}%", letter),
-                &format!("{}%", letter.to_uppercase()),
-            ],
+            &[&format!("{}%", letter)],
         )
         .unwrap();
 

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -21,7 +21,7 @@ impl_webpage! {
 }
 
 pub fn sitemapindex_handler(req: &mut Request) -> IronResult<Response> {
-    let sitemaps: Vec<char> = (b'a'..=b'z').map(char::from).collect();
+    let sitemaps: Vec<char> = ('a'..='z').collect();
 
     SitemapIndexXml { sitemaps }.into_response(req)
 }
@@ -216,7 +216,7 @@ mod tests {
             assert!(!(content.contains(&"some_random_crate_that_failed")));
 
             // and not in the others
-            for letter in ('a'..='z').filter(|&&c| c != 's') {
+            for letter in ('a'..='z').filter(|&c| c != 's') {
                 let response = web
                     .get(&format!("/-/sitemap/{}/sitemap.xml", letter))
                     .send()?;

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -58,8 +58,11 @@ pub fn sitemap_handler(req: &mut Request) -> IronResult<Response> {
              GROUP BY crates.name
              ",
             &[
-                // this LIKE pattern has the '%' only at the end,
-                // so postgres can use the index on `name`
+                // postgres can use the normal BTREE index on `name`
+                // for LIKE queries, if they are anchored to the
+                // beginning of the string.
+                // This does not work for ILIKE and alphabetic
+                // characters, hence the OR.
                 &format!("{}%", letter),
                 &format!("{}%", letter.to_uppercase()),
             ],

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -218,7 +218,7 @@ mod tests {
             assert!(!(content.contains(&"some_random_crate_that_failed")));
 
             // and not in the others
-            for letter in letters.iter().filter(|&&c| c != 's') {
+            for letter in ('a'..='z').filter(|&&c| c != 's') {
                 let response = web
                     .get(&format!("/-/sitemap/{}/sitemap.xml", letter))
                     .send()?;

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -196,10 +196,8 @@ mod tests {
         wrapper(|env| {
             let web = env.frontend();
 
-            let letters: Vec<char> = (b'a'..=b'z').map(char::from).collect();
-
             // letter-sitemaps always work, even without crates & releases
-            for letter in letters.iter().as_ref() {
+            for letter in 'a'..='z' {
                 assert_success(&format!("/-/sitemap/{}/sitemap.xml", letter), web)?;
             }
 

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -40,7 +40,7 @@ impl_webpage! {
 
 pub fn sitemap_handler(req: &mut Request) -> IronResult<Response> {
     let router = extension!(req, Router);
-    let which = cexpect!(req, router.find("which")).to_lowercase();
+    let letter = cexpect!(req, router.find("letter")).to_lowercase();
 
     let mut conn = extension!(req, Pool).get()?;
     let query = conn
@@ -60,8 +60,8 @@ pub fn sitemap_handler(req: &mut Request) -> IronResult<Response> {
             &[
                 // this LIKE pattern has the '%' only at the end,
                 // so postgres can use the index on `name`
-                &format!("{}%", which),
-                &format!("{}%", which.to_uppercase()),
+                &format!("{}%", letter),
+                &format!("{}%", letter.to_uppercase()),
             ],
         )
         .unwrap();

--- a/templates/core/sitemapindex.xml
+++ b/templates/core/sitemapindex.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    {% for which in sitemaps -%}
+        <sitemap>
+            <loc>https://docs.rs/-/sitemap/{{ which }}/sitemap.xml</loc>
+        </sitemap>
+    {%- endfor %}
+</sitemapindex>


### PR DESCRIPTION
This is a first draft of an implementation for #1174. 

My idea was to split the sitemap by starting letter, since 
- this is rather static on the index-side, 
- allows an easy and indexed  filtering by postgres when generating the sub-sitemaps, 
- and doesn't change the result when re-requesting a site-map. 

(crate-count per letter below) 

Also I changed the query from `DISTINCT ON` to using `GROUP BY` and `MAX`. 
Since we don't do `ORDER BY`, `DISTINCT ON` relies on the order the columns have on disk. If you don't do anything apart from working on single records, it doesn't matter and the first records (which are picked by `DISTINCT ON`) are the newest records. This only can be different with different data loading techniques, or when manually handling many records. I think the `GROUP BY` and `MAX` is more explicit, so better in that case. 
But I'm also happy to revert that part if you don't think it's a good idea. 

While I have a (long) history in software-dev and databases, I'm relatively new to rust. Also this is my first contribution to this project. So I'm happy to implement any changes / improvements. 

Things that I could see, but I'm not sure if necessary: 
- different tests? more tests? (i tried to follow the existing pattern / depth) 
- make sitemap-index completely static? (though that would have quite some repetition) 
- make `robots.txt` reference the sub-sitemaps, not the index? (so, also use a template?)
- different URL-pattern? (the thing I originally wanted was a file-name with a variable element like `sitemap.a.xml`, but I couldn't find an easy way to get router to handle this, and it's tricky to find much information about iron). 



## the data (tm)

<details>
<summary>starting letters in crates.io index</summary>
<div>

```
s       5406
r       4376
c       4305
a       3080
t       3042
p       2983
m       2931
g       2582
l       2500
d       2259
b       2226
f       2116
e       1783
i       1576
n       1570
w       1426
h       1398
o       1225
u       942
k       818
v       760
j       636
x       454
q       374
y       370
z       354
G       13
R       13
C       11
H       10
A       9
I       8
M       8
P       8
S       8
N       7
D       5
F       5
L       5
T       5
Q       4
Y       4
B       3
E       3
K       3
U       3
X       3
W       2
Z       2
J       1
O       1
```
</div>
</details>

<details>
<summary>starting letters in crates.io index (convert to lowercase)</summary>
<div>

```
s       5414
r       4389
c       4316
a       3089
t       3047
p       2991
m       2939
g       2595
l       2505
d       2264
b       2229
f       2121
e       1786
i       1584
n       1577
w       1428
h       1408
o       1226
u       945
k       821
v       760
j       637
x       457
q       378
y       374
z       356
```
</div>
</details>

<details>
<summary>code used</summary>
<div>

```rust 
use counter::Counter;
use crates_index;

fn main() {
    let index = crates_index::BareIndex::new_cargo_default();

    let repo = index.open_or_clone().unwrap();

    let counter = repo
        .crates()
        .map(|c| c.name().to_lowercase().chars().nth(0).unwrap())
        .collect::<Counter<_>>();

    for (elem, c) in counter.most_common_ordered() {
        println!("{}\t{}", elem, c);
    }
}
```

</div>
</details>