### PR TITLE
Show at most one crate from the same repo in /releases search

### DIFF
--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -368,14 +368,16 @@ impl FakeGithubStats {
             .get(0);
         let host_id = base64::encode(format!("FAKE ID {}", existing_count));
 
-        let data = conn.query_one(
+        let data = conn.query(
             "INSERT INTO repositories (host, host_id, name, description, last_commit, stars, forks, issues, updated_at)
              VALUES ('github.com', $1, $2, 'Fake description!', NOW(), $3, $4, $5, NOW())
+             ON CONFLICT (host, name) DO UPDATE SET stars = $3, forks = $4, issues = $5
              RETURNING id;",
             &[&host_id, &self.repo, &self.stars, &self.forks, &self.issues],
         )?;
+        assert_eq!(data.len(), 1);
 
-        Ok(data.get(0))
+        Ok(data[0].get(0))
     }
 }
 


### PR DESCRIPTION
This avoids showing rustc_ap_* three dozen times in a row.

TODO: is it correct to pick the latest published crate? Is there a way
to find the "main" crate from a repository?

The first commit caught several bugs and should go in separately even if this doesn't land.

Fixes https://github.com/rust-lang/docs.rs/issues/985.