### PR TITLE
CI: split build-tests into separate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,12 @@ jobs:
             -executable -type f \
             -exec cp {} ./test-binaries/ \;
 
-      - name: set up test binaries to cache
-        uses: actions/cache@v2
+      - uses: actions/upload-artifact@v2
+        name: set up test binaries to cache
         with:
-          path: "./test-binaries"
-          key: test-binaries-${{ github.sha }}
+          name: test-binaries-${{ github.sha }}
+          path: ./test-binaries/
+          retention-days: 1
 
   test:
     runs-on: ubuntu-latest
@@ -44,10 +45,10 @@ jobs:
       - uses: actions/checkout@master
 
       - name: get test binaries from cache
-        uses: actions/cache@v2
+        uses: actions/download-artifact@v2
         with:
-          path: "./test-binaries"
-          key: test-binaries-${{ github.sha }}
+          name: test-binaries-${{ github.sha }}
+          path: ./test-binaries/
 
       - name: Launch postgres and min.io
         run: |
@@ -65,6 +66,7 @@ jobs:
         run: |
           for f in ./test-binaries/*; do
             echo "running $f"
+            chmod +x $f  # GH action artifacts don't handle permissions
             $f || exit 1
           done
 
@@ -79,10 +81,10 @@ jobs:
       - uses: actions/checkout@master
 
       - name: get test binaries from cache
-        uses: actions/cache@v2
+        uses: actions/download-artifact@v2
         with:
-          path: "./test-binaries"
-          key: test-binaries-${{ github.sha }}
+          name: test-binaries-${{ github.sha }}
+          path: ./test-binaries/
 
       - name: Launch postgres and min.io
         run: |
@@ -102,6 +104,7 @@ jobs:
         run: |
           for f in ./test-binaries/*; do
             echo "running $f"
+            chmod +x $f  # GH action artifacts don't handle permissions
             $f --ignored || exit 1
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,8 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  test:
-    name: Test
+  build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@master
       - id: install
@@ -20,6 +18,36 @@ jobs:
 
       - name: restore build & cargo cache
         uses: Swatinem/rust-cache@v1
+
+      - name: Build
+        run: cargo build --workspace --locked
+
+      - name: compile test binaries
+        run: |
+          cargo test --no-run
+          mkdir ./test-binaries/
+          find ./target \
+            -name "docs_rs*" \
+            -executable -type f \
+            -exec cp {} ./test-binaries/ \;
+
+      - name: set up test binaries to cache
+        uses: actions/cache@v2
+        with:
+          path: "./test-binaries"
+          key: test-binaries-${{ github.sha }}
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@master
+
+      - name: get test binaries from cache
+        uses: actions/cache@v2
+        with:
+          path: "./test-binaries"
+          key: test-binaries-${{ github.sha }}
 
       - name: Launch postgres and min.io
         run: |
@@ -32,17 +60,50 @@ jobs:
           # Make sure the database is actually working
           psql "${CRATESFYI_DATABASE_URL}"
 
-      - name: Build
-        run: cargo build --workspace --locked
+      - name: run tests
+        shell: bash
+        run: |
+          for f in ./test-binaries/*; do
+            echo "running $f"
+            $f || exit 1
+          done
 
-      - name: fast tests
-        run: cargo test --workspace --locked
+      - name: Clean up the database
+        run: docker-compose down --volumes
+
+  build_tests:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: get test binaries from cache
+        uses: actions/cache@v2
+        with:
+          path: "./test-binaries"
+          key: test-binaries-${{ github.sha }}
+
+      - name: Launch postgres and min.io
+        run: |
+          cp .env.sample .env
+          . .env
+          mkdir -p ${CRATESFYI_PREFIX}/public-html
+          docker-compose up -d db s3
+          # Give the database enough time to start up
+          sleep 5
+          # Make sure the database is actually working
+          psql "${CRATESFYI_DATABASE_URL}"
 
       - name: slow tests
         env:
           DOCSRS_INCLUDE_DEFAULT_TARGETS: true
           DOCSRS_DOCKER_IMAGE: ghcr.io/rust-lang/crates-build-env/linux-micro
-        run: cargo test --workspace --locked -- --ignored
+        run: |
+          for f in ./test-binaries/*; do
+            echo "running $f"
+            $f --ignored || exit 1
+          done
 
       - name: Clean up the database
         run: docker-compose down --volumes


### PR DESCRIPTION
Downside is that all the setup has to be done twice, while I believe that with caching most builds should be faster. 