### PR TITLE
Improve topbar crate dropdown menu by removing uneeded information

### DIFF
--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -23,7 +23,7 @@
                     </li>
 
                     <li class="pure-menu-item">
-                        <a href="{{ crate_url | safe }}" class="pure-menu-link description">
+                        <a href="{{ crate_url | safe }}" class="pure-menu-link description" title="See {{ krate.name }} in docs.rs">
                             {{ "cube" | fas(fw=true) }} Docs.rs crate page
                         </a>
                     </li>
@@ -86,12 +86,6 @@
                                 <a href="{{ crate_url | safe }}/source/" title="Browse source of {{ metadata.name }}-{{ metadata.version }}" class="pure-menu-link">
                                     {{ "folder-open" | fas(fw=true) }}
                                     <span class="title">Source</span>
-                                </a>
-                            </li>
-
-                            <li class="pure-menu-item">
-                                <a href="{{ crate_url | safe }}" class="pure-menu-link" title="See {{ krate.name }} in docs.rs">
-                                    {{ "cube" | fas(fw=true) }} More information
                                 </a>
                             </li>
                         </ul>

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -23,8 +23,8 @@
                     </li>
 
                     <li class="pure-menu-item">
-                        <a href="{{ crate_url | safe }}" class="pure-menu-link" class="description">
-                            {{ "cube" | fas(fw=true) }} {{ krate.description }}
+                        <a href="{{ crate_url | safe }}" class="pure-menu-link description">
+                            {{ "cube" | fas(fw=true) }} Docs.rs crate page
                         </a>
                     </li>
 

--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -39,6 +39,10 @@ div.nav-container {
         font-weight: 400;
         color: var(--color-navbar-standard);
 
+        &.description {
+            font-size: 0.9em;
+        }
+
         // Improves menu link readability when inverting the colors on focus.
         // Vendor do background-color #eee, looks weird on different theme.
         &:focus {


### PR DESCRIPTION
I always found the link to go to the crate page very misleading because you don't expect a description to be this link. Instead, I removed this description from the menu completely (I think the menu is already very loaded) and made it clear what the link was about.

![Screenshot from 2021-01-22 15-01-20](https://user-images.githubusercontent.com/3050060/105500236-e88e9000-5cc2-11eb-923a-b8bf544305c8.png)
