### PR TITLE
Tune and add breakpoints for the navbar to address overflow issues under certain conditions.

### DIFF
--- a/templates/header/topbar_begin.html
+++ b/templates/header/topbar_begin.html
@@ -9,8 +9,11 @@
 <div class="nav-container">
     <div class="container">
         <div class="pure-menu pure-menu-horizontal" role="navigation" aria-label="Main navigation">
-            <form action="/releases/search" method="GET"
-                class="landing-search-form-nav {% if is_latest_version is defined and not is_latest_version %}not-latest{% endif %}">
+            <form action="/releases/search"
+                  method="GET"
+                  class="landing-search-form-nav {%
+                  if is_latest_version is defined and not is_latest_version %}not-latest{% endif
+                  %} {% if metadata.yanked %}yanked{% endif %}">
                 {# The search bar #}
                 <div id="search-input-nav" class="pure-menu-right">
                     <label for="nav-search">

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -84,6 +84,14 @@
                                 </a>
                             </li>
 
+                            {# A link to the release's source view #}
+                            <li class="pure-menu-item">
+                                <a href="{{ crate_url | safe }}/source/" title="Browse source of {{ metadata.name }}-{{ metadata.version }}" class="pure-menu-link">
+                                    {{ "folder-open" | fas(fw=true) }}
+                                    <span class="title">Source</span>
+                                </a>
+                            </li>
+
                             <li class="pure-menu-item">
                                 <a href="{{ crate_url | safe }}" class="pure-menu-link" title="See {{ krate.name }} in docs.rs">
                                     {{ "cube" | fas(fw=true) }} More information
@@ -204,16 +212,7 @@
         </li>
     {%- endif -%}
 
-    {# A link to the release's source view
-    #}<li class="pure-menu-item">
-        <a href="{{ crate_url | safe }}/source/" title="Browse source of {{ metadata.name }}-{{ metadata.version }}" class="pure-menu-link">
-            {{ "folder-open" | far }}
-            <span class="title">Source</span>
-        </a>
-    </li>{#
-
-    Display the platforms that the release has been built for
-    #}
+    {# Display the platforms that the release has been built for #}
     {% if metadata.doc_targets %}
     <li class="pure-menu-item pure-menu-has-children">
         <a href="#" class="pure-menu-link" aria-label="Platform">

--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -131,38 +131,86 @@ div.nav-container {
         }
     }
 
+    // These hardcoded values are "magic", in the sense they were observed to be the lowest-possible
+    // thresholds through experimentation with a package name that hit the max-width of the element.
+    $full-width: 1142px;
+    $medium-width: 994px;
+    $narrow-width: 901px;
+
     // use a .title span inside a menu to hide it on small screens
     span.title {
         display: none;
-        @media screen and (min-width: 872px) {
+        @media screen and (min-width: #{$narrow-width}) {
             display: inline;
         }
     }
 
     .pure-menu-right span.title {
-        @media screen and (min-width: 872px) {
-            display: none;
-        }
-        @media screen and (min-width: 965px) {
+        display: none;
+        @media screen and (min-width: #{$medium-width}) {
             display: inline;
         }
     }
 
-    form.landing-search-form-nav.not-latest {
-        span.title {
+     /// Generate the rules for the navbar menu item labels at various dimensions.
+     ///
+     /// @param {number} $medium-breakpoint [$medium-width] - the medium breakpoint
+     /// @param {number} $full-breakpoint [$full-width] - the full breakpoint
+     /// @param {boolean} $show-medium [true] - whether labels should be shown after the medium breakpoint
+     /// @param {boolean} $show-full [true] - whether labels should be shown after the full breakpoint
+    @mixin navbar-menu-labels(
+        $medium-breakpoint: $medium-width,
+        $full-breakpoint: $full-width,
+        $show-medium: true,
+        $show-full: true
+    ) {
+        .pure-menu-item span.title {
             display: none;
-            @media screen and (min-width: 973px) {
-                display: inline;
+            @media screen and (min-width: #{$medium-breakpoint}) {
+                @if $show-medium {
+                    display: inline;
+                }
+                @else {
+                    display: none;
+                }
             }
         }
-
         .pure-menu-right span.title {
-            @media screen and (min-width: 973px) {
-                display: none;
+            display: none;
+            @media screen and (min-width: #{$full-breakpoint}) {
+                @if $show-full {
+                    display: inline;
+                }
+                @else {
+                    display: none;
+                }
             }
-            @media screen and (min-width: 1125px) {
-                display: inline;
+        }
+    }
+
+    form.landing-search-form-nav {
+        // These hardcoded values are "magic", in the sense they were observed to be the lowest-possible
+        // thresholds through experimentation with a package name that hit the max-width of the element,
+        // and various combinations of latest, not latest, and yanked states.
+        &.not-latest {
+            @include navbar-menu-labels(1061px, 1153px);
+        }
+
+        &.yanked {
+            @include navbar-menu-labels(1119px, $full-width, $show-full: false);
+        }
+
+        &.not-latest.yanked {
+            $medium-width: 1191px;
+
+            // Because this message is very long, steal some additional space from the search input
+            #search-input-nav {
+                @media screen and (min-width: #{$medium-width}) {
+                    max-width: 150px;
+                }
             }
+
+            @include navbar-menu-labels($medium-width, $full-width, $show-full: false);
         }
     }
 


### PR DESCRIPTION
With crates with long names, and when the "Go to latest version" or "Yanked" warning badges present, the navbar doesn't overflow correctly.  This PR adds some additional breakpoints to ensure we don't experience the visual glitch of the overflow, as well as moves the "Source" link to the crate menu to buy some additional space.

## To test

```
# add two versions of a crate with a long name
cargo run -- build crate air-interpreter-wasm 0.0.33                                                                                                                                                                   
cargo run -- build crate air-interpreter-wasm 0.0.35

# Start the webserver
cargo run -- start-web-server --reload-templates

# From the web UI, verify that the breakpoints are correctly hit for the latest version
<browse to http://localhost:3000/air-interpreter-wasm/0.0.35/air_interpreter_wasm/index.html >
# From the web UI, verify that the breakpoints are correctly hit for an older version
<browse to http://localhost:3000/air-interpreter-wasm/0.0.33/air_interpreter_wasm/index.html >

# Now, yank both versions
psql postgresql://cratesfyi:password@localhost:15432 -c "UPDATE releases SET yanked = true FROM  crates WHERE releases.crate_id = crates.id AND crates.name = 'air-interpreter-wasm'"

# From the web UI, verify that the breakpoints are correctly hit for the latest version
<browse to http://localhost:3000/air-interpreter-wasm/0.0.35/air_interpreter_wasm/index.html >
# From the web UI, verify that the breakpoints are correctly hit for an older version
<browse to http://localhost:3000/air-interpreter-wasm/0.0.33/air_interpreter_wasm/index.html >
```

Fixes #1205