### PR TITLE
Fix code blocks in `/about`

### DIFF
--- a/templates/core/about/builds.html
+++ b/templates/core/about/builds.html
@@ -32,13 +32,11 @@
     <p>
         To recognize Docs.rs from <code>build.rs</code> files, you can test for the environment variable <code>DOCS_RS</code>, e.g.:
         {% filter dedent(levels=4) -%}
-        <pre>
-            <code>
-                if let Ok(_) = std::env::var("DOCS_RS") {
-                    // ... your code here ...
-                }
-            </code>
-        </pre>
+        <pre><code class="lang-rust">
+            if let Ok(_) = std::env::var("DOCS_RS") {
+                // ... your code here ...
+            }
+        </code></pre>
         {%- endfilter %}
         This approach can be helpful if you need dependencies for building the library, but not for building the documentation.
     </p>
@@ -51,12 +49,10 @@
     <p>
         You can configure how your crate is built by adding <a href="metadata">package metadata</a> to your <code>Cargo.toml</code>, e.g.:
         {% filter dedent -%}
-        <pre>
-            <code>
-                [package.metadata.docs.rs]
-                rustc-args = ["--cfg", "docsrs"]
-            </code>
-        </pre>
+        <pre><code class="lang-toml">
+            [package.metadata.docs.rs]
+            rustc-args = ["--cfg", "docsrs"]
+        </code></pre>
         {%- endfilter %}
         Here, the compiler arguments are set so that <code>#[cfg(docsrs)]</code> (not to be confused with <code>#[cfg(doc)]</code>) can be used for conditional compilation.
         This approach is also useful for setting <a href="https://doc.rust-lang.org/cargo/reference/features.html">cargo features</a>.

--- a/templates/core/about/metadata.html
+++ b/templates/core/about/metadata.html
@@ -14,7 +14,7 @@
 
 	<p>The available configuration flags you can customize are:</p>
 
-	<pre><code>{%- include "core/Cargo.toml.example" -%}</code></pre>
+	<pre><code class="lang-toml">{%- include "core/Cargo.toml.example" -%}</code></pre>
 	</div>
 	</div>
 {%- endblock body %}


### PR DESCRIPTION
* Add `lang-` classes so hl.js identifies them correctly (it thought
  Rust was C++ and TOML was INI before)

* Remove large blank space caused by newlines in HTML source
