### PR TITLE
Fix search redirection for `crate::some::path` to use `?search=`

### DIFF
--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -562,7 +562,7 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
         }
 
         let (krate, query) = match query.split_once("::") {
-            Some((krate, query)) => (krate.to_string(), format!("?query={query}")),
+            Some((krate, query)) => (krate.to_string(), format!("?search={query}")),
             None => (query.clone(), "".to_string()),
         };
 
@@ -884,12 +884,12 @@ mod tests {
 
             assert_redirect(
                 "/releases/search?query=some_random_crate::somepath",
-                "/some_random_crate/1.0.0/some_random_crate/?query=somepath",
+                "/some_random_crate/1.0.0/some_random_crate/?search=somepath",
                 web,
             )?;
             assert_redirect(
                 "/releases/search?query=some_random_crate::some::path",
-                "/some_random_crate/1.0.0/some_random_crate/?query=some::path",
+                "/some_random_crate/1.0.0/some_random_crate/?search=some::path",
                 web,
             )?;
             Ok(())

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -71,7 +71,7 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
             url_str.push('?');
             url_str.push_str(query);
         } else if let Some(path) = path_in_crate {
-            url_str.push_str("?query=");
+            url_str.push_str("?search=");
             url_str.push_str(path);
         }
         let url = ctry!(req, Url::parse(&url_str));
@@ -1724,12 +1724,12 @@ mod test {
 
             assert_redirect(
                 "/some_random_crate::somepath",
-                "/some_random_crate/latest/some_random_crate/?query=somepath",
+                "/some_random_crate/latest/some_random_crate/?search=somepath",
                 web,
             )?;
             assert_redirect(
                 "/some_random_crate::some::path",
-                "/some_random_crate/latest/some_random_crate/?query=some::path",
+                "/some_random_crate/latest/some_random_crate/?search=some::path",
                 web,
             )?;
             Ok(())


### PR DESCRIPTION
Search within crates uses `?search=`, not `?query=`.
