### PR TITLE
Remove rust-navigation-item style

### DIFF
--- a/templates/style/base.scss
+++ b/templates/style/base.scss
@@ -727,13 +727,6 @@ div.search-page-search-form {
     }
 }
 
-.rust-navigation-item {
-    background: url(/rust-logo.png) no-repeat;
-    background-position: 15px 45%;
-    background-size: 12px;
-    padding-left: 35px;
-}
-
 .about {
     font-family: $font-family-serif;
     color: var(--color-standard);


### PR DESCRIPTION
AFAICT the only code that generated nodes with this class was removed in
9826ca0f1ed6b373ff49f182a5e44f8fe25ba89f. I noticed the issue because
/rust-logo.png shows up as one of the top requested URLs, but is a 404.