### PR TITLE
Make font-awesome-as-a-crate usable from a const context

### DIFF
--- a/crates/font-awesome-as-a-crate/Cargo.toml
+++ b/crates/font-awesome-as-a-crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-awesome-as-a-crate"
-version = "0.1.2"
+version = "0.2.0"
 # https://github.com/FortAwesome/Font-Awesome/blob/master/composer.json
 authors = ["Michael Howell <michael@notriddle.com>", "Travis Chase", "Dave Gandy", "Rob Madole", "Jory Raphael", "Geremia Taglialatela", "Brian Talbot", "Mike Wilkerson", "Fonticons Inc <hello@fontawesome.com>"]
 edition = "2018"

--- a/crates/font-awesome-as-a-crate/build.rs
+++ b/crates/font-awesome-as-a-crate/build.rs
@@ -14,7 +14,7 @@ fn write_fontawesome_sprite() {
     let dest_path = Path::new(&env::var("OUT_DIR").unwrap()).join("fontawesome.rs");
     let mut dest_file = File::create(&dest_path).unwrap();
     dest_file
-        .write_all(b"fn fontawesome_svg(dir:&str,file:&str)->&'static str{match(dir,file){")
+        .write_all(b"const fn fontawesome_svg(dir:&str,file:&str)->&'static str{match(dir.as_bytes(),file.as_bytes()){")
         .expect("fontawesome fn write");
     for dirname in &["brands", "regular", "solid"] {
         let dir = read_dir(Path::new("fontawesome-free-5.14.0-web/svgs").join(dirname)).unwrap();
@@ -34,7 +34,7 @@ fn write_fontawesome_sprite() {
             dest_file
                 .write_all(
                     format!(
-                        r####"("{dirname}","{filename}")=>r###"{data}"###,"####,
+                        r####"(b"{dirname}",b"{filename}")=>r###"{data}"###,"####,
                         data = data,
                         dirname = dirname,
                         filename = filename.replace(".svg", ""),

--- a/crates/font-awesome-as-a-crate/src/lib.rs
+++ b/crates/font-awesome-as-a-crate/src/lib.rs
@@ -49,7 +49,7 @@ impl Display for NameError {
 impl Error for NameError {}
 
 impl Type {
-    pub fn as_str(self) -> &'static str {
+    pub const fn as_str(self) -> &'static str {
         match self {
             Type::Brands => "brands",
             Type::Regular => "regular",
@@ -79,7 +79,7 @@ impl Display for Type {
 /**
 Get a fontawesome svg file by its name.
 */
-pub fn svg(type_: Type, name: &str) -> Result<&'static str, NameError> {
+pub const fn svg(type_: Type, name: &str) -> Result<&'static str, NameError> {
     let svg = fontawesome_svg(type_.as_str(), name);
     if svg.is_empty() {
         return Err(NameError);
@@ -89,6 +89,13 @@ pub fn svg(type_: Type, name: &str) -> Result<&'static str, NameError> {
 
 #[cfg(test)]
 mod tests {
+    const fn usable_as_const_() {
+        assert!(crate::svg(crate::Type::Solid, "cog").is_ok());
+    }
+    #[test]
+    fn usable_as_const() {
+        usable_as_const_();
+    }
     #[test]
     fn it_works() {
         assert!(crate::svg(crate::Type::Solid, "cog").is_ok());


### PR DESCRIPTION
This allows it to fit more cleanly into codebases like rustdoc that use constants for their assets.

https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/icon.20harmonization/near/263796393