### PR TITLE
Better fix code blocks in `/about`

### DIFF
--- a/templates/core/Cargo.toml.example
+++ b/templates/core/Cargo.toml.example
@@ -1,4 +1,4 @@
-{# The example Cargo.toml used in about.html #}
+{~# The example Cargo.toml used in about.html #~}
 [package]
 name = "test"
 

--- a/templates/core/about/builds.html
+++ b/templates/core/about/builds.html
@@ -31,12 +31,10 @@
     <h4 id="detecting-docsrs"> <a href="#detecting-docsrs">Detecting Docs.rs</a> </h4>
     <p>
         To recognize Docs.rs from <code>build.rs</code> files, you can test for the environment variable <code>DOCS_RS</code>, e.g.:
-        {% filter dedent(levels=4) -%}
-        <pre><code class="lang-rust">
-            if let Ok(_) = std::env::var("DOCS_RS") {
+        {% filter dedent(levels=3) -%}
+        <pre><code class="lang-rust">if let Ok(_) = std::env::var("DOCS_RS") {
                 // ... your code here ...
-            }
-        </code></pre>
+            }</code></pre>
         {%- endfilter %}
         This approach can be helpful if you need dependencies for building the library, but not for building the documentation.
     </p>
@@ -49,10 +47,8 @@
     <p>
         You can configure how your crate is built by adding <a href="metadata">package metadata</a> to your <code>Cargo.toml</code>, e.g.:
         {% filter dedent -%}
-        <pre><code class="lang-toml">
-            [package.metadata.docs.rs]
-            rustc-args = ["--cfg", "docsrs"]
-        </code></pre>
+        <pre><code class="lang-toml">[package.metadata.docs.rs]
+            rustc-args = ["--cfg", "docsrs"]</code></pre>
         {%- endfilter %}
         Here, the compiler arguments are set so that <code>#[cfg(docsrs)]</code> (not to be confused with <code>#[cfg(doc)]</code>) can be used for conditional compilation.
         This approach is also useful for setting <a href="https://doc.rust-lang.org/cargo/reference/features.html">cargo features</a>.


### PR DESCRIPTION
This is a followup to #1315 to fix the extra blank line at the top and
to fix the indentation.

This fix is based on this suggestion: https://github.com/rust-lang/docs.rs/pull/1315#issuecomment-803492287
