### PR TITLE
Remove `<span class="title">` around `Source` link on dropdown

### DIFF
--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -76,8 +76,7 @@ extra whitespace unremovable, need to use html tags unaffacted by whitespace T_T
                             {# A link to the release's source view #}
                             <li class="pure-menu-item">
                                 <a href="{{ crate_url | safe }}/source/" title="Browse source of {{ metadata.name }}-{{ metadata.version }}" class="pure-menu-link">
-                                    {{ "folder-open" | fas(fw=true) }}
-                                    <span class="title">Source</span>
+                                    {{ "folder-open" | fas(fw=true) }} Source
                                 </a>
                             </li>
                         </ul>


### PR DESCRIPTION
This fixes a bug where it would disappear if the screen width got too
narrow (https://github.com/rust-lang/docs.rs/issues/1422).

Hmm, r? @jsha maybe?