### PR TITLE
Allow unauthenticated users to set basic status labels

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,0 +1,6 @@
+[relabel]
+allow-unauthenticated = [
+    "S-waiting-on-review",
+    "S-waiting-on-author",
+    "S-blocked",
+]


### PR DESCRIPTION
More labels can be permitted later, but these labels are useful to
indicate the status of a PR. E.g., if someone addresses a review,
there should be a way for them to switch `S-waiting-on-author` to
`S-waiting-on-review`.
