### PR TITLE
Switch from position: fixed to sticky

### DIFF
--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -15,7 +15,7 @@ div.nav-container {
     left: 0;
     right: 0;
     top: 0;
-    position: fixed;
+    position: sticky;
     color: var(--color-navbar-standard);
     font-family: $font-family-sans;
 
@@ -286,17 +286,6 @@ div.nav-container {
 
 #nav-search {
     color: var(--color-navbar-standard);
-}
-
-body {
-    // Since top navbar is fixed, we need to add padding to the body content.
-    padding-top: $top-navbar-height !important;
-
-    // The scroll padding on the <body> is necessary for Chrome
-    // browsers for now (see
-    // https://css-tricks.com/fixed-headers-on-page-links-and-overlapping-content-oh-my/
-    // for an explanation)
-    scroll-padding-top: $top-navbar-height;
 }
 
 html {

--- a/templates/style/base.scss
+++ b/templates/style/base.scss
@@ -102,7 +102,7 @@ body {
     padding: 0;
     margin: 0;
     position: relative;
-    min-height: calc(100vh - #{$top-navbar-height});
+    min-height: 100vh; /* Tall enough to stick the footer to the bottom */
 
     * {
         -webkit-box-sizing: border-box;

--- a/templates/style/rustdoc-common.scss
+++ b/templates/style/rustdoc-common.scss
@@ -3,7 +3,7 @@
 
 // This rule is needed to be sure that the footer will always be at the bottom of the page.
 #rustdoc_body_wrapper {
-    min-height: calc(100vh - #{$top-navbar-height + $footer-height + 2});
+    min-height: calc(100vh - #{$footer-height + 2});
 }
 
 #clipboard {


### PR DESCRIPTION
This allows us to remove `padding-top: $top-navbar-height !important` on body.

Also, remove an obsolete workaround for older Chrome browsers to put scroll-padding-top on `body` rather than `html`.

Part of #1595

Tested locally with latest Chrome on Desktop in Dev Tools mobile mode, and latest Chrome on latest Android.