### PR TITLE
upgrade `rustwide`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3004,9 +3004,9 @@ dependencies = [
 
 [[package]]
 name = "rustwide"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d992b62e3d6559d0ef9fdd666d59942037dadca58c0625c896fc223e31ab3"
+checksum = "fad1c7516d4138e9f7bf4b0f56d41585f5aa1ba57dce6df34b4e90ba9db7d18b"
 dependencies = [
  "attohttpc",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ schemamama = "0.3"
 schemamama_postgres = "0.3"
 systemstat = "0.1.4"
 prometheus = { version = "0.10.0", default-features = false }
-rustwide = "0.13"
+rustwide = "0.14.0"
 mime_guess = "2"
 dotenv = "0.15"
 zstd = "0.5"


### PR DESCRIPTION
https://github.com/rust-lang/rustwide/compare/0.13.1...0.14.0

```bash
$ cargo upgrade rustwide
docs-rs:
    Upgrading rustwide v0.13 -> v0.14.0
```
