### PR TITLE
daily purge of purge rustwide caches

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -98,7 +98,14 @@ impl RustwideBuilder {
             .enable_networking(limits.networking())
     }
 
-    pub fn update_toolchain(&mut self) -> Result<()> {
+    pub fn purge_caches(&self) -> Result<()> {
+        self.workspace
+            .purge_all_caches()
+            .map_err(FailureError::compat)?;
+        Ok(())
+    }
+
+    pub fn update_toolchain(&mut self) -> Result<bool> {
         // Ignore errors if detection fails.
         let old_version = self.detect_rustc_version().ok();
 
@@ -157,11 +164,12 @@ impl RustwideBuilder {
         }
 
         self.rustc_version = self.detect_rustc_version()?;
-        if old_version.as_deref() != Some(&self.rustc_version) {
+
+        let has_changed = old_version.as_deref() != Some(&self.rustc_version);
+        if has_changed {
             self.add_essential_files()?;
         }
-
-        Ok(())
+        Ok(has_changed)
     }
 
     fn detect_rustc_version(&self) -> Result<String> {


### PR DESCRIPTION
Next to some rustwide related cache directories this cleans these folders after each nightly update (so roughly every day):  

- `/workspace/cargo-home/registry/cache/` (9.4 GiB currently)
- `/workspace/cargo-home/registry/index/github.com-1ecc6299db9ec823/.cache` (345 MiB currently)
- `/workspace/cargo-home/registry/src/` (59 GiB currently)


I initially thought about putting this inside `RustwideBuilder::update_toolchain`, but like this it's clearly separate. Also the purge is not done when `update_toolchain` is called from other places. 

There is a possible race condition when we run a manual build from the commandline while the cache-purge from the queue is running, but realistically I would judge this as a non-issue. 

Binding this to a successful nightly toolchain fetch was an idea by @pietroalbini 

#### deploy 
before I would deploy this I would actually to the initial delete of the `/src` directory manually (lock the queue, wait until the current build is finished, delete the folder and unlock again). 