### PR TITLE
Revert "Set overflow-y: hidden on navbar"

### DIFF
--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -28,12 +28,6 @@ div.nav-container {
     color: var(--color-navbar-standard);
     /* The font size must be specified in pixels because the height is specified in pixels. */
     font: 16px $font-family-sans;
-    /* In some unusual situations, like a locally installed copy of "Fira Sans," elements
-       of the navbar might overflow vertically and start interfering with the main body
-       content. To ensure that doesn't happen, hide any vertical overflow.
-       See https://github.com/rust-lang/docs.rs/issues/1669.
-       */
-    overflow-y: hidden;
 
     li {
         border-left: 1px solid var(--color-border);


### PR DESCRIPTION
This reverts commit 6e6f370f14e4fd9d5f7659f2a6c66971d69bbab0 and fixes #1714 .