### PR TITLE
Update vulnerable dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,7 +1068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
- "version_check 0.9.1",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -2382,7 +2382,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "version_check 0.9.1",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -2395,7 +2395,7 @@ dependencies = [
  "quote",
  "syn",
  "syn-mid",
- "version_check 0.9.1",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -3624,7 +3624,7 @@ dependencies = [
  "standback",
  "stdweb",
  "time-macros",
- "version_check 0.9.1",
+ "version_check 0.9.2",
  "winapi 0.3.8",
 ]
 
@@ -3910,7 +3910,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.9.1",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -4019,9 +4019,9 @@ checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "void"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
+checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
 
 [[package]]
 name = "arrayref"
@@ -109,7 +109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "object",
  "rustc-demangle",
@@ -187,7 +187,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.3",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -264,6 +264,12 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
@@ -361,6 +367,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,7 +434,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -479,7 +491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg 1.0.0",
- "cfg-if",
+ "cfg-if 0.1.10",
  "crossbeam-utils",
  "lazy_static",
  "maybe-uninit",
@@ -493,7 +505,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "crossbeam-utils",
 ]
 
@@ -504,7 +516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg 1.0.0",
- "cfg-if",
+ "cfg-if 0.1.10",
  "lazy_static",
 ]
 
@@ -514,7 +526,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.14.3",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -533,7 +545,7 @@ dependencies = [
  "proc-macro2",
  "procedural-masquerade",
  "quote",
- "smallvec 0.6.13",
+ "smallvec 0.6.14",
  "syn",
 ]
 
@@ -550,7 +562,7 @@ dependencies = [
  "phf 0.8.0",
  "proc-macro2",
  "quote",
- "smallvec 1.4.0",
+ "smallvec 1.6.1",
  "syn",
 ]
 
@@ -606,7 +618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f260e2fc850179ef410018660006951c1b55b79e8087e87111a2c388994b9b5"
 dependencies = [
  "ahash",
- "cfg-if",
+ "cfg-if 0.1.10",
  "num_cpus",
 ]
 
@@ -636,7 +648,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.3",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -645,7 +657,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "dirs-sys",
 ]
 
@@ -773,7 +785,7 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -835,7 +847,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
  "winapi 0.3.8",
@@ -847,7 +859,7 @@ version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "crc32fast",
  "libc",
  "miniz_oxide",
@@ -956,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.5"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
+checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -966,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.5"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
 
 [[package]]
 name = "futures-executor"
@@ -983,15 +995,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.5"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
+checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.5"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
+checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1001,24 +1013,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.5"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
+checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
 
 [[package]]
 name = "futures-task"
-version = "0.3.5"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
-dependencies = [
- "once_cell",
-]
+checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
 
 [[package]]
 name = "futures-util"
-version = "0.3.5"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
+checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1027,7 +1036,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr 2.3.3",
- "pin-project",
+ "pin-project-lite 0.2.4",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1054,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60fb4bb6bba52f78a471264d9a3b7d026cc0af47b22cd2cffbc0b787ca003e63"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check 0.9.1",
@@ -1068,7 +1077,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi",
 ]
@@ -1243,6 +1252,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
 name = "humansize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.6"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e7655b9594024ad0ee439f3b5a7299369dc2a3f459b47c696f9ff676f9aa1f"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1290,13 +1305,13 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
- "log 0.4.8",
- "pin-project",
+ "pin-project 1.0.5",
  "socket2",
- "time 0.1.43",
  "tokio",
  "tower-service",
+ "tracing",
  "want",
 ]
 
@@ -1307,7 +1322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
 dependencies = [
  "bytes",
- "hyper 0.13.6",
+ "hyper 0.13.10",
  "native-tls",
  "tokio",
  "tokio-tls",
@@ -1584,7 +1599,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -1594,7 +1609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "169299b3b58aa5cd8ad25fd8fe984e93748046d24c80f05aaadd9022f95423ec"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 0.1.10",
  "cssparser 0.25.9",
  "encoding_rs",
  "lazy_static",
@@ -1728,7 +1743,7 @@ version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
@@ -1828,7 +1843,7 @@ version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.8",
 ]
@@ -1847,7 +1862,7 @@ checksum = "becb657d662f1cd2ef38c7ad480ec6b8cf9e96b27adb543e594f9cf0f2e6065c"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "void",
 ]
@@ -1954,7 +1969,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 0.1.10",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -2016,11 +2031,11 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
- "smallvec 1.4.0",
+ "smallvec 1.6.1",
  "winapi 0.3.8",
 ]
 
@@ -2030,12 +2045,12 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi 0.1.0",
  "instant",
  "libc",
  "redox_syscall",
- "smallvec 1.4.0",
+ "smallvec 1.6.1",
  "winapi 0.3.8",
 ]
 
@@ -2208,7 +2223,16 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edc93aeee735e60ecb40cf740eb319ff23eab1c5748abfdb5c180e4ce49f7791"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 0.4.17",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
+dependencies = [
+ "pin-project-internal 1.0.5",
 ]
 
 [[package]]
@@ -2223,10 +2247,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-internal"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7505eeebd78492e0f6108f7171c4948dbb120ee8119d9d77d0afa5469bef67f"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
@@ -2359,9 +2400,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.15"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
@@ -2371,9 +2412,9 @@ checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.13"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
@@ -2405,7 +2446,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d70cf4412832bcac9cffe27906f4a66e450d323525e977168c70d1b36120ae"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fnv",
  "lazy_static",
  "parking_lot 0.11.0",
@@ -2705,7 +2746,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
- "hyper 0.13.6",
+ "hyper 0.13.10",
  "hyper-tls",
  "js-sys",
  "lazy_static",
@@ -2714,7 +2755,7 @@ dependencies = [
  "mime_guess 2.0.3",
  "native-tls",
  "percent-encoding 2.1.0",
- "pin-project-lite",
+ "pin-project-lite 0.1.5",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2762,13 +2803,13 @@ dependencies = [
  "crc32fast",
  "futures",
  "http",
- "hyper 0.13.6",
+ "hyper 0.13.10",
  "hyper-tls",
  "lazy_static",
  "log 0.4.8",
  "md5",
  "percent-encoding 2.1.0",
- "pin-project",
+ "pin-project 0.4.17",
  "rusoto_credential",
  "rusoto_signature",
  "rustc_version",
@@ -2788,8 +2829,8 @@ dependencies = [
  "chrono",
  "dirs",
  "futures",
- "hyper 0.13.6",
- "pin-project",
+ "hyper 0.13.10",
+ "pin-project 0.4.17",
  "regex",
  "serde",
  "serde_json",
@@ -2823,16 +2864,16 @@ dependencies = [
  "hex",
  "hmac",
  "http",
- "hyper 0.13.6",
+ "hyper 0.13.10",
  "log 0.4.8",
  "md5",
  "percent-encoding 2.1.0",
- "pin-project",
+ "pin-project 0.4.17",
  "rusoto_credential",
  "rustc_version",
  "serde",
  "sha2",
- "time 0.2.16",
+ "time 0.2.25",
  "tokio",
 ]
 
@@ -3029,7 +3070,7 @@ dependencies = [
  "phf_codegen 0.7.24",
  "precomputed-hash",
  "servo_arc",
- "smallvec 0.6.13",
+ "smallvec 0.6.14",
  "thin-slice",
 ]
 
@@ -3049,7 +3090,7 @@ dependencies = [
  "phf_codegen 0.8.0",
  "precomputed-hash",
  "servo_arc",
- "smallvec 1.4.0",
+ "smallvec 1.6.1",
  "thin-slice",
 ]
 
@@ -3157,7 +3198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 0.1.10",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -3214,18 +3255,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
 dependencies = [
  "maybe-uninit",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.4.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "smol_str"
@@ -3242,7 +3283,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
  "winapi 0.3.8",
@@ -3403,9 +3444,9 @@ checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "syn"
-version = "1.0.22"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1425de3c33b0941002740a420b1a906a350b88d08b82b2c8a01035a3f9447bac"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3468,7 +3509,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand 0.7.3",
  "redox_syscall",
@@ -3574,11 +3615,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.16"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a51cadc5b1eec673a685ff7c33192ff7b7603d0b75446fb354939ee615acb15"
+checksum = "1195b046942c221454c2539395f85413b33383a067449d78aab2b7b052a142f7"
 dependencies = [
- "cfg-if",
+ "const_fn",
  "libc",
  "standback",
  "stdweb",
@@ -3637,7 +3678,7 @@ dependencies = [
  "mio-named-pipes",
  "mio-uds",
  "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.1.5",
  "signal-hook-registry",
  "slab",
  "tokio-macros",
@@ -3670,7 +3711,7 @@ dependencies = [
  "parking_lot 0.11.0",
  "percent-encoding 2.1.0",
  "phf 0.8.0",
- "pin-project-lite",
+ "pin-project-lite 0.1.5",
  "postgres-protocol",
  "postgres-types",
  "tokio",
@@ -3697,7 +3738,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log 0.4.8",
- "pin-project-lite",
+ "pin-project-lite 0.1.5",
  "tokio",
 ]
 
@@ -3715,6 +3756,27 @@ name = "tower-service"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+
+[[package]]
+name = "tracing"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "log 0.4.8",
+ "pin-project-lite 0.2.4",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "traitobject"
@@ -3866,7 +3928,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec 1.4.0",
+ "smallvec 1.6.1",
 ]
 
 [[package]]
@@ -4000,7 +4062,7 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -4027,7 +4089,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a369c5e1dfb7569e14d62af4da642a3cbc2f9a3652fe586e26ac22222aa4b04"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "js-sys",
  "wasm-bindgen",
  "web-sys",


### PR DESCRIPTION
This brings the number of vulnerable dependencies down from 8 to 1.
The remaining vulnerability can't be easily fixed:

```
> cargo tree -i generic-array:0.12.3
generic-array v0.12.3
├── block-buffer v0.7.3
│   └── sha-1 v0.8.2
│       [build-dependencies]
│       └── pest_meta v2.1.3
│           └── pest_generator v2.1.3
│               └── pest_derive v2.1.0 (proc-macro)
│                   ├── comrak v0.9.1
│                   │   └── docs-rs v0.6.0 (/home/joshua/src/rust/docs.rs)
│                   └── tera v1.5.0
│                       └── docs-rs v0.6.0 (/home/joshua/src/rust/docs.rs)
└── digest v0.8.1
    └── sha-1 v0.8.2 (*)
```

`pest` or `sha-1` will need to release a new version that depends on a
fixed version of generic-array. Fortunately it's only a build-time dependency for a pre-determined grammar, so it shouldn't impact us in practice.

Here's a list of all changes:

<details>

```
$ cat updates.txt
comrak
futures-core
futures-util
generic-array:0.12.3
generic-array:0.14.3
hyper:0.10.16
hyper:0.13.6
pest_derive
pest_generator
pest_meta
sha-1
smallvec:0.6.13
smallvec:1.4.0
time:0.2.16
$ xargs -n1 cargo update -p < updates.txt
    Updating arc-swap v0.4.6 -> v0.4.8
    Updating futures-core v0.3.5 -> v0.3.13
    Updating futures-channel v0.3.5 -> v0.3.13
    Updating futures-io v0.3.5 -> v0.3.13
    Updating futures-macro v0.3.5 -> v0.3.13
    Updating futures-sink v0.3.5 -> v0.3.13
    Updating futures-task v0.3.5 -> v0.3.13
    Updating futures-util v0.3.5 -> v0.3.13
      Adding pin-project-lite v0.2.4
    Updating proc-macro-hack v0.5.15 -> v0.5.19
    Updating generic-array v0.14.3 -> v0.14.4
      Adding cfg-if v1.0.0
      Adding httpdate v0.3.2
    Updating hyper v0.13.6 -> v0.13.10
      Adding pin-project v1.0.5
      Adding pin-project-internal v1.0.5
    Updating proc-macro2 v1.0.13 -> v1.0.24
    Updating syn v1.0.22 -> v1.0.60
      Adding tracing v0.1.25
      Adding tracing-core v0.1.17
    Updating smallvec v0.6.13 -> v0.6.14
    Updating smallvec v1.4.0 -> v1.6.1
      Adding const_fn v0.4.5
    Updating time v0.2.16 -> v0.2.25
```

</details>

Here are the previous warnings:

<details>

```
> cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 249 security advisories (from /home/joshua/.local/lib/cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (417 crate dependencies)
error: Vulnerable crates found!

ID:       RUSTSEC-2020-0091
Crate:    arc-swap
Version:  0.4.6
Date:     2020-12-10
URL:      https://rustsec.org/advisories/RUSTSEC-2020-0091
Title:    Dangling reference in `access::Map` with Constant
Solution:  upgrade to >= 1.1.0 OR >= 0.4.8
Dependency tree:
arc-swap 0.4.6
├── signal-hook-registry 1.2.0
│   └── tokio 0.2.22
│       ├── tokio-util 0.3.1
│       │   ├── tokio-postgres 0.5.5
│       │   │   └── postgres 0.17.5
│       │   │       ├── schemamama_postgres 0.3.0
│       │   │       │   └── docs-rs 0.6.0
│       │   │       ├── r2d2_postgres 0.16.0
│       │   │       │   └── docs-rs 0.6.0
│       │   │       └── docs-rs 0.6.0
│       │   └── h2 0.2.5
│       │       └── hyper 0.13.6
│       ├── tokio-tls 0.3.1
│       │   ├── reqwest 0.10.6
│       │   │   ├── rustwide 0.11.0
│       │   │   │   └── docs-rs 0.6.0
│       │   │   └── docs-rs 0.6.0
│       │   └── hyper-tls 0.4.1
│       │       ├── rusoto_core 0.45.0
│       │       │   ├── rusoto_s3 0.45.0
│       │       │   │   └── docs-rs 0.6.0
│       │       │   └── docs-rs 0.6.0
│       │       └── reqwest 0.10.6
│       ├── tokio-postgres 0.5.5
│       ├── rustwide 0.11.0
│       ├── rusoto_signature 0.45.0
│       │   └── rusoto_core 0.45.0
│       ├── rusoto_credential 0.45.0
│       │   ├── rusoto_signature 0.45.0
│       │   ├── rusoto_core 0.45.0
│       │   └── docs-rs 0.6.0
│       ├── rusoto_core 0.45.0
│       ├── reqwest 0.10.6
│       ├── postgres 0.17.5
│       ├── hyper-tls 0.4.1
│       ├── hyper 0.13.6
│       ├── h2 0.2.5
│       └── docs-rs 0.6.0
└── docs-rs 0.6.0

ID:       RUSTSEC-2020-0060
Crate:    futures-task
Version:  0.3.5
Date:     2020-09-04
URL:      https://rustsec.org/advisories/RUSTSEC-2020-0060
Title:    futures_task::waker may cause a use-after-free if used on a type that isn't 'static
Solution:  upgrade to >= 0.3.6
Dependency tree:
futures-task 0.3.5
├── futures-util 0.3.5
│   ├── rustwide 0.11.0
│   │   └── docs-rs 0.6.0
│   ├── reqwest 0.10.6
│   │   ├── rustwide 0.11.0
│   │   └── docs-rs 0.6.0
│   ├── hyper 0.13.6
│   ├── h2 0.2.5
│   │   └── hyper 0.13.6
│   ├── futures-executor 0.3.5
│   │   └── futures 0.3.5
│   │       ├── tokio-postgres 0.5.5
│   │       │   └── postgres 0.17.5
│   │       │       ├── schemamama_postgres 0.3.0
│   │       │       │   └── docs-rs 0.6.0
│   │       │       ├── r2d2_postgres 0.16.0
│   │       │       │   └── docs-rs 0.6.0
│   │       │       └── docs-rs 0.6.0
│   │       ├── rusoto_signature 0.45.0
│   │       │   └── rusoto_core 0.45.0
│   │       │       ├── rusoto_s3 0.45.0
│   │       │       │   └── docs-rs 0.6.0
│   │       │       └── docs-rs 0.6.0
│   │       ├── rusoto_s3 0.45.0
│   │       ├── rusoto_credential 0.45.0
│   │       │   ├── rusoto_signature 0.45.0
│   │       │   ├── rusoto_core 0.45.0
│   │       │   └── docs-rs 0.6.0
│   │       ├── rusoto_core 0.45.0
│   │       └── postgres 0.17.5
│   ├── futures 0.3.5
│   └── docs-rs 0.6.0
├── futures-executor 0.3.5
└── futures 0.3.5

ID:       RUSTSEC-2020-0059
Crate:    futures-util
Version:  0.3.5
Date:     2020-10-22
URL:      https://rustsec.org/advisories/RUSTSEC-2020-0059
Title:    MutexGuard::map can cause a data race in safe code
Solution:  upgrade to >= 0.3.7
Dependency tree:
futures-util 0.3.5
├── rustwide 0.11.0
│   └── docs-rs 0.6.0
├── reqwest 0.10.6
│   ├── rustwide 0.11.0
│   └── docs-rs 0.6.0
├── hyper 0.13.6
├── h2 0.2.5
│   └── hyper 0.13.6
├── futures-executor 0.3.5
│   └── futures 0.3.5
│       ├── tokio-postgres 0.5.5
│       │   └── postgres 0.17.5
│       │       ├── schemamama_postgres 0.3.0
│       │       │   └── docs-rs 0.6.0
│       │       ├── r2d2_postgres 0.16.0
│       │       │   └── docs-rs 0.6.0
│       │       └── docs-rs 0.6.0
│       ├── rusoto_signature 0.45.0
│       │   └── rusoto_core 0.45.0
│       │       ├── rusoto_s3 0.45.0
│       │       │   └── docs-rs 0.6.0
│       │       └── docs-rs 0.6.0
│       ├── rusoto_s3 0.45.0
│       ├── rusoto_credential 0.45.0
│       │   ├── rusoto_signature 0.45.0
│       │   ├── rusoto_core 0.45.0
│       │   └── docs-rs 0.6.0
│       ├── rusoto_core 0.45.0
│       └── postgres 0.17.5
├── futures 0.3.5
└── docs-rs 0.6.0

ID:       RUSTSEC-2020-0146
Crate:    generic-array
Version:  0.12.3
Date:     2020-04-09
URL:      https://rustsec.org/advisories/RUSTSEC-2020-0146
Title:    arr! macro erases lifetimes
Solution:  upgrade to >= 0.14.0
Dependency tree:
generic-array 0.12.3

ID:       RUSTSEC-2021-0020
Crate:    hyper
Version:  0.13.6
Date:     2021-02-05
URL:      https://rustsec.org/advisories/RUSTSEC-2021-0020
Title:    Multiple Transfer-Encoding headers misinterprets request payload
Solution:  upgrade to >= 0.14.3 OR ^0.13.10
Dependency tree:
hyper 0.13.6

ID:       RUSTSEC-2021-0003
Crate:    smallvec
Version:  0.6.13
Date:     2021-01-08
URL:      https://rustsec.org/advisories/RUSTSEC-2021-0003
Title:    Buffer overflow in SmallVec::insert_many
Solution:  upgrade to >= 0.6.14, < 1.0.0 OR >= 1.6.1
Dependency tree:
smallvec 0.6.13

ID:       RUSTSEC-2021-0003
Crate:    smallvec
Version:  1.4.0
Date:     2021-01-08
URL:      https://rustsec.org/advisories/RUSTSEC-2021-0003
Title:    Buffer overflow in SmallVec::insert_many
Solution:  upgrade to >= 0.6.14, < 1.0.0 OR >= 1.6.1
Dependency tree:
smallvec 1.4.0

ID:       RUSTSEC-2020-0071
Crate:    time
Version:  0.2.16
Date:     2020-11-18
URL:      https://rustsec.org/advisories/RUSTSEC-2020-0071
Title:    Potential segfault in the time crate
Solution:  upgrade to >= 0.2.23
Dependency tree:
time 0.2.16
```

</details>