### PR TITLE
use crates.io search to search crates

### DIFF
--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -97,11 +97,6 @@ impl<'a> FakeRelease<'a> {
         }
     }
 
-    pub(crate) fn downloads(mut self, downloads: i32) -> Self {
-        self.registry_release_data.downloads = downloads;
-        self
-    }
-
     pub(crate) fn description(mut self, new: impl Into<String>) -> Self {
         self.package.description = Some(new.into());
         self

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -23,6 +23,12 @@ mod queue_builder;
 mod rustc_version;
 pub(crate) mod sized_buffer;
 
+pub(crate) const APP_USER_AGENT: &str = concat!(
+    env!("CARGO_PKG_NAME"),
+    " ",
+    include_str!(concat!(env!("OUT_DIR"), "/git_version"))
+);
+
 pub(crate) fn report_error(err: &anyhow::Error) {
     if std::env::var("SENTRY_DSN").is_ok() {
         sentry_anyhow::capture_anyhow(err);

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -287,8 +287,8 @@ fn get_search_results(
 
     Ok(SearchResult {
         // start with the original names from crates.io to keep the original ranking,
-        // extend with the release/build information from docs.rs, if we already
-        // know about the crate.
+        // extend with the release/build information from docs.rs
+        // Crates that are not on docs.rs yet will not be returned.
         results: names
             .iter()
             .filter_map(|name| crates.get(name))

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -241,7 +241,7 @@ fn get_search_results(
                 crates.name,
                 releases.version,
                 releases.description,
-                releases.release_time,
+                builds.build_time,
                 releases.target_name,
                 releases.rustdoc_status,
                 repositories.stars
@@ -261,6 +261,7 @@ fn get_search_results(
                 WHERE releases.rank = 1
             ) AS latest_release ON latest_release.crate_id = crates.id
             INNER JOIN releases ON latest_release.id = releases.id
+            INNER JOIN builds ON releases.id = builds.rid
             LEFT JOIN repositories ON releases.repository_id = repositories.id
 
             WHERE crates.name = ANY($1)",
@@ -276,7 +277,7 @@ fn get_search_results(
                     name,
                     version: row.get("version"),
                     description: row.get("description"),
-                    build_time: row.get("release_time"),
+                    build_time: row.get("build_time"),
                     target_name: row.get("target_name"),
                     rustdoc_status: row.get("rustdoc_status"),
                     stars: stars.unwrap_or(0),

--- a/templates/releases/releases.html
+++ b/templates/releases/releases.html
@@ -57,26 +57,25 @@
             </ul>
 
             <div class="pagination">
-                {%- if release_type == 'owner' -%}
-                    {%- set page_link = "/releases/" ~ owner -%}
-                {%- else -%}
-                    {%- set page_link = "/releases/" ~ release_type -%}
-                {%- endif -%}
-                {%- if release_type == 'search' -%}
-                    {%- set query = "?search=" ~ search_query -%}
-                {%- endif -%}
+                {% block pagination %}
+                    {%- if release_type == 'owner' -%}
+                        {%- set page_link = "/releases/" ~ owner -%}
+                    {%- else -%}
+                        {%- set page_link = "/releases/" ~ release_type -%}
+                    {%- endif -%}
 
-                {%- if show_previous_page -%}
-                    <a class="pure-button pure-button-normal" href="{{ page_link | safe }}/{{ page_number - 1 }}{{ query | default(value='') }}">
-                        {{ "arrow-left" | fas }} Previous Page
-                    </a>
-                {%- endif -%}
+                    {%- if show_previous_page -%}
+                        <a class="pure-button pure-button-normal" href="{{ page_link | safe }}/{{ page_number - 1 }}{{ query | default(value='') }}">
+                            {{ "arrow-left" | fas }} Previous Page
+                        </a>
+                    {%- endif -%}
 
-                {%- if show_next_page -%}
-                    <a class="pure-button pure-button-normal" href="{{ page_link | safe }}/{{ page_number + 1 }}{{ query | default(value='') }}">
-                        Next Page {{ "arrow-right" | fas }}
-                    </a>
-                {%- endif -%}
+                    {%- if show_next_page -%}
+                        <a class="pure-button pure-button-normal" href="{{ page_link | safe }}/{{ page_number + 1 }}{{ query | default(value='') }}">
+                            Next Page {{ "arrow-right" | fas }}
+                        </a>
+                    {%- endif -%}
+                {% endblock pagination %}
             </div>
         </div>
     </div>

--- a/templates/releases/search_results.html
+++ b/templates/releases/search_results.html
@@ -1,0 +1,15 @@
+{%- extends "releases/releases.html" -%}
+
+{% block pagination %}
+    {%- if previous_page_link -%}
+        <a class="pure-button pure-button-normal" href="{{ previous_page_link|safe }}">
+            {{ "arrow-left" | fas }} Previous Page
+        </a>
+    {%- endif -%}
+
+    {%- if next_page_link -%}
+        <a class="pure-button pure-button-normal" href="{{ next_page_link|safe }}">
+            Next Page {{ "arrow-right" | fas }}
+        </a>
+    {%- endif -%}
+{% endblock pagination %}


### PR DESCRIPTION
This removes our own custom search with an API-Call to crates.io. 

Most of the actual API-call is based on #1224, while I reverted some parts of it. 
I added `rustdoc_status` to the `match_version` output so the `search_handler` looks better. 

Since crates or versions returned from the crates.io search might not exist in docs.rs yet, we are 
* matching the returned crate-names with our own database 
* using the old logic to find the latest version to show in the result. 
* but we are keeping the ranking/ordering. 
* pagination is purely based on the `next_page` and `prev_page` values coming from crates.io, following what @pietroalbini said in the chat. 

### My thoughts on the version being shown: 
IMHO using `max_version` or `max_stable_version` from crates.io is out of the picture since it might not exist in docs.rs yet. 
Other release-list pages use `crates.latest_version_id`, which is why I was thinking of using this version, but since this would be changed behavior I left the version logic as-is. 

### for the future 
**I believe we should _change_ the content of `crates.latest_version_id` to match `CrateDetails.latest_release`**. Then a click on the release-lists or search-results always takes you to a version without a _go to latest version_ link. 

So you don't have to look it up, we are showing the semver-highest version which is not yanked and no prerelease. What is different compared to the current version showed by search is that the `latest_release` definition includes releases with failed builds. 

But I would change this (and we can discuss details) in a separate PR. 

Related issues: #708, perhaps #1009 