### PR TITLE
remove update-release-activity background job and calculate the release-activity on the fly

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -392,9 +392,6 @@ enum DatabaseSubcommand {
         prefix: String,
     },
 
-    /// Updates monthly release activity chart
-    UpdateReleaseActivity,
-
     /// Remove documentation from the database
     Delete {
         #[structopt(subcommand)]
@@ -449,12 +446,6 @@ impl DatabaseSubcommand {
             Self::AddDirectory { directory, prefix } => {
                 add_path_into_database(&*ctx.storage()?, &prefix, directory)
                     .context("Failed to add directory into database")?;
-            }
-
-            // FIXME: This is actually util command not database
-            Self::UpdateReleaseActivity => {
-                docs_rs::utils::update_release_activity(&mut *ctx.conn()?)
-                    .context("Failed to update release activity")?
             }
 
             Self::Delete {

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -626,8 +626,8 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> CratesfyiResult<(
             CREATE MATERIALIZED VIEW releases_statistics AS 
             SELECT
                 release_time::date as date,
-                count(*) AS counts,
-                count(CASE WHEN is_library = TRUE AND build_status = FALSE THEN 1 ELSE 0 END) AS failures
+                COUNT(*) AS counts,
+                SUM(CASE WHEN is_library = TRUE AND build_status = FALSE THEN 1 ELSE 0 END) AS failures
             FROM
                 releases
             GROUP BY

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -619,9 +619,9 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> CratesfyiResult<(
             ",
         ),
         migration!(
-            context, 
-            27, 
-            "create materialized view for release-statistics", 
+            context,
+            27,
+            "create materialized view for release-statistics",
             // upgrade
             "
             CREATE MATERIALIZED VIEW releases_statistics AS 

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -618,30 +618,6 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> CratesfyiResult<(
             DROP INDEX github_repos_stars_idx;
             ",
         ),
-        migration!(
-            context,
-            27,
-            "create materialized view for release-statistics",
-            // upgrade
-            "
-            CREATE MATERIALIZED VIEW releases_statistics AS 
-            SELECT
-                release_time::date as date,
-                COUNT(*) AS counts,
-                SUM(CASE WHEN is_library = TRUE AND build_status = FALSE THEN 1 ELSE 0 END) AS failures
-            FROM
-                releases
-            GROUP BY
-                release_time::date
-            ;
-            CREATE INDEX releases_statistics_date_idx ON releases_statistics (date);
-            ",
-            // downgrade 
-            "
-            DROP INDEX releases_statistics_date_idx;
-            DROP MATERIALIZED VIEW releases_statistics;
-            ",
-        ),
     ];
 
     for migration in migrations {

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -622,6 +622,7 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> CratesfyiResult<(
             context, 
             27, 
             "create materialized view for release-statistics", 
+            // upgrade
             "
             CREATE MATERIALIZED VIEW releases_statistics AS 
             SELECT
@@ -635,6 +636,7 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> CratesfyiResult<(
             ;
             CREATE INDEX releases_statistics_date_idx ON releases_statistics (date);
             ",
+            // downgrade 
             "
             DROP INDEX releases_statistics_date_idx;
             DROP MATERIALIZED VIEW releases_statistics;

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -618,6 +618,28 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> CratesfyiResult<(
             DROP INDEX github_repos_stars_idx;
             ",
         ),
+        migration!(
+            context, 
+            27, 
+            "create materialized view for release-statistics", 
+            "
+            CREATE MATERIALIZED VIEW releases_statistics AS 
+            SELECT
+                release_time::date as date,
+                count(*) AS counts,
+                count(CASE WHEN is_library = TRUE AND build_status = FALSE THEN 1 ELSE 0 END) AS failures
+            FROM
+                releases
+            GROUP BY
+                release_time::date
+            ;
+            CREATE INDEX releases_statistics_date_idx ON releases_statistics (date);
+            ",
+            "
+            DROP INDEX releases_statistics_date_idx;
+            DROP MATERIALIZED VIEW releases_statistics;
+            ",
+        ),
     ];
 
     for migration in migrations {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,7 +7,6 @@ pub use self::github_updater::GithubUpdater;
 pub(crate) use self::html::rewrite_lol;
 pub use self::queue::{get_crate_priority, remove_crate_priority, set_crate_priority};
 pub use self::queue_builder::queue_builder;
-pub use self::release_activity_updater::update_release_activity;
 pub(crate) use self::rustc_version::parse_rustc_version;
 
 #[cfg(test)]
@@ -23,6 +22,5 @@ mod html;
 mod pubsubhubbub;
 mod queue;
 mod queue_builder;
-mod release_activity_updater;
 mod rustc_version;
 pub(crate) mod sized_buffer;

--- a/src/utils/release_activity_updater.rs
+++ b/src/utils/release_activity_updater.rs
@@ -1,8 +1,0 @@
-use crate::error::Result;
-use postgres::Client;
-
-pub fn update_release_activity(conn: &mut Client) -> Result<()> {
-    conn.execute("REFRESH MATERIALIZED VIEW releases_statistics", &[])?;
-
-    Ok(())
-}

--- a/src/utils/release_activity_updater.rs
+++ b/src/utils/release_activity_updater.rs
@@ -1,70 +1,8 @@
 use crate::error::Result;
-use chrono::{Duration, Utc};
 use postgres::Client;
-use serde_json::{Map, Value};
 
 pub fn update_release_activity(conn: &mut Client) -> Result<()> {
-    let mut dates = Vec::with_capacity(30);
-    let mut crate_counts = Vec::with_capacity(30);
-    let mut failure_counts = Vec::with_capacity(30);
-
-    for day in 0..30 {
-        let rows = conn.query(
-            format!(
-                "SELECT COUNT(*)
-                 FROM releases
-                 WHERE release_time < NOW() - INTERVAL '{} day' AND
-                       release_time > NOW() - INTERVAL '{} day'",
-                day,
-                day + 1
-            )
-            .as_str(),
-            &[],
-        )?;
-        let failures_count_rows = conn.query(
-            format!(
-                "SELECT COUNT(*)
-                 FROM releases
-                 WHERE is_library = TRUE AND
-                       build_status = FALSE AND
-                       release_time < NOW() - INTERVAL '{} day' AND
-                       release_time > NOW() - INTERVAL '{} day'",
-                day,
-                day + 1
-            )
-            .as_str(),
-            &[],
-        )?;
-
-        let release_count: i64 = rows[0].get(0);
-        let failure_count: i64 = failures_count_rows[0].get(0);
-        let now = Utc::now().naive_utc();
-        let date = now - Duration::days(day);
-
-        dates.push(format!("{}", date.format("%d %b")));
-        crate_counts.push(release_count);
-        failure_counts.push(failure_count);
-    }
-
-    dates.reverse();
-    crate_counts.reverse();
-    failure_counts.reverse();
-
-    let map = {
-        let mut map = Map::new();
-        map.insert("dates".to_owned(), serde_json::to_value(dates)?);
-        map.insert("counts".to_owned(), serde_json::to_value(crate_counts)?);
-        map.insert("failures".to_owned(), serde_json::to_value(failure_counts)?);
-
-        Value::Object(map)
-    };
-
-    conn.query(
-        "INSERT INTO config (name, value) VALUES ('release_activity', $1)
-         ON CONFLICT (name) DO UPDATE
-            SET value = $1 WHERE config.name = 'release_activity'",
-        &[&map],
-    )?;
+    conn.execute("REFRESH MATERIALIZED VIEW releases_statistics", &[])?;
 
     Ok(())
 }

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -675,7 +675,7 @@ pub fn activity_handler(req: &mut Request) -> IronResult<Response> {
         conn.query(
             "
             WITH dates AS (
-                -- we need this series to we have also days in the statistic that don't have any releases
+                -- we need this series so that days in the statistic that don't have any releases are included
                 SELECT generate_series( 
                         CURRENT_DATE - interval '30 days',
                         CURRENT_DATE - interval '1 day',

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -17,7 +17,6 @@ use iron::{
 use postgres::Client;
 use router::Router;
 use serde::Serialize;
-use serde_json::{json, Value};
 
 /// Number of release in home page
 const RELEASES_IN_HOME: i64 = 15;
@@ -659,7 +658,9 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 struct ReleaseActivity {
     description: &'static str,
-    activity_data: Value,
+    dates: Vec<String>,
+    counts: Vec<i64>,
+    failures: Vec<i64>,
 }
 
 impl_webpage! {
@@ -714,13 +715,12 @@ pub fn activity_handler(req: &mut Request) -> IronResult<Response> {
 
     ReleaseActivity {
         description: "Monthly release activity",
-        activity_data: json!(
-            {
-                "dates": data.iter().map(|&d| d.0.format("%d %b").to_string()).collect::<Vec<_>>(),
-                "counts": data.iter().map(|&d| d.1).collect::<Vec<_>>(),
-                "failures": data.iter().map(|&d| d.2).collect::<Vec<_>>(),
-            }
-        ),
+        dates: data
+            .iter()
+            .map(|&d| d.0.format("%d %b").to_string())
+            .collect(),
+        counts: data.iter().map(|&d| d.1).collect(),
+        failures: data.iter().map(|&d| d.2).collect(),
     }
     .into_response(req)
 }

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -677,16 +677,16 @@ pub fn activity_handler(req: &mut Request) -> IronResult<Response> {
             WITH dates AS (
                 -- we need this series so that days in the statistic that don't have any releases are included
                 SELECT generate_series( 
-                        CURRENT_DATE - interval '30 days',
-                        CURRENT_DATE - interval '1 day',
+                        CURRENT_DATE - INTERVAL '30 days',
+                        CURRENT_DATE - INTERVAL '1 day',
                         '1 day'::interval
                     )::date AS date_
             ), 
             release_stats AS (
                 SELECT
                     release_time::date AS date_,
-                    count(*) AS counts,
-                    sum(CASE WHEN is_library = TRUE AND build_status = FALSE THEN 1 ELSE 0 END) AS failures
+                    COUNT(*) AS counts,
+                    SUM(CAST((is_library = TRUE AND build_status = FALSE) AS INT)) AS failures
                 FROM
                     releases
                 WHERE
@@ -696,12 +696,12 @@ pub fn activity_handler(req: &mut Request) -> IronResult<Response> {
                     release_time::date
             ) 
             SELECT 
-                dates.date_ as date,
-                COALESCE(rs.counts, 0) as counts,
-                COALESCE(rs.failures, 0) as failures 
+                dates.date_ AS date,
+                COALESCE(rs.counts, 0) AS counts,
+                COALESCE(rs.failures, 0) AS failures 
             FROM
                 dates 
-                left outer join release_stats as rs on dates.date_ = rs.date_
+                LEFT OUTER JOIN Release_stats AS rs ON dates.date_ = rs.date_
 
             ORDER BY 
                 dates.date_

--- a/templates/releases/activity.html
+++ b/templates/releases/activity.html
@@ -28,27 +28,21 @@
         new Chart(ctx, {
             type: "line",
             data: {
-                labels: [
-                    {% if activity_data.dates -%}
-                        {%- for date in activity_data.dates -%}
-                            {{ "'" ~ date ~ "'," }}
-                        {%- endfor -%}
-                    {%- endif %}
-                ],
+                labels: {{ dates | json_encode() | safe }},
                 datasets: [
                     {
                         label: "Releases",
                         borderColor: "#4d76ae",
                         backgroundColor: "#4d76ae",
                         fill: false,
-                        data: [{{ activity_data.counts | default(value=[]) | join(sep=", ") }}],
+                        data: {{ counts | json_encode() | safe }},
                     },
                     {
                         label: "Build Failures",
                         borderColor: "#434348",
                         backgroundColor: "#434348",
                         fill: false,
-                        data: [{{ activity_data.failures | default(value=[]) | join(sep=", ") }}],
+                        data: {{ failures | json_encode() | safe }},
                     },
                 ]
             },


### PR DESCRIPTION
the previous solution in `update_release_activity` used 60 separate queries. 

We can easily replace this with a materialized view while also extending the range to all of history (refreshing the view takes ~200ms currently). This would enable us also to extend the time being shown, if we wanted to. 

Another alternative approach could be to drop the background job completely (simplifying is always nice), and use a simple query with GROUP. 
This would runs in ~15ms  (compared to the <1ms for the query based on the materialized view). 

When there is a decision on which way to go I would also add some more tests. 