### PR TITLE
don't upload to docker in forked repos

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,4 +20,4 @@ jobs:
           region: us-west-1
           aws_access_key_id: "${{ secrets.aws_access_key_id }}"
           aws_secret_access_key: "${{ secrets.aws_secret_access_key }}"
-        if: github.ref == 'refs/heads/master'
+        if: ${{ github.ref == 'refs/heads/master' && github.repository_owner == 'rust-lang' }}


### PR DESCRIPTION
This was the last check that failed every night for me. We only need to upload the image on the main repo master, not on the forks. 