### PR TITLE
upgrade zip to 0.6.2, reduce features to only needed ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -4279,16 +4279,14 @@ checksum = "50344758e2f40e3a1fcfc8f6f91aa57b5f8ebd8d27919fe6451f15aaaf9ee608"
 
 [[package]]
 name = "zip"
-version = "0.5.13"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+checksum = "bf225bcf73bb52cbb496e70475c7bd7a3f769df699c0020f6c7bd9a96dcf0b8d"
 dependencies = [
  "byteorder",
  "bzip2",
  "crc32fast",
- "flate2",
- "thiserror",
- "time 0.1.43",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ font-awesome-as-a-crate = { path = "crates/font-awesome-as-a-crate" }
 dashmap = "5.1.0"
 string_cache = "0.8.0"
 postgres-types = { version = "0.2", features = ["derive"] }
-zip = "0.5.11"
+zip = {version = "0.6.2", default-features = false, features = ["bzip2"]}
 bzip2 = "0.4.2"
 serde_cbor = "0.11.1"
 getrandom = "0.2.1"


### PR DESCRIPTION
Upgrading zip broke because it added zstd compression, but with a different version than we do. 

While checking the default features I saw that we could also remove some other features we don't use. 

Sadly no changelog, but: https://github.com/zip-rs/zip/compare/v0.5.11...master (I scanned over the commit messages but didn't see anything problematic for us. Also we have tests covering archives.