### PR TITLE
Make storage-change-detection.html cacheable

### DIFF
--- a/src/web/page/web_page.rs
+++ b/src/web/page/web_page.rs
@@ -1,7 +1,12 @@
 use super::TemplateData;
 use crate::ctry;
 use crate::web::csp::Csp;
-use iron::{headers::ContentType, response::Response, status::Status, IronResult, Request};
+use iron::{
+    headers::{CacheControl, ContentType},
+    response::Response,
+    status::Status,
+    IronResult, Request,
+};
 use serde::Serialize;
 use std::borrow::Cow;
 use tera::Context;
@@ -77,6 +82,7 @@ pub trait WebPage: Serialize + Sized {
 
         let mut response = Response::with((status, rendered));
         response.headers.set(Self::content_type());
+        response.headers.set(Self::cache_control());
 
         Ok(response)
     }
@@ -92,5 +98,10 @@ pub trait WebPage: Serialize + Sized {
     /// The content type that the template should be served with, defaults to html
     fn content_type() -> ContentType {
         ContentType::html()
+    }
+
+    /// The contents of the Cache-Control header. Defaults to no caching.
+    fn cache_control() -> CacheControl {
+        CacheControl(vec![])
     }
 }

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -1,5 +1,11 @@
+use crate::web::page::WebPage;
+
 use super::metrics::RequestRecorder;
-use iron::middleware::Handler;
+use ::std::borrow::Cow;
+use iron::{
+    headers::{CacheControl, CacheDirective},
+    middleware::Handler,
+};
 use router::Router;
 use std::collections::HashSet;
 
@@ -34,7 +40,15 @@ pub(super) fn build_routes() -> Routes {
     routes.internal_page("/-/storage-change-detection.html", {
         #[derive(Debug, serde::Serialize)]
         struct StorageChangeDetection {}
-        crate::impl_webpage!(StorageChangeDetection = "storage-change-detection.html");
+
+        impl WebPage for StorageChangeDetection {
+            fn template(&self) -> Cow<'static, str> {
+                "storage-change-detection.html".into()
+            }
+            fn cache_control() -> CacheControl {
+                CacheControl(vec![CacheDirective::MaxAge(604800)])
+            }
+        }
         fn storage_change_detection(req: &mut iron::Request) -> iron::IronResult<iron::Response> {
             crate::web::page::WebPage::into_response(StorageChangeDetection {}, req)
         }


### PR DESCRIPTION
This is one of the most-requested URLs on the site, because it is embedded in a lot of different pages and is not cacheable.