### PR TITLE
upgrade `semver` and refactor `match_version`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ dependencies = [
  "num_cpus",
  "rayon",
  "rustc-hash",
- "semver 1.0.4",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",
@@ -783,7 +783,7 @@ dependencies = [
  "sass-rs",
  "schemamama",
  "schemamama_postgres",
- "semver 0.9.0",
+ "semver",
  "sentry",
  "sentry-anyhow",
  "sentry-log",
@@ -2913,7 +2913,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.4",
+ "semver",
 ]
 
 [[package]]
@@ -3106,25 +3106,12 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
- "serde",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "sentry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ structopt = "0.3"
 crates-index = { version = "0.18.5", optional = true }
 crates-index-diff = "8.0.0"
 reqwest = { version = "0.11", features = ["blocking", "json"] } # TODO: Remove blocking when async is ready
-semver = { version = "0.9", features = ["serde"] }
+semver = { version = "1.0.4", features = ["serde"] }
 slug = "0.1.1"
 env_logger = "0.9.0"
 r2d2 = "0.8"

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -423,7 +423,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
     // Get the latest version of the crate
     let latest_version = latest_release.version.to_string();
     let is_latest_version = latest_version == version;
-    let is_prerelease = semver::Version::parse(&version)
+    let is_prerelease = !(semver::Version::parse(&version)
         .with_context(|| {
             format!(
                 "invalid semver in database for crate {}: {}",
@@ -436,7 +436,8 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
             utils::report_error(&err);
             Nope::InternalServerError
         })?
-        .is_prerelease();
+        .pre
+        .is_empty());
 
     // The path within this crate version's rustdoc output
     let (target, inner_path) = {


### PR DESCRIPTION
While working on the preparation for #1646 I was digging into the `match_version` logic. 

Under the premise that we only support semver-compatible versions and ignore unparsable identifiers I think we can simplify the logic in `match_version`. 

Reusing `releases_for_crate` leads to one additional query that needs to be done here, which IMO is OK for the sake of readability here. 

