### PR TITLE
Smarter sub-menu positioning on narrow displays

### DIFF
--- a/static/menu.js
+++ b/static/menu.js
@@ -1,9 +1,19 @@
+const updateMenuPositionForSubMenu = (currentMenuSupplier) => {
+    const currentMenu = currentMenuSupplier();
+    const subMenu = currentMenu?.getElementsByClassName('pure-menu-children')?.[0];
+
+    subMenu?.style.setProperty('--menu-x', `${currentMenu.getBoundingClientRect().x}px`);
+}
+
 // Allow menus to be open and used by keyboard.
 (function() {
     var currentMenu;
     var backdrop = document.createElement("div");
     backdrop.style = "display:none;position:fixed;width:100%;height:100%;z-index:1";
     document.documentElement.insertBefore(backdrop, document.querySelector("body"));
+
+    addEventListener('resize', () => updateMenuPositionForSubMenu(() => currentMenu));
+
     function previous(allItems, item) {
         var i = 1;
         var l = allItems.length;
@@ -52,6 +62,9 @@
             this.blur();
         } else {
             if (currentMenu) closeMenu();
+
+            updateMenuPositionForSubMenu(() => this.parentNode);
+
             openMenu(this.parentNode);
         }
         e.preventDefault();

--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -50,6 +50,12 @@ div.nav-container {
         }
     }
 
+    .pure-menu-has-children.pure-menu-active > .pure-menu-link {
+        &:after {
+            content:"\25B2";
+        }
+    }
+
     .pure-menu-link {
         font-size: 12.8px;
         font-weight: 400;

--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -139,10 +139,19 @@ div.nav-container {
     }
 
     .pure-menu-children {
+        --menu-x: 0;
+
+        // #{} interpolates a SassScript expression. Using this prevents
+        // SASS from using its built-in min/max over the CSS min/max functions
+        --clamped-offset: m#{i}n(var(--menu-x), calc(100vw - 100%));
+
         border: 1px solid var(--color-border);
         border-radius: 0 0 2px 2px;
-        margin-left: -1px;
         background-color: var(--color-background);
+
+        left: 0;
+        position: fixed;
+        transform: translateX(m#{a}x(0%, var(--clamped-offset)));
 
         li {
             border-left: none;


### PR DESCRIPTION
Hi there,

I pulled up [docs.rs](https://docs.rs/) on my phone the other day and noticed that the navbar's sub-menus behave pretty poorly.

The left edge of the sub-menus is always in line with the menu link's left edge. On narrower displays this results in the menus extending off screen, causing the page to stretch and the user to have to scroll to the right to see the entirety of the sub-menu:

https://user-images.githubusercontent.com/1179754/181129059-6c0b919e-3cf0-4b82-8860-39d0526b87b7.mp4

I have written some code to adjust the sub-menus' positions based on the current width of the page. If the sub-menu would overflow off the right side of the screen, it is instead shifted left so that it is fully visible and the page does not expand and require horizontal scrolling. If for some reason the shifting to the left would cause the sub-menu to clip with the left edge of the page it is then shifted back to the right so that the left edge is at `x = 0`.

https://user-images.githubusercontent.com/1179754/181129455-b576569f-46e1-4e2a-95b5-ebd6bb237253.mp4

Since this change necessitates the sub-menus not always being vertically aligned with the left edge of the menu links, I also tweaked the CSS for the menu links to show the drop down arrow flipped 180º when the menu's sub-menu is open. Hopefully this helps to visually link the sub-menu to its parent menu link in these cases.

I've had some difficulties getting this up and running on my M1 Mac, which I suspect is the cause of the visual differences between the two videos.