### PR TITLE
ignore audit advisories we want to ignore, or cannot do anything right now

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,32 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2020-0016", # net2 crate has been deprecated; use socket2 instead
+    # https://github.com/rust-lang/docs.rs/issues/760
+
+    "RUSTSEC-2020-0036", # failure is officially deprecated/unmaintained
+    # https://github.com/rust-lang/docs.rs/issues/1014
+
+    "RUSTSEC-2020-0056", # stdweb is unmaintained
+    # https://github.com/rust-lang/docs.rs/issues/1122
+
+    "RUSTSEC-2020-0071", # `time` localtime_r segfault
+    # https://github.com/rust-lang/docs.rs/issues/1523
+
+    "RUSTSEC-2020-0095", # difference is unmaintained
+    # https://github.com/rust-lang/docs.rs/issues/1357
+
+    "RUSTSEC-2020-0159", # `chrono` localtime_r segfault
+    # https://github.com/rust-lang/docs.rs/issues/1525
+
+    "RUSTSEC-2021-0078", # Lenient hyper header parsing of Content-Length could allow request smuggling
+    # https://github.com/rust-lang/docs.rs/issues/1460
+
+    "RUSTSEC-2021-0079", # Integer overflow in hyper's parsing of the Transfer-Encoding header leads to data loss
+    # https://github.com/rust-lang/docs.rs/issues/1459
+]
+informational_warnings = ["unmaintained"] # warn for categories of informational advisories
+severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "critical")
+
+[output]
+quiet = false
+deny = ["unmaintained"] # yanked is allowed for now

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
+      - ".cargo/audit.toml"
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
If we want the audit checks on PRs or in forks to pass we have to ignore everything we don't directly fix. 

I'm not 100% sure what to add in the comments, I'm happy to add more. 

I also set `deny = ["warnings"]` which makes the audit fail when unmaintained crates are added like I did in #1541 . 