### PR TITLE
Remove all traces of cratesfyi (to the extent possible)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,7 @@
-DOCSRS_PREFIX=ignored/cratesfyi-prefix
-DOCSRS_DATABASE_URL=postgresql://cratesfyi:password@localhost:15432
+DOCSRS_PREFIX=ignored/docsrs-prefix
+DOCSRS_DATABASE_URL=postgresql://docsrs:password@localhost:15432
 DOCSRS_LOG=docs_rs=debug,rustwide=info
-AWS_ACCESS_KEY_ID=cratesfyi
+AWS_ACCESS_KEY_ID=docsrs
 AWS_SECRET_ACCESS_KEY=secret_key
 S3_ENDPOINT=http://localhost:9000
 DOCSRS_INCLUDE_DEFAULT_TARGETS=false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ name = "compression"
 harness = false
 
 [[bin]]
-name = "cratesfyi"
+name = "docsrs"
+path = "src/main.rs"
 test = false
 doc = false

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cd docs.rs
 # Configure the default settings for external services
 cp .env.sample .env
 # Create the DOCSRS_PREFIX directory
-mkdir -p ignored/cratesfyi-prefix/crates.io-index
+mkdir -p ignored/docsrs-prefix/crates.io-index
 # Builds the docs.rs binary
 cargo build
 # Start the external services
@@ -121,8 +121,8 @@ Three services are defined:
 | name | access                                          | credentials                | description                            |
 |------|-------------------------------------------------|----------------------------|----------------------------------------|
 | web  | http://localhost:3000                           | N/A                        | A container running the docs.rs binary |
-| db   | postgresql://cratesfyi:password@localhost:15432 | -                          | Postgres database used by web          |
-| s3   | http://localhost:9000                           | `cratesfyi` - `secret_key` | MinIO (simulates AWS S3) used by web   |
+| db   | postgresql://docsrs:password@localhost:15432 | -                          | Postgres database used by web          |
+| s3   | http://localhost:9000                           | `docsrs` - `secret_key` | MinIO (simulates AWS S3) used by web   |
 
 [docker-compose.yml]: ./docker-compose.yml
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,10 @@ services:
             - "cratesio-index:/opt/docsrs/prefix/crates.io-index"
         environment:
             DOCSRS_RUSTWIDE_WORKSPACE: /opt/docsrs/rustwide
-            DOCSRS_DATABASE_URL: postgresql://cratesfyi:password@db
+            DOCSRS_DATABASE_URL: postgresql://docsrs:password@db
             DOCSRS_STORAGE_BACKEND: s3
             S3_ENDPOINT: http://s3:9000
-            AWS_ACCESS_KEY_ID: cratesfyi
+            AWS_ACCESS_KEY_ID: docsrs
             AWS_SECRET_ACCESS_KEY: secret_key
         env_file:
             - .env
@@ -37,13 +37,13 @@ services:
         volumes:
             - postgres-data:/var/lib/postgresql/data
         environment:
-            POSTGRES_USER: cratesfyi
+            POSTGRES_USER: docsrs
             POSTGRES_PASSWORD: password
         ports:
             # Use a non-standard port on the host to avoid conflicting with existing postgres servers
             - "15432:5432"
         healthcheck:
-            test: ["CMD", "pg_isready", "--username", "cratesfyi"]
+            test: ["CMD", "pg_isready", "--username", "docsrs"]
             interval: 10s
             timeout: 5s
             retries: 10
@@ -61,7 +61,7 @@ services:
         volumes:
             - minio-data:/data
         environment:
-            MINIO_ROOT_USER: cratesfyi
+            MINIO_ROOT_USER: docsrs
             MINIO_ROOT_PASSWORD: secret_key
         healthcheck:
             test:

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -31,9 +31,7 @@ COPY benches benches
 COPY Cargo.lock Cargo.toml ./
 COPY crates/metadata crates/metadata/
 COPY crates/font-awesome-as-a-crate crates/font-awesome-as-a-crate
-RUN mkdir -p src/bin && \
-    echo "fn main() {}" > src/bin/cratesfyi.rs && \
-    echo "fn main() {}" > build.rs
+RUN echo "fn main() {}" > src/main.rs && echo "fn main() {}" > build.rs
 
 RUN cargo fetch
 RUN cargo build --release
@@ -71,7 +69,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 
 RUN mkdir -p /opt/docsrs/prefix
 
-COPY --from=build /build/target/release/cratesfyi /usr/local/bin
+COPY --from=build /build/target/release/docsrs /usr/local/bin
 COPY static /opt/docsrs/static
 COPY templates /opt/docsrs/templates
 COPY dockerfiles/entrypoint.sh /opt/docsrs/

--- a/dockerfiles/entrypoint.sh
+++ b/dockerfiles/entrypoint.sh
@@ -13,7 +13,7 @@ export PATH="$PATH:/build/target/release"
 set +e
 failed=0
 while true; do
-    if ! cratesfyi database migrate; then
+    if ! docsrs database migrate; then
         ((failed=failed + 1))
         if [ "${failed}" -eq 5 ]; then
             exit 1
@@ -33,6 +33,6 @@ if ! [ -d "${DOCSRS_PREFIX}/crates.io-index/.git" ]; then
     git --git-dir="$DOCSRS_PREFIX/crates.io-index/.git" branch crates-index-diff_last-seen
 fi
 
-cratesfyi build update-toolchain --only-first-time
+docsrs build update-toolchain --only-first-time
 
-cratesfyi "$@"
+docsrs "$@"

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ enum Toggle {
 
 #[derive(Debug, Clone, PartialEq, Eq, StructOpt)]
 #[structopt(
-    name = "cratesfyi",
+    name = "docsrs",
     about = env!("CARGO_PKG_DESCRIPTION"),
     version = docs_rs::BUILD_VERSION,
     rename_all = "kebab-case",


### PR DESCRIPTION
Fixes https://github.com/rust-lang/docs.rs/issues/244.

Either I or @pietroalbini needs to audit where `cratesfyi` is used in production before this is deployed. I expect it will be annoying to get the systemd unit file to work atomically.