### PR TITLE
strip blank line from examples in <pre>

### DIFF
--- a/templates/core/about/builds.html
+++ b/templates/core/about/builds.html
@@ -32,11 +32,9 @@
     <p>
         To recognize Docs.rs from <code>build.rs</code> files, you can test for the environment variable <code>DOCS_RS</code>, e.g.:
         {% filter dedent(levels=4) -%}
-        <pre><code class="lang-rust">
-            if let Ok(_) = std::env::var("DOCS_RS") {
+        <pre><code class="lang-rust">if let Ok(_) = std::env::var("DOCS_RS") {
                 // ... your code here ...
-            }
-        </code></pre>
+            }</code></pre>
         {%- endfilter %}
         This approach can be helpful if you need dependencies for building the library, but not for building the documentation.
     </p>
@@ -49,10 +47,8 @@
     <p>
         You can configure how your crate is built by adding <a href="metadata">package metadata</a> to your <code>Cargo.toml</code>, e.g.:
         {% filter dedent -%}
-        <pre><code class="lang-toml">
-            [package.metadata.docs.rs]
-            rustc-args = ["--cfg", "docsrs"]
-        </code></pre>
+        <pre><code class="lang-toml">[package.metadata.docs.rs]
+            rustc-args = ["--cfg", "docsrs"]</code></pre>
         {%- endfilter %}
         Here, the compiler arguments are set so that <code>#[cfg(docsrs)]</code> (not to be confused with <code>#[cfg(doc)]</code>) can be used for conditional compilation.
         This approach is also useful for setting <a href="https://doc.rust-lang.org/cargo/reference/features.html">cargo features</a>.


### PR DESCRIPTION
There is a special parsing rule for the &lt;pre> tag itself which forces to
ignore the leading line breaks to be removed[1]. But it does not work on a
nested &lt;code> tag.

[1]: https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody

***

I am sure there should be a better way to do it. Heck, I'm not even sure if this would be rendered correctly! But for now, pointing out a problem, and providing you with such PR is the best I can do.