### PR TITLE
update zip to fix broken archives with more than 64k files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,16 +272,6 @@ checksum = "716960a18f978640f25101b5cbf1c6f6b0d3192fab36a2d98ca96f0ecbe41010"
 
 [[package]]
 name = "bzip2"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abf8012c8a15d5df745fcf258d93e6149dcf102882c8d8702d9cff778eab43a8"
@@ -766,7 +756,7 @@ dependencies = [
  "arc-swap",
  "backtrace",
  "base64 0.13.0",
- "bzip2 0.4.2",
+ "bzip2",
  "chrono",
  "comrak",
  "crates-index",
@@ -4433,12 +4423,12 @@ checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 
 [[package]]
 name = "zip"
-version = "0.5.11"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8264fcea9b7a036a4a5103d7153e988dbc2ebbafb34f68a3c2d404b6b82d74b6"
+checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
 dependencies = [
  "byteorder",
- "bzip2 0.3.3",
+ "bzip2",
  "crc32fast",
  "flate2",
  "thiserror",


### PR DESCRIPTION
We got a report by @adamgreig that the docs for [stm32ral](https://docs.rs/stm32ral/) don't work. 

Some digging lead to discovering https://github.com/zip-rs/zip/issues/106, and then to https://github.com/zip-rs/zip/pull/200, where the library silently creates a broken archive when it exceeds the old ZIP specification (4 GB archive, 64k files, 4GB per file in archive). The new version silently upgrades the format to ZIP64, which the library could also read the whole time.  

Upgrading the version of the zip-library fixes the issue. 

I ran local tests: 
- writing and reading the `stm32ral` archive (1.2 mio files) (ZIP limitation is 64k files) 
- writing and reading an archive > 5GB 

I didn't use the new `large_file` setting which we would need when a single file could exceed 4 GB, which I doubt. 

While we could in theory write a command that recompresses these archives, we could also just rebuild the affected crates. I'm not sure how we would find these, or if we would rebuild all crates? 