### PR TITLE
retry toolchain update, only lock queue after 3 failed attempts

### DIFF
--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -229,7 +229,11 @@ fn retry<T>(mut f: impl FnMut() -> Result<T>) -> Result<T> {
                 if attempt > MAX_ATTEMPTS {
                     return Err(err);
                 } else {
-                    log::warn!("got error {:?} on attempt {}, will try again", err, attempt);
+                    log::warn!(
+                        "got error on attempt {}, will try again:\n{:?}",
+                        attempt,
+                        err
+                    );
                 }
             }
         }


### PR DESCRIPTION
This is a simple attempt at solving #1787. 

Since I don't know details about `update_toolchain`: are there any possible errors that might leave the toolchain in a broken state where a retry would make it worse? 