### PR TITLE
Only list open issues instead of all issues

### DIFF
--- a/src/utils/github_updater.rs
+++ b/src/utils/github_updater.rs
@@ -28,7 +28,7 @@ const GRAPHQL_UPDATE: &str = "query($ids: [ID!]!) {
             description
             stargazerCount
             forkCount
-            issues { totalCount }
+            issues(states: [OPEN]) { totalCount }
         }
     }
     rateLimit {
@@ -44,7 +44,7 @@ const GRAPHQL_SINGLE: &str = "query($owner: String!, $repo: String!) {
         description
         stargazerCount
         forkCount
-        issues { totalCount }
+        issues(states: [OPEN]) { totalCount }
     }
 }";
 


### PR DESCRIPTION
Currently, it's the total number of issues which is returned. I think it doesn't make much sense, generally we only look at the number of open issues.