### PR TITLE
Authenticate jsha to use Google Search Console

### DIFF
--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -21,6 +21,10 @@ pub(super) fn build_routes() -> Routes {
     //   https://developers.google.com/search/reference/robots_txt#handling-http-result-codes
     //   https://support.google.com/webmasters/answer/183668?hl=en
     routes.static_resource("/robots.txt", PermanentRedirect("/-/static/robots.txt"));
+    routes.static_resource(
+        "/googleb54494ba4d52c200.html",
+        super::sitemap::google_search_console_handler,
+    );
     routes.static_resource("/favicon.ico", PermanentRedirect("/-/static/favicon.ico"));
     routes.internal_page("/sitemap.xml", super::sitemap::sitemapindex_handler);
     routes.internal_page(

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -148,6 +148,16 @@ pub fn about_handler(req: &mut Request) -> IronResult<Response> {
     .into_response(req)
 }
 
+// This authenticates @jsha (https://github.com/jsha) to use the Google Search Console
+// https://support.google.com/webmasters/answer/9128668?visit_id=637926083810327397-791277710&rd=2
+// for docs.rs. Removing this handler will de-authenticate. Additional handlers can be
+// added for additional users.
+pub fn google_search_console_handler(_req: &mut Request) -> IronResult<Response> {
+    Ok(Response::with(
+        "google-site-verification: googleb54494ba4d52c200.html".to_string(),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::test::{assert_success, wrapper};


### PR DESCRIPTION
This allows troubleshooting issues with why Google doesn't crawl docs.rs deeply enough.

Related to https://github.com/rust-lang/docs.rs/issues/1438#issuecomment-1174811787

Per https://support.google.com/webmasters/answer/9128668?visit_id=637926083810327397-791277710&rd=2:

> Search Console offers tools and reports for the following actions:
>
> - Confirm that Google can find and crawl your site.
> - Fix indexing problems and request re-indexing of new or updated content.
> - View Google Search traffic data for your site: how often your site appears in
> - Google Search, which search queries show your site, how often searchers click through for those queries, and more.
> - Receive alerts when Google encounters indexing, spam, or other issues on your site.
> - Show you which sites link to your website.
> - Troubleshoot issues for AMP, mobile usability, and other Search features.
>

Per https://support.google.com/webmasters/answer/7687615#manage-owners&zippy=%2Cadd-or-remove-verified-owners, removing this handler later will deauthenticate me.

Here's an example of the sort of report I'll be able to get from Google Search Console:

![image](https://user-images.githubusercontent.com/220205/178861149-9414932e-1c92-43ff-bda8-dc2a62fdedcc.png)


