### PR TITLE
Platform top-bar directly links target index pages, sets no-follow for target-redirect

### DIFF
--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -1167,9 +1167,8 @@ mod test {
                         .borrow()
                         .get("href")
                         .expect("href")
-                        .trim()
                         .to_string();
-                    let name = el.text_contents().trim().to_string();
+                    let name = el.text_contents();
                     (name, url)
                 })
                 .collect())

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -1167,8 +1167,9 @@ mod test {
                         .borrow()
                         .get("href")
                         .expect("href")
+                        .trim()
                         .to_string();
-                    let name = el.text_contents();
+                    let name = el.text_contents().trim().to_string();
                     (name, url)
                 })
                 .collect())

--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -13,6 +13,7 @@
   {%- set inner_path = details.metadata.target_name ~ "/index.html" -%}
   {%- set is_latest_version = true -%}
   {%- set is_prerelease = false -%}
+  {%- set use_direct_platform_links = true -%}
   {%- include "rustdoc/topbar.html" -%}
 {%- endblock topbar -%}
 

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -223,14 +223,13 @@
 
         {# Build the dropdown list showing available targets #}
         <ul class="pure-menu-children">
-            {%- set inner_path_when_root = metadata.name ~ "/index.html" -%}
             {%- for target in metadata.doc_targets -%}
                 {#
-                    The index pages for every target always exist, so we don't need `target-redirect` for them.
-                    Also, crawlers don't have to follow the `target-redirect` links, since they already reach the
-                    target-specific pages through the root.
+                    The crate-detail page is the only page where we want to allow google to follow
+                    the target-links. On that page we also don't have to use `/target-redirect/`
+                    because the documentation root page is guaranteed to exist for all targets.
                 #}
-                {%- if inner_path == inner_path_when_root -%}
+                {%- if use_direct_platform_links -%}
                     {%- set target_url = "/" ~ metadata.name ~ "/" ~ metadata.version ~ "/" ~ target ~ "/" ~ inner_path -%}
                     {%- set target_no_follow = "" -%}
                 {%- else -%}

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -223,11 +223,25 @@
 
         {# Build the dropdown list showing available targets #}
         <ul class="pure-menu-children">
+            {%- set inner_path_when_root = metadata.name ~ "/index.html" -%}
             {%- for target in metadata.doc_targets -%}
-                {%- set target_url = "/crate/" ~ metadata.name ~ "/" ~ metadata.version ~ "/target-redirect/" ~ target ~ "/" ~ inner_path -%}
+                {#
+                    The index pages for every target always exist, so we don't need `target-redirect` for them.
+                    Also, crawlers don't have to follow the `target-redirect` links, since they already reach the
+                    target-specific pages through the root.
+                #}
+                {%- if inner_path == inner_path_when_root -%}
+                    {%- set target_url = "/" ~ metadata.name ~ "/" ~ metadata.version ~ "/" ~ target ~ "/" ~ inner_path -%}
+                    {%- set target_no_follow = "" -%}
+                {%- else -%}
+                    {%- set target_url = "/crate/" ~ metadata.name ~ "/" ~ metadata.version ~ "/target-redirect/" ~ target ~ "/" ~ inner_path -%}
+                    {%- set target_no_follow = "nofollow" -%}
+                {%- endif -%}
 
                 <li class="pure-menu-item">
-                    <a href="{{ target_url | safe }}" class="pure-menu-link" data-fragment="retain">{{ target }}</a>
+                    <a href="{{ target_url | safe }}" class="pure-menu-link" data-fragment="retain" rel="{{ target_no_follow }}">
+                        {{ target }}
+                    </a>
                 </li>
             {%- endfor -%}
         </ul>

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -240,7 +240,7 @@
 
                 <li class="pure-menu-item">
                     <a href="{{ target_url | safe }}" class="pure-menu-link" data-fragment="retain" rel="{{ target_no_follow }}">
-                        {{ target }}
+                        {{- target -}}
                     </a>
                 </li>
             {%- endfor -%}


### PR DESCRIPTION
First draft of a solution to #1161 . 

Everything works, current tests pass (`assert_redirect` only checks if the destination page exists, not if there is a  redirect, so we are still fine). 
The new `.trim()` in the tests is coming from me splitting the link into multiple lines, while `kuchiki` also returns line breaks when parsing the HTML. 

Open for me: 
- is there a better way to find our if we just serve the root-page? somewhere in the (long) `rustdoc_html_server_handler`? Then I could pass the info as bool to the `RustdocPage` context. 
- do we want tests for the follow/no-follow behaviour? 
- do I have to set  different attributes for the no-follow? Can the `rel` attribute exist and be empty? 