### PR TITLE
Update comrak to 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "comrak"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e35da16961500625e065fba09983bb300bbf3c6fbc1840bd5bbda595ee6d80"
+checksum = "b423acba50d5016684beaf643f9991e622633a4c858be6885653071c2da2b0c6"
 dependencies = [
  "entities",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ badge = { path = "crates/badge" }
 docsrs-metadata = { path = "crates/metadata" }
 backtrace = "0.3"
 failure = { version = "0.1.3", features = ["backtrace"] }
-comrak = { version = "0.9.1", default-features = false }
+comrak = { version = "0.10.1", default-features = false }
 toml = "0.5"
 schemamama = "0.3"
 schemamama_postgres = "0.3"


### PR DESCRIPTION
Another XSS vulnerability (similar to #1282) has been reported; see https://github.com/kivikakk/comrak/issues/187.