### PR TITLE
add build tests for the doc-build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,13 @@ jobs:
       - name: Build
         run: cargo build --workspace --locked
 
-      - name: Test
+      - name: fast tests
         run: cargo test --workspace --locked
+
+      - name: slow tests
+        env:
+          DOCSRS_INCLUDE_DEFAULT_TARGETS: true
+        run: cargo test --workspace --locked -- --ignored
 
       - name: Clean up the database
         run: docker-compose down --volumes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,14 @@ jobs:
       - name: fast tests
         run: cargo test --workspace --locked
 
+      - name: create small build-environment
+        run: |
+          docker build -t buildenv - < dockerfiles/Dockerfile-small-build-env
+
       - name: slow tests
         env:
           DOCSRS_INCLUDE_DEFAULT_TARGETS: true
+          DOCS_RS_LOCAL_DOCKER_IMAGE: buildenv
         run: cargo test --workspace --locked -- --ignored
 
       - name: Clean up the database

--- a/dockerfiles/Dockerfile-small-build-env
+++ b/dockerfiles/Dockerfile-small-build-env
@@ -1,0 +1,6 @@
+FROM ubuntu:focal
+
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends apt-utils build-essential sudo git
+
+CMD ["bash"]

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -763,8 +763,9 @@ mod tests {
     #[ignore]
     fn test_build_crate() {
         wrapper(|env| {
-            let crate_ = "log";
-            let version = "0.4.14";
+            let crate_ = DUMMY_CRATE_NAME;
+            let crate_path = crate_.replace("-", "_");
+            let version = DUMMY_CRATE_VERSION;
             let default_target = "x86_64-unknown-linux-gnu";
 
             assert_eq!(env.config().include_default_targets, true);
@@ -821,21 +822,24 @@ mod tests {
             let base = format!("rustdoc/{}/{}", crate_, version);
 
             // default target was built and is accessible
-            assert!(storage.exists(&format!("{}/{}/index.html", base, crate_))?);
-            assert_success(&format!("/{0}/{1}/{0}", crate_, version), web)?;
+            assert!(storage.exists(&format!("{}/{}/index.html", base, crate_path))?);
+            assert_success(&format!("/{}/{}/{}", crate_, version, crate_path), web)?;
 
             // other targets too
             for target in DEFAULT_TARGETS {
                 let target_docs_present =
-                    storage.exists(&format!("{}/{}/{}/index.html", base, target, crate_))?;
+                    storage.exists(&format!("{}/{}/{}/index.html", base, target, crate_path))?;
 
-                let target_url = format!("/{0}/{1}/{2}/{0}/index.html", crate_, version, target);
+                let target_url = format!(
+                    "/{}/{}/{}/{}/index.html",
+                    crate_, version, target, crate_path
+                );
 
                 if target == &default_target {
                     assert!(!target_docs_present);
                     assert_redirect(
                         &target_url,
-                        &format!("/{0}/{1}/{0}/index.html", crate_, version),
+                        &format!("/{}/{}/{}/index.html", crate_, version, crate_path),
                         web,
                     )?;
                 } else {

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -753,3 +753,19 @@ pub(crate) struct BuildResult {
     pub(crate) docsrs_version: String,
     pub(crate) successful: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::wrapper;
+
+    #[test]
+    fn test_build_crate() {
+        wrapper(|env| {
+            let mut builder = RustwideBuilder::init(env).unwrap();
+            builder
+                .build_package("log", "0.4.14", PackageKind::CratesIo)
+                .map(|_| ())
+        })
+    }
+}

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -87,6 +87,9 @@ impl RustwideBuilder {
         if let Some(custom_image) = &config.local_docker_image {
             builder = builder.sandbox_image(SandboxImage::local(&custom_image)?);
         }
+        if cfg!(test) {
+            builder = builder.fast_init(true);
+        }
 
         let workspace = builder.init()?;
         workspace.purge_all_build_dirs()?;


### PR DESCRIPTION
We don't have any tests for the build-process, here we can add some. 

I don't know the build-process in detail, so 
- What would be valid assertions here? 
- should we test `add-essential-files` separately? 
- what other tests should we have? 

My current (not yet validated) assumption is that the container and rustwide `.workspace` will only set up once per job, and not per test-case. 

Also, these tests would definitely fail on macs, and also on some linux-machines (cc @Nemo157 ). What would be the best rust-way of splitting them and only running them on CI? Not sure if `#[ignore]` and `cargo test -- --ignored` is too hidden