### PR TITLE
set default target to linux for tests so we can run the tests on non-linux machines

### DIFF
--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -325,6 +325,10 @@ impl<'a> FakeRelease<'a> {
         if let Some(markdown) = self.readme {
             fs::write(crate_dir.join("README.md"), markdown)?;
         }
+
+        // Many tests rely on the default-target being linux, so it should not
+        // be set to docsrs_metadata::HOST_TARGET, because then tests fail on all
+        // non-linux platforms.
         let default_target = self.default_target.unwrap_or("x86_64-unknown-linux-gnu");
         let release_id = crate::db::add_package_into_database(
             &mut db.conn(),

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -325,7 +325,7 @@ impl<'a> FakeRelease<'a> {
         if let Some(markdown) = self.readme {
             fs::write(crate_dir.join("README.md"), markdown)?;
         }
-        let default_target = self.default_target.unwrap_or(docsrs_metadata::HOST_TARGET);
+        let default_target = self.default_target.unwrap_or("x86_64-unknown-linux-gnu");
         let release_id = crate::db::add_package_into_database(
             &mut db.conn(),
             &package,


### PR DESCRIPTION
I found out that df489659d0de9baa5f23896dbc9260a00206f633 broke the tests in `web/rustdoc` for me, since it changes from a hard-coded linux default-target to using `docsrs_metadata::HOST_TARGET`, which is `x86_64-apple-darwin` on my machine. 

Some test-cases ( for example `web::rustdoc::test::default_target_redirects_to_base`) rely on the default-target of the fake-release being linux. 

This PR reverts that part of df489659d0de9baa5f23896dbc9260a00206f633 so the tests are fine again. 