### PR TITLE
upgrade sentry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3211,9 +3211,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "sentry"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546b9b6f76c26c60ffbcf0b7136e15169fe13d43949b4aadb7c1edc1c3f3a26f"
+checksum = "610e3553f6b91f4f011f9946f846c560e72836023f29ca3d931db9163ba8545c"
 dependencies = [
  "httpdate",
  "reqwest",
@@ -3226,9 +3226,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-anyhow"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338ef04f73ca2fb1130ebab3853dca36041aa219a442ae873627373887660c36"
+checksum = "6d178d802db45d23d6629929ab0d9fd1b941d0119235308aaa0c489c596e653d"
 dependencies = [
  "anyhow",
  "sentry-backtrace",
@@ -3237,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd0cba2aff36ac98708f7a6e7abbdde82dbaf180d5870c41084dc1b473648b9"
+checksum = "889f9e50df954acd94e8837f342669c3fecbc6692ad7518713aea0c4f6b62085"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -3249,14 +3249,12 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bacf1c62427c6c97b896640d0c4dd204bbd3b79dd192d7cb40891aa5ee11d58"
+checksum = "5fc5b73c3729038e4409f2803997c728a28f67a2f3637972fecd3d3e6e136b42"
 dependencies = [
  "hostname",
- "lazy_static",
  "libc",
- "regex",
  "rustc_version",
  "sentry-core",
  "uname",
@@ -3264,11 +3262,10 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a957270c9a430218f8031c866493061a27e35a70250e9527f093563a33ce6b"
+checksum = "3f94c25642abfdd1d7c41b9dfe4314e976bd2535ed0ab72cb9444a1310f67a19"
 dependencies = [
- "chrono",
  "lazy_static",
  "rand 0.8.4",
  "sentry-types",
@@ -3278,9 +3275,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66da5759b0704a2fb0d420863b0795ea3429739e188ff67fff82bb13dcd3cc50"
+checksum = "496cf37951256d6651c4174057fe61b1b9c72254800a4d87f46adf9dcdf1f28a"
 dependencies = [
  "log 0.4.14",
  "sentry-core",
@@ -3288,9 +3285,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692bf989f0c99f025e33d7f58e62822c3771f56d189698c66dcc863122255d95"
+checksum = "6a7fea11ef064f27ca54eb6c78b1d09ab9633e2dbfe75beafcf118b11085e4c0"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -3298,15 +3295,17 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4dd2266fee014a86e250e98e389191ecd23be546b5c42b6a2fb9af2972fadac"
+checksum = "d27bfee0f8f05e60d17b740ab56f0e3cda1eca5e68905923245a1840a93b31a8"
 dependencies = [
- "chrono",
  "debugid",
+ "getrandom 0.2.4",
+ "hex",
  "serde",
  "serde_json",
  "thiserror",
+ "time 0.3.6",
  "url 2.2.2",
  "uuid",
 ]
@@ -3775,6 +3774,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d54b9298e05179c335de2b9645d061255bcd5155f843b3e328d2cfe0a5b413"
 dependencies = [
+ "itoa 1.0.1",
  "libc",
  "num_threads",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ exclude = [
 consistency_check = ["crates-index"]
 
 [dependencies]
-sentry = "0.23.0"
-sentry-log = "0.23.0"
-sentry-panic = "0.23.0"
-sentry-anyhow = { version = "0.23.0", features = ["backtrace"] }
+sentry = "0.24.1"
+sentry-log = "0.24.1"
+sentry-panic = "0.24.1"
+sentry-anyhow = { version = "0.24.1", features = ["backtrace"] }
 log = "0.4"
 regex = "1"
 structopt = "0.3"


### PR DESCRIPTION
to reproduce: 
```
$ cargo upgrade sentry sentry-log sentry-panic sentry-anyhow                                                                                                                             Upgrading sentry-panic v0.23.0 -> v0.24.1
    Upgrading sentry-anyhow v0.23.0 -> v0.24.1
    Upgrading sentry v0.23.0 -> v0.24.1
    Upgrading sentry-log v0.23.0 -> v0.24.1
```

In [release notes](https://github.com/getsentry/sentry-rust/releases/tag/0.24.1) there are **breaking changes** but I believe we're fine. 