### PR TITLE
Fix invalid title on search results page

### DIFF
--- a/templates/releases/releases.html
+++ b/templates/releases/releases.html
@@ -1,7 +1,7 @@
 {%- extends "base.html" -%}
 {%- import "releases/header.html" as release_macros -%}
 
-{%- block title -%}Releases - Docs.rs{%- endblock title -%}
+{%- block title -%}{{ title | default(value="Releases - Docs.rs")}}{%- endblock title -%}
 
 {%- block header -%}
     {# These all have defaults so searches work #}


### PR DESCRIPTION
When you get on the page for search URL (something like `/releases/search?query=r`), the title is "Releases - Docs.rs", which isn't great. I replaced it with "Search results for 'r'".