### PR TITLE
(draft) run CI also on Mac OS for developers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,11 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [macos-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@master
@@ -17,34 +21,23 @@ jobs:
         with:
           toolchain: stable
           override: true
+
+      - uses: Swatinem/rust-cache@v1
+
       - uses: actions-rs/cargo@v1
         with:
           command: install
           args: cargo-sweep
-
-      - name: Cache directories
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/bin
-            ~/.cargo/git
-          key: cargo-test-dirs-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-test-dirs-
-      - name: Cache build
-        uses: actions/cache@v2
-        with:
-          path: target
-          key: cargo-test-build-${{ steps.install.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cargo-test-build-${{ steps.install.outputs.rustc_hash }}-
-            cargo-test-build-
 
       - name: Register artifacts
         uses: actions-rs/cargo@v1
         with:
           command: sweep
           args: --stamp
+
+      - name: installing docker
+        uses: docker-practice/actions-setup-docker@master
+        if: ${{ matrix.os == 'macos-latest' }}
 
       - name: Launch postgres and min.io
         run: |
@@ -96,34 +89,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
+
       - id: install
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
           components: clippy
+
+      - uses: Swatinem/rust-cache@v1
+
       - uses: actions-rs/cargo@v1
         with:
           command: install
           args: cargo-sweep
-
-      - name: Cache directories
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/bin
-            ~/.cargo/git
-          key: cargo-clippy-dirs-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-clippy-dirs-
-      - name: Cache build
-        uses: actions/cache@v2
-        with:
-          path: target
-          key: cargo-clippy-${{ steps.install.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cargo-clippy-${{ steps.install.outputs.rustc_hash }}-
-            cargo-clippy-
 
       - name: Register artifacts
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
(need this PR to test the actual CI runs)

results until now: 
- the [setup-docker](https://github.com/marketplace/actions/setup-docker )  action takes >10 minutes to setup docker, and tests are really slow 
- the normal `services` technique doesn't work at all on windows and mac builds. 
- I'm looking again into setup-docker to see if it would be cached and the timeout errors could be solved