### PR TITLE
Allow to specify a key for private registries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "crates-index-diff"
-version = "7.1.2"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64af39a9a6805d715f8b72307d70815ed1ee38ef84e9de250fcdd56fe75a0e19"
+checksum = "9f04ef23e6e584a3f8f7860274e0daf1c46e859d387cebdad1de54091d7cea08"
 dependencies = [
  "git2",
  "serde",
@@ -3106,9 +3106,8 @@ dependencies = [
 
 [[package]]
 name = "rustwide"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689b0858f1118c80702a03f9cee1ab09955b55b4166b72457859212790afe129"
+version = "0.14.0"
+source = "git+https://github.com/l4l/rustwide.git?branch=registry-key#bd25fcf067ad47c42bc2431a83a4306de005f85a"
 dependencies = [
  "attohttpc",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4"
 regex = "1"
 structopt = "0.3"
 crates-index = { version = "0.15.1", optional = true }
-crates-index-diff = "7.1.1"
+crates-index-diff = "8.0.0"
 reqwest = { version = "0.11", features = ["blocking", "json"] } # TODO: Remove blocking when async is ready
 semver = { version = "0.9", features = ["serde"] }
 slug = "=0.1.1"
@@ -48,7 +48,7 @@ schemamama = "0.3"
 schemamama_postgres = "0.3"
 systemstat = "0.1.4"
 prometheus = { version = "0.10.0", default-features = false }
-rustwide = "0.13"
+rustwide = { git = "https://github.com/l4l/rustwide.git", branch = "registry-key" }
 mime_guess = "2"
 dotenv = "0.15"
 zstd = "0.5"

--- a/dockerfiles/entrypoint.sh
+++ b/dockerfiles/entrypoint.sh
@@ -6,6 +6,7 @@ export DOCSRS_PREFIX=/opt/docsrs/prefix
 export DOCSRS_DOCKER=true
 export DOCSRS_LOG=${DOCSRS_LOG-"docs-rs,rustwide=info"}
 export PATH="$PATH:/build/target/release"
+export REGISTRY_URL=${REGISTRY_URL:-https://github.com/rust-lang/crates.io-index}
 
 # Try migrating the database multiple times if it fails
 # This avoids the docker container crashing the first time it's started with
@@ -28,7 +29,7 @@ done
 set -e
 
 if ! [ -d "${DOCSRS_PREFIX}/crates.io-index/.git" ]; then
-    git clone https://github.com/rust-lang/crates.io-index "${DOCSRS_PREFIX}/crates.io-index"
+    git clone ${REGISTRY_URL} "${DOCSRS_PREFIX}/crates.io-index"
     # Prevent new crates built before the container creation to be built
     git --git-dir="$DOCSRS_PREFIX/crates.io-index/.git" branch crates-index-diff_last-seen
 fi

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -334,7 +334,9 @@ impl BuildSubcommand {
                         .build_local_package(&path)
                         .context("Building documentation failed")?;
                 } else {
-                    let registry_url = ctx.config()?.registry_url.clone();
+                    let config = ctx.config()?;
+                    let registry_url = config.registry_url.clone();
+                    let registry_key = config.registry_key.clone();
                     builder
                         .build_package(
                             &crate_name
@@ -343,7 +345,10 @@ impl BuildSubcommand {
                                 .with_context(|| anyhow!("must specify version if not local"))?,
                             registry_url
                                 .as_ref()
-                                .map(|s| PackageKind::Registry(s.as_str()))
+                                .map(|s| PackageKind::Registry {
+                                    url: s.as_str(),
+                                    key: registry_key,
+                                })
                                 .unwrap_or(PackageKind::CratesIo),
                         )
                         .context("Building documentation failed")?;
@@ -598,7 +603,7 @@ impl Context for BinContext {
             let config = self.config()?;
             let path = config.registry_index_path.clone();
             if let Some(registry_url) = config.registry_url.clone() {
-                Index::from_url(path, registry_url)
+                Index::from_url(path, registry_url, config.registry_key.clone())
             } else {
                 Index::new(path)
             }?

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -257,7 +257,10 @@ impl BuildQueue {
             let kind = krate
                 .registry
                 .as_ref()
-                .map(|r| PackageKind::Registry(r.as_str()))
+                .map(|r| PackageKind::Registry {
+                    url: r.as_str(),
+                    key: self.config.registry_key.clone(),
+                })
                 .unwrap_or(PackageKind::CratesIo);
 
             if let Err(err) = builder

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ pub struct Config {
     pub prefix: PathBuf,
     pub registry_index_path: PathBuf,
     pub registry_url: Option<String>,
+    pub registry_key: Option<String>,
 
     // Database connection params
     pub(crate) database_url: String,
@@ -98,6 +99,15 @@ impl Config {
 
             registry_index_path: env("REGISTRY_INDEX_PATH", prefix.join("crates.io-index"))?,
             registry_url: maybe_env("REGISTRY_URL")?,
+            registry_key: maybe_env::<String>("REGISTRY_KEY").and_then(|key| {
+                Ok(if let Some(key) = key {
+                    Some(key)
+                } else {
+                    maybe_env::<String>("REGISTRY_KEY_PATH")?
+                        .map(std::fs::read_to_string)
+                        .transpose()?
+                })
+            })?,
             prefix: prefix.clone(),
 
             database_url: require_env("DOCSRS_DATABASE_URL")?,


### PR DESCRIPTION
Tried to build a crate for private repo and it works fine. The fixes actually looks really awkward due to weird git2 interface, would love to hear any comments how to make it more readable.

Related PR in rustwide: https://github.com/rust-lang/rustwide/pull/65
And a version update for crates-index-diff: https://github.com/Byron/crates-index-diff-rs/pull/11