### PR TITLE
return `false` again for file-exist queries when the archive or its index don't exist

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -878,6 +878,10 @@ mod backend_tests {
         Ok(())
     }
 
+    fn test_delete_prefix_without_matches(storage: &Storage) -> Result<()> {
+        storage.delete_prefix("prefix_without_objects")
+    }
+
     fn test_delete_prefix(storage: &Storage) -> Result<()> {
         test_deletion(
             storage,
@@ -1003,6 +1007,7 @@ mod backend_tests {
             test_get_range,
             test_get_too_big,
             test_delete_prefix,
+            test_delete_prefix_without_matches,
             test_delete_percent,
             test_exists_without_remote_archive,
         }


### PR DESCRIPTION
this is a regression coming from the archive-storage implementation. 

`exists_in_archive` was erroring when the index didn't exist remotely or locally, while it actually should return `false` to mimic the old single-file-storage behavior. 

While writing the test I discovered that `storage.delete_prefix` will error on S3 when the list of files to be deleted is empty, which I fixed too. 

