### PR TITLE
add dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
seeing a3efa45f7f0fbc4ca7aefbd3042ae57351975e4a I thought this could be one case where we could use dependabot. 