### PR TITLE
Fix missing repository link in dropdown for non-github crates

### DIFF
--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -1659,4 +1659,60 @@ mod test {
             Ok(())
         })
     }
+
+    #[test]
+    fn test_repository_link_in_topbar_dropdown() {
+        wrapper(|env| {
+            env.fake_release()
+                .name("testing")
+                .repo("https://git.example.com")
+                .version("0.1.0")
+                .rustdoc_file("testing/index.html")
+                .create()?;
+
+            let dom = kuchiki::parse_html().one(
+                env.frontend()
+                    .get("/testing/0.1.0/testing/")
+                    .send()?
+                    .text()?,
+            );
+
+            assert_eq!(
+                dom.select(r#"ul > li a[href="https://git.example.com"]"#)
+                    .unwrap()
+                    .count(),
+                1,
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_repository_link_in_topbar_dropdown_github() {
+        wrapper(|env| {
+            env.fake_release()
+                .name("testing")
+                .version("0.1.0")
+                .rustdoc_file("testing/index.html")
+                .github_stats("https://git.example.com", 123, 321, 333)
+                .create()?;
+
+            let dom = kuchiki::parse_html().one(
+                env.frontend()
+                    .get("/testing/0.1.0/testing/")
+                    .send()?
+                    .text()?,
+            );
+
+            assert_eq!(
+                dom.select(r#"ul > li a[href="https://git.example.com"]"#)
+                    .unwrap()
+                    .count(),
+                1,
+            );
+
+            Ok(())
+        })
+    }
 }

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -70,7 +70,7 @@
                                 </li>
 
                             {# If all the crate has is a repo url, show it #}
-                            {%- elif repository_url -%}
+                            {%- elif krate.repository_url -%}
                                 <li class="pure-menu-item">
                                     <a href="{{ krate.repository_url }}" class="pure-menu-link">
                                         {{ "code-branch" | fas(fw=true) }} Repository


### PR DESCRIPTION
This should fix #1217, also adds tests for both paths (github-repo and non-github repo). 

I'm not very good with CSS selectors, perhaps someone has a better idea to select the links from the _LINKS_ section of the dropdown. 
