### PR TITLE
Set explicit font size for topbar

### DIFF
--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -26,7 +26,8 @@ div.nav-container {
     top: 0;
     position: sticky;
     color: var(--color-navbar-standard);
-    font-family: $font-family-sans;
+    /* The font size must be specified in pixels because the height is specified in pixels. */
+    font: 16px $font-family-sans;
 
     li {
         border-left: 1px solid var(--color-border);


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/93171.

Explanation: Since https://github.com/rust-lang/rust/pull/92448, the docs.rs topbar will misbehave when the user's font size is >16px. Some items in the navbar will overflow their allotted height of 33px. This wasn't happening before because the navbar was inheriting rustdoc's styles on the `<body>` element, which included `font-size: 16px`. It turns out docs.rs was implicitly relying on that `font-size: 16px`, so add it here explicitly.

To test: Set your browser font-size to anything >16px. Visit a documentation page. It should have the normal width.

/cc @cynecx @GuillaumeGomez @syphar 