### PR TITLE
Reduce logging at startup

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -144,7 +144,7 @@ where
             .map(Some)
             .with_context(|_| format!("failed to parse configuration variable {}", var))?),
         Err(VarError::NotPresent) => {
-            log::debug!("optional configuration variable {} is not set", var);
+            log::trace!("optional configuration variable {} is not set", var);
             Ok(None)
         }
         Err(VarError::NotUnicode(_)) => bail!("configuration variable {} is not UTF-8", var),


### PR DESCRIPTION
There are enough unset env variables that I've stopped reading them all,
and this has just become noise.

Before, useful information would be drowned in debug logging:

```
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable DOCSRS_BUILD_ATTEMPTS is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable REGISTRY_INDEX_PATH is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable REGISTRY_URL is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable DOCSRS_MAX_POOL_SIZE is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable DOCSRS_MIN_POOL_IDLE is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable DOCSRS_S3_BUCKET is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable S3_REGION is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable S3_ENDPOINT is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable DOCSRS_GITHUB_UPDATER_MIN_RATE_LIMIT is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable DOCSRS_GITLAB_ACCESSTOKEN is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable DOCSRS_MAX_FILE_SIZE is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable DOCSRS_MAX_FILE_SIZE_HTML is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable DOCSRS_MAX_PARSE_MEMORY is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable DOCSRS_REGISTRY_GC_INTERVAL is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable DOCSRS_RANDOM_CRATE_SEARCH_VIEW_SIZE is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable DOCSRS_CSP_REPORT_ONLY is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable DOCS_RS_DOCKER is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable DOCS_RS_LOCAL_DOCKER_IMAGE is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable DOCSRS_INCLUDE_DEFAULT_TARGETS is not set
2021/04/18 13:56:21 [DEBUG] docs_rs::config: optional configuration variable DOCSRS_DISABLE_MEMORY_LIMIT is not set
2021/04/18 09:57:17 [WARN] docs_rs::repositories::github: did not collect `github.com` stats as no token was provided
2021/04/18 09:57:17 [WARN] docs_rs::repositories::gitlab: will try to retrieve `gitlab.com` stats without token since none was provided
2021/04/18 09:57:17 [WARN] docs_rs::repositories::gitlab: will try to retrieve `gitlab.freedesktop.org` stats without token since none was provided
2021/04/18 09:57:17 [INFO] docs_rs::web: Running docs.rs web server on http://0.0.0.0:3000
```

Now, only useful info is shown:

```
2021/04/18 09:57:17 [WARN] docs_rs::repositories::github: did not collect `github.com` stats as no token was provided
2021/04/18 09:57:17 [WARN] docs_rs::repositories::gitlab: will try to retrieve `gitlab.com` stats without token since none was provided
2021/04/18 09:57:17 [WARN] docs_rs::repositories::gitlab: will try to retrieve `gitlab.freedesktop.org` stats without token since none was provided
2021/04/18 09:57:17 [INFO] docs_rs::web: Running docs.rs web server on http://0.0.0.0:3000
```

r? @Nemo157