### PR TITLE
Add "y" shortcut for permalink

### DIFF
--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -476,8 +476,8 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
     };
 
     let permalink_path = format!(
-        "/crate/{}/{}{}{}",
-        name, latest_version, target_redirect, query_string
+        "/{}/{}/{}{}",
+        name, latest_version, inner_path, query_string
     );
 
     let latest_path = format!("/crate/{}/latest{}{}", name, target_redirect, query_string);
@@ -834,7 +834,7 @@ mod test {
             let body = String::from_utf8(resp.bytes().unwrap().to_vec()).unwrap();
             assert!(body.contains("<a href=\"/crate/dummy/latest/source/\""));
             assert!(body.contains("<a href=\"/crate/dummy/latest\""));
-            assert!(body.contains("<a href=\"/crate/dummy/0.1.0/target-redirect/x86_64-unknown-linux-gnu/dummy/index.html\""));
+            assert!(body.contains("<a href=\"/dummy/0.1.0/dummy/index.html\""));
             Ok(())
         })
     }

--- a/static/menu.js
+++ b/static/menu.js
@@ -241,11 +241,7 @@
             if (document.location.hash != "") {
               permalink.href += "#" + document.location.hash;
             }
-            // Note: It would be nicer to do history.replaceState here and avoid a page load
-            // (that's what GitHub does), but the permalink goes through a redirect, so you wind up
-            // with a weird URL like:
-            // http://localhost:3000/crate/regex/1.3.1/target-redirect/x86_64-unknown-linux-gnu/regex/index.html
-            permalink.click();
+            history.replaceState({}, null, permalink.href);
         }
     });
 })();

--- a/static/menu.js
+++ b/static/menu.js
@@ -235,4 +235,17 @@
         menu.firstElementChild.addEventListener("click", menuOnClick);
     }
     document.documentElement.addEventListener("keydown", menuKeyDown);
+    document.documentElement.addEventListener("keydown", function(ev) {
+        if (ev.key == "y") {
+            let permalink = document.getElementById("permalink");
+            if (document.location.hash != "") {
+              permalink.href += "#" + document.location.hash;
+            }
+            // Note: It would be nicer to do history.replaceState here and avoid a page load
+            // (that's what GitHub does), but the permalink goes through a redirect, so you wind up
+            // with a weird URL like:
+            // http://localhost:3000/crate/regex/1.3.1/target-redirect/x86_64-unknown-linux-gnu/regex/index.html
+            permalink.click();
+        }
+    });
 })();

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -24,7 +24,7 @@ extra whitespace unremovable, need to use html tags unaffacted by whitespace T_T
 
                     {%- if metadata.version_or_latest == "latest" -%}
                     <li class="pure-menu-item">
-                        <a href="{{permalink_path | safe}}" class="pure-menu-link description" title="Get a link to this specific version">
+                        <a href="{{permalink_path | safe}}" class="pure-menu-link description" id="permalink" title="Get a link to this specific version">
                             {{ "link" | fas }} Permalink
                         </a>
                     </li>


### PR DESCRIPTION
This follows the example of GitHub's "y" shortcut, which updates the current URL to contain the commit hash you're looking at.