### PR TITLE
Add styles for rustdoc mobile-topbar

### DIFF
--- a/templates/style/rustdoc-common.scss
+++ b/templates/style/rustdoc-common.scss
@@ -101,6 +101,7 @@ div.rustdoc {
         }
     }
 
+    .mobile-topbar,
     #source-sidebar {
         top: $top-navbar-height;
     }


### PR DESCRIPTION
Offset it by the size of the docs.rs topbar.

After https://github.com/rust-lang/rust/pull/92692 lands, this will be needed so rustdoc's mobile topbar won't hide underneath the docs.rs topbar.

Unfortunately there isn't a good way to test this until the PR lands. Locally I've tested this by building from a `try` artifact.