### PR TITLE
Fixes footer with new sidebar changes

### DIFF
--- a/templates/style/rustdoc-2021-12-05.scss
+++ b/templates/style/rustdoc-2021-12-05.scss
@@ -10,9 +10,13 @@
     .sidebar {
         margin-top: 0;
         top: $top-navbar-height;
+        height: calc(100vh - $top-navbar-height);
+        /* Since we use `overflow-wrap: anywhere;`, we never have the need for a X scrollbar... */
+        overflow-x: hidden;
 
         .sidebar-menu {
             top: $top-navbar-height;
+            margin-bottom: $footer-height;
         }
     }
 
@@ -25,12 +29,7 @@ div.container-rustdoc {
     > .docs-rs-footer {
         bottom: 0;
         right: 0;
-    }
-}
-
-div.container-rustdoc:not(.source) {
-    > .docs-rs-footer {
-        left: 200px;
+        left: 0;
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/docs.rs/issues/1613.

Since https://github.com/rust-lang/rust/pull/92692, the sidebar width varies between 200 and 250 pixels, making it impossible to adapt the footer to this change without integrating it into the rustdoc main container directly. Another interesting change that was added to the sidebar was `position: sticky` which allowed me instead to move the footer completely at the bottom and to add `margin-bottom` on the sidebar. Here is a video of the change when you scroll to the end of the page:

https://user-images.githubusercontent.com/3050060/150654687-be1c4f29-e60b-4429-bc0e-ebf20febbb33.mp4

cc @syphar @jsha 