### PR TITLE
Resolves #1151 - send errors, error-logs and panics to sentry

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,3 +6,4 @@ AWS_SECRET_ACCESS_KEY=secret_key
 S3_ENDPOINT=http://localhost:9000
 DOCSRS_INCLUDE_DEFAULT_TARGETS=false
 DOCSRS_DOCKER_IMAGE=ghcr.io/rust-lang/crates-build-env/linux-micro
+SENTRY_ENVIRONMENT=dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -697,6 +697,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91cf5a8c2f2097e2a32627123508635d47ce10563d999ec1a95addf08b502ba"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,7 +817,11 @@ dependencies = [
  "sass-rs",
  "schemamama",
  "schemamama_postgres",
- "semver",
+ "semver 0.9.0",
+ "sentry",
+ "sentry-anyhow",
+ "sentry-log",
+ "sentry-panic",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -1341,6 +1355,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,6 +1824,12 @@ dependencies = [
  "string_cache_codegen",
  "tendril",
 ]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matches"
@@ -2996,7 +3027,7 @@ dependencies = [
  "log 0.4.14",
  "rusoto_credential",
  "rusoto_signature",
- "rustc_version",
+ "rustc_version 0.2.3",
  "serde",
  "serde_json",
  "tokio",
@@ -3052,7 +3083,7 @@ dependencies = [
  "percent-encoding 2.1.0",
  "pin-project-lite",
  "rusoto_credential",
- "rustc_version",
+ "rustc_version 0.2.3",
  "serde",
  "sha2",
  "time 0.2.25",
@@ -3071,7 +3102,16 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.4",
 ]
 
 [[package]]
@@ -3267,10 +3307,118 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+
+[[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "sentry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "546b9b6f76c26c60ffbcf0b7136e15169fe13d43949b4aadb7c1edc1c3f3a26f"
+dependencies = [
+ "httpdate",
+ "reqwest",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-panic",
+ "tokio",
+]
+
+[[package]]
+name = "sentry-anyhow"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338ef04f73ca2fb1130ebab3853dca36041aa219a442ae873627373887660c36"
+dependencies = [
+ "anyhow",
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd0cba2aff36ac98708f7a6e7abbdde82dbaf180d5870c41084dc1b473648b9"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bacf1c62427c6c97b896640d0c4dd204bbd3b79dd192d7cb40891aa5ee11d58"
+dependencies = [
+ "hostname",
+ "lazy_static",
+ "libc",
+ "regex",
+ "rustc_version 0.4.0",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a957270c9a430218f8031c866493061a27e35a70250e9527f093563a33ce6b"
+dependencies = [
+ "chrono",
+ "lazy_static",
+ "rand 0.8.3",
+ "sentry-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-log"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66da5759b0704a2fb0d420863b0795ea3429739e188ff67fff82bb13dcd3cc50"
+dependencies = [
+ "log 0.4.14",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692bf989f0c99f025e33d7f58e62822c3771f56d189698c66dcc863122255d95"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4dd2266fee014a86e250e98e389191ecd23be546b5c42b6a2fb9af2972fadac"
+dependencies = [
+ "chrono",
+ "debugid",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "url 2.2.1",
+ "uuid",
+]
 
 [[package]]
 name = "serde"
@@ -3485,7 +3633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
 dependencies = [
  "discard",
- "rustc_version",
+ "rustc_version 0.2.3",
  "stdweb-derive",
  "stdweb-internal-macros",
  "stdweb-internal-runtime",
@@ -4035,6 +4183,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "unchecked-index"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4194,6 +4351,16 @@ name = "utf-8"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.2",
+ "serde",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ exclude = [
 consistency_check = ["crates-index"]
 
 [dependencies]
+sentry = "0.23.0"
+sentry-log = "0.23.0"
+sentry-panic = "0.23.0"
+sentry-anyhow = { version = "0.23.0", features = ["backtrace"] }
 log = "0.4"
 regex = "1"
 structopt = "0.3"

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -11,7 +11,6 @@ use docs_rs::{
     BuildQueue, Config, Context, Index, Metrics, PackageKind, RustwideBuilder, Server, Storage,
 };
 use once_cell::sync::OnceCell;
-use sentry_anyhow::capture_anyhow;
 use sentry_log::SentryLogger;
 use structopt::StructOpt;
 use strum::VariantNames;
@@ -46,10 +45,6 @@ pub fn main() {
         if !backtrace.is_empty() {
             eprintln!("\nStack backtrace:\n{}", backtrace);
         }
-
-        capture_anyhow(&err);
-
-        eprintln!("{}", msg);
 
         // we need to drop the sentry guard here so all unsent
         // errors are sent to sentry

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -47,7 +47,8 @@ pub fn main() {
         }
 
         // we need to drop the sentry guard here so all unsent
-        // errors are sent to sentry
+        // errors are sent to sentry before
+        // process::exit kills everything.
         drop(_sentry_guard);
         std::process::exit(1);
     }

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -3,7 +3,7 @@ use crate::docbuilder::PackageKind;
 use crate::error::Result;
 use crate::utils::{get_crate_priority, report_error};
 use crate::{Config, Index, Metrics, RustwideBuilder};
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 
 use crates_index_diff::ChangeKind;
 use log::debug;

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -194,13 +194,13 @@ impl BuildQueue {
                     let res = conn
                         .execute(
                             "
-                        UPDATE releases
-                            SET yanked = TRUE
-                        FROM crates
-                        WHERE crates.id = releases.crate_id
-                            AND name = $1
-                            AND version = $2
-                        ",
+                            UPDATE releases
+                                SET yanked = TRUE
+                            FROM crates
+                            WHERE crates.id = releases.crate_id
+                                AND name = $1
+                                AND version = $2
+                            ",
                             &[&krate.name, &krate.version],
                         )
                         .with_context(|| {
@@ -260,8 +260,10 @@ impl BuildQueue {
                 .map(|r| PackageKind::Registry(r.as_str()))
                 .unwrap_or(PackageKind::CratesIo);
 
-            if let Err(err) = builder.update_toolchain() {
-                let err = anyhow!(err).context("Updating toolchain failed, locking queue");
+            if let Err(err) = builder
+                .update_toolchain()
+                .context("Updating toolchain failed, locking queue")
+            {
                 report_error(&err);
                 self.lock()?;
                 return Err(err);

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -129,11 +129,8 @@ impl BuildQueue {
                 }
 
                 error!(
-                    "Failed to build package {}-{} from queue: {}\nBacktrace: {}",
-                    to_process.name,
-                    to_process.version,
-                    e,
-                    e.backtrace()
+                    "Failed to build package {}-{} from queue: {}",
+                    to_process.name, to_process.version, e,
                 );
             }
         }

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -6,7 +6,7 @@ use crate::{Config, Index, Metrics, RustwideBuilder};
 use anyhow::anyhow;
 
 use crates_index_diff::ChangeKind;
-use log::{debug, warn};
+use log::debug;
 
 use std::fs;
 use std::path::PathBuf;
@@ -129,13 +129,10 @@ impl BuildQueue {
                     self.metrics.failed_builds.inc();
                 }
 
-                warn!(
-                    "Failed to build package {}-{} from queue: {}\nBacktrace: {}",
-                    to_process.name,
-                    to_process.version,
-                    e,
-                    e.backtrace()
-                );
+                report_error(&anyhow!(e).context(format!(
+                    "Failed to build package {}-{} from queue",
+                    to_process.name, to_process.version
+                )));
             }
         }
 

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -106,13 +106,11 @@ impl Index {
             .arg("-C")
             .arg(&self.path)
             .args(&["gc", "--auto"])
-            .output();
+            .output()
+            .with_context(|| format!("failed to run `git gc --auto`\npath: {:#?}", &self.path));
 
         if let Err(err) = gc {
-            report_error(&anyhow!(err).context(format!(
-                "failed to run `git gc --auto`\npath: {:#?}",
-                &self.path
-            )));
+            report_error(&err);
         }
     }
 

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1,10 +1,11 @@
 use std::{path::PathBuf, process::Command};
 
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use url::Url;
 
 use self::api::Api;
 use crate::error::Result;
+use crate::utils::report_error;
 
 pub(crate) mod api;
 #[cfg(feature = "consistency_check")]
@@ -108,11 +109,10 @@ impl Index {
             .output();
 
         if let Err(err) = gc {
-            log::error!(
-                "failed to run `git gc --auto`\npath: {:#?}\nerror: {:#?}",
-                &self.path,
-                err
-            );
+            report_error(&anyhow!(err).context(format!(
+                "failed to run `git gc --auto`\npath: {:#?}",
+                &self.path
+            )));
         }
     }
 

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, process::Command};
 
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use url::Url;
 
 use self::api::Api;

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -200,7 +200,7 @@ impl<'a> StorageTransaction for S3StorageTransaction<'a> {
                                 self.s3.metrics.uploaded_files_total.inc();
                             })
                             .map_err(|err| {
-                                log::error!("Failed to upload blob to S3: {:?}", err);
+                                log::warn!("Failed to upload blob to S3: {:?}", err);
                                 // Reintroduce failed blobs for a retry
                                 blob
                             }),

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -7,7 +7,7 @@ use crate::{
     Context, RustwideBuilder,
 };
 use anyhow::{anyhow, Error};
-use log::{debug, info, warn};
+use log::{debug, info};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -30,7 +30,7 @@ fn start_registry_watcher(context: &dyn Context) -> Result<(), Error> {
                     debug!("Checking new crates");
                     match build_queue.get_new_crates(&index) {
                         Ok(n) => debug!("{} crates added to queue", n),
-                        Err(e) => warn!("Failed to get new crates: {}", e),
+                        Err(e) => report_error(&anyhow!(e).context("Failed to get new crates")),
                     }
                 }
 

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -6,7 +6,7 @@ use crate::{
     utils::{queue_builder, report_error},
     Context, RustwideBuilder,
 };
-use anyhow::{anyhow, Error};
+use anyhow::{anyhow, Context as _, Error};
 use log::{debug, info};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -28,9 +28,12 @@ fn start_registry_watcher(context: &dyn Context) -> Result<(), Error> {
                     debug!("Lock file exists, skipping checking new crates");
                 } else {
                     debug!("Checking new crates");
-                    match build_queue.get_new_crates(&index) {
+                    match build_queue
+                        .get_new_crates(&index)
+                        .context("Failed to get new crates")
+                    {
                         Ok(n) => debug!("{} crates added to queue", n),
-                        Err(e) => report_error(&anyhow!(e).context("Failed to get new crates")),
+                        Err(e) => report_error(&e),
                     }
                 }
 

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -100,10 +100,10 @@ where
         .name(name.into())
         .spawn(move || loop {
             thread::sleep(interval);
-            if let Err(err) = exec() {
-                report_error(
-                    &anyhow!(err).context(format!("failed to run scheduled task '{}'", name)),
-                );
+            if let Err(err) =
+                exec().with_context(|| format!("failed to run scheduled task '{}'", name))
+            {
+                report_error(&err);
             }
         })?;
     Ok(())

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -22,3 +22,11 @@ mod queue;
 mod queue_builder;
 mod rustc_version;
 pub(crate) mod sized_buffer;
+
+pub(crate) fn report_error(err: &anyhow::Error) {
+    if std::env::var("SENTRY_DSN").is_ok() {
+        sentry_anyhow::capture_anyhow(err);
+    } else {
+        log::error!("{}", err);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -27,6 +27,7 @@ pub(crate) fn report_error(err: &anyhow::Error) {
     if std::env::var("SENTRY_DSN").is_ok() {
         sentry_anyhow::capture_anyhow(err);
     } else {
-        log::error!("{}", err);
+        // Debug-format for anyhow errors includes context & backtrace
+        log::error!("{:?}", err);
     }
 }

--- a/src/utils/queue_builder.rs
+++ b/src/utils/queue_builder.rs
@@ -88,7 +88,7 @@ pub fn queue_builder(
         // If a panic occurs while building a crate, lock the queue until an admin has a chance to look at it.
         let res = catch_unwind(AssertUnwindSafe(|| {
             match build_queue.build_next_queue_package(&mut builder) {
-                Err(e) => warn!("Failed to build crate from queue: {}", e),
+                Err(e) => report_error(&anyhow!(e).context("Failed to build crate from queue")),
                 Ok(crate_built) => {
                     if crate_built {
                         status.increment();

--- a/src/utils/queue_builder.rs
+++ b/src/utils/queue_builder.rs
@@ -102,7 +102,6 @@ pub fn queue_builder(
         }));
 
         if let Err(e) = res {
-            // TODO: how to report this?
             error!("GRAVE ERROR Building new crates panicked: {:?}", e);
             // If we panic here something is really truly wrong and trying to handle the error won't help.
             build_queue.lock().expect("failed to lock queue");

--- a/src/utils/queue_builder.rs
+++ b/src/utils/queue_builder.rs
@@ -3,7 +3,7 @@ use crate::{
     utils::{pubsubhubbub, report_error},
     BuildQueue,
 };
-use anyhow::{anyhow, Context, Error};
+use anyhow::{Context, Error};
 use log::{debug, error, info, warn};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -3,7 +3,7 @@
 pub(crate) mod page;
 
 use crate::utils::report_error;
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, Context as _};
 use log::info;
 use serde_json::Value;
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -196,13 +196,14 @@ impl Handler for MainHandler {
                 {
                     error::Nope::ResourceNotFound
                 } else if e.response.status == Some(status::InternalServerError) {
-                    report_error(&anyhow!(format!("internal server error: {}", e.error)));
+                    report_error(&anyhow!("internal server error: {}", e.error));
                     error::Nope::InternalServerError
                 } else {
-                    report_error(&anyhow!(format!(
+                    report_error(&anyhow!(
                         "No error page for status {:?}; {}",
-                        e.response.status, e.error
-                    )));
+                        e.response.status,
+                        e.error
+                    ));
                     // TODO: add in support for other errors that are actually used
                     error::Nope::InternalServerError
                 };

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -15,11 +15,11 @@ macro_rules! ctry {
             Err(error) => {
                 let request: &::iron::Request = $req;
 
+                // TODO this should be `capture_anyhow` if error is `anyhow::Error`
                 ::log::error!(
-                    "called ctry!() on an `Err` value: {:?}\nnote: while attempting to fetch the route {:?}\n{:?}",
+                    "called ctry!() on an `Err` value: {:?}\nnote: while attempting to fetch the route {:?}",
                     error,
                     request.url,
-                    ::backtrace::Backtrace::new(),
                 );
 
                 // This is very ugly, but it makes it impossible to get a type inference error
@@ -48,9 +48,8 @@ macro_rules! cexpect {
                 let request: &::iron::Request = $req;
 
                 ::log::error!(
-                    "called cexpect!() on a `None` value while attempting to fetch the route {:?}\n{:?}",
+                    "called cexpect!() on a `None` value while attempting to fetch the route {:?}",
                     request.url,
-                    ::backtrace::Backtrace::new(),
                 );
 
                 // This is very ugly, but it makes it impossible to get a type inference error

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -4,9 +4,11 @@ use crate::{
     build_queue::QueuedCrate,
     db::{Pool, PoolClient},
     impl_webpage,
+    utils::report_error,
     web::{error::Nope, match_version, page::WebPage, redirect_base},
     BuildQueue, Config,
 };
+use anyhow::anyhow;
 use chrono::{DateTime, NaiveDate, Utc};
 use iron::{
     headers::{ContentType, Expires, HttpDate},
@@ -481,7 +483,7 @@ fn redirect_to_random_crate(req: &Request, conn: &mut PoolClient) -> IronResult<
 
         Ok(super::redirect(url))
     } else {
-        log::error!("found no result in random crate search");
+        report_error(&anyhow!("found no result in random crate search"));
         Err(Nope::NoResults.into())
     }
 }

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     Config, Metrics, Storage,
 };
+use anyhow::anyhow;
 use iron::url::percent_encoding::percent_decode;
 use iron::{
     headers::{Expires, HttpDate},
@@ -229,7 +230,7 @@ impl RustdocPage {
                 metrics.html_rewrite_ooms.inc();
 
                 let config = extension!(req, Config);
-                let err = anyhow::anyhow!(
+                let err = anyhow!(
                     "Failed to serve the rustdoc file '{}' because rewriting it surpassed the memory limit of {} bytes",
                     file_path, config.max_parse_memory,
                 );
@@ -397,12 +398,10 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
         // should be impossible unless there is a semver incompatible version in the db
         // Note that there is a redirect earlier for semver matches to the exact version
         .map_err(|err| {
-            log::error!(
-                "invalid semver in database for crate {}: {}. Err: {}",
-                name,
-                &version,
-                err
-            );
+            utils::report_error(&anyhow!(err).context(format!(
+                "invalid semver in database for crate {}: {}",
+                name, &version,
+            )));
             Nope::InternalServerError
         })?
         .is_prerelease();

--- a/src/web/statics.rs
+++ b/src/web/statics.rs
@@ -1,6 +1,6 @@
 use super::{error::Nope, redirect, redirect_base, STATIC_FILE_CACHE_DURATION};
 use crate::utils::report_error;
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use chrono::Utc;
 use iron::{
     headers::CacheDirective,


### PR DESCRIPTION
This PR starts sending errors to sentry. 

What is sent to sentry now (including backtraces): 
- `log::error!` 
- `anyhow::Error`, when ending up in the `main` handler 
- `panic!` everywhere 

I'm not 100% sure if there need to be more places changed? 

### open topics / question 
- should all the `error!` calls in the codebase stay errors being sent to sentry? I could imagine some of them should be changed to warnings? Or should we exclude error-logs from sentry? 
- ~~I would love to switch the handling code in the `ctry!` to use `capture_anyhow` when it gets a fitting error type, but I wasn't sure about the best approach.~~ (done, thanks to @jyn514) 