### PR TITLE
Add ayu-highlight.css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target
 *.css
 *.css.map
 !vendor/**/*.css
+!static/ayu-highlight.css
 .sass-cache
 .vagrant
 .rustwide

--- a/static/ayu-highlight.css
+++ b/static/ayu-highlight.css
@@ -1,0 +1,79 @@
+/*
+Based off of the Ayu theme
+Original by Dempfi (https://github.com/dempfi/ayu)
+*/
+
+.hljs {
+    display: block;
+    overflow-x: auto;
+    background: #191f26;
+    color: #e6e1cf;
+    padding: 0.5em;
+}
+
+.hljs-comment,
+.hljs-quote {
+    color: #5c6773;
+    font-style: italic;
+}
+
+.hljs-variable,
+.hljs-template-variable,
+.hljs-attribute,
+.hljs-attr,
+.hljs-regexp,
+.hljs-link,
+.hljs-selector-id,
+.hljs-selector-class {
+    color: #ff7733;
+}
+
+.hljs-number,
+.hljs-meta,
+.hljs-builtin-name,
+.hljs-literal,
+.hljs-type,
+.hljs-params {
+    color: #ffee99;
+}
+
+.hljs-string,
+.hljs-bullet {
+    color: #b8cc52;
+}
+
+.hljs-title,
+.hljs-built_in,
+.hljs-section {
+    color: #ffb454;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-symbol {
+    color: #ff7733;
+}
+
+.hljs-name {
+    color: #36a3d9;
+}
+
+.hljs-tag {
+    color: #00568d;
+}
+
+.hljs-emphasis {
+    font-style: italic;
+}
+
+.hljs-strong {
+    font-weight: bold;
+}
+
+.hljs-addition {
+    color: #91b362;
+}
+
+.hljs-deletion {
+    color: #d96c75;
+}

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -26,8 +26,10 @@
         // Choose which highlight.js theme to load based on the user theme
         var stylesheet;
         switch(document.documentElement.dataset.theme) {
-            case "dark":
             case "ayu":
+                stylesheet = "/-/static/ayu-highlight.css";
+                break;
+            case "dark":
                 stylesheet = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/styles/dark.min.css";
                 break;
             case "null": // The user is visiting docs.rs for the first time and hasn't set a theme yet.


### PR DESCRIPTION
Follow-up to #1221.

I began putting a theme together and thought "hmm, I feel like I've done this before." Turns out... I did! https://github.com/rust-lang/mdBook/blob/master/src/theme/ayu-highlight.css

I copied that CSS into `static/ayu-highlight.css` and added an exception for it to the `.gitignore`; if there's a better way to include it, let me know.

Here's what it looks like:

![image](https://user-images.githubusercontent.com/13814214/103196436-34ac0780-48b2-11eb-8f45-cf935914002f.png)

Note that a nice, easy way to see what it looks like for a large variety of input is to go to https://highlightjs.org/static/demo/ and replace the default stylesheet with the contents of whatever theme you'd like to test:

<details>
<summary>Example</summary>

![image](https://user-images.githubusercontent.com/13814214/103196617-80f74780-48b2-11eb-9d27-3681f6879b66.png)

</details>