### PR TITLE
change URLs in releases-pages to remove unnecessary redirect

### DIFF
--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -1166,7 +1166,7 @@ mod tests {
             assert_eq!(links.len(), 2);
             assert_eq!(
                 links[0],
-                "/crate_that_succeeded_with_github/0.2.0/crate_that_succeeded_with_github"
+                "/crate_that_succeeded_with_github/0.2.0/crate_that_succeeded_with_github/"
             );
             assert_eq!(links[1], "/crate/crate_that_failed_with_github/0.1.0");
 
@@ -1277,7 +1277,7 @@ mod tests {
                 assert_eq!(links[0], "/crate/crate_that_failed/0.1.0");
                 assert_eq!(
                     links[1],
-                    "/crate_that_succeeded_with_github/0.2.0/crate_that_succeeded_with_github"
+                    "/crate_that_succeeded_with_github/0.2.0/crate_that_succeeded_with_github/"
                 );
             }
 

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -35,7 +35,7 @@
             <ul>
                 {%- for release in recent_releases -%}
                     {%- if release.rustdoc_status -%}
-                        {%- set release_url = "/" ~ release.name ~ "/" ~ release.version ~ "/" ~ release.target_name -%}
+                        {%- set release_url = "/" ~ release.name ~ "/" ~ release.version ~ "/" ~ release.target_name ~ "/" -%}
                     {%- else -%}
                         {%- set release_url = "/crate/" ~ release.name ~ "/" ~ release.version -%}
                     {%- endif -%}

--- a/templates/releases/feed.xml
+++ b/templates/releases/feed.xml
@@ -13,7 +13,7 @@
 
     {%- for release in recent_releases -%}
         {%- if release.rustdoc_status -%}
-            {%- set link = "/" ~ release.name ~ "/" ~ release.version ~ "/" ~ release.target_name -%}
+            {%- set link = "/" ~ release.name ~ "/" ~ release.version ~ "/" ~ release.target_name ~ "/" -%}
         {%- else -%}
             {%- set link = "/crate/" ~ release.name ~ "/" ~ release.version -%}
         {%- endif %}

--- a/templates/releases/releases.html
+++ b/templates/releases/releases.html
@@ -22,7 +22,7 @@
                 {# TODO: If there are no releases, then display a message that says so #}
                 {%- for release in releases -%}
                     {%- if release.rustdoc_status -%}
-                        {% set link = "/" ~ release.name ~ "/" ~ release.version ~ "/" ~ release.target_name -%}
+                        {% set link = "/" ~ release.name ~ "/" ~ release.version ~ "/" ~ release.target_name ~ "/" -%}
                     {%- else -%}
                         {% set link = "/crate/" ~ release.name ~ "/" ~ release.version -%}
                     {%- endif -%}


### PR DESCRIPTION
stumbled on this while testing around. 

The release-pages link to the docs without the trailing `/`, and the rustdoc page then appends the `/` with a redirect. 

Not not any more