### PR TITLE
Add hack so that docs from 2018-11-29 are styled correctly

### DIFF
--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -134,7 +134,7 @@ pub(super) fn build_routes() -> Routes {
     );
     routes.rustdoc_page(
         "/:crate/:version/:target",
-        super::rustdoc::rustdoc_redirector_handler,
+        super::rustdoc::rustdoc_static_file_hack,
     );
     routes.rustdoc_page(
         "/:crate/:version/:target/",


### PR DESCRIPTION
See comments in code. Fixes https://github.com/rust-lang/docs.rs/issues/1327.

r? @Nemo157 