### PR TITLE
only report errors when handling crate-deletes

### DIFF
--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -257,12 +257,11 @@ impl BuildQueue {
                 }
 
                 Change::Deleted(krate) => {
-                    info!(
-                        "crate {} was deleted from the index and will be deleted from the database",
-                        krate
-                    );
-                    delete_crate(&mut conn, &self.storage, &self.config, krate)
-                        .with_context(|| format!("failed to delete crate {}", krate))?;
+                    match delete_crate(&mut conn, &self.storage, &self.config, krate)
+                        .with_context(|| format!("failed to delete crate {}", krate)) {
+                            Ok(_) => info!("crate {} was deleted from the index and will be deleted from the database", krate), 
+                            Err(err) => report_error(&err),
+                        }
                 }
             }
         }


### PR DESCRIPTION
following the same pattern as in handling other index-updates we just
want to report eventual errors and continue handling the current
index-commit and others.