### PR TITLE
Fix "I'm feeling lucky" search to include all crates

### DIFF
--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -69,6 +69,9 @@ metrics! {
 
         /// The number of attempted files that failed due to a memory limit
         pub(crate) html_rewrite_ooms: IntCounter,
+
+        /// the number of "I'm feeling lucky" searches for crates
+        pub(crate) im_feeling_lucky_searches: IntCounter,
     }
 
     // The Rust prometheus library treats the namespace as the "prefix" of the metric name: a

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -550,6 +550,9 @@ fn redirect_to_random_crate(req: &Request, conn: &mut PoolClient) -> IronResult<
             let mut resp = Response::with((status::Found, Redirect(url)));
             resp.headers.set(Expires(HttpDate(time::now())));
 
+            let metrics = extension!(req, crate::Metrics).clone();
+            metrics.im_feeling_lucky_searches.inc();
+
             log::debug!("finished random crate search on iteration {}", i);
             return Ok(resp);
         } else {

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -500,7 +500,7 @@ impl Default for Search {
 fn redirect_to_random_crate(req: &Request, conn: &mut PoolClient) -> IronResult<Response> {
     // since there is a chance of this query returning an empty result,
     // we retry a certain amount of times, and log a warning.
-    for _ in 0..20 {
+    for i in 0..20 {
         let rows = ctry!(
             req,
             conn.query(
@@ -550,12 +550,13 @@ fn redirect_to_random_crate(req: &Request, conn: &mut PoolClient) -> IronResult<
             let mut resp = Response::with((status::Found, Redirect(url)));
             resp.headers.set(Expires(HttpDate(time::now())));
 
+            log::debug!("finished random crate search on iteration {}", i);
             return Ok(resp);
         } else {
-            ::log::warn!("retrying random crate search");
+            log::warn!("retrying random crate search");
         }
     }
-    ::log::error!("found no result in random crate search");
+    log::error!("found no result in random crate search");
 
     Err(Nope::NoResults.into())
 }


### PR DESCRIPTION
This fixes the _I'm feeling lucky_ search ( #789 ) to do an efficient search over all creates, not only the first 280 ones. 

I was searching and testing through many different ways to get a random record, and found this to be the best for our dataset. (see also [this stackoverflow answer](https://stackoverflow.com/a/8675160/1194456) for some overview). 

I tested this locally with a dummy-dataset with 600 crates >100 stars, and out of 10k of these queries there were only <50 which needed a second try. In the statement execution time was <10ms all the time. 

Other approaches felt too complex in code, were too slow, or were too slow randomly. 

I'm happy to implement any needed changes. 

In #789 @Kixiron was mentioning metrics to be added, while I'm not sure which metrics are needed.  