### PR TITLE
Use 301 redirects when redirect target is /latest/

### DIFF
--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -71,7 +71,12 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
             url_str.push_str(query);
         }
         let url = ctry!(req, Url::parse(&url_str));
-        let mut resp = Response::with((status::Found, Redirect(url)));
+        let status_code = if vers == "latest" {
+            status::MovedPermanently
+        } else {
+            status::Found
+        };
+        let mut resp = Response::with((status_code, Redirect(url)));
         resp.headers.set(Expires(HttpDate(time::now())));
 
         Ok(resp)


### PR DESCRIPTION
Part of #1756.

Note: I tried adding the test case below, but got 200 instead of a redirect. Any idea what I'm doing wrong?

```rust
    #[test]
    fn test_redirect_to_latest_301() {
        wrapper(|env| {
            env.fake_release().name("dummy").version("1.0.0").create()?;
            let web = env.frontend();
            assert_eq!(
                web.get("/dummy").send()?.status(),
                StatusCode::MOVED_PERMANENTLY,
            );
            Ok(())
        })
    }
```