### PR TITLE
Use `pull_request_target` event type for labeling

### DIFF
--- a/.github/workflows/tag-merged-pr.yml
+++ b/.github/workflows/tag-merged-pr.yml
@@ -1,11 +1,11 @@
 on:
-  pull_request:
+  pull_request_target:
     branches: 
       - master
     types: [closed]
 
 jobs:
-  my-action:
+  update-labels:
     if: ${{ github.event.pull_request.merged }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This will run in the context of the target branch, so have write permissions even when the PR is from a fork.