### PR TITLE
Upload exactly the shared files needed and give precedence to global files over local ones

### DIFF
--- a/src/utils/copy.rs
+++ b/src/utils/copy.rs
@@ -1,41 +1,17 @@
-use std::ffi::OsStr;
 use std::fs;
 use std::io;
 use std::path::Path;
 
-use crate::error::Result;
-use regex::Regex;
-
-/// Copies documentation from a crate's target directory to destination.
-///
-/// Target directory must have doc directory.
-///
-/// This function is designed to avoid file duplications.
-pub(crate) fn copy_doc_dir(source: impl AsRef<Path>, destination: impl AsRef<Path>) -> Result<()> {
-    // Avoid copying common files
-    let dup_regex = Regex::new(
-        r"(\.lock|\.txt|\.woff|\.svg|\.css|main-.*\.css|main-.*\.js|normalize-.*\.js|rustdoc-.*\.css|storage-.*\.js|theme-.*\.js)$")
-        .unwrap();
-
-    copy_dir_all(source, destination, |filename| {
-        dup_regex.is_match(filename.to_str().unwrap())
-    })
-    .map_err(Into::into)
-}
-
-pub(crate) fn copy_dir_all(
-    src: impl AsRef<Path>,
-    dst: impl AsRef<Path>,
-    should_copy: impl Copy + Fn(&OsStr) -> bool,
-) -> io::Result<()> {
+/// cp -r src dst
+pub(crate) fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
     let dst = dst.as_ref();
     fs::create_dir_all(dst)?;
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let filename = entry.file_name();
         if entry.file_type()?.is_dir() {
-            copy_dir_all(entry.path(), dst.join(filename), should_copy)?;
-        } else if should_copy(&filename) {
+            copy_dir_all(entry.path(), dst.join(filename))?;
+        } else {
             fs::copy(entry.path(), dst.join(filename))?;
         }
     }
@@ -62,21 +38,11 @@ mod test {
         fs::create_dir(doc.join("inner")).unwrap();
 
         fs::write(doc.join("index.html"), "<html>spooky</html>").unwrap();
-        fs::write(doc.join("index.txt"), "spooky").unwrap();
         fs::write(doc.join("inner").join("index.html"), "<html>spooky</html>").unwrap();
-        fs::write(doc.join("inner").join("index.txt"), "spooky").unwrap();
-        fs::write(doc.join("inner").join("important.svg"), "<svg></svg>").unwrap();
 
         // lets try to copy a src directory to tempdir
-        copy_doc_dir(source.path().join("doc"), destination.path()).unwrap();
+        copy_dir_all(source.path().join("doc"), destination.path()).unwrap();
         assert!(destination.path().join("index.html").exists());
-        assert!(!destination.path().join("index.txt").exists());
         assert!(destination.path().join("inner").join("index.html").exists());
-        assert!(!destination.path().join("inner").join("index.txt").exists());
-        assert!(!destination
-            .path()
-            .join("inner")
-            .join("important.svg")
-            .exists());
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,7 +1,7 @@
 //! Various utilities for docs.rs
 
 pub(crate) use self::cargo_metadata::{CargoMetadata, Package as MetadataPackage};
-pub(crate) use self::copy::{copy_dir_all, copy_doc_dir};
+pub(crate) use self::copy::copy_dir_all;
 pub use self::daemon::start_daemon;
 pub use self::github_updater::GithubUpdater;
 pub(crate) use self::html::rewrite_lol;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,7 +1,7 @@
 //! Various utilities for docs.rs
 
 pub(crate) use self::cargo_metadata::{CargoMetadata, Package as MetadataPackage};
-pub(crate) use self::copy::copy_doc_dir;
+pub(crate) use self::copy::{copy_dir_all, copy_doc_dir};
 pub use self::daemon::start_daemon;
 pub use self::github_updater::GithubUpdater;
 pub(crate) use self::html::rewrite_lol;


### PR DESCRIPTION
See [rust-lang/rust#83784](https://github.com/rust-lang/rust/issues/83784#user-content-why-does-this-feature-exist) for more info about the history of this PR (and the commits also have more information).

- Use `--emit=unversioned-files,toolchain-shared-files` for generating the shared files
- Use `--emit=invocation-specific` for building crates
- Give precedence to global shared files over local ones
  
Fixes https://github.com/rust-lang/docs.rs/issues/1327. Fixes https://github.com/rust-lang/docs.rs/issues/294 (hopefully for real this time).

r? @Nemo157