### PR TITLE
Don't discard errors from r2d2 when printing error chain

### DIFF
--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -132,8 +132,8 @@ pub enum PoolError {
     InvalidDatabaseUrl(#[from] postgres::Error),
 
     #[error("failed to create the database connection pool")]
-    PoolCreationFailed(r2d2::Error),
+    PoolCreationFailed(#[source] r2d2::Error),
 
     #[error("failed to get a database connection")]
-    ClientError(r2d2::Error),
+    ClientError(#[source] r2d2::Error),
 }


### PR DESCRIPTION
Previously:
```
Error: failed to create the database connection pool

Caused by:
    failed to create the database connection pool
```

Now:
```
Error: failed to create the database connection pool

Caused by:
    failed to create the database connection pool

Caused by:
    timed out waiting for connection: error connecting to server: Connection refused (os error 111)
```

r? @Nemo157