### PR TITLE
Handle 404s and semver in source file viewer

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -47,6 +47,13 @@ pub(crate) fn assert_success(path: &str, web: &TestFrontend) -> Result<(), Error
     Ok(())
 }
 
+/// Make sure that a URL returns a 404
+pub(crate) fn assert_not_found(path: &str, web: &TestFrontend) -> Result<(), Error> {
+    let status = web.get(path).send()?.status();
+    assert_eq!(status, 404, "GET {} should have been a 404", path);
+    Ok(())
+}
+
 /// Make sure that a URL redirects to a specific page
 pub(crate) fn assert_redirect(
     path: &str,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -16,7 +16,7 @@ macro_rules! ctry {
                 let request: &::iron::Request = $req;
 
                 ::log::error!(
-                    "called ctry!() on an `Err` value: {}\nnote: while attempting to fetch the route {:?}\n{:?}",
+                    "called ctry!() on an `Err` value: {:?}\nnote: while attempting to fetch the route {:?}\n{:?}",
                     error,
                     request.url,
                     ::backtrace::Backtrace::new(),


### PR DESCRIPTION
This also changes `ctry!` to print the debug version of errors so it's possible to see what goes wrong when a template fails to render.

Closes https://github.com/rust-lang/docs.rs/issues/1344. Closes https://github.com/rust-lang/docs.rs/issues/1347.