### PR TITLE
Fix typos

### DIFF
--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -313,7 +313,7 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> crate::error::Res
             // version
             9,
             // description
-            "Allow max number of targets to be overriden",
+            "Allow max number of targets to be overridden",
             // upgrade query
             "ALTER TABLE sandbox_overrides ADD COLUMN max_targets INT;",
             // downgrade query

--- a/src/utils/html.rs
+++ b/src/utils/html.rs
@@ -48,7 +48,7 @@ pub(crate) fn rewrite_lol(
         rustdoc_body_class.set_tag_name("div")?;
         // Prepend the tera content
         rustdoc_body_class.prepend(&tera_body, ContentType::Html);
-        // Wrap the tranformed body and topbar into a <body> element
+        // Wrap the transformed body and topbar into a <body> element
         rustdoc_body_class.before(r#"<body class="rustdoc-page">"#, ContentType::Html);
         // Insert the topbar outside of the rustdoc div
         rustdoc_body_class.before(&tera_rustdoc_topbar, ContentType::Html);

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -621,7 +621,7 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
                 // the crates.io API.
                 // The whole point of the `paginate` design is that we don't
                 // know anything about the pagination args and crates.io can
-                // change them as they whish, so we cannot do any more checks here.
+                // change them as they wish, so we cannot do any more checks here.
                 warn!(
                     "didn't get query args in `paginate` arguments for search: \"{}\"",
                     query_params


### PR DESCRIPTION
Found via `codespell -L crate,ser,statics,ot,te,ue,isnt,inout`