### PR TITLE
Emit canonical URLs for all rustdoc pages

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -247,7 +247,7 @@ impl TestEnvironment {
     }
 
     pub(crate) fn override_frontend(&self, init: impl FnOnce(&mut TestFrontend)) -> &TestFrontend {
-        let mut frontend = TestFrontend::new(&*self);
+        let mut frontend = TestFrontend::new(self);
         init(&mut frontend);
         if self.frontend.set(frontend).is_err() {
             panic!("cannot call override_frontend after frontend is initialized");
@@ -256,7 +256,7 @@ impl TestEnvironment {
     }
 
     pub(crate) fn frontend(&self) -> &TestFrontend {
-        self.frontend.get_or_init(|| TestFrontend::new(&*self))
+        self.frontend.get_or_init(|| TestFrontend::new(self))
     }
 
     pub(crate) fn fake_release(&self) -> fakes::FakeRelease {

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -490,25 +490,16 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
     let latest_path = format!("/crate/{}/latest{}{}", name, target_redirect, query_string);
 
     // Set the canonical URL for search engines to the `/latest/` page on docs.rs.
-    // For crates with a documentation URL, where that URL doesn't point at docs.rs,
-    // omit the canonical link to avoid penalizing external documentation.
     // Note: The URL this points to may not exist. For instance, if we're rendering
     // `struct Foo` in version 0.1.0 of a crate, and version 0.2.0 of that crate removes
     // `struct Foo`, this will point at a 404. That's fine: search engines will crawl
     // the target and will not canonicalize to a URL that doesn't exist.
-    let canonical_url = if krate.documentation_url.is_none()
-        || krate
-            .documentation_url
-            .as_ref()
-            .unwrap()
-            .starts_with("https://docs.rs/")
-    {
-        // Don't include index.html in the canonical URL.
-        let canonical_path = inner_path.replace("index.html", "");
-        format!("https://docs.rs/{}/latest/{}", name, canonical_path)
-    } else {
-        "".to_string()
-    };
+    // Don't include index.html in the canonical URL.
+    let canonical_url = format!(
+        "https://docs.rs/{}/latest/{}",
+        name,
+        inner_path.replace("index.html", "")
+    );
 
     metrics
         .recently_accessed_releases
@@ -2063,7 +2054,7 @@ mod test {
 
             let web = env.frontend();
 
-            assert!(!web
+            assert!(web
                 .get("/dummy-dash/0.1.0/dummy_dash/")
                 .send()?
                 .text()?

--- a/templates/rustdoc/head.html
+++ b/templates/rustdoc/head.html
@@ -3,8 +3,6 @@
 
         <link rel="search" href="/-/static/opensearch.xml" type="application/opensearchdescription+xml" title="Docs.rs" />
 
-        {%- if canonical_url -%}
         <link rel="canonical" href="{{canonical_url | safe}}" />
-        {%- endif -%}
 
         <script type="text/javascript">{%- include "theme.js" -%}</script>


### PR DESCRIPTION
Previously, we did not emit canonical URLs for crates that had an alternate documentation URL. However, this produces bad results for those crates, with older versions being selected as canonical even if the latest version uses docs.rs as its documentation URL.

Part of #74