### PR TITLE
Upgrade procfs from 0.12 to 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,6 +1122,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,6 +1741,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c3f4eff5495aee4c0399d7b6a0dc2b6e81be84242ffbfcf253ebacccc1d0cb"
+
+[[package]]
 name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,6 +1882,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
@@ -2639,9 +2672,9 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0941606b9934e2d98a3677759a971756eb821f75764d0e0d26946d08e74d9104"
+checksum = "57928c5e4262566636d405e7c6a5a4f59bcb61a04a65dea57cf26b0dc3de6423"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -2649,7 +2682,7 @@ dependencies = [
  "flate2",
  "hex",
  "lazy_static",
- "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -3069,6 +3102,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.35.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51cc38aa10f6bbb377ed28197aa052aa4e2b762c22be9d3153d01822587e787"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ features = ["with-chrono-0_4", "with-serde_json-1"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Process information
-procfs = "0.12.0"
+procfs = "0.13.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -179,7 +179,7 @@ impl Metrics {
 
         let process = Process::myself().unwrap();
         self.open_file_descriptors
-            .set(process.fd().unwrap().len() as i64);
+            .set(process.fd_count().unwrap() as i64);
         self.running_threads
             .set(process.stat().unwrap().num_threads as i64);
     }


### PR DESCRIPTION
Hi, procfs maintainer here 👋 I saw the [comment](https://github.com/rust-lang/docs.rs/pull/1751#issuecomment-1173149682) from @syphar in #1751 and thought I'd help with the upgrade.



In addition to upgrading to [0.13](https://github.com/eminence/procfs/releases/tag/v0.13.0), this also switches to a more efficient way to get the number of open file descriptors.