### PR TITLE
Fix nightly dead_code warnings

### DIFF
--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -20,11 +20,8 @@ pub struct Index {
 #[derive(Debug, serde::Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
 struct IndexConfig {
-    dl: String,
     #[serde(default)]
     api: Option<Url>,
-    #[serde(default)]
-    allowed_registries: Vec<String>,
 }
 
 /// Inspects the given repository to find the config as specified in [RFC 2141][], assumes that the

--- a/src/repositories/gitlab.rs
+++ b/src/repositories/gitlab.rs
@@ -205,18 +205,21 @@ struct GraphResponse<T> {
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)] // used by anyhow for error reporting; apparently the compiler isn't smart enough to tell
 struct GraphError {
     message: String,
     locations: Vec<GraphErrorLocation>,
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct GraphErrorLocation {
     line: u32,
     column: u32,
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct GraphRateLimit {
     remaining: u32,
 }


### PR DESCRIPTION
- Remove unused fields for custom repository
- Ignore warnings for deserialized errors. These are actually useful.