### PR TITLE
Sort (and display) releases by build time, not release time

### DIFF
--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -58,8 +58,8 @@
                                     </div>
                                 {%- else -%}
                                     <div class="pure-u-1 pure-u-sm-4-24 pure-u-md-3-24 date"
-                                        title="{{ release.release_time | date(format='%FT%TZ') }}">
-                                        {{ release.release_time | timeformat(relative=true) }}
+                                        title="{{ release.build_time | date(format='%FT%TZ') }}">
+                                        {{ release.build_time | timeformat(relative=true) }}
                                     </div>
                                 {%- endif -%}
                             </div>

--- a/templates/releases/feed.xml
+++ b/templates/releases/feed.xml
@@ -9,7 +9,7 @@
     <link href="https://pubsubhubbub.superfeedr.com" rel="hub" />
 
     <id>urn:docs-rs:{{ docsrs_version() }}</id>
-    <updated>{{ recent_releases[0].release_time | default(value=now()) | date(format="%+") }}</updated>
+    <updated>{{ recent_releases[0].build_time | default(value=now()) | date(format="%+") }}</updated>
 
     {%- for release in recent_releases -%}
         {%- if release.rustdoc_status -%}
@@ -23,7 +23,7 @@
 
             <link href="{{ link | safe }}" />
             <id>urn:docs-rs:{{ release.name }}:{{ release.version }}</id>
-            <updated>{{ release.release_time | date(format="%+") }}</updated>
+            <updated>{{ release.build_time | date(format="%+") }}</updated>
 
             <summary>
                 {{ release.description | default(value="") | escape_xml }}

--- a/templates/releases/releases.html
+++ b/templates/releases/releases.html
@@ -40,14 +40,14 @@
 
                                 {% if release_type == 'owner' -%}
                                     <div class="pure-u-1 pure-u-sm-4-24 pure-u-md-3-24 date"
-                                        title="Published {{ release.release_time | timeformat(relative=true) }}">
+                                        title="Published {{ release.build_time | timeformat(relative=true) }}">
                                         {{ release.stars }}
                                         {{ "star" | fas }}
                                     </div>
                                 {%- else -%}
                                     <div class="pure-u-1 pure-u-sm-4-24 pure-u-md-3-24 date"
-                                        title="{{ release.release_time | date(format='%FT%TZ') }}">
-                                        {{ release.release_time | timeformat(relative=true) }}
+                                        title="{{ release.build_time | date(format='%FT%TZ') }}">
+                                        {{ release.build_time | timeformat(relative=true) }}
                                     </div>
                                 {%- endif %}
                             </div>


### PR DESCRIPTION
This avoids confusing situations where docs.rs will show "one hour ago"
for a crate it just built.

Fixes https://github.com/rust-lang/docs.rs/issues/1337.

r? @Nemo157