### PR TITLE
Set overflow-y: hidden on navbar

### DIFF
--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -28,6 +28,12 @@ div.nav-container {
     color: var(--color-navbar-standard);
     /* The font size must be specified in pixels because the height is specified in pixels. */
     font: 16px $font-family-sans;
+    /* In some unusual situations, like a locally installed copy of "Fira Sans," elements
+       of the navbar might overflow vertically and start interfering with the main body
+       content. To ensure that doesn't happen, hide any vertical overflow.
+       See https://github.com/rust-lang/docs.rs/issues/1669.
+       */
+    overflow-y: hidden;
 
     li {
         border-left: 1px solid var(--color-border);


### PR DESCRIPTION
In some unusual circumstances, parts of the navbar can overflow vertically. This interferes with the main body content in surprising ways, so we want to prevent that.

Fixes #1669. I've reproduce the issue from #1669 locally by [installing the copy of Fira Sans from this comment](https://github.com/rust-lang/docs.rs/issues/1669#issuecomment-1068396583), and can confirm that the overflow-y setting fixes the problem.