### PR TITLE
Remove JS workaround for scroll-padding-top

### DIFF
--- a/templates/rustdoc/body.html
+++ b/templates/rustdoc/body.html
@@ -1,36 +1,5 @@
 <script type="text/javascript" src="/-/static/menu.js?{{ docsrs_version() | slugify }}"></script>
 <script type="text/javascript" src="/-/static/index.js?{{ docsrs_version() | slugify }}"></script>
-<script>
-  // Reset the scroll offset on browsers that don't support
-  // scroll-padding-top (Desktop & Mobile Safari):
-  const maybeFixupViewPortPosition = function() {
-    if (window.location.hash) {
-      const anchorElement = document.getElementById(window.location.hash.substr(1));
-      const navBarHeight = document.getElementsByClassName("nav-container-rustdoc")[0].offsetHeight;
-      if (anchorElement &&
-          anchorElement.getBoundingClientRect().top <= navBarHeight &&
-          Math.abs(anchorElement.getBoundingClientRect().top) >= 0) {
-        // It's just overlapped by the nav bar. This can't be a coincidence, scroll it into view:
-        requestAnimationFrame(function() {
-          scrollBy(0, -navBarHeight);
-        });
-      }
-    }
-  };
-  window.addEventListener("hashchange", maybeFixupViewPortPosition, false);
-  // Fix up the scroll position if this was a direct visit to the page
-  // (not back/forward navigation):
-  if (window.performance) {
-    const navEntries = window.performance.getEntriesByType('navigation');
-    const usedBack = navEntries.length > 0 && navEntries[0].type === 'back_forward' ||
-          (window.performance.navigation &&
-           window.performance.navigation.type == window.performance.navigation.TYPE_BACK_FORWARD);
-    if (!usedBack && window.location.hash) {
-      window.addEventListener("scroll", maybeFixupViewPortPosition, {"once": true});
-    }
-  }
-</script>
-
 {# see comment in ../storage-change-detection.html for details #}
 <iframe src="/-/storage-change-detection.html" width="0" height="0" style="display: none"></iframe>
 {%- include "footer.html" -%}


### PR DESCRIPTION
Safari didn't previously support it, put it is now supported since version 14 (latest is 15).

Fixes #1334. Related: #1595.

I've tested locally with latest Safari on iPad and iPhone.