### PR TITLE
Assert that redirects go directly to their target location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,6 +999,7 @@ dependencies = [
  "dotenv",
  "env_logger",
  "failure",
+ "fn-error-context",
  "font-awesome-as-a-crate",
  "futures-util",
  "getrandom 0.2.7",
@@ -1205,6 +1206,17 @@ checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fn-error-context"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "236b4e4ae2b8be5f7a5652f6108c4a0f2627c569db4e7923333d31c7dbfed0fb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ kuchiki = "0.8"
 rand = "0.8"
 mockito = "0.31.0"
 test-case = "2.0.0"
+fn-error-context = "0.2.0"
 
 [build-dependencies]
 time = "0.3"

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -76,6 +76,7 @@ pub struct Release {
     pub yanked: bool,
     pub is_library: bool,
     pub rustdoc_status: bool,
+    pub target_name: String,
 }
 
 impl CrateDetails {
@@ -246,15 +247,16 @@ pub(crate) fn releases_for_crate(
 ) -> Result<Vec<Release>, anyhow::Error> {
     let mut releases: Vec<Release> = conn
         .query(
-            "SELECT 
-                id, 
+            "SELECT
+                id,
                 version,
                 build_status,
                 yanked,
                 is_library,
-                rustdoc_status
+                rustdoc_status,
+                target_name
              FROM releases
-             WHERE 
+             WHERE
                  releases.crate_id = $1",
             &[&crate_id],
         )?
@@ -269,6 +271,7 @@ pub(crate) fn releases_for_crate(
                     yanked: row.get("yanked"),
                     is_library: row.get("is_library"),
                     rustdoc_status: row.get("rustdoc_status"),
+                    target_name: row.get("target_name"),
                 }),
                 Err(err) => {
                     report_error(&anyhow!(err).context(format!(
@@ -505,6 +508,7 @@ mod tests {
                         is_library: true,
                         rustdoc_status: true,
                         id: details.releases[0].id,
+                        target_name: "foo".to_owned(),
                     },
                     Release {
                         version: semver::Version::parse("0.12.0")?,
@@ -513,6 +517,7 @@ mod tests {
                         is_library: true,
                         rustdoc_status: true,
                         id: details.releases[1].id,
+                        target_name: "foo".to_owned(),
                     },
                     Release {
                         version: semver::Version::parse("0.3.0")?,
@@ -521,6 +526,7 @@ mod tests {
                         is_library: true,
                         rustdoc_status: false,
                         id: details.releases[2].id,
+                        target_name: "foo".to_owned(),
                     },
                     Release {
                         version: semver::Version::parse("0.2.0")?,
@@ -529,6 +535,7 @@ mod tests {
                         is_library: true,
                         rustdoc_status: true,
                         id: details.releases[3].id,
+                        target_name: "foo".to_owned(),
                     },
                     Release {
                         version: semver::Version::parse("0.2.0-alpha")?,
@@ -537,6 +544,7 @@ mod tests {
                         is_library: true,
                         rustdoc_status: true,
                         id: details.releases[4].id,
+                        target_name: "foo".to_owned(),
                     },
                     Release {
                         version: semver::Version::parse("0.1.1")?,
@@ -545,6 +553,7 @@ mod tests {
                         is_library: true,
                         rustdoc_status: true,
                         id: details.releases[5].id,
+                        target_name: "foo".to_owned(),
                     },
                     Release {
                         version: semver::Version::parse("0.1.0")?,
@@ -553,6 +562,7 @@ mod tests {
                         is_library: true,
                         rustdoc_status: true,
                         id: details.releases[6].id,
+                        target_name: "foo".to_owned(),
                     },
                     Release {
                         version: semver::Version::parse("0.0.1")?,
@@ -561,6 +571,7 @@ mod tests {
                         is_library: false,
                         rustdoc_status: false,
                         id: details.releases[7].id,
+                        target_name: "foo".to_owned(),
                     },
                 ]
             );

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -92,6 +92,12 @@ impl<'a> RenderingTimesRecorder<'a> {
 
     fn record_current(&mut self) {
         if let Some(current) = self.current.take() {
+            #[cfg(test)]
+            log::debug!(
+                "rendering time - {}: {:?}",
+                current.step,
+                current.start.elapsed()
+            );
             self.metric
                 .with_label_values(&[current.step])
                 .observe(duration_to_seconds(current.start.elapsed()));

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -223,6 +223,7 @@ struct MatchVersion {
     pub corrected_name: Option<String>,
     pub version: MatchSemver,
     pub rustdoc_status: bool,
+    pub target_name: String,
 }
 
 impl MatchVersion {
@@ -324,6 +325,7 @@ fn match_version(
                 corrected_name,
                 version: MatchSemver::Exact((release.version.to_string(), release.id)),
                 rustdoc_status: release.rustdoc_status,
+                target_name: release.target_name.clone(),
             });
         }
     }
@@ -358,6 +360,7 @@ fn match_version(
                 MatchSemver::Semver((release.version.to_string(), release.id))
             },
             rustdoc_status: release.rustdoc_status,
+            target_name: release.target_name.clone(),
         });
     }
 
@@ -371,6 +374,7 @@ fn match_version(
                 corrected_name: corrected_name.clone(),
                 version: MatchSemver::Semver((release.version.to_string(), release.id)),
                 rustdoc_status: release.rustdoc_status,
+                target_name: release.target_name.clone(),
             })
             .ok_or(Nope::VersionNotFound);
     }
@@ -759,7 +763,7 @@ mod test {
                 .create()
                 .unwrap();
             let web = env.frontend();
-            assert_redirect("/bat//", "/bat/latest/bat/", web)?;
+            assert_redirect_unchecked("/bat//", "/bat/", web)?;
             Ok(())
         })
     }

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -173,10 +173,18 @@ pub(super) fn build_routes() -> Routes {
             &format!("/{}", redirect),
             super::rustdoc::RustLangRedirector::new("stable", redirect),
         );
+        routes.internal_page(
+            &format!("/{}/", redirect),
+            super::rustdoc::RustLangRedirector::new("stable", redirect),
+        );
     }
     // redirect proc-macro to proc_macro
     routes.internal_page(
         "/proc-macro",
+        super::rustdoc::RustLangRedirector::new("stable", "proc_macro"),
+    );
+    routes.internal_page(
+        "/proc-macro/",
         super::rustdoc::RustLangRedirector::new("stable", "proc_macro"),
     );
     // redirect rustc to nightly rustc docs
@@ -184,9 +192,17 @@ pub(super) fn build_routes() -> Routes {
         "/rustc",
         super::rustdoc::RustLangRedirector::new("nightly", "nightly-rustc"),
     );
+    routes.internal_page(
+        "/rustc/",
+        super::rustdoc::RustLangRedirector::new("nightly", "nightly-rustc"),
+    );
     // redirect rustdoc to nightly rustdoc docs
     routes.internal_page(
         "/rustdoc",
+        super::rustdoc::RustLangRedirector::new("nightly", "nightly-rustc/rustdoc"),
+    );
+    routes.internal_page(
+        "/rustdoc/",
         super::rustdoc::RustLangRedirector::new("nightly", "nightly-rustc/rustdoc"),
     );
 


### PR DESCRIPTION
Previously the assertion allowed multiple redirect steps as long as it eventually got to the target. Now it's checked that the very first response directly returns a `Location` header to the final target.

This should save a couple RTTs for some urls.