### PR TITLE
use different crate for cross-compile non-host default test

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -1004,8 +1004,8 @@ mod tests {
     #[ignore]
     fn test_cross_compile_non_host_default() {
         wrapper(|env| {
-            let crate_ = "xingapi";
-            let version = "0.3.3";
+            let crate_ = "windows-win";
+            let version = "2.4.1";
             let mut builder = RustwideBuilder::init(env).unwrap();
             assert!(builder.build_package(crate_, version, PackageKind::CratesIo)?);
 


### PR DESCRIPTION
I tried to find a different example to be used via: 
```
select
distinct crates.name

from
releases,
crates

where
releases.crate_id = crates.id and
default_target = 'i686-pc-windows-msvc' and
doc_targets::jsonb ? 'x86_64-unknown-linux-gnu'

order by crates.name;
```

Which only gave me **2** results, the now yanked crate, and this one. 

