### PR TITLE
Use linux-micro sandbox image for local development

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,3 +5,4 @@ AWS_ACCESS_KEY_ID=cratesfyi
 AWS_SECRET_ACCESS_KEY=secret_key
 S3_ENDPOINT=http://localhost:9000
 DOCSRS_INCLUDE_DEFAULT_TARGETS=false
+DOCSRS_DOCKER_IMAGE=ghcr.io/rust-lang/crates-build-env/linux-micro

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,10 @@ jobs:
       - name: fast tests
         run: cargo test --workspace --locked
 
-      - name: create small build-environment
-        run: |
-          docker build -t buildenv - < dockerfiles/Dockerfile-small-build-env
-
       - name: slow tests
         env:
           DOCSRS_INCLUDE_DEFAULT_TARGETS: true
-          DOCS_RS_LOCAL_DOCKER_IMAGE: buildenv
+          DOCSRS_DOCKER_IMAGE: ghcr.io/rust-lang/crates-build-env/linux-micro
         run: cargo test --workspace --locked -- --ignored
 
       - name: Clean up the database

--- a/dockerfiles/Dockerfile-small-build-env
+++ b/dockerfiles/Dockerfile-small-build-env
@@ -1,6 +1,0 @@
-FROM ubuntu:focal
-
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends apt-utils build-essential sudo git
-
-CMD ["bash"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,7 +57,7 @@ pub struct Config {
     pub(crate) build_attempts: u16,
     pub(crate) rustwide_workspace: PathBuf,
     pub(crate) inside_docker: bool,
-    pub(crate) local_docker_image: Option<String>,
+    pub(crate) docker_image: Option<String>,
     pub(crate) toolchain: String,
     pub(crate) build_cpu_limit: Option<u32>,
     pub(crate) include_default_targets: bool,
@@ -108,7 +108,8 @@ impl Config {
 
             rustwide_workspace: env("CRATESFYI_RUSTWIDE_WORKSPACE", PathBuf::from(".workspace"))?,
             inside_docker: env("DOCS_RS_DOCKER", false)?,
-            local_docker_image: maybe_env("DOCS_RS_LOCAL_DOCKER_IMAGE")?,
+            docker_image: maybe_env("DOCS_RS_LOCAL_DOCKER_IMAGE")?
+                .or(maybe_env("DOCSRS_DOCKER_IMAGE")?),
             toolchain: env("CRATESFYI_TOOLCHAIN", "nightly".to_string())?,
             build_cpu_limit: maybe_env("DOCS_RS_BUILD_CPU_LIMIT")?,
             include_default_targets: env("DOCSRS_INCLUDE_DEFAULT_TARGETS", true)?,


### PR DESCRIPTION
- Add support for overriding remote docker images

  Previously, only local images could be overridden.

  This adds a new env variable DOCSRS_DOCKER_IMAGE, and makes the existing
  variable DOCS_RS_LOCAL_DOCKER_IMAGE a synonym for it. At some point I
  want to remove the old name, but that requires updating forge first.

- Use the linux-micro image for tests

  I tested that this can build `hexponent 0.3.0` successfully. This cuts
  the download size down from over 1 GB to about 150 MB.

Thank you pietro for your hard work on https://github.com/rust-lang/crates-build-env/pull/78!

r? @pietroalbini
cc @rust-lang/docs-rs - you'll want to update your .env files so it's easier to run builds.