### PR TITLE
add scheduled test-run at night

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
 
 env:
   RUST_BACKTRACE: 1


### PR DESCRIPTION
following the issue with nightly breaking our build we should start having a nightly test-run to be notified when the build breaks. 

IMHO it doesn't hurt to just run the normal CI-job, of course we could split these into two separate workflows where we only schedule the build-test. 