### PR TITLE
fix(mobile): sidebar & footer layout issue

### DIFF
--- a/templates/style/rustdoc-2021-12-05.scss
+++ b/templates/style/rustdoc-2021-12-05.scss
@@ -33,8 +33,14 @@ div.container-rustdoc {
     }
 }
 
-div.rustdoc {
+@media (max-width: 700px) {
+    .source main {
+        height: auto;
+    }
+}
+
+@media (max-width: 464px) {
     #sidebar-toggle {
-        top: 0;
+        top: 32px;
     }
 }


### PR DESCRIPTION
## Before

<img width="354" alt="Screen Shot 2022-07-21 at 8 05 35 AM" src="https://user-images.githubusercontent.com/27926/180102817-7607bb49-5f2c-4129-8ea8-9e6141f34dd3.png">

## After

<img width="328" alt="Screen Shot 2022-07-21 at 8 13 41 AM" src="https://user-images.githubusercontent.com/27926/180103492-1a4f74d0-da42-4bb8-b24b-bd55289c4e98.png">

