### PR TITLE
Add docs.rs/rustc redirect.

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -728,6 +728,12 @@ mod test {
             // with or without slash
             assert_redirect("/rustc", target, web)?;
             assert_redirect("/rustc/", target, web)?;
+
+            let target = "https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc/";
+            // with or without slash
+            assert_redirect("/rustdoc", target, web)?;
+            assert_redirect("/rustdoc/", target, web)?;
+
             Ok(())
         })
     }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -723,6 +723,11 @@ mod test {
             // with or without slash
             assert_redirect("/proc-macro", target, web)?;
             assert_redirect("/proc-macro/", target, web)?;
+
+            let target = "https://doc.rust-lang.org/nightly/nightly-rustc/";
+            // with or without slash
+            assert_redirect("/rustc", target, web)?;
+            assert_redirect("/rustc/", target, web)?;
             Ok(())
         })
     }

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -170,6 +170,11 @@ pub(super) fn build_routes() -> Routes {
         "/rustc",
         super::rustdoc::RustLangRedirector::new("nightly", "nightly-rustc"),
     );
+    // redirect rustdoc to nightly rustdoc docs
+    routes.internal_page(
+        "/rustdoc",
+        super::rustdoc::RustLangRedirector::new("nightly", "nightly-rustc/rustdoc"),
+    );
 
     routes
 }

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -157,13 +157,18 @@ pub(super) fn build_routes() -> Routes {
     for redirect in DOC_RUST_LANG_ORG_REDIRECTS {
         routes.internal_page(
             &format!("/{}", redirect),
-            super::rustdoc::RustLangRedirector::new(redirect),
+            super::rustdoc::RustLangRedirector::new("stable", redirect),
         );
     }
     // redirect proc-macro to proc_macro
     routes.internal_page(
         "/proc-macro",
-        super::rustdoc::RustLangRedirector::new("proc_macro"),
+        super::rustdoc::RustLangRedirector::new("stable", "proc_macro"),
+    );
+    // redirect rustc to nightly rustc docs
+    routes.internal_page(
+        "/rustc",
+        super::rustdoc::RustLangRedirector::new("nightly", "nightly-rustc"),
     );
 
     routes

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -27,11 +27,10 @@ pub struct RustLangRedirector {
 }
 
 impl RustLangRedirector {
-    pub fn new(target: &'static str) -> Self {
-        let url = iron::url::Url::parse("https://doc.rust-lang.org/stable/")
-            .expect("failed to parse rust-lang.org base URL")
-            .join(target)
-            .expect("failed to append crate name to rust-lang.org base URL");
+    pub fn new(version: &str, target: &str) -> Self {
+        let url =
+            iron::url::Url::parse(&format!("https://doc.rust-lang.org/{}/{}", version, target))
+                .expect("failed to parse rust-lang.org doc URL");
         let url = Url::from_generic_url(url).expect("failed to convert url::Url to iron::Url");
 
         Self { url }


### PR DESCRIPTION
This adds a redirect from `docs.rs/rustc` to the nightly rustc docs.

`rustc` is a reserved crate name and will not appear on crates.io: https://github.com/rust-lang/crates.io/blob/master/migrations/20170305095748_create_reserved_crate_names/up.sql

Unlike the redirects for `std`, `core`, etc., this uses nightly rather than stable, because all development on rustc is happening on nightly. (And also `https://doc.rust-lang.org/stable/nightly-rustc/` looks a bit confusing. :P)