### PR TITLE
add clippy book to Rust dropdown menu

### DIFF
--- a/templates/header/topbar_end.html
+++ b/templates/header/topbar_end.html
@@ -65,6 +65,12 @@
                                 text="The Cargo Guide",
                                 target="_blank"
                             ) }}
+
+                            {{ macros::menu_link(
+                                href="https://doc.rust-lang.org/nightly/clippy",
+                                text="Clippy Documentation",
+                                target="_blank"
+                            ) }}
                         </ul>
                     </li>
                 </ul>


### PR DESCRIPTION
It came to my attention that docs.rs has nothing about clippy, despite it being an official Rust component for a while. This PR puts the nightly clippy book into the Rust dropdown menu so people will have an easier time finding it.