### PR TITLE
Resolves #530 - add_package - makes less database calls & add tests for keywords and owners

### DIFF
--- a/src/index/api.rs
+++ b/src/index/api.rs
@@ -41,7 +41,7 @@ impl Default for ReleaseData {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CrateOwner {
     pub(crate) avatar: String,
     pub(crate) email: String,

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -188,6 +188,11 @@ impl<'a> FakeRelease<'a> {
         self
     }
 
+    pub(crate) fn keywords(mut self, keywords: Vec<String>) -> Self {
+        self.package.keywords = keywords;
+        self
+    }
+
     pub(crate) fn add_platform<S: Into<String>>(mut self, platform: S) -> Self {
         let platform = platform.into();
         let name = self.package.targets[0].name.clone();

--- a/src/utils/cargo_metadata.rs
+++ b/src/utils/cargo_metadata.rs
@@ -44,7 +44,7 @@ impl CargoMetadata {
     }
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Default)]
 pub(crate) struct Package {
     pub(crate) id: String,
     pub(crate) name: String,


### PR DESCRIPTION
This reduces the amount of queries for adding/updating owners and keywords in the database. For both parts I added some tests. 

I kept single queries for some parts because the prepare/execute combination is typically only slightly slower than the bulk-query, and bulk-insert/update queries imply constructing the sql & escaping it correctly, which makes it less readable IMHO without having an ORM. 

As always, I'm happy to implement any improvements / changes or fix any mistakes I made. 