### PR TITLE
Fix dropdown menu display in top navbar

### DIFF
--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -28,12 +28,6 @@ div.nav-container {
     color: var(--color-navbar-standard);
     /* The font size must be specified in pixels because the height is specified in pixels. */
     font: 16px $font-family-sans;
-    /* In some unusual situations, like a locally installed copy of "Fira Sans," elements
-       of the navbar might overflow vertically and start interfering with the main body
-       content. To ensure that doesn't happen, hide any vertical overflow.
-       See https://github.com/rust-lang/docs.rs/issues/1669.
-       */
-    overflow-y: hidden;
 
     li {
         border-left: 1px solid var(--color-border);
@@ -120,6 +114,17 @@ div.nav-container {
         input.search-input-nav:focus {
             outline: unset;
         }
+
+
+        /* In some unusual situations, like a locally installed copy of "Fira Sans," elements
+           of the navbar might overflow vertically and start interfering with the main body
+           content. To ensure that doesn't happen, hide any vertical overflow.
+           See https://github.com/rust-lang/docs.rs/issues/1669.
+           */
+       .pure-menu-item a {
+            /* 0.5 em is the padding */
+            max-height: calc(#{$top-navbar-height} - 0.5em * 2);
+       }
     }
 
     .pure-menu-children {


### PR DESCRIPTION
Fixes https://github.com/rust-lang/docs.rs/issues/1714.

We can't use `overflow-y: hidden` because it's then impossible (unless we use `position: fixed`) to display the dropdown menus. There is an ongoing discussion in the w3c about this [here](https://github.com/w3c/csswg-drafts/issues/4092). But still far from done and even more far from implementation.