### PR TITLE
Add print to show on which address the server has been started

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -117,6 +117,11 @@ impl CommandLine {
                 reload_templates,
             } => {
                 // Blocks indefinitely
+                log::info!(
+                    "Starting server on `{}`... (reload templates: {})",
+                    socket_addr,
+                    reload_templates,
+                );
                 let _ = Server::start(Some(&socket_addr), reload_templates, &ctx)?;
             }
             Self::Daemon {


### PR DESCRIPTION
It happens to me everytime: I forget which port is being used when I start the server... So instead of looking in the code every time, I think it'd be better to just display it.

It looks like this:

```
$ cargo run -- start-web-server --reload-templates
   Compiling docs-rs v0.6.0 (/home/imperio/rust/docs.rs)
    Finished dev [unoptimized + debuginfo] target(s) in 11.16s
     Running `target/debug/cratesfyi start-web-server --reload-templates`
2021/01/06 17:05:04 [INFO] cratesfyi: Starting server on `0.0.0.0:3000`... (reload templates: true)
```