### PR TITLE
Remove `database_file_handler`; give precendence to router error messages

### DIFF
--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -163,9 +163,6 @@ mod tests {
 
     #[test]
     fn check_404_page_content_resource() {
-        // Resources with a `.js` and `.ico` extension are special cased in the
-        // routes_handler which is currently run last. This means that `get("resource.exe")` will
-        // fail with a `no so such crate` instead of 'no such resource'
         wrapper(|env| {
             let page = kuchiki::parse_html().one(
                 env.frontend()
@@ -180,7 +177,7 @@ mod tests {
                     .next()
                     .unwrap()
                     .text_contents(),
-                "The requested crate does not exist",
+                "The requested resource does not exist",
             );
 
             Ok(())
@@ -200,7 +197,7 @@ mod tests {
                     .next()
                     .unwrap()
                     .text_contents(),
-                "The requested crate does not exist",
+                "The requested version does not exist",
             );
 
             Ok(())
@@ -219,7 +216,7 @@ mod tests {
                     .next()
                     .unwrap()
                     .text_contents(),
-                "The requested crate does not exist",
+                "The requested version does not exist",
             );
 
             Ok(())
@@ -242,7 +239,7 @@ mod tests {
                     .next()
                     .unwrap()
                     .text_contents(),
-                "The requested crate does not exist",
+                "The requested version does not exist",
             );
 
             Ok(())

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -7,7 +7,7 @@ use iron::status::Status;
 use prometheus::{Encoder, HistogramVec, TextEncoder};
 use std::time::{Duration, Instant};
 
-pub fn metrics_handler(req: &mut Request) -> IronResult<Response> {
+pub(super) fn metrics_handler(req: &mut Request) -> IronResult<Response> {
     let metrics = extension!(req, Metrics);
     let pool = extension!(req, Pool);
     let queue = extension!(req, BuildQueue);
@@ -30,7 +30,7 @@ fn duration_to_seconds(d: Duration) -> f64 {
     d.as_secs() as f64 + nanos
 }
 
-pub struct RequestRecorder {
+pub(super) struct RequestRecorder {
     handler: Box<dyn iron::Handler>,
     route_name: String,
 }

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -516,7 +516,7 @@ pub fn target_redirect_handler(req: &mut Request) -> IronResult<Response> {
 
     let crate_details = match CrateDetails::new(&mut conn, &name, &version) {
         Some(krate) => krate,
-        None => return Err(Nope::ResourceNotFound.into()),
+        None => return Err(Nope::VersionNotFound.into()),
     };
 
     //   [crate, :name, :version, target-redirect, :target, *path]


### PR DESCRIPTION
The database handler was unused; the router already serves the favicon and it
doesn't do anything else. Note that 'database handler' is different
from 'files served from storage', the router already handles those.

This also fixes the long standing bug that all 404 errors are either
'crate not found' or 'resource not found'.

Closes https://github.com/rust-lang/docs.rs/issues/55. This builds on https://github.com/rust-lang/docs.rs/pull/1324.