### PR TITLE
Don't spam migrating logs when running tests

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 DOCSRS_PREFIX=ignored/cratesfyi-prefix
 DOCSRS_DATABASE_URL=postgresql://cratesfyi:password@localhost:15432
-DOCSRS_LOG=docs_rs,rustwide=info
+DOCSRS_LOG=docs_rs=debug,rustwide=info
 AWS_ACCESS_KEY_ID=cratesfyi
 AWS_SECRET_ACCESS_KEY=secret_key
 S3_ENDPOINT=http://localhost:9000

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -1,6 +1,6 @@
 //! Database migrations
 
-use log::info;
+use log::{log, Level};
 use postgres::{Client, Error as PostgresError, Transaction};
 use schemamama::{Migration, Migrator, Version};
 use schemamama_postgres::{PostgresAdapter, PostgresMigration};
@@ -27,9 +27,16 @@ macro_rules! migration {
                 $description.to_owned()
             }
         }
+
         impl PostgresMigration for Amigration {
             fn up(&self, transaction: &mut Transaction) -> Result<(), PostgresError> {
-                info!(
+                let level = if cfg!(test) {
+                    Level::Trace
+                } else {
+                    Level::Info
+                };
+                log!(
+                    level,
                     "Applying migration {}: {}",
                     self.version(),
                     self.description()
@@ -37,7 +44,13 @@ macro_rules! migration {
                 transaction.batch_execute($up).map(|_| ())
             }
             fn down(&self, transaction: &mut Transaction) -> Result<(), PostgresError> {
-                info!(
+                let level = if cfg!(test) {
+                    Level::Trace
+                } else {
+                    Level::Info
+                };
+                log!(
+                    level,
                     "Removing migration {}: {}",
                     self.version(),
                     self.description()


### PR DESCRIPTION
We run these all the way from 0 to 29 and back when running tests, which
causes quite a lot of output. This changes the output to `trace` in
tests, and changes the default logging to only show `debug` and above.

r? @Nemo157 