### PR TITLE
Pass `rustc-args` to build dependencies too

### DIFF
--- a/crates/metadata/lib.rs
+++ b/crates/metadata/lib.rs
@@ -281,6 +281,10 @@ impl Metadata {
             let rustflags =
                 toml::to_string(&self.rustc_args).expect("serializing a string should never fail");
             cargo_args.push(format!("build.rustflags={}", rustflags));
+            cargo_args.push("-Zhost-config".into());
+            cargo_args.push("-Ztarget-applies-to-host".into());
+            cargo_args.push("--config".into());
+            cargo_args.push(format!("host.rustflags={}", rustflags));
         }
 
         if !all_rustdoc_args.is_empty() {

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -1081,4 +1081,16 @@ mod tests {
             Ok(())
         });
     }
+
+    #[test]
+    #[ignore]
+    fn test_rustflags_are_passed_to_build_script() {
+        wrapper(|env| {
+            let crate_ = "proc-macro2";
+            let version = "1.0.33";
+            let mut builder = RustwideBuilder::init(env).unwrap();
+            assert!(builder.build_package(crate_, version, PackageKind::CratesIo)?);
+            Ok(())
+        });
+    }
 }


### PR DESCRIPTION
This was the previous behaviour before https://github.com/rust-lang/docs.rs/pull/1559 for the default target and is most likely expected by users.

fixes #1580 