### PR TITLE
Fix source code file sidebar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -21,7 +21,7 @@
         {%- block css -%}{%- endblock css -%}
     </head>
 
-    <body>
+    <body class="{% block body_classes %}{% endblock body_classes %}">
         {%- block topbar -%}
           {%- include "header/topbar.html" -%}
         {%- endblock topbar -%}

--- a/templates/crate/source.html
+++ b/templates/crate/source.html
@@ -21,6 +21,10 @@
     {{ navigation::package_navigation(metadata=file_list.metadata, active_tab="source") }}
 {%- endblock header -%}
 
+{%- block body_classes -%}
+    {%- if file_content -%}flex{%- endif -%}
+{%- endblock body_classes -%}
+
 {%- block body -%}
     <div class="container package-page-container small-bottom-pad">
         <div class="pure-g">

--- a/templates/style/base.scss
+++ b/templates/style/base.scss
@@ -437,6 +437,7 @@ $sidebar-side-padding: 10px;
 
 div.package-page-container {
     padding-bottom: 50px;
+    width: 100%;
 
     &.small-bottom-pad {
         padding-bottom: 30px;
@@ -796,6 +797,24 @@ ul.pure-menu-list {
 }
 
 @media screen and (min-width: 35.5em) {
+    body.flex {
+        display: flex;
+        flex-direction: column;
+
+        .package-page-container {
+            flex-grow: 1;
+            position: relative;
+            display: flex;
+
+            .pure-g {
+                width: 100%;
+                -webkit-flex-flow: unset;
+                -webkit-align-content: unset;
+                align-content: unset;
+            }
+        }
+    }
+
     ul.pure-menu-list {
         li.toggle-source {
             display: list-item;
@@ -827,7 +846,7 @@ ul.pure-menu-list {
             top: $top-navbar-height;
             overflow: auto;
             max-height: calc(100vh - #{$top-navbar-height});
-            height: calc(100% - #{$top-navbar-height});
+            height: 100%;
 
             .pure-menu-list {
                 position: absolute;


### PR DESCRIPTION
Fixes #1492.

Now both elements takes the whole remaining available space (if the source code is too short to take it):

![Screenshot from 2021-09-13 16-52-20](https://user-images.githubusercontent.com/3050060/133106682-d5123aa9-4723-4ba3-8263-19c3e4425c10.png)
