### PR TITLE
Add explicit padding-top: 0 to topbar body style

### DIFF
--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -6,6 +6,15 @@
     color: var(--color-standard);
 }
 
+/* Body must have no padding so the topbar sticks to the top of the viewport
+   and extends to both sides of the screen.
+   Some versions of rustdoc had this style, which we need to override:
+   body { padding: 10px 15px 20px 15px; }
+*/
+body {
+    padding: 0;
+}
+
 div.nav-container {
     // Nothing is supposed to be over or hovering the top navbar. Maybe add a few others '('? :)
     z-index: 999;


### PR DESCRIPTION
This should fix #1608, based on testing by editing the styles in Dev Tools. I don't have docs built during the relevant time period (prior to https://github.com/rust-lang/rust/commit/135281ed1525db15edd8ebd092aa10aa40df2386, Sep 30 2021), so can't do a full test locally.