### PR TITLE
fixes #1409: internal server error with two slashes at the end of the URL

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -167,18 +167,6 @@ impl Handler for MainHandler {
             }
         }
 
-        fn pass_iron_errors_with_redirect(e: IronError) -> IronResult<Response> {
-            // in some cases the iron router will return a redirect as an `IronError`.
-            // Here we convert these into an `Ok(Response)`.
-            if e.error.downcast_ref::<TrailingSlash>().is_some()
-                || e.response.status == Some(status::MovedPermanently)
-            {
-                Ok(e.response)
-            } else {
-                Err(e)
-            }
-        }
-
         // This is kind of a mess.
         //
         // Almost all files should be served through the `router_handler`; eventually
@@ -195,7 +183,17 @@ impl Handler for MainHandler {
         self.shared_resource_handler
             .handle(req)
             .or_else(|e| if_404(e, || self.router_handler.handle(req)))
-            .or_else(pass_iron_errors_with_redirect)
+            .or_else(|e| {
+                // in some cases the iron router will return a redirect as an `IronError`.
+                // Here we convert these into an `Ok(Response)`.
+                if e.error.downcast_ref::<TrailingSlash>().is_some()
+                    || e.response.status == Some(status::MovedPermanently)
+                {
+                    Ok(e.response)
+                } else {
+                    Err(e)
+                }
+            })
             .or_else(|e| {
                 let err = if let Some(err) = e.error.downcast_ref::<error::Nope>() {
                     *err


### PR DESCRIPTION
When iron finds a slash at the end of the route if will try to redirect if the route exists without the slash in the end. 
This leads to an `IronError` which contains a normal permanent redirect as response. 

This is no error for us, we can just return `Ok(error.response)` for these cases. 

