### PR TITLE
Give a hard error if outdated environment variables are set

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -66,6 +66,26 @@ pub struct Config {
 
 impl Config {
     pub fn from_env() -> Result<Self, Error> {
+        let old_vars = [
+            ("CRATESFYI_PREFIX", "DOCSRS_PREFIX"),
+            ("CRATESFYI_DATABASE_URL", "DOCSRS_DATABASE_URL"),
+            ("CRATESFYI_GITHUB_ACCESSTOKEN", "DOCSRS_GITHUB_ACCESSTOKEN"),
+            ("CRATESFYI_RUSTWIDE_WORKSPACE", "DOCSRS_RUSTWIDE_WORKSPACE"),
+            ("CRATESFYI_TOOLCHAIN", "DOCSRS_TOOLCHAIN"),
+            ("DOCS_RS_DOCKER", "DOCSRS_DOCKER"),
+            ("DOCS_RS_LOCAL_DOCKER_IMAGE", "DOCSRS_DOCKER_IMAGE"),
+            ("DOCS_RS_BULID_CPU_LIMIT", "DOCSRS_BULID_CPU_LIMIT"),
+        ];
+        for (old_var, new_var) in old_vars {
+            if std::env::var(old_var).is_ok() {
+                failure::bail!(
+                    "env variable {} is no longer accepted; use {} instead",
+                    old_var,
+                    new_var
+                );
+            }
+        }
+
         let prefix: PathBuf = require_env("DOCSRS_PREFIX")?;
 
         Ok(Self {


### PR DESCRIPTION
This avoids confusion where the environment variable works with some versions of docs.rs but fails silently with others.

Follow-up to https://github.com/rust-lang/docs.rs/pull/1373.

r? @pietroalbini