### PR TITLE
Don't execute a build when not enough memory is available

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -55,6 +55,7 @@ pub struct Config {
     pub(crate) toolchain: String,
     pub(crate) build_cpu_limit: Option<u32>,
     pub(crate) include_default_targets: bool,
+    pub(crate) disable_memory_limit: bool,
 }
 
 impl Config {
@@ -101,6 +102,7 @@ impl Config {
             toolchain: env("CRATESFYI_TOOLCHAIN", "nightly".to_string())?,
             build_cpu_limit: maybe_env("DOCS_RS_BUILD_CPU_LIMIT")?,
             include_default_targets: env("DOCSRS_INCLUDE_DEFAULT_TARGETS", true)?,
+            disable_memory_limit: env("DOCSRS_DISABLE_MEMORY_LIMIT", false)?,
         })
     }
 }


### PR DESCRIPTION
Example error:

```
2021/02/15 01:43:12 [INFO] docs_rs::docbuilder::rustwide_builder: building package regex 1.3.1
Error: Building documentation failed

Caused by:
    not enough memory to build regex 1.3.1: needed 3072 MiB, have 2909 MiB
help: set DOCSRS_DISABLE_MEMORY_LIMIT=true to force a build
```

Fixes #657.

r? @pietroalbini or @Nemo157 