### PR TITLE
improve archive index reading performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,6 +785,7 @@ dependencies = [
  "kuchiki",
  "log 0.4.14",
  "lol_html",
+ "memmap",
  "mime_guess 2.0.3",
  "mockito",
  "notify",
@@ -1844,6 +1845,16 @@ name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "memoffset"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ rusoto_credential = "0.46.0"
 # Data serialization and deserialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+memmap = "0.7.0"
 
 # iron dependencies
 iron = "0.6"

--- a/src/storage/archive_index.rs
+++ b/src/storage/archive_index.rs
@@ -66,12 +66,6 @@ pub(crate) fn find_in_slice(bytes: &[u8], search_for: &str) -> Result<Option<Fil
         search_for: String,
     }
 
-    impl FindFileListVisitor {
-        pub fn new(path: String) -> Self {
-            FindFileListVisitor { search_for: path }
-        }
-    }
-
     impl<'de> Visitor<'de> for FindFileListVisitor {
         type Value = Option<FileInfo>;
 
@@ -89,12 +83,6 @@ pub(crate) fn find_in_slice(bytes: &[u8], search_for: &str) -> Result<Option<Fil
             /// `None`.
             struct FindFileVisitor {
                 search_for: String,
-            }
-
-            impl FindFileVisitor {
-                pub fn new(search_for: String) -> Self {
-                    FindFileVisitor { search_for }
-                }
             }
 
             impl<'de> DeserializeSeed<'de> for FindFileVisitor {
@@ -140,7 +128,9 @@ pub(crate) fn find_in_slice(bytes: &[u8], search_for: &str) -> Result<Option<Fil
 
             while let Some(key) = map.next_key::<&str>()? {
                 if key == "files" {
-                    return map.next_value_seed(FindFileVisitor::new(self.search_for));
+                    return map.next_value_seed(FindFileVisitor {
+                        search_for: self.search_for,
+                    });
                 }
             }
 
@@ -159,7 +149,10 @@ pub(crate) fn find_in_slice(bytes: &[u8], search_for: &str) -> Result<Option<Fil
         }
     }
 
-    Ok(FindFileListVisitor::new(search_for.to_string()).deserialize(&mut deserializer)?)
+    Ok(FindFileListVisitor {
+        search_for: search_for.to_string(),
+    }
+    .deserialize(&mut deserializer)?)
 }
 
 pub(crate) fn find_in_file<P: AsRef<Path>>(

--- a/src/storage/archive_index.rs
+++ b/src/storage/archive_index.rs
@@ -1,10 +1,14 @@
 use crate::error::Result;
 use crate::storage::{compression::CompressionAlgorithm, FileRange};
 use anyhow::{bail, Context as _};
-use serde::{Deserialize, Serialize};
+use memmap::MmapOptions;
+use serde::de::DeserializeSeed;
+use serde::de::{IgnoredAny, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
-use std::io;
-use std::path::{Path, PathBuf};
+use std::fmt;
+use std::path::Path;
+use std::{fs, io};
 
 #[derive(Deserialize, Serialize)]
 pub(crate) struct FileInfo {
@@ -21,51 +25,155 @@ impl FileInfo {
     }
 }
 
-#[derive(Deserialize, Serialize)]
-pub(crate) struct Index {
-    files: HashMap<PathBuf, FileInfo>,
+#[derive(Serialize)]
+struct Index {
+    files: HashMap<String, FileInfo>,
 }
 
-impl Index {
-    pub(crate) fn load(reader: impl io::Read) -> Result<Index> {
-        serde_cbor::from_reader(reader).context("deserialization error")
-    }
+pub(crate) fn create<R: io::Read + io::Seek, W: io::Write>(
+    zipfile: &mut R,
+    writer: &mut W,
+) -> Result<()> {
+    let mut archive = zip::ZipArchive::new(zipfile)?;
 
-    pub(crate) fn save(&self, writer: impl io::Write) -> Result<()> {
-        serde_cbor::to_writer(writer, self).context("serialization error")
-    }
+    // get file locations
+    let mut files: HashMap<String, FileInfo> = HashMap::with_capacity(archive.len());
+    for i in 0..archive.len() {
+        let zf = archive.by_index(i)?;
 
-    pub(crate) fn new_from_zip<R: io::Read + io::Seek>(zipfile: &mut R) -> Result<Index> {
-        let mut archive = zip::ZipArchive::new(zipfile)?;
-
-        // get file locations
-        let mut files: HashMap<PathBuf, FileInfo> = HashMap::with_capacity(archive.len());
-        for i in 0..archive.len() {
-            let zf = archive.by_index(i)?;
-
-            files.insert(
-                PathBuf::from(zf.name()),
-                FileInfo {
-                    range: FileRange::new(
-                        zf.data_start(),
-                        zf.data_start() + zf.compressed_size() - 1,
-                    ),
-                    compression: match zf.compression() {
-                        zip::CompressionMethod::Bzip2 => CompressionAlgorithm::Bzip2,
-                        c => bail!("unsupported compression algorithm {} in zip-file", c),
-                    },
+        files.insert(
+            zf.name().to_string(),
+            FileInfo {
+                range: FileRange::new(zf.data_start(), zf.data_start() + zf.compressed_size() - 1),
+                compression: match zf.compression() {
+                    zip::CompressionMethod::Bzip2 => CompressionAlgorithm::Bzip2,
+                    c => bail!("unsupported compression algorithm {} in zip-file", c),
                 },
-            );
+            },
+        );
+    }
+
+    serde_cbor::to_writer(writer, &Index { files }).context("serialization error")
+}
+
+pub(crate) fn find_in_slice(bytes: &[u8], search_for: &str) -> Result<Option<FileInfo>> {
+    let mut deserializer = serde_cbor::Deserializer::from_slice(bytes);
+
+    /// This visitor will just find the `files` element in the top-level map.
+    /// Then it will call the `FindFileVisitor` that should find the actual
+    /// FileInfo for the path we are searching for.
+    struct FindFileListVisitor {
+        search_for: String,
+    }
+
+    impl FindFileListVisitor {
+        pub fn new(path: String) -> Self {
+            FindFileListVisitor { search_for: path }
+        }
+    }
+
+    impl<'de> Visitor<'de> for FindFileListVisitor {
+        type Value = Option<FileInfo>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            write!(formatter, "a map with a 'files' key")
         }
 
-        Ok(Index { files })
+        fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+        where
+            V: MapAccess<'de>,
+        {
+            /// This visitor will walk the full `files` map and search for
+            /// the path we want to have.
+            /// Return value is just the `FileInfo` we want to have, or
+            /// `None`.
+            struct FindFileVisitor {
+                search_for: String,
+            }
+
+            impl FindFileVisitor {
+                pub fn new(search_for: String) -> Self {
+                    FindFileVisitor { search_for }
+                }
+            }
+
+            impl<'de> DeserializeSeed<'de> for FindFileVisitor {
+                type Value = Option<FileInfo>;
+                fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+                where
+                    D: Deserializer<'de>,
+                {
+                    deserializer.deserialize_map(self)
+                }
+            }
+
+            impl<'de> Visitor<'de> for FindFileVisitor {
+                type Value = Option<FileInfo>;
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    write!(
+                        formatter,
+                        "a map with path => FileInfo, searching for path {:?}",
+                        self.search_for
+                    )
+                }
+                fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+                where
+                    V: MapAccess<'de>,
+                {
+                    while let Some(key) = map.next_key::<&str>()? {
+                        if key == self.search_for {
+                            let value = map.next_value::<FileInfo>()?;
+                            // skip over the rest of the data without really parsing it.
+                            // If we don't do this the serde_cbor deserializer fails because not
+                            // the whole map is consumed.
+                            while map.next_entry::<IgnoredAny, IgnoredAny>()?.is_some() {}
+                            return Ok(Some(value));
+                        } else {
+                            // skip parsing the FileInfo structure when the key doesn't match.
+                            map.next_value::<IgnoredAny>()?;
+                        }
+                    }
+
+                    Ok(None)
+                }
+            }
+
+            while let Some(key) = map.next_key::<&str>()? {
+                if key == "files" {
+                    return map.next_value_seed(FindFileVisitor::new(self.search_for));
+                }
+            }
+
+            Ok(None)
+        }
     }
 
-    pub(crate) fn find_file<P: AsRef<Path>>(&self, path: P) -> Result<&FileInfo> {
-        self.files
-            .get(path.as_ref())
-            .ok_or_else(|| super::PathNotFoundError.into())
+    impl<'de> DeserializeSeed<'de> for FindFileListVisitor {
+        type Value = Option<FileInfo>;
+
+        fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserializer.deserialize_map(self)
+        }
     }
+
+    Ok(FindFileListVisitor::new(search_for.to_string()).deserialize(&mut deserializer)?)
+}
+
+pub(crate) fn find_in_file<P: AsRef<Path>>(
+    archive_index_path: P,
+    search_for: &str,
+) -> Result<Option<FileInfo>> {
+    let file = fs::File::open(archive_index_path).context("could not open file")?;
+    let mmap = unsafe {
+        MmapOptions::new()
+            .map(&file)
+            .context("could not create memory map")?
+    };
+
+    find_in_slice(&mmap, search_for)
 }
 
 #[cfg(test)]
@@ -73,14 +181,6 @@ mod tests {
     use super::*;
     use std::io::Write;
     use zip::write::FileOptions;
-
-    fn validate_index(index: &Index) {
-        assert_eq!(index.files.len(), 1);
-
-        let fi = index.files.get(&PathBuf::from("testfile1")).unwrap();
-        assert_eq!(fi.range, FileRange::new(39, 459));
-        assert_eq!(fi.compression, CompressionAlgorithm::Bzip2);
-    }
 
     #[test]
     fn index_create_save_load() {
@@ -98,13 +198,13 @@ mod tests {
         archive.write_all(&objectcontent).unwrap();
         tf = archive.finish().unwrap();
 
-        let index = Index::new_from_zip(&mut tf).unwrap();
-        validate_index(&index);
-
         let mut buf = Vec::new();
-        index.save(&mut buf).unwrap();
+        create(&mut tf, &mut buf).unwrap();
 
-        let new_index = Index::load(io::Cursor::new(&buf)).unwrap();
-        validate_index(&new_index);
+        let fi = find_in_slice(&buf, "testfile1").unwrap().unwrap();
+        assert_eq!(fi.range, FileRange::new(39, 459));
+        assert_eq!(fi.compression, CompressionAlgorithm::Bzip2);
+
+        assert!(find_in_slice(&buf, "some_other_file").unwrap().is_none());
     }
 }


### PR DESCRIPTION
* use a streaming parser to find a file in the local index
* switch to memmap as reader

For the extreme case (`stm32ral`, 1.2 million files in the archive) index-read gets from ~3.5s to ~~600ms~~ ~300ms. 


This is the first time I worked with custom serde deserializers, I didn't find a way to: 
- only use 1 custom visitor and still pass the seed (the path to search) into the other visitor 
- actually stop reading data when we found the entry (this could improve performance even further).
I'm happy to add any improvements :) 

There are still possible improvements when downloading the index, but for local indexes we probably don't have much more we can optimize without changing the format. 
