### PR TITLE
(WIP) rustdoc redirect caching in the CDN

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,7 @@ pub struct Config {
     // Time between 'git gc --auto' calls in seconds
     pub(crate) registry_gc_interval: u64,
 
+<<<<<<< HEAD
     // random crate search generates a number of random IDs to
     // efficiently find a random crate with > 100 GH stars.
     // The amount depends on the ratio of crates with >100 stars
@@ -46,6 +47,10 @@ pub struct Config {
     // `500` for a ratio of 7249 over 54k crates.
     // For unit-tests the number has to be higher.
     pub(crate) random_crate_search_view_size: u32,
+=======
+    // CDN / caching settings
+    pub(crate) cache_rustdoc_redirects: u32,
+>>>>>>> 53d35de (Set CDN caching headers for rustdoc redirects)
 
     // Build params
     pub(crate) build_attempts: u16,
@@ -94,6 +99,7 @@ impl Config {
             registry_gc_interval: env("DOCSRS_REGISTRY_GC_INTERVAL", 60 * 60)?,
 
             random_crate_search_view_size: env("DOCSRS_RANDOM_CRATE_SEARCH_VIEW_SIZE", 500)?,
+            cache_rustdoc_redirects: env("DOCSRS_CACHE_RUSTDOC_REDIRECTS", 30 * 60)?,
 
             rustwide_workspace: env("CRATESFYI_RUSTWIDE_WORKSPACE", PathBuf::from(".workspace"))?,
             inside_docker: env("DOCS_RS_DOCKER", false)?,

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,7 +56,7 @@ pub struct Config {
     // Time to cache release-level redirects in rustdoc, in seconds.
     // Here the destination can only change after
     // rebuilds or yanks, so very infrequently.
-    pub(crate) cache_rustdoc_redirects_version: u32,
+    pub(crate) cache_rustdoc_redirects_release: u32,
 
     // Build params
     pub(crate) build_attempts: u16,
@@ -106,7 +106,7 @@ impl Config {
 
             random_crate_search_view_size: env("DOCSRS_RANDOM_CRATE_SEARCH_VIEW_SIZE", 500)?,
             cache_rustdoc_redirects_crate: env("DOCSRS_CACHE_RUSTDOC_REDIRECTS_CRATE", 15 * 60)?, // 15 minutes
-            cache_rustdoc_redirects_version: env(
+            cache_rustdoc_redirects_release: env(
                 "DOCSRS_CACHE_RUSTDOC_REDIRECTS_RELEASE",
                 7 * 24 * 60 * 60, // 7 days
             )?,

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,8 +46,17 @@ pub struct Config {
     // `500` for a ratio of 7249 over 54k crates.
     // For unit-tests the number has to be higher.
     pub(crate) random_crate_search_view_size: u32,
-    // CDN / caching settings
-    pub(crate) cache_rustdoc_redirects: u32,
+
+    // Time to cache crate-level redirects in rustdoc, in seconds.
+    // This is for redirects where the destination
+    // can change after the release of a new version
+    // of a crate.
+    pub(crate) cache_rustdoc_redirects_crate: u32,
+
+    // Time to cache release-level redirects in rustdoc, in seconds.
+    // Here the destination can only change after
+    // rebuilds or yanks, so very infrequently.
+    pub(crate) cache_rustdoc_redirects_version: u32,
 
     // Build params
     pub(crate) build_attempts: u16,
@@ -96,7 +105,11 @@ impl Config {
             registry_gc_interval: env("DOCSRS_REGISTRY_GC_INTERVAL", 60 * 60)?,
 
             random_crate_search_view_size: env("DOCSRS_RANDOM_CRATE_SEARCH_VIEW_SIZE", 500)?,
-            cache_rustdoc_redirects: env("DOCSRS_CACHE_RUSTDOC_REDIRECTS", 30 * 60)?,
+            cache_rustdoc_redirects_crate: env("DOCSRS_CACHE_RUSTDOC_REDIRECTS_CRATE", 15 * 60)?, // 15 minutes
+            cache_rustdoc_redirects_version: env(
+                "DOCSRS_CACHE_RUSTDOC_REDIRECTS_RELEASE",
+                7 * 24 * 60 * 60, // 7 days
+            )?,
 
             rustwide_workspace: env("CRATESFYI_RUSTWIDE_WORKSPACE", PathBuf::from(".workspace"))?,
             inside_docker: env("DOCS_RS_DOCKER", false)?,

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,7 +38,6 @@ pub struct Config {
     // Time between 'git gc --auto' calls in seconds
     pub(crate) registry_gc_interval: u64,
 
-<<<<<<< HEAD
     // random crate search generates a number of random IDs to
     // efficiently find a random crate with > 100 GH stars.
     // The amount depends on the ratio of crates with >100 stars
@@ -47,10 +46,8 @@ pub struct Config {
     // `500` for a ratio of 7249 over 54k crates.
     // For unit-tests the number has to be higher.
     pub(crate) random_crate_search_view_size: u32,
-=======
     // CDN / caching settings
     pub(crate) cache_rustdoc_redirects: u32,
->>>>>>> 53d35de (Set CDN caching headers for rustdoc redirects)
 
     // Build params
     pub(crate) build_attempts: u16,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -99,7 +99,7 @@ use extensions::InjectExtensions;
 use failure::Error;
 use iron::{
     self,
-    headers::{CacheControl, CacheDirective, Expires, HttpDate},
+    headers::{CacheControl, CacheDirective},
     modifiers::Redirect,
     status,
     status::Status,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -496,7 +496,7 @@ fn redirect(url: Url) -> Response {
     resp
 }
 
-/// creates a redirect-response which is cached on the CDN level for
+/// Creates a redirect-response which is cached on the CDN level for
 /// the given amount of seconds. Browser-Local caching is deactivated.
 /// The used s-maxage is respected by CloudFront (which we can invalidate
 /// if we need to), and perhaps by other proxies in between.

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -491,7 +491,8 @@ fn duration_to_str(init: DateTime<Utc>) -> String {
 /// `Request`.
 fn redirect(url: Url) -> Response {
     let mut resp = Response::with((status::Found, Redirect(url)));
-    resp.headers.set(Expires(HttpDate(time::now())));
+    resp.headers
+        .set(CacheControl(vec![CacheDirective::MaxAge(0)]));
 
     resp
 }
@@ -509,7 +510,7 @@ fn redirect(url: Url) -> Response {
 /// CloudFront ignores it when it gets `Cache-Control: max-age` or
 /// `s-maxage`.
 fn cached_redirect(url: Url, cache_seconds: u32) -> Response {
-    let mut resp = redirect(url);
+    let mut resp = Response::with((status::Found, Redirect(url)));
     resp.headers.set(CacheControl(vec![
         CacheDirective::MaxAge(0),
         CacheDirective::SMaxAge(cache_seconds),

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -152,7 +152,7 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
 
     // redirects with an existing version in the URL can be cached for longer.
     let cache_redirect_for = if let Some(_) = req_version {
-        config.cache_rustdoc_redirects_version
+        config.cache_rustdoc_redirects_release
     } else {
         config.cache_rustdoc_redirects_crate
     };
@@ -303,7 +303,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
 
         Ok(super::cached_redirect(
             url,
-            config.cache_rustdoc_redirects_version,
+            config.cache_rustdoc_redirects_release,
         ))
     };
 
@@ -575,7 +575,7 @@ pub fn target_redirect_handler(req: &mut Request) -> IronResult<Response> {
     let url = ctry!(req, Url::parse(&url));
     Ok(super::cached_redirect(
         url,
-        config.cache_rustdoc_redirects_version,
+        config.cache_rustdoc_redirects_release,
     ))
 }
 

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -70,14 +70,8 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
         }
         let url = ctry!(req, Url::parse(&url_str));
         let config = extension!(req, Config);
-        let mut resp = Response::with((status::Found, Redirect(url)));
-        resp.headers.set(CacheControl(vec![
-            CacheDirective::MaxAge(0),
-            // s-maxage is only for the CDN.
-            CacheDirective::SMaxAge(config.cache_rustdoc_redirects),
-        ]));
 
-        Ok(resp)
+        Ok(super::cached_redirect(url, config.cache_rustdoc_redirects))
     }
 
     fn redirect_to_crate(req: &Request, name: &str, vers: &str) -> IronResult<Response> {
@@ -87,14 +81,7 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
         );
 
         let config = extension!(req, Config);
-        let mut resp = Response::with((status::Found, Redirect(url)));
-        resp.headers.set(CacheControl(vec![
-            CacheDirective::MaxAge(0),
-            // s-maxage is only for the CDN.
-            CacheDirective::SMaxAge(config.cache_rustdoc_redirects),
-        ]));
-
-        Ok(resp)
+        Ok(super::cached_redirect(url, config.cache_rustdoc_redirects))
     }
 
     let metrics = extension!(req, Metrics).clone();
@@ -292,7 +279,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
         );
         let url = ctry!(req, Url::parse(&redirect_path));
 
-        Ok(super::redirect(url))
+        Ok(super::cached_redirect(url, config.cache_rustdoc_redirects))
     };
 
     rendering_time.step("match version");
@@ -561,10 +548,7 @@ pub fn target_redirect_handler(req: &mut Request) -> IronResult<Response> {
     );
 
     let url = ctry!(req, Url::parse(&url));
-    let mut resp = Response::with((status::Found, Redirect(url)));
-    resp.headers.set(Expires(HttpDate(time::now())));
-
-    Ok(resp)
+    Ok(super::cached_redirect(url, config.cache_rustdoc_redirects))
 }
 
 pub fn badge_handler(req: &mut Request) -> IronResult<Response> {

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -12,7 +12,6 @@ use crate::{
 use iron::url::percent_encoding::percent_decode;
 use iron::{
     headers::{CacheControl, CacheDirective, Expires, HttpDate},
-    modifiers::Redirect,
     status, Handler, IronResult, Request, Response, Url,
 };
 use lol_html::errors::RewritingError;
@@ -37,8 +36,12 @@ impl RustLangRedirector {
 }
 
 impl iron::Handler for RustLangRedirector {
-    fn handle(&self, _req: &mut Request) -> IronResult<Response> {
-        Ok(Response::with((status::Found, Redirect(self.url.clone()))))
+    fn handle(&self, req: &mut Request) -> IronResult<Response> {
+        let config = extension!(req, Config);
+        Ok(super::cached_redirect(
+            self.url.clone(),
+            config.cache_rustdoc_redirects,
+        ))
     }
 }
 

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -69,8 +69,13 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
             url_str.push_str(query);
         }
         let url = ctry!(req, Url::parse(&url_str));
+        let config = extension!(req, Config);
         let mut resp = Response::with((status::Found, Redirect(url)));
-        resp.headers.set(Expires(HttpDate(time::now())));
+        resp.headers.set(CacheControl(vec![
+            CacheDirective::MaxAge(0),
+            // s-maxage is only for the CDN.
+            CacheDirective::SMaxAge(config.cache_rustdoc_redirects),
+        ]));
 
         Ok(resp)
     }
@@ -81,8 +86,13 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
             Url::parse(&format!("{}/crate/{}/{}", redirect_base(req), name, vers)),
         );
 
+        let config = extension!(req, Config);
         let mut resp = Response::with((status::Found, Redirect(url)));
-        resp.headers.set(Expires(HttpDate(time::now())));
+        resp.headers.set(CacheControl(vec![
+            CacheDirective::MaxAge(0),
+            // s-maxage is only for the CDN.
+            CacheDirective::SMaxAge(config.cache_rustdoc_redirects),
+        ]));
 
         Ok(resp)
     }


### PR DESCRIPTION
regularly using docs.rs there was another possible performance improvement that I saw. 

I feel currently the server-side performance is (for now) not the issue any more, the next big lever would be working on caching the S3 file downloads. In #1004 if we combine it with local caching on the server, or just a webserver-local LRU cache, or perhaps a proxy between the webserver and S3. 

From what I see, for users outside the US most of the time is not spent on the webserver any more, but on the roundtrip to the US, or data-download from the US. 

Both could be solved by starting to cache more things on the CDN level. 

Coming from previous discussion in the channel, I would rule out: 
- active invalidation-requests because of costs 
- caching the doc-pages themselves because of WIP around security with @pietroalbini 
- moving to a more capable CDN  ([fastly](https://www.fastly.com/open-source) for example is used my many other open source projects, while I'm not sure if it's really free or only cheap :) ) 

The remaining thing are (IMHO) the redirects, which are (according to @jyn514 ) also heavily used. When I test these from Berlin, it's about 150-200ms only spent in the redirect. 

A simple strategy which has often more impact that we think is setting cache-headers for the CDN to a short amount of time. Even caching a thing for 15, 30, 60 minutes will gain quite much performance for pages that are regularly used, at least because the response is returned from a local POP. 

In a discussion with @pietroalbini I got the impression (correct me if I'm wrong please 😄 ) that we can actually assume old version builds won't change any more. Also in that discussion a label like _this version is yanked_ or _go to latest version_ was ok to be outdated for 15 minutes (or so). 

This would actually lead me to the conclusion that we can 
- cache crate/version internal redirects forever 
- cache redirects that are based on the latest version for 15-30 minutes 

under the assumption that **we cache only on the CDN level**, which enables us to manually invalidate the whole cache if we want to (up to 1000 invalidations are free in CloudFront, which likely is fine for manual invalidations/new code, but not for automatic invalidations for every crate release). 

If in general this is fine for you, I can continue on working out more details, likely 
- add tests 
- change the version-internal redirects to cache longer 
- add more caching headers (?) 
- do some testing with CloudFront (do we have a staging environment?). 


This is just an offer and I won't take it personally if it doesn't match your strategy for the platform. Also my assumptions or my understand might be wrong, please point me to mistakes I made. 

I definitely would be happy to invest more time in this to improve the site. 



### links 
- [AWS cross-datacenter roundtrip times](https://www.cloudping.co/grid/p_90/timeframe/1D): example for me: `eu-central-1` (Frankfurt) to `us-east-1` (are we located there?)  are still **~100ms** 
- [CloudFront caching headers + behavior](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/header-caching.html) 