### PR TITLE
Make it more obvious that this is the repository link

### DIFF
--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -53,6 +53,7 @@ struct GitHubMetadata {
     stars: i32,
     forks: i32,
     issues: i32,
+    name: Option<String>,
 }
 
 fn optional_markdown<S>(markdown: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
@@ -102,6 +103,7 @@ impl CrateDetails {
                 github_repos.stars AS github_stars,
                 github_repos.forks AS github_forks,
                 github_repos.issues AS github_issues,
+                github_repos.name AS github_name,
                 releases.is_library,
                 releases.yanked,
                 releases.doc_targets,
@@ -150,6 +152,7 @@ impl CrateDetails {
                 issues: krate.get("github_issues"),
                 stars: krate.get("github_stars"),
                 forks: krate.get("github_forks"),
+                name: krate.get("github_name"),
             })
         } else {
             None

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -301,9 +301,9 @@ impl tera::Filter for IconType {
         let mut aria_hidden = true;
         let icon_name = tera::escape_html(value.as_str().expect("Icons only take strings"));
         let class = if args.get("fw").and_then(|fw| fw.as_bool()).unwrap_or(false) {
-            "class=\"fa-svg fa-svg-fw\""
+            "fa-svg fa-svg-fw"
         } else {
-            "class=\"fa-svg\""
+            "fa-svg"
         };
         let aria_label = args
             .get("aria-label")
@@ -332,9 +332,12 @@ impl tera::Filter for IconType {
         let icon_file_string = font_awesome_as_a_crate::svg(type_, &icon_name[..]).unwrap_or("");
 
         let icon = format!(
-            r#"<span {class} aria-hidden="{aria_hidden}"{aria_label}{id}>{icon_file_string}</span>"#,
+            "<span \
+                class=\"{class} {class_extra}\" \
+                aria-hidden=\"{aria_hidden}\"{aria_label}{id}>{icon_file_string}</span>",
             icon_file_string = icon_file_string,
             class = class,
+            class_extra = args.get("extra").and_then(|s| s.as_str()).unwrap_or(""),
             aria_hidden = aria_hidden,
             aria_label = aria_label,
             id = id,

--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -75,12 +75,21 @@
                                     {# If the repo link is for github, show some github stats #}
                                     {# TODO: add support for hosts besides github (#35) #}
                                     {%- if details.github_metadata -%}
-                                        {{ "star" | fas(fw=true) }} {{ details.github_metadata.stars }}
+                                        {{ "github" | fab(fw=true) }}
+                                        {% if details.github_metadata.name %}
+                                            {{details.github_metadata.name}}
+                                        {% else %}
+                                            Repository
+                                        {% endif %}
+                                        <br>
+                                        {{ "star" | fas(fw=true, extra="left-margin") }} {{ details.github_metadata.stars }}
                                         {{ "code-branch" | fas(fw=true) }} {{ details.github_metadata.forks }}
-                                        {{ "exclamation-circle" | fas(fw=true) }} {{ details.github_metadata.issues }}<br>
-                                    {%- endif -%}
+                                        {{ "exclamation-circle" | fas(fw=true) }} {{ details.github_metadata.issues }}
 
-                                    {{ "code-branch" | fas(fw=true) }} Repository
+                                    {# If the repo link is unknown, just show a normal link #}
+                                    {%- else -%}
+                                        {{ "code-branch" | fas(fw=true) }} Repository
+                                    {%- endif -%}
                                 </a>
                             </li>
                         {%- endif -%}

--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -75,15 +75,12 @@
                                     {# If the repo link is for github, show some github stats #}
                                     {# TODO: add support for hosts besides github (#35) #}
                                     {%- if details.github_metadata -%}
-                                        {{ "github" | fab(fw=true) }}
                                         {{ "star" | fas(fw=true) }} {{ details.github_metadata.stars }}
                                         {{ "code-branch" | fas(fw=true) }} {{ details.github_metadata.forks }}
-                                        {{ "exclamation-circle" | fas(fw=true) }} {{ details.github_metadata.issues }}
-
-                                    {# If the repo link is unknown, just show a normal link #}
-                                    {%- else -%}
-                                        {{ "code-branch" | fas(fw=true) }} Repository
+                                        {{ "exclamation-circle" | fas(fw=true) }} {{ details.github_metadata.issues }}<br>
                                     {%- endif -%}
+
+                                    {{ "code-branch" | fas(fw=true) }} Repository
                                 </a>
                             </li>
                         {%- endif -%}

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -62,10 +62,7 @@
                             {%- if krate.github_metadata -%}
                                 <li class="pure-menu-item">
                                     <a href="{{ krate.repository_url }}" class="pure-menu-link">
-                                        {{ "github" | fab(fw=true) }}
-                                        {{ "star" | fas(fw=true) }} {{ krate.github_metadata.stars }}
-                                        {{ "code-branch" | fas(fw=true) }} {{ krate.github_metadata.forks }}
-                                        {{ "exclamation-circle" | fas(fw=true) }} {{ krate.github_metadata.issues }}
+                                        {{ "code-branch" | fas(fw=true) }} Repository
                                     </a>
                                 </li>
 

--- a/templates/style/_fa.scss
+++ b/templates/style/_fa.scss
@@ -4,6 +4,10 @@
     display: inline-block;
 }
 
+.fa-svg.left-margin {
+    margin-left: 1.25em;
+}
+
 .fa-svg svg {
     width: 1em;
     height: 1em;


### PR DESCRIPTION
Before:

![Screenshot from 2021-01-06 15-48-06](https://user-images.githubusercontent.com/3050060/103781427-a44e8f00-5036-11eb-8371-1d1ec06dedec.png)

After:

![Screenshot from 2021-01-06 21-09-31](https://user-images.githubusercontent.com/3050060/103815644-f4901600-5063-11eb-8fa7-c4d08a469e02.png)

And the menu "repository link" will always look like this:

![Screenshot from 2021-01-13 14-09-47](https://user-images.githubusercontent.com/3050060/104456595-327fc380-55a9-11eb-9848-07e7bec4a60b.png)

What do you think?
