### PR TITLE
upgrade crates-index-diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "crates-index-diff"
-version = "7.1.2"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64af39a9a6805d715f8b72307d70815ed1ee38ef84e9de250fcdd56fe75a0e19"
+checksum = "9f04ef23e6e584a3f8f7860274e0daf1c46e859d387cebdad1de54091d7cea08"
 dependencies = [
  "git2",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4"
 regex = "1"
 structopt = "0.3"
 crates-index = { version = "0.15.1", optional = true }
-crates-index-diff = "7.1.1"
+crates-index-diff = "8.0.0"
 reqwest = { version = "0.11", features = ["blocking", "json"] } # TODO: Remove blocking when async is ready
 semver = { version = "0.9", features = ["serde"] }
 slug = "=0.1.1"

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -44,7 +44,10 @@ impl Index {
         let url = repository_url.clone();
         let diff = crates_index_diff::Index::from_path_or_cloned_with_options(
             &path,
-            crates_index_diff::CloneOptions { repository_url },
+            crates_index_diff::CloneOptions {
+                repository_url,
+                ..Default::default()
+            },
         )
         .context("initialising registry index repository")?;
 
@@ -75,7 +78,10 @@ impl Index {
         let options = self
             .repository_url
             .clone()
-            .map(|repository_url| crates_index_diff::CloneOptions { repository_url })
+            .map(|repository_url| crates_index_diff::CloneOptions {
+                repository_url,
+                ..Default::default()
+            })
             .unwrap_or_default();
         let diff = crates_index_diff::Index::from_path_or_cloned_with_options(&self.path, options)
             .context("re-opening registry index for diff")?;


### PR DESCRIPTION
<https://github.com/Byron/crates-index-diff-rs/blob/master/changelog.md#v800-2021-07-31>

```bash
$ cargo upgrade crates-index-diff
docs-rs:
    Upgrading crates-index-diff v7.1.1 -> v8.0.0
```

