### PR TITLE
Sort crates by version in ascending order

### DIFF
--- a/src/docbuilder/crates.rs
+++ b/src/docbuilder/crates.rs
@@ -52,7 +52,6 @@ where
     }
 
     if !name.is_empty() {
-        versions.reverse();
         for version in versions {
             func(&name, &version);
         }


### PR DESCRIPTION
This patch perhaps looks supper weird but otherwise `build world` shows oldest crates at recent releases.

Firstly, the newest crate is built and the latest is the oldest one. It leads that "Recent Releases" page shows the oldest available crates, e.g. for building world.

Is it an intended behavior, or not?