### PR TITLE
Allow to click on the footer again by positioning the footer on top of the main div

### DIFF
--- a/templates/style/rustdoc-common.scss
+++ b/templates/style/rustdoc-common.scss
@@ -36,7 +36,7 @@ div.container-rustdoc:not(.source) {
     }
 }
 
-div.container-rustdoc.source {
+div.container-rustdoc {
     > .docs-rs-footer {
         left: -15px;
         // This is needed because even though the sidebar only contains the header, it still takes


### PR DESCRIPTION
Fixes #1599.

It'd be nice to start having GUI tests for docs.rs like rustdoc (with the same or a different GUI test framework, doesn't matter).