### PR TITLE
Do not duplicate `#` when using the `y` permalink shortcut

### DIFF
--- a/static/menu.js
+++ b/static/menu.js
@@ -239,7 +239,7 @@
         if (ev.key == "y") {
             let permalink = document.getElementById("permalink");
             if (document.location.hash != "") {
-              permalink.href += "#" + document.location.hash;
+              permalink.href += document.location.hash;
             }
             history.replaceState({}, null, permalink.href);
         }


### PR DESCRIPTION
Given the issue #1609, it looks like `document.location.hash` already bundles `#`?

  - ~~If my hypothesis is correct~~, this should~~ fix #1609, but I may also be wrong. Either way, the review ought to be simple, @jsha: either I'm right and this can be merged, or I'm wrong, and this can be closed~~ 😄 

  - EDIT: This does fix #1609