### PR TITLE
Add top and height settings for mobile sidebar

### DIFF
--- a/templates/style/rustdoc-common.scss
+++ b/templates/style/rustdoc-common.scss
@@ -98,6 +98,16 @@ div.rustdoc {
                     top: $top-navbar-height;
                 }
             }
+
+            // A later version of rustdoc uses the .sidebar.shown instead of .sidebar.mobile, and
+            // also needs a height adjustment.
+            &.shown {
+                width: 250px;
+                margin-left: 0;
+                // 45px is the size of the rustdoc mobile-topbar
+                top: 45px + $top-navbar-height !important;
+                height: calc(100vh - 45px - #{$top-navbar-height}) !important;
+            }
         }
     }
 


### PR DESCRIPTION
The CSS classes for the mobile sidebar changed recently, so use the new
classes. Also set the height of the sidebar appropriately.

This fixes a bug where the sidebar is on top of the hamburger menu,
which prevents closing it once you've opened it.