### PR TITLE
add rendering time metrics to rustdoc-redirector-handler

### DIFF
--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -47,6 +47,8 @@ metrics! {
         pub(crate) response_time: HistogramVec["route"],
         /// The time it takes to render a rustdoc page
         pub(crate) rustdoc_rendering_times: HistogramVec["step"],
+        /// The time it takes to render a rustdoc redirect page
+        pub(crate) rustdoc_redirect_rendering_times: HistogramVec["step"],
 
         /// Count of recently accessed crates
         pub(crate) recent_crates: IntGaugeVec["duration"],


### PR DESCRIPTION
as we talked about. 

Default `routes_visited` and `response_time` metrics are unified for all `rustdoc` views. 
While we could use a different name for the redirect view to see these metrics separated, for a route used heavily it's better to have more detailed data. 