### PR TITLE
Fix the sidebar height

### DIFF
--- a/templates/style/rustdoc-2021-12-05.scss
+++ b/templates/style/rustdoc-2021-12-05.scss
@@ -10,7 +10,7 @@
     .sidebar {
         margin-top: 0;
         top: $top-navbar-height;
-        height: calc(100vh - $top-navbar-height);
+        height: calc(100vh - #{$top-navbar-height});
         /* Since we use `overflow-wrap: anywhere;`, we never have the need for a X scrollbar... */
         overflow-x: hidden;
 


### PR DESCRIPTION
`calc` is parsed specially in SASS as if the interior is a plain unquoted string and requires using explicit interpolation syntax (see the "fun fact" at https://sass-lang.com/documentation/at-rules/function#plain-css-functions).

Though, that [appears to have changed in DartSASS 1.40](https://sass-lang.com/documentation/values/calculations), where the original code would have worked as-is. LibSASS hasn't had the same change applied (and probably won't since it's deprecated...).

Can test at https://www.sassmeister.com/ with:

```scss
$top-navbar-height: 32px;

#rustdoc_body_wrapper {
    .sidebar {
        top: $top-navbar-height;
        height: calc(100vh - $top-navbar-height);
    }
}

#rustdoc_body_wrapper {
    .sidebar {
        top: $top-navbar-height;
        height: calc(100vh - #{$top-navbar-height});
    }
}
```

fixes #1761