### PR TITLE
Update font-awesome-as-a-crate locked version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "font-awesome-as-a-crate"
-version = "0.1.2"
+version = "0.2.0"
 
 [[package]]
 name = "foreign-types"


### PR DESCRIPTION
There's some annoying cargo behavior around versions of `path` dependencies before/after publish that requires an extra update post-publish.