### PR TITLE
add missing index for builds.build-time for a faster "recent releases" page

### DIFF
--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -754,6 +754,11 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> crate::error::Res
             "ALTER TABLE releases ADD COLUMN archive_storage BOOL NOT NULL DEFAULT FALSE;",
             "ALTER TABLE releases DROP COLUMN archive_storage;",
         ),
+        migration!(
+            context, 31, "add index on builds.build_time", 
+            "CREATE INDEX builds_build_time_idx ON builds (build_time DESC);",
+            "DROP INDEX builds_build_time_idx;",
+        ),
     ];
 
     for migration in migrations {


### PR DESCRIPTION
This is a performance regression from 3868e79026c45a6281ac7a41fb91a74179696100 / #1491 . 

I visited the homepage and the loading-time felt too long. `releases.release_time` has an index to improve exactly this query, but `builds.build_time` didn't have it. 

local execution plan without the index: 
```
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                                          QUERY PLAN                                                                           │
├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Limit  (cost=12393.36..12409.68 rows=20 width=559) (actual time=70.925..74.048 rows=20 loops=1)                                                               │
│   ->  Nested Loop Left Join  (cost=12393.36..69507.73 rows=69970 width=559) (actual time=70.864..73.985 rows=20 loops=1)                                      │
│         ->  Nested Loop  (cost=12393.21..57955.01 rows=69970 width=559) (actual time=70.846..73.960 rows=20 loops=1)                                          │
│               Join Filter: (crates.latest_version_id = releases.id)                                                                                           │
│               ->  Gather Merge  (cost=12392.79..20541.95 rows=69970 width=27) (actual time=70.804..73.882 rows=20 loops=1)                                    │
│                     Workers Planned: 2                                                                                                                        │
│                     Workers Launched: 2                                                                                                                       │
│                     ->  Sort  (cost=11392.76..11465.65 rows=29154 width=27) (actual time=63.858..63.878 rows=443 loops=3)                                     │
│                           Sort Key: builds.build_time DESC                                                                                                    │
│                           Sort Method: quicksort  Memory: 2610kB                                                                                              │
│                           Worker 0:  Sort Method: quicksort  Memory: 2611kB                                                                                   │
│                           Worker 1:  Sort Method: quicksort  Memory: 2615kB                                                                                   │
│                           ->  Parallel Hash Join  (cost=2018.08..9230.79 rows=29154 width=27) (actual time=16.557..58.313 rows=23323 loops=3)                 │
│                                 Hash Cond: (builds.rid = crates.latest_version_id)                                                                            │
│                                 ->  Parallel Seq Scan on builds  (cost=0.00..6355.25 rows=182925 width=12) (actual time=0.013..18.934 rows=146340 loops=3)    │
│                                       Filter: (build_time IS NOT NULL)                                                                                        │
│                                 ->  Parallel Hash  (cost=1503.59..1503.59 rows=41159 width=15) (actual time=15.433..15.433 rows=23323 loops=3)                │
│                                       Buckets: 131072  Batches: 1  Memory Usage: 4608kB                                                                       │
│                                       ->  Parallel Seq Scan on crates  (cost=0.00..1503.59 rows=41159 width=15) (actual time=0.031..5.575 rows=23323 loops=3) │
│               ->  Index Scan using releases_pkey on releases  (cost=0.42..0.52 rows=1 width=544) (actual time=0.003..0.003 rows=1 loops=20)                   │
│                     Index Cond: (id = builds.rid)                                                                                                             │
│                     Filter: ((NOT build_status) AND is_library)                                                                                               │
│         ->  Index Scan using repositories_pkey on repositories  (cost=0.15..0.17 rows=1 width=8) (actual time=0.001..0.001 rows=0 loops=20)                   │
│               Index Cond: (id = releases.repository_id)                                                                                                       │
│ Planning Time: 5.177 ms                                                                                                                                       │
│ Execution Time: 74.886 ms                                                                                                                                     │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

and with the index: 
```
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                                         QUERY PLAN                                                                         │
├────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Limit  (cost=1.28..60.94 rows=20 width=559) (actual time=0.084..0.241 rows=20 loops=1)                                                                     │
│   ->  Nested Loop Left Join  (cost=1.28..208688.11 rows=69970 width=559) (actual time=0.083..0.238 rows=20 loops=1)                                        │
│         ->  Nested Loop  (cost=1.14..197135.40 rows=69970 width=559) (actual time=0.074..0.222 rows=20 loops=1)                                            │
│               Join Filter: (crates.latest_version_id = releases.id)                                                                                        │
│               ->  Nested Loop  (cost=0.71..159722.33 rows=69970 width=27) (actual time=0.060..0.172 rows=20 loops=1)                                       │
│                     ->  Index Scan using aaa on builds  (cost=0.42..13708.26 rows=439019 width=12) (actual time=0.039..0.053 rows=94 loops=1)              │
│                           Index Cond: (build_time IS NOT NULL)                                                                                             │
│                     ->  Index Scan using crates_latest_version_idx on crates  (cost=0.29..0.32 rows=1 width=15) (actual time=0.001..0.001 rows=0 loops=94) │
│                           Index Cond: (latest_version_id = builds.rid)                                                                                     │
│               ->  Index Scan using releases_pkey on releases  (cost=0.42..0.52 rows=1 width=544) (actual time=0.002..0.002 rows=1 loops=20)                │
│                     Index Cond: (id = builds.rid)                                                                                                          │
│                     Filter: ((NOT build_status) AND is_library)                                                                                            │
│         ->  Index Scan using repositories_pkey on repositories  (cost=0.15..0.17 rows=1 width=8) (actual time=0.000..0.000 rows=0 loops=20)                │
│               Index Cond: (id = releases.repository_id)                                                                                                    │
│ Planning Time: 3.774 ms                                                                                                                                    │
│ Execution Time: 0.338 ms                                                                                                                                   │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```