### PR TITLE
don't report sentry error for invalid semver requirements

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -333,7 +333,11 @@ fn match_version(
         VersionReq::STAR
     } else {
         VersionReq::parse(&req_version).map_err(|err| {
-            report_error(&anyhow!(err).context("could not parse version requirement"));
+            log::info!(
+                "could not parse version requirement \"{}\": {:?}",
+                req_version,
+                err
+            );
             Nope::VersionNotFound
         })?
     };


### PR DESCRIPTION
I would like to keep the log for some time until I'm sure there are no new edge-cases due to the refactored `match_version`