### PR TITLE
Automatically add "S-waiting-on-deploy" label on a merged PR

### DIFF
--- a/.github/workflows/tag-merged-pr.yml
+++ b/.github/workflows/tag-merged-pr.yml
@@ -1,0 +1,14 @@
+on:
+  pull_request:
+    branches: 
+      - master
+    types: [closed]
+
+jobs:
+  my-action:
+    if: ${{ github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: S-waiting-on-deploy

--- a/.github/workflows/tag-merged-pr.yml
+++ b/.github/workflows/tag-merged-pr.yml
@@ -12,3 +12,11 @@ jobs:
       - uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: S-waiting-on-deploy
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: |
+            S-waiting-on-async
+            S-waiting-on-author
+            S-waiting-on-crate-author
+            S-waiting-on-decision
+            S-waiting-on-review


### PR DESCRIPTION
I used [this action](https://github.com/actions-ecosystem/action-add-labels) to add the label and [this one](https://github.com/actions-ecosystem/action-remove-labels) to remove labels. The only extra thing needed is to create a token. For which event to used, I used [github docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request).