### PR TITLE
Fix sidebar rendering bugs

### DIFF
--- a/templates/style/rustdoc.scss
+++ b/templates/style/rustdoc.scss
@@ -29,8 +29,9 @@ body.blur {
 
 // rustdoc overrides
 div.rustdoc {
+    $padding-x: 15px;
     font-family: $font-family-serif;
-    padding: 10px 15px 20px 15px;
+    padding: 10px $padding-x 20px;
     position: relative;
 
     @media (max-width: 700px) {
@@ -47,8 +48,13 @@ div.rustdoc {
         }
 
         @media (max-width: 700px) {
+            margin-left: -2 * $padding-x; // offset the additional padding added by the parent containers
+            width: calc(100% + #{4 * $padding-x});
+
             &.mobile {
                 top: $top-navbar-height;
+                margin-left: 0; // since the sidebar is now fixed position, remove the padding workaround
+                width: 100%;
 
                 .sidebar-elems.show-it {
                     top: 45px + $top-navbar-height;

--- a/templates/style/rustdoc.scss
+++ b/templates/style/rustdoc.scss
@@ -50,8 +50,8 @@ div.rustdoc {
             &.mobile {
                 top: $top-navbar-height;
 
-                .sidebar-elems .show-it {
-                    top: 77px;
+                .sidebar-elems.show-it {
+                    top: 45px + $top-navbar-height;
                 }
 
                 #sidebar-filler {


### PR DESCRIPTION
This corrects two bugs with the sidebar's presentation:

* The CSS selector to reposition the top offset of the rustdoc sidebar menu was not being applied to the element. It also updates the magic number to be less magical :sparkles: (Fixes #1121)
* Due to the padding being applied to the rustdoc container, the sidebar nav's sizing and position was offset, resulting in some jank. This addresses it.
  * Before: ![Before](https://user-images.githubusercontent.com/139487/103431979-b21f9280-4ba6-11eb-97d3-55d02bdd9f4d.mp4)
  * After: ![After](https://user-images.githubusercontent.com/139487/103431987-bb106400-4ba6-11eb-96b5-870a3cc45d40.mp4)

The fixes are grouped by commit so they can be separately reviewed.

Thanks, and Happy New Year! :fireworks: :crossed_fingers: 



