### PR TITLE
replace deprecated failure library with anyhow and thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,12 +10,18 @@ checksum = "2b7e4e8cf778db814365e46839949ca74df4efb10e87ba4913e6ec5967ef0285"
 
 [[package]]
 name = "addr2line"
-version = "0.12.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
+checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
 dependencies = [
  "gimli",
 ]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler32"
@@ -48,6 +54,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+dependencies = [
+ "backtrace",
 ]
 
 [[package]]
@@ -124,13 +139,15 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.48"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130"
+checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
 dependencies = [
  "addr2line",
- "cfg-if 0.1.10",
+ "cc",
+ "cfg-if 1.0.0",
  "libc",
+ "miniz_oxide 0.4.4",
  "object",
  "rustc-demangle",
 ]
@@ -273,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.54"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 dependencies = [
  "jobserver",
 ]
@@ -723,6 +740,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 name = "docs-rs"
 version = "0.6.0"
 dependencies = [
+ "anyhow",
  "arc-swap",
  "backtrace",
  "badge",
@@ -778,6 +796,7 @@ dependencies = [
  "systemstat",
  "tempfile",
  "tera",
+ "thiserror",
  "thread_local",
  "time 0.1.43",
  "tokio",
@@ -918,7 +937,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "crc32fast",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.3.6",
 ]
 
 [[package]]
@@ -1167,9 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.21.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
+checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "git2"
@@ -1607,9 +1626,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.91"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "libflate"
@@ -1772,9 +1791,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
@@ -1829,6 +1848,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5"
 dependencies = [
  "adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -2044,9 +2073,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.19.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
+checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
@@ -3727,18 +3759,18 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.20"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.20"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,10 @@ r2d2_postgres = "0.18"
 url = { version = "2.1.1", features = ["serde"] }
 badge = { path = "crates/badge" }
 docsrs-metadata = { path = "crates/metadata" }
-backtrace = "0.3"
-failure = { version = "0.1.3", features = ["backtrace"] }
+anyhow = { version = "1.0.42", features = ["backtrace"]}
+backtrace = "0.3.61"
+failure = "0.1.8"
+thiserror = "1.0.26"
 comrak = { version = "0.10.1", default-features = false }
 toml = "0.5"
 schemamama = "0.3"

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context as ErrContext, Error, Result};
+use anyhow::{anyhow, Context as _, Error, Result};
 use docs_rs::db::{self, add_path_into_database, Pool, PoolClient};
 use docs_rs::repositories::RepositoryStatsUpdater;
 use docs_rs::utils::{remove_crate_priority, set_crate_priority};
@@ -26,7 +26,7 @@ pub fn main() {
         }
         eprintln!("{}", msg);
 
-        let backtrace = format!("{}", err.backtrace());
+        let backtrace = err.backtrace().to_string();
         if !backtrace.is_empty() {
             eprintln!("\nStack backtrace:\n{}", backtrace);
         }

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -3,6 +3,7 @@ use std::fmt::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use anyhow::{anyhow, Context as ErrContext, Error, Result};
 use docs_rs::db::{self, add_path_into_database, Pool, PoolClient};
 use docs_rs::repositories::RepositoryStatsUpdater;
 use docs_rs::utils::{remove_crate_priority, set_crate_priority};
@@ -10,7 +11,6 @@ use docs_rs::{
     BuildQueue, Config, Context, DocBuilder, Index, Metrics, PackageKind, RustwideBuilder, Server,
     Storage,
 };
-use failure::{err_msg, Error, ResultExt};
 use once_cell::sync::OnceCell;
 use structopt::StructOpt;
 use strum::VariantNames;
@@ -21,12 +21,14 @@ pub fn main() {
 
     if let Err(err) = CommandLine::from_args().handle_args() {
         let mut msg = format!("Error: {}", err);
-        for cause in err.iter_causes() {
+        for cause in err.chain() {
             write!(msg, "\n\nCaused by:\n    {}", cause).unwrap();
         }
         eprintln!("{}", msg);
-        if !err.backtrace().is_empty() {
-            eprintln!("\nStack backtrace:\n{}", err.backtrace());
+
+        let backtrace = format!("{}", err.backtrace());
+        if !backtrace.is_empty() {
+            eprintln!("\nStack backtrace:\n{}", backtrace);
         }
         std::process::exit(1);
     }
@@ -108,7 +110,7 @@ enum CommandLine {
 }
 
 impl CommandLine {
-    pub fn handle_args(self) -> Result<(), Error> {
+    pub fn handle_args(self) -> Result<()> {
         let ctx = BinContext::new();
 
         match self {
@@ -166,7 +168,7 @@ enum QueueSubcommand {
 }
 
 impl QueueSubcommand {
-    pub fn handle_args(self, ctx: BinContext) -> Result<(), Error> {
+    pub fn handle_args(self, ctx: BinContext) -> Result<()> {
         match self {
             Self::Add {
                 crate_name,
@@ -205,7 +207,7 @@ enum PrioritySubcommand {
 }
 
 impl PrioritySubcommand {
-    pub fn handle_args(self, ctx: BinContext) -> Result<(), Error> {
+    pub fn handle_args(self, ctx: BinContext) -> Result<()> {
         match self {
             Self::Set { pattern, priority } => {
                 set_crate_priority(&mut *ctx.conn()?, &pattern, priority)
@@ -239,7 +241,7 @@ struct Build {
 }
 
 impl Build {
-    pub fn handle_args(self, ctx: BinContext) -> Result<(), Error> {
+    pub fn handle_args(self, ctx: BinContext) -> Result<()> {
         self.subcommand.handle_args(ctx, self.skip_if_exists)
     }
 }
@@ -286,10 +288,10 @@ enum BuildSubcommand {
 }
 
 impl BuildSubcommand {
-    pub fn handle_args(self, ctx: BinContext, skip_if_exists: bool) -> Result<(), Error> {
+    pub fn handle_args(self, ctx: BinContext, skip_if_exists: bool) -> Result<()> {
         let docbuilder = DocBuilder::new(ctx.config()?, ctx.pool()?, ctx.build_queue()?);
 
-        let rustwide_builder = || -> Result<RustwideBuilder, Error> {
+        let rustwide_builder = || -> Result<RustwideBuilder> {
             let mut builder = RustwideBuilder::init(&ctx)?;
             builder.set_skip_build_if_exists(skip_if_exists);
             Ok(builder)
@@ -317,9 +319,10 @@ impl BuildSubcommand {
                     let registry_url = ctx.config()?.registry_url.clone();
                     builder
                         .build_package(
-                            &crate_name.ok_or_else(|| err_msg("must specify name if not local"))?,
+                            &crate_name
+                                .with_context(|| anyhow!("must specify name if not local"))?,
                             &crate_version
-                                .ok_or_else(|| err_msg("must specify version if not local"))?,
+                                .with_context(|| anyhow!("must specify version if not local"))?,
                             registry_url
                                 .as_ref()
                                 .map(|s| PackageKind::Registry(s.as_str()))
@@ -412,7 +415,7 @@ enum DatabaseSubcommand {
 }
 
 impl DatabaseSubcommand {
-    pub fn handle_args(self, ctx: BinContext) -> Result<(), Error> {
+    pub fn handle_args(self, ctx: BinContext) -> Result<()> {
         match self {
             Self::Migrate { version } => {
                 db::migrate(version, &mut *ctx.conn()?)
@@ -482,7 +485,7 @@ enum BlacklistSubcommand {
 }
 
 impl BlacklistSubcommand {
-    fn handle_args(self, ctx: BinContext) -> Result<(), Error> {
+    fn handle_args(self, ctx: BinContext) -> Result<()> {
         let mut conn = &mut *ctx.conn()?;
         match self {
             Self::List => {
@@ -545,14 +548,14 @@ impl BinContext {
         }
     }
 
-    fn conn(&self) -> Result<PoolClient, Error> {
+    fn conn(&self) -> Result<PoolClient> {
         Ok(self.pool()?.get()?)
     }
 }
 
 macro_rules! lazy {
     ( $(fn $name:ident($self:ident) -> $type:ty = $init:expr);+ $(;)? ) => {
-        $(fn $name(&$self) -> Result<Arc<$type>, Error> {
+        $(fn $name(&$self) -> Result<Arc<$type>> {
             Ok($self
                 .$name
                 .get_or_try_init::<_, Error>(|| Ok(Arc::new($init)))?
@@ -591,7 +594,7 @@ impl Context for BinContext {
         };
     }
 
-    fn pool(&self) -> Result<Pool, Error> {
+    fn pool(&self) -> Result<Pool> {
         Ok(self
             .pool
             .get_or_try_init::<_, Error>(|| Ok(Pool::new(&*self.config()?, self.metrics()?)?))?

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -170,7 +170,7 @@ mod tests {
             let assert_next_and_fail = |name| -> Result<()> {
                 queue.process_next_crate(|krate| {
                     assert_eq!(name, krate.name);
-                    failure::bail!("simulate a failure");
+                    anyhow::bail!("simulate a failure");
                 })?;
                 Ok(())
             };
@@ -278,7 +278,7 @@ mod tests {
                 assert_eq!(queue.failed_count()?, 0);
                 queue.process_next_crate(|krate| {
                     assert_eq!("foo", krate.name);
-                    failure::bail!("this failed");
+                    anyhow::bail!("this failed");
                 })?;
             }
             assert_eq!(queue.failed_count()?, 1);

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,15 +1,15 @@
 use crate::db::Pool;
+use crate::error::Result;
 use crate::repositories::RepositoryStatsUpdater;
 use crate::{BuildQueue, Config, Index, Metrics, Storage};
-use failure::Error;
 use std::sync::Arc;
 
 pub trait Context {
-    fn config(&self) -> Result<Arc<Config>, Error>;
-    fn build_queue(&self) -> Result<Arc<BuildQueue>, Error>;
-    fn storage(&self) -> Result<Arc<Storage>, Error>;
-    fn pool(&self) -> Result<Pool, Error>;
-    fn metrics(&self) -> Result<Arc<Metrics>, Error>;
-    fn index(&self) -> Result<Arc<Index>, Error>;
-    fn repository_stats_updater(&self) -> Result<Arc<RepositoryStatsUpdater>, Error>;
+    fn config(&self) -> Result<Arc<Config>>;
+    fn build_queue(&self) -> Result<Arc<BuildQueue>>;
+    fn storage(&self) -> Result<Arc<Storage>>;
+    fn pool(&self) -> Result<Pool>;
+    fn metrics(&self) -> Result<Arc<Metrics>>;
+    fn index(&self) -> Result<Arc<Index>>;
+    fn repository_stats_updater(&self) -> Result<Arc<RepositoryStatsUpdater>>;
 }

--- a/src/db/delete.rs
+++ b/src/db/delete.rs
@@ -8,7 +8,7 @@ static STORAGE_PATHS_TO_DELETE: &[&str] = &["rustdoc", "sources"];
 
 #[derive(Debug, thiserror::Error)]
 enum CrateDeletionError {
-    #[error("crate is missing: {}", .0)]
+    #[error("crate is missing: {0}")]
     MissingCrate(String),
 }
 

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -122,14 +122,14 @@ impl r2d2::CustomizeConnection<Client, postgres::Error> for SetSchema {
     }
 }
 
-#[derive(Debug, failure::Fail)]
+#[derive(Debug, thiserror::Error)]
 pub enum PoolError {
-    #[fail(display = "the provided database URL was not valid")]
-    InvalidDatabaseUrl(#[fail(cause)] postgres::Error),
+    #[error("the provided database URL was not valid")]
+    InvalidDatabaseUrl(#[from] postgres::Error),
 
-    #[fail(display = "failed to create the database connection pool")]
-    PoolCreationFailed(#[fail(cause)] r2d2::Error),
+    #[error("failed to create the database connection pool")]
+    PoolCreationFailed(r2d2::Error),
 
-    #[fail(display = "failed to get a database connection")]
-    ClientError(#[fail(cause)] r2d2::Error),
+    #[error("failed to get a database connection")]
+    ClientError(r2d2::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,18 +1,7 @@
 //! Errors used in docs.rs
 
-use std::result::Result as StdResult;
+pub(crate) use anyhow::Result;
 
-pub(crate) use failure::Error;
-
-pub type Result<T> = StdResult<T, Error>;
-
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, thiserror::Error)]
+#[error("the size limit for the buffer was reached")]
 pub(crate) struct SizeLimitReached;
-
-impl std::error::Error for SizeLimitReached {}
-
-impl std::fmt::Display for SizeLimitReached {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "the size limit for the buffer was reached")
-    }
-}

--- a/src/index/api.rs
+++ b/src/index/api.rs
@@ -1,5 +1,5 @@
+use anyhow::{anyhow, Context};
 use chrono::{DateTime, Utc};
-use failure::{err_msg, ResultExt};
 use reqwest::header::{HeaderValue, ACCEPT, USER_AGENT};
 use semver::Version;
 use serde::Deserialize;
@@ -68,7 +68,7 @@ impl Api {
     fn api_base(&self) -> Result<Url> {
         self.api_base
             .clone()
-            .ok_or_else(|| err_msg("index is missing an api base url"))
+            .with_context(|| anyhow!("index is missing an api base url"))
     }
 
     pub fn get_crate_data(&self, name: &str) -> Result<CrateData> {
@@ -100,7 +100,7 @@ impl Api {
         let url = {
             let mut url = self.api_base()?;
             url.path_segments_mut()
-                .map_err(|()| err_msg("Invalid API url"))?
+                .map_err(|()| anyhow!("Invalid API url"))?
                 .extend(&["api", "v1", "crates", name, "versions"]);
             url
         };
@@ -128,7 +128,7 @@ impl Api {
             .versions
             .into_iter()
             .find(|data| data.num == version)
-            .ok_or_else(|| err_msg("Could not find version in response"))?;
+            .with_context(|| anyhow!("Could not find version in response"))?;
 
         Ok((version.created_at, version.yanked, version.downloads))
     }
@@ -138,7 +138,7 @@ impl Api {
         let url = {
             let mut url = self.api_base()?;
             url.path_segments_mut()
-                .map_err(|()| err_msg("Invalid API url"))?
+                .map_err(|()| anyhow!("Invalid API url"))?
                 .extend(&["api", "v1", "crates", name, "owners"]);
             url
         };

--- a/src/index/crates.rs
+++ b/src/index/crates.rs
@@ -1,6 +1,5 @@
+use anyhow::Context;
 use crates_index::Crate;
-use failure::ResultExt;
-
 pub(crate) struct Crates {
     repo: git2::Repository,
 }
@@ -10,7 +9,7 @@ impl Crates {
         Self { repo }
     }
 
-    pub(crate) fn walk(&self, mut f: impl FnMut(Crate)) -> Result<(), failure::Error> {
+    pub(crate) fn walk(&self, mut f: impl FnMut(Crate)) -> Result<(), anyhow::Error> {
         log::debug!("Walking crates in index");
         let tree = self
             .repo
@@ -28,9 +27,9 @@ impl Crates {
                         log::warn!("not a crate '{}'", entry.name().unwrap());
                     }
                 }
-                Result::<(), failure::Error>::Ok(())
+                Result::<(), anyhow::Error>::Ok(())
             })()
-            .with_context(|_| {
+            .with_context(|| {
                 format!(
                     "loading crate details from '{}'",
                     entry.name().unwrap_or("<unknown>")

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1,10 +1,10 @@
 use std::{path::PathBuf, process::Command};
 
+use anyhow::Context;
 use url::Url;
 
 use self::api::Api;
 use crate::error::Result;
-use failure::ResultExt;
 
 pub(crate) mod api;
 #[cfg(feature = "consistency_check")]
@@ -36,7 +36,7 @@ fn load_config(repo: &git2::Repository) -> Result<IndexConfig> {
         .tree()?;
     let file = tree
         .get_name("config.json")
-        .ok_or_else(|| failure::format_err!("registry index missing config"))?;
+        .with_context(|| anyhow::anyhow!("registry index missing config"))?;
     let config = serde_json::from_slice(repo.find_blob(file.id())?.content())?;
     Ok(config)
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -5,8 +5,8 @@ use self::macros::MetricFromOpts;
 use crate::db::Pool;
 use crate::target::TargetAtom;
 use crate::BuildQueue;
+use anyhow::Error;
 use dashmap::DashMap;
-use failure::Error;
 use prometheus::proto::MetricFamily;
 use std::time::{Duration, Instant};
 

--- a/src/repositories/github.rs
+++ b/src/repositories/github.rs
@@ -144,7 +144,7 @@ impl RepositoryForge for GitHub {
                 ("RATE_LIMITED", []) => {
                     return Err(RateLimitReached.into());
                 }
-                _ => failure::bail!("error updating repositories: {}", error.message),
+                _ => anyhow::bail!("error updating repositories: {}", error.message),
             }
         }
 
@@ -258,6 +258,7 @@ struct GraphIssues {
 mod tests {
     use super::GitHub;
     use crate::repositories::updater::{repository_name, RepositoryForge};
+    use crate::repositories::RateLimitReached;
     use mockito::mock;
 
     #[test]
@@ -275,7 +276,7 @@ mod tests {
                 .create();
 
             match updater.fetch_repositories(&[String::new()]) {
-                Err(e) if format!("{:?}", e).contains("RateLimitReached") => {}
+                Err(e) if e.downcast_ref::<RateLimitReached>().is_some() => {}
                 x => panic!("Expected Err(RateLimitReached), found: {:?}", x),
             }
             Ok(())
@@ -295,7 +296,7 @@ mod tests {
                 .create();
 
             match updater.fetch_repositories(&[String::new()]) {
-                Err(e) if format!("{:?}", e).contains("RateLimitReached") => {}
+                Err(e) if e.downcast_ref::<RateLimitReached>().is_some() => {}
                 x => panic!("Expected Err(RateLimitReached), found: {:?}", x),
             }
             Ok(())

--- a/src/repositories/mod.rs
+++ b/src/repositories/mod.rs
@@ -11,8 +11,8 @@ pub const APP_USER_AGENT: &str = concat!(
     include_str!(concat!(env!("OUT_DIR"), "/git_version"))
 );
 
-#[derive(Debug, failure::Fail)]
-#[fail(display = "rate limit reached")]
+#[derive(Debug, thiserror::Error)]
+#[error("rate limit reached")]
 struct RateLimitReached;
 
 mod github;

--- a/src/repositories/updater.rs
+++ b/src/repositories/updater.rs
@@ -119,7 +119,7 @@ impl RepositoryStatsUpdater {
             };
             return match res {
                 Ok(repo_id) => Ok(Some(repo_id)),
-                Err(err) => failure::bail!("failed to collect `{}` stats: {}", updater.host(), err),
+                Err(err) => anyhow::bail!("failed to collect `{}` stats: {}", updater.host(), err),
             };
         }
         // It means that none of our updaters have a matching host.

--- a/src/storage/compression.rs
+++ b/src/storage/compression.rs
@@ -1,4 +1,4 @@
-use failure::Error;
+use anyhow::Error;
 use std::{collections::HashSet, fmt, io::Read};
 
 pub type CompressionAlgorithms = HashSet<CompressionAlgorithm>;

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -3,8 +3,8 @@ use crate::docbuilder::{BuildResult, DocCoverage};
 use crate::index::api::{CrateData, CrateOwner, ReleaseData};
 use crate::storage::Storage;
 use crate::utils::{Dependency, MetadataPackage, Target};
+use anyhow::{Context, Error};
 use chrono::{DateTime, Utc};
-use failure::{Error, ResultExt};
 use postgres::Client;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -278,13 +278,13 @@ impl<'a> FakeRelease<'a> {
 
             for (path, data) in files {
                 if path.starts_with('/') {
-                    failure::bail!("absolute paths not supported");
+                    anyhow::bail!("absolute paths not supported");
                 }
                 // allow `src/main.rs`
                 if let Some(parent) = Path::new(path).parent() {
                     let path = path_prefix.join(parent);
                     fs::create_dir_all(&path)
-                        .with_context(|_| format!("failed to create {}", path.display()))?;
+                        .with_context(|| format!("failed to create {}", path.display()))?;
                 }
                 let file = path_prefix.join(&path);
                 log::debug!("writing file {}", file.display());

--- a/src/utils/cargo_metadata.rs
+++ b/src/utils/cargo_metadata.rs
@@ -1,4 +1,5 @@
 use crate::error::Result;
+use anyhow::bail;
 use rustwide::{cmd::Command, Toolchain, Workspace};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -24,9 +25,7 @@ impl CargoMetadata {
         let metadata = if let (Some(serialized), None) = (iter.next(), iter.next()) {
             serde_json::from_str::<DeserializedMetadata>(serialized)?
         } else {
-            return Err(::failure::err_msg(
-                "invalid output returned by `cargo metadata`",
-            ));
+            bail!("invalid output returned by `cargo metadata`");
         };
 
         let root = metadata.resolve.root;

--- a/src/utils/consistency/db.rs
+++ b/src/utils/consistency/db.rs
@@ -1,7 +1,7 @@
 use super::data::{Crate, CrateName, Data, Release, Version};
 use std::collections::BTreeMap;
 
-pub(crate) fn load(conn: &mut postgres::Client) -> Result<Data, failure::Error> {
+pub(crate) fn load(conn: &mut postgres::Client) -> Result<Data, anyhow::Error> {
     let rows = conn.query(
         "
         SELECT

--- a/src/utils/consistency/index.rs
+++ b/src/utils/consistency/index.rs
@@ -1,7 +1,7 @@
 use super::data::{Crate, CrateName, Data, Release, Version};
 use crate::Index;
 
-pub(crate) fn load(index: &Index) -> Result<Data, failure::Error> {
+pub(crate) fn load(index: &Index) -> Result<Data, anyhow::Error> {
     let mut data = Data::default();
 
     index.crates()?.walk(|krate| {

--- a/src/utils/consistency/mod.rs
+++ b/src/utils/consistency/mod.rs
@@ -1,6 +1,5 @@
 use self::diff::{Diff, Diffable};
 use crate::Index;
-use failure::ResultExt;
 
 mod data;
 mod db;
@@ -11,9 +10,9 @@ pub fn run_check(
     conn: &mut postgres::Client,
     index: &Index,
     dry_run: bool,
-) -> Result<(), failure::Error> {
+) -> Result<(), anyhow::Error> {
     if !dry_run {
-        failure::bail!("TODO: only a --dry-run synchronization is supported currently");
+        anyhow::bail!("TODO: only a --dry-run synchronization is supported currently");
     }
 
     log::info!("Loading data from database...");

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -3,7 +3,7 @@
 //! This daemon will start web server, track new packages and build them
 
 use crate::{utils::queue_builder, Context, DocBuilder, RustwideBuilder};
-use failure::Error;
+use anyhow::Error;
 use log::{debug, error, info};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -87,11 +87,11 @@ pub fn start_daemon(context: &dyn Context, enable_registry_watcher: bool) -> Res
     )?;
 
     // Never returns; `server` blocks indefinitely when dropped
-    // NOTE: if a failure occurred earlier in `start_daemon`, the server will _not_ be joined -
+    // NOTE: if a anyhow occurred earlier in `start_daemon`, the server will _not_ be joined -
     // instead it will get killed when the process exits.
     server_thread
         .join()
-        .map_err(|_| failure::err_msg("web server panicked"))
+        .map_err(|_| anyhow::anyhow!("web server panicked"))
 }
 
 pub(crate) fn cron<F>(name: &'static str, interval: Duration, exec: F) -> Result<(), Error>

--- a/src/utils/queue_builder.rs
+++ b/src/utils/queue_builder.rs
@@ -1,5 +1,5 @@
 use crate::{docbuilder::RustwideBuilder, utils::pubsubhubbub, BuildQueue, DocBuilder};
-use failure::Error;
+use anyhow::Error;
 use log::{debug, error, info, warn};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;

--- a/src/utils/rustc_version.rs
+++ b/src/utils/rustc_version.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use failure::err_msg;
+use anyhow::{anyhow, Context};
 use regex::Regex;
 
 /// Parses rustc commit hash from rustc version string
@@ -7,7 +7,7 @@ pub fn parse_rustc_version<S: AsRef<str>>(version: S) -> Result<String> {
     let version_regex = Regex::new(r" ([\w.-]+) \((\w+) (\d+)-(\d+)-(\d+)\)")?;
     let captures = version_regex
         .captures(version.as_ref())
-        .ok_or_else(|| err_msg("Failed to parse rustc version"))?;
+        .with_context(|| anyhow!("Failed to parse rustc version"))?;
 
     Ok(format!(
         "{}{}{}-{}-{}",

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -309,7 +309,7 @@ mod tests {
     use super::*;
     use crate::index::api::CrateOwner;
     use crate::test::{wrapper, TestDatabase};
-    use failure::Error;
+    use anyhow::{Context, Error};
     use kuchiki::traits::TendrilSink;
     use std::collections::HashMap;
 
@@ -325,7 +325,7 @@ mod tests {
             version,
             db.repository_stats_updater(),
         )
-        .ok_or_else(|| failure::err_msg("could not fetch crate details"))?;
+        .with_context(|| anyhow::anyhow!("could not fetch crate details"))?;
 
         assert_eq!(
             details.last_successful_build,

--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -2,36 +2,25 @@ use crate::{
     db::PoolError,
     web::{page::WebPage, releases::Search, ErrorPage},
 };
-use failure::Fail;
 use iron::{status::Status, Handler, IronError, IronResult, Request, Response};
-use std::{error::Error, fmt};
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, thiserror::Error)]
 pub enum Nope {
+    #[error("Requested resource not found")]
     ResourceNotFound,
+    #[error("Requested build not found")]
     BuildNotFound,
+    #[error("Requested crate not found")]
     CrateNotFound,
+    #[error("Requested owner not found")]
     OwnerNotFound,
+    #[error("Requested crate does not have specified version")]
     VersionNotFound,
+    #[error("Search yielded no results")]
     NoResults,
+    #[error("Internal server error")]
     InternalServerError,
 }
-
-impl fmt::Display for Nope {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(match *self {
-            Nope::ResourceNotFound => "Requested resource not found",
-            Nope::BuildNotFound => "Requested build not found",
-            Nope::CrateNotFound => "Requested crate not found",
-            Nope::OwnerNotFound => "Requested owner not found",
-            Nope::VersionNotFound => "Requested crate does not have specified version",
-            Nope::NoResults => "Search yielded no results",
-            Nope::InternalServerError => "Internal server error",
-        })
-    }
-}
-
-impl Error for Nope {}
 
 impl From<Nope> for IronError {
     fn from(err: Nope) -> IronError {
@@ -139,7 +128,7 @@ impl Handler for Nope {
 
 impl From<PoolError> for IronError {
     fn from(err: PoolError) -> IronError {
-        IronError::new(err.compat(), Status::InternalServerError)
+        IronError::new(err, Status::InternalServerError)
     }
 }
 

--- a/src/web/extensions.rs
+++ b/src/web/extensions.rs
@@ -2,7 +2,7 @@ use crate::web::page::TemplateData;
 use crate::{
     db::Pool, repositories::RepositoryStatsUpdater, BuildQueue, Config, Context, Metrics, Storage,
 };
-use failure::Error;
+use anyhow::Error;
 use iron::{BeforeMiddleware, IronResult, Request};
 use std::sync::Arc;
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -94,11 +94,11 @@ mod source;
 mod statics;
 
 use crate::{impl_webpage, Context};
+use anyhow::Error;
 use chrono::{DateTime, Utc};
 use csp::CspMiddleware;
 use error::Nope;
 use extensions::InjectExtensions;
-use failure::Error;
 use iron::{
     self,
     headers::{Expires, HttpDate},

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -180,7 +180,7 @@ fn get_search_results(
     mut query: &str,
     page: i64,
     limit: i64,
-) -> Result<(i64, Vec<Release>), failure::Error> {
+) -> Result<(i64, Vec<Release>), anyhow::Error> {
     query = query.trim();
     if query.is_empty() {
         return Ok((0, Vec::new()));
@@ -696,8 +696,8 @@ mod tests {
     use super::*;
     use crate::index::api::CrateOwner;
     use crate::test::{assert_redirect, assert_success, wrapper, TestFrontend};
+    use anyhow::Error;
     use chrono::{Duration, TimeZone};
-    use failure::Error;
     use kuchiki::traits::TendrilSink;
     use std::collections::HashSet;
 


### PR DESCRIPTION
remembering that the failure crate is deprecated I replaced it with the recommended replacements. 
- Partially also replacing `Result<T, Error` with `anyhow::Result<T>`
- for now mapping the failures coming from rustwide. 

Some code by the WIP branch by @Nemo157. 

I'm happy to add any improvements. 