### PR TITLE
CI: use rust-cache action for faster CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,34 +17,9 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-sweep
 
-      - name: Cache directories
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/bin
-            ~/.cargo/git
-          key: cargo-test-dirs-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-test-dirs-
-      - name: Cache build
-        uses: actions/cache@v2
-        with:
-          path: target
-          key: cargo-test-build-${{ steps.install.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cargo-test-build-${{ steps.install.outputs.rustc_hash }}-
-            cargo-test-build-
-
-      - name: Register artifacts
-        uses: actions-rs/cargo@v1
-        with:
-          command: sweep
-          args: --stamp
+      - name: restore build & cargo cache
+        uses: Swatinem/rust-cache@v1
 
       - name: Launch postgres and min.io
         run: |
@@ -76,12 +51,6 @@ jobs:
       - name: Clean up the database
         run: docker-compose down --volumes
 
-      - name: Clean unused artifacts
-        uses: actions-rs/cargo@v1
-        with:
-          command: sweep
-          args: --file
-
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
@@ -112,42 +81,11 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-sweep
 
-      - name: Cache directories
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/bin
-            ~/.cargo/git
-          key: cargo-clippy-dirs-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-clippy-dirs-
-      - name: Cache build
-        uses: actions/cache@v2
-        with:
-          path: target
-          key: cargo-clippy-${{ steps.install.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cargo-clippy-${{ steps.install.outputs.rustc_hash }}-
-            cargo-clippy-
-
-      - name: Register artifacts
-        uses: actions-rs/cargo@v1
-        with:
-          command: sweep
-          args: --stamp
+      - name: restore build & cargo cache
+        uses: Swatinem/rust-cache@v1
 
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --all-targets --workspace --locked -- -D warnings
-
-      - name: Clean unused artifacts
-        uses: actions-rs/cargo@v1
-        with:
-          command: sweep
-          args: --file


### PR DESCRIPTION
rust-cache caches most of the directories we cached previously, while
additionally deleting files that we don't need in the cache (about the files being cached, see [here](https://github.com/Swatinem/rust-cache/blob/a9bca6b5a60ce11e166697c7b09cfa308d92746a/src/common.ts#L25-L31) and [here](https://github.com/Swatinem/rust-cache/blob/a9bca6b5a60ce11e166697c7b09cfa308d92746a/src/common.ts#L73-L75))

Since the action already removes old files from the cache, we don't need
cargo-sweep any more. Slight difference is (to my understanding) that sweep is based on timestamping before and after the build, and this action [just deletes files with mtime > 7 days](https://github.com/Swatinem/rust-cache/blob/a9bca6b5a60ce11e166697c7b09cfa308d92746a/src/common.ts#L226-L228). 

improvements: 
- ~2 minutes for installing cargo sweep are removed 
- cache size is cut in half (from 1 gb to ~500MB) 
- due to the smaller cache size, restoring the cache goes down from 60-90 seconds to ~30 seconds

If I'm wrong with the assumption that we can remove cargo-sweep I'm happy to add it back, with the difference of the cache being used. 