### PR TITLE
Don't try to delete rustdoc files for binary releases

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -447,7 +447,9 @@ impl DatabaseSubcommand {
 
             Self::Delete {
                 command: DeleteSubcommand::Version { name, version },
-            } => db::delete_version(&ctx, &name, &version).context("failed to delete the crate")?,
+            } => {
+                db::delete_version(&ctx, &name, &version).context("failed to delete the version")?
+            }
             Self::Delete {
                 command: DeleteSubcommand::Crate { name },
             } => db::delete_crate(&ctx, &name).context("failed to delete the crate")?,


### PR DESCRIPTION
This avoids confusing errors like the following:
```
Error: failed to delete the crate

Caused by:
    <?xml version="1.0" encoding="UTF-8"?>
<Error><Code>MalformedXML</Code><Message>The XML you provided was not well-formed or did not validate against our published schema</Message><RequestId>9F280BB6EBFEC7F3</RequestId><HostId>sgrbwS6rXn83txaNR4V3+YyVm/+VhIrD1Nhaiv9og8H5hNnGq2yntXaGt45DQ8rcmopLRGoPqkg=</HostId></Error>
```

Tested locally like so:
```
$ cargo run build crate regex 1.4.1
$ cargo run build crate bat 0.12.1
$ psql postgresql://cratesfyi:password@localhost:15432
cratesfyi=# select path from files where path like '%bat%';
             path
------------------------------
 sources/bat/0.12.1.zip
 sources/bat/0.12.1.zip.index
(2 rows)

cratesfyi=# select path from files where path like '%regex%';
             path
-------------------------------
 rustdoc/regex/1.4.1.zip
 rustdoc/regex/1.4.1.zip.index
 sources/regex/1.4.1.zip
 sources/regex/1.4.1.zip.index
(4 rows)

cratesfyi=# \q
$ cargo run database delete version regex 1.4.1
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/cratesfyi database delete version regex 1.4.1`
$ psql postgresql://cratesfyi:password@localhost:15432
cratesfyi=# select path from files where path like '%regex%';
 path
------
(0 rows)

cratesfyi=# select path from files where path like '%bat%';
             path
------------------------------
 sources/bat/0.12.1.zip
 sources/bat/0.12.1.zip.index
(2 rows)

cratesfyi=# \q
$ cargo run database delete version bat 0.12.1
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/cratesfyi database delete version bat 0.12.1`
$ psql postgresql://cratesfyi:password@localhost:15432
cratesfyi=# select path from files where path like '%bat%';
 path
------
(0 rows)

cratesfyi=# \q
```

Fixes https://github.com/rust-lang/docs.rs/issues/899.

r? @syphar 