### PR TITLE
Don't read Cargo.toml.orig

### DIFF
--- a/crates/metadata/lib.rs
+++ b/crates/metadata/lib.rs
@@ -166,20 +166,14 @@ pub struct BuildTargets<'a> {
 impl Metadata {
     /// Read the `Cargo.toml` from a source directory, then parse the build metadata.
     ///
-    /// If both `Cargo.toml` and `Cargo.toml.orig` exist in the directory,
-    /// `Cargo.toml.orig` will take precedence.
-    ///
     /// If you already have the path to a TOML file, use [`Metadata::from_manifest`] instead.
     pub fn from_crate_root<P: AsRef<Path>>(source_dir: P) -> Result<Metadata, MetadataError> {
-        let source_dir = source_dir.as_ref();
-        for &c in &["Cargo.toml.orig", "Cargo.toml"] {
-            let manifest_path = source_dir.join(c);
-            if manifest_path.exists() {
-                return Metadata::from_manifest(manifest_path);
-            }
+        let manifest_path = source_dir.as_ref().join("Cargo.toml");
+        if manifest_path.exists() {
+            Metadata::from_manifest(manifest_path)
+        } else {
+            Err(io::Error::new(io::ErrorKind::NotFound, "no Cargo.toml").into())
         }
-
-        Err(io::Error::new(io::ErrorKind::NotFound, "no Cargo.toml").into())
     }
 
     /// Read the given file into a string, then parse the build metadata.


### PR DESCRIPTION
Cargo won't use it, so neither should docs.rs. It's purely informative
for people reading source code.

Fixes https://github.com/rust-lang/docs.rs/issues/1286.

r? @Nemo157 