### PR TITLE
Remove wrong and unnecessary check for `build world`

### DIFF
--- a/src/docbuilder/crates.rs
+++ b/src/docbuilder/crates.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use anyhow::{ensure, Context};
+use anyhow::Context;
 use serde_json::Value;
 use std::io::prelude::*;
 use std::io::BufReader;
@@ -63,8 +63,6 @@ pub fn crates_from_path<F>(path: &Path, func: &mut F) -> Result<()>
 where
     F: FnMut(&str, &str),
 {
-    ensure!(!path.is_dir(), "Not a directory");
-
     for file in path.read_dir()? {
         let file = file?;
         let path = file.path();


### PR DESCRIPTION
This was changed in 18fecf555ea79898cf518dd1cdd5f7d244aaaf3f to negate
the condition (`!is_dir()` -> `is_dir()`), which is a bug. However, the
whole check is unnecessary, `read_dir` already returns an error if the
path isn't a directory.

r? @Nemo157