### PR TITLE
use BufReader to read archive index files

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -249,8 +249,7 @@ impl Storage {
             .join(&remote_index_path);
 
         if local_index_path.exists() {
-            let mut file = fs::File::open(local_index_path)?;
-            archive_index::Index::load(&mut file)
+            archive_index::Index::load(io::BufReader::new(fs::File::open(local_index_path)?))
         } else {
             let index_content = self.get(&remote_index_path, std::usize::MAX)?.content;
 


### PR DESCRIPTION
I ran test with an index with 17k files: 
- it took ~250ms to load the index 
- after this change it only takes 25ms 
- for the problematic crate ( #1528 ) it still takes ~250ms

Since the average archive-size for docs is just around 600 I think we should merge and deploy this first. 
Using mmap made it only slightly faster, which is why I didn't add the additional dependency. 

The next optimization is probably not to load the whole index into memory but to answer the find-file requests while streaming the content of the index. But I would like to gather more data on archive-sizes first and benchmark it. 

