### PR TITLE
migrate timestamp fields to timestamptz

### DIFF
--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -92,7 +92,7 @@ pub(crate) fn add_package_into_database(
         &[
             &crate_id,
             &metadata_pkg.version,
-            &registry_data.release_time.naive_utc(),
+            &registry_data.release_time,
             &serde_json::to_value(&dependencies)?,
             &metadata_pkg.package_name(),
             &registry_data.yanked,

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -556,6 +556,49 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> CratesfyiResult<(
                     ADD COLUMN github_last_update TIMESTAMP;
             "
         ),
+        migration!(
+            context, 
+            24, 
+            "migrate timestamp to be timezone aware",
+            // upgrade
+            "
+                ALTER TABLE builds 
+                    ALTER build_time TYPE timestamptz USING build_time AT TIME ZONE 'UTC';
+
+                ALTER TABLE files
+                    ALTER date_added TYPE timestamptz USING date_added AT TIME ZONE 'UTC',
+                    ALTER date_updated TYPE timestamptz USING date_updated AT TIME ZONE 'UTC';
+
+                ALTER TABLE github_repos 
+                    ALTER updated_at TYPE timestamptz USING updated_at AT TIME ZONE 'UTC', 
+                    ALTER last_commit TYPE timestamptz USING last_commit AT TIME ZONE 'UTC';
+
+                ALTER TABLE queue 
+                    ALTER date_added TYPE timestamptz USING date_added AT TIME ZONE 'UTC';
+
+                ALTER TABLE releases 
+                    ALTER release_time TYPE timestamptz USING release_time AT TIME ZONE 'UTC';
+            ",
+            // downgrade 
+            "
+                ALTER TABLE builds 
+                    ALTER build_time TYPE timestamp USING build_time AT TIME ZONE 'UTC';
+
+                ALTER TABLE files
+                    ALTER date_added TYPE timestamp USING date_added AT TIME ZONE 'UTC',
+                    ALTER date_updated TYPE timestamp USING date_updated AT TIME ZONE 'UTC';
+
+                ALTER TABLE github_repos 
+                    ALTER updated_at TYPE timestamp USING updated_at AT TIME ZONE 'UTC', 
+                    ALTER last_commit TYPE timestamp USING last_commit AT TIME ZONE 'UTC';
+
+                ALTER TABLE queue 
+                    ALTER date_added TYPE timestamp USING date_added AT TIME ZONE 'UTC';
+
+                ALTER TABLE releases 
+                    ALTER release_time TYPE timestamp USING release_time AT TIME ZONE 'UTC';
+            ",
+        ),
     ];
 
     for migration in migrations {

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -557,8 +557,8 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> CratesfyiResult<(
             "
         ),
         migration!(
-            context, 
-            24, 
+            context,
+            24,
             "migrate timestamp to be timezone aware",
             // upgrade
             "

--- a/src/storage/database.rs
+++ b/src/storage/database.rs
@@ -1,7 +1,6 @@
 use super::{Blob, StorageTransaction};
 use crate::db::Pool;
 use crate::Metrics;
-use chrono::{DateTime, NaiveDateTime, Utc};
 use failure::Error;
 use postgres::Transaction;
 use std::sync::Arc;
@@ -61,7 +60,7 @@ impl DatabaseBackend {
             Ok(Blob {
                 path: row.get("path"),
                 mime: row.get("mime"),
-                date_updated: DateTime::from_utc(row.get::<_, NaiveDateTime>("date_updated"), Utc),
+                date_updated: row.get("date_updated"),
                 content: row.get("content"),
                 compression,
             })

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -4,7 +4,7 @@ use crate::{
     impl_webpage,
     web::{page::WebPage, MetaData},
 };
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use iron::{
     headers::{
         AccessControlAllowOrigin, CacheControl, CacheDirective, ContentType, Expires, HttpDate,
@@ -80,7 +80,7 @@ pub fn build_list_handler(req: &mut Request) -> IronResult<Response> {
                 rustc_version: row.get("rustc_version"),
                 docsrs_version: row.get("cratesfyi_version"),
                 build_status: row.get("build_status"),
-                build_time: DateTime::from_utc(row.get::<_, NaiveDateTime>("build_time"), Utc),
+                build_time: row.get("build_time"),
                 output: row.get("output"),
             };
 

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -1,6 +1,6 @@
 use super::{match_version, redirect_base, render_markdown, MatchSemver, MetaData};
 use crate::{db::Pool, impl_webpage, web::page::WebPage};
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use iron::prelude::*;
 use iron::Url;
 use postgres::Client;
@@ -181,7 +181,7 @@ impl CrateDetails {
             dependencies: krate.get("dependencies"),
             readme: krate.get("readme"),
             rustdoc: krate.get("description_long"),
-            release_time: DateTime::from_utc(krate.get::<_, NaiveDateTime>("release_time"), Utc),
+            release_time: krate.get("release_time"),
             build_status: krate.get("build_status"),
             last_successful_build: None,
             rustdoc_status: krate.get("rustdoc_status"),

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -7,7 +7,7 @@ use crate::{
     web::{error::Nope, match_version, page::WebPage, redirect_base},
     BuildQueue,
 };
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use iron::{
     headers::{ContentType, Expires, HttpDate},
     mime::{Mime, SubLevel, TopLevel},
@@ -102,7 +102,7 @@ pub(crate) fn get_releases(conn: &mut Client, page: i64, limit: i64, order: Orde
             version: row.get(1),
             description: row.get(2),
             target_name: row.get(3),
-            release_time: DateTime::from_utc(row.get::<_, NaiveDateTime>(4), Utc),
+            release_time: row.get(4),
             rustdoc_status: row.get(5),
             stars: row.get::<_, Option<i32>>(6).unwrap_or(0),
         })
@@ -149,7 +149,7 @@ fn get_releases_by_author(
                 version: row.get(1),
                 description: row.get(2),
                 target_name: row.get(3),
-                release_time: DateTime::from_utc(row.get::<_, NaiveDateTime>(4), Utc),
+                release_time: row.get(4),
                 rustdoc_status: row.get(5),
                 stars: row.get::<_, Option<i32>>(6).unwrap_or(0),
             }
@@ -203,7 +203,7 @@ fn get_releases_by_owner(
                 version: row.get(1),
                 description: row.get(2),
                 target_name: row.get(3),
-                release_time: DateTime::from_utc(row.get::<_, NaiveDateTime>(4), Utc),
+                release_time: row.get(4),
                 rustdoc_status: row.get(5),
                 stars: row.get::<_, Option<i32>>(6).unwrap_or(0),
             }
@@ -286,7 +286,7 @@ fn get_search_results(
             version: row.get("version"),
             description: row.get("description"),
             target_name: row.get("target_name"),
-            release_time: DateTime::from_utc(row.get("release_time"), Utc),
+            release_time: row.get("release_time"),
             rustdoc_status: row.get("rustdoc_status"),
             stars: row.get::<_, Option<i32>>("github_stars").unwrap_or(0),
         })

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -1,5 +1,5 @@
 use crate::{db::Pool, docbuilder::Limits, impl_webpage, web::page::WebPage};
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use iron::{
     headers::ContentType,
     mime::{Mime, SubLevel, TopLevel},
@@ -37,9 +37,7 @@ pub fn sitemap_handler(req: &mut Request) -> IronResult<Response> {
     let releases = query
         .into_iter()
         .map(|row| {
-            let time = DateTime::<Utc>::from_utc(row.get::<_, NaiveDateTime>(1), Utc)
-                .format("%+")
-                .to_string();
+            let time = row.get::<_, DateTime<Utc>>(1).format("%+").to_string();
 
             (row.get(0), time)
         })


### PR DESCRIPTION
with some time on my hands I started on  #1067 with the migration to timezone aware datetime fields. 
In general I believe it's a good idea to be explicit about timezones also on the database level. 

As we see, it simplifies quite some code :) 

I'm happy to apply any changes needed (the column defaults actually don't have to be changed, since `NOW()` and `CURRENT TIMESTAMP` already are timezone aware) 

Tests work locally, not sure what else needs to be tested. 