### PR TITLE
Remove the 'build queue' link from the topbar

### DIFF
--- a/templates/header/topbar_begin.html
+++ b/templates/header/topbar_begin.html
@@ -44,7 +44,6 @@
                             {{ macros::menu_link(href="/releases/recent-failures", text="Recent Build Failures") }}
                             {{ macros::menu_link(href="/releases/failures", text="Build Failures by Stars") }}
                             {{ macros::menu_link(href="/releases/activity", text="Release Activity") }}
-                            {{ macros::menu_link(href="/releases/queue", text="Build Queue") }}
                         </ul>
                     </li>{#
 


### PR DESCRIPTION
It's already linked prominently in the footer, it doesn't need to be in both.