### PR TITLE
remove dotenv dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ env:
   DOCSRS_INCLUDE_DEFAULT_TARGETS: false
   DOCSRS_DOCKER_IMAGE: ghcr.io/rust-lang/crates-build-env/linux-micro
   SENTRY_ENVIRONMENT: dev
-  DOCSRS_METADATA_HOST_TARGET: aarch64-unknown-linux-gnu
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,16 @@ on:
 
 env:
   RUST_BACKTRACE: 1
+  DOCSRS_PREFIX: ignored/cratesfyi-prefix
+  DOCSRS_DATABASE_URL: postgresql://cratesfyi:password@localhost:15432
+  DOCSRS_LOG: docs_rs=debug,rustwide=info
+  AWS_ACCESS_KEY_ID: cratesfyi
+  AWS_SECRET_ACCESS_KEY: secret_key
+  S3_ENDPOINT: http://localhost:9000
+  DOCSRS_INCLUDE_DEFAULT_TARGETS: false
+  DOCSRS_DOCKER_IMAGE: ghcr.io/rust-lang/crates-build-env/linux-micro
+  SENTRY_ENVIRONMENT: dev
+  DOCSRS_METADATA_HOST_TARGET: aarch64-unknown-linux-gnu
 
 jobs:
   build:
@@ -57,7 +67,6 @@ jobs:
       - name: Launch postgres and min.io
         run: |
           cp .env.sample .env
-          . .env
           mkdir -p ${DOCSRS_PREFIX}/public-html
           docker-compose up -d db s3
           # Give the database enough time to start up
@@ -93,7 +102,6 @@ jobs:
       - name: Launch postgres and min.io
         run: |
           cp .env.sample .env
-          . .env
           mkdir -p ${DOCSRS_PREFIX}/public-html
           docker-compose up -d db s3
           # Give the database enough time to start up
@@ -104,13 +112,12 @@ jobs:
       - name: slow tests
         env:
           DOCSRS_INCLUDE_DEFAULT_TARGETS: true
-          DOCSRS_DOCKER_IMAGE: ghcr.io/rust-lang/crates-build-env/linux-micro
         run: |
           for f in ./test-binaries/*; do
             echo "running $f"
             chmod +x $f  # GH action artifacts don't handle permissions
             # run build-tests. Limited to one thread since we don't support parallel builds.
-            $f --ignored --test-threads=1 || exit 1  
+            $f --ignored --test-threads=1 || exit 1
           done
 
       - name: Clean up the database

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,7 +996,6 @@ dependencies = [
  "criterion",
  "dashmap",
  "docsrs-metadata",
- "dotenv",
  "env_logger",
  "failure",
  "font-awesome-as-a-crate",
@@ -1065,12 +1064,6 @@ dependencies = [
  "thiserror",
  "toml",
 ]
-
-[[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dtoa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ systemstat = "0.1.4"
 prometheus = { version = "0.13.0", default-features = false }
 rustwide = "0.15.0"
 mime_guess = "2"
-dotenv = "0.15"
 zstd = "0.11.0"
 git2 = { version = "0.14.4", default-features = false }
 path-slash = "0.2.0"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ mkdir -p ignored/cratesfyi-prefix/crates.io-index
 cargo build
 # Start the external services
 docker-compose up -d db s3
+# anything that doesn't run via docker-compose needs the settings defined in 
+# .env. Either via `. .env` as below, or via any dotenv shell integration
+(dotenv, direnv, ...).
+. .env
 # Setup the database you just created
 cargo run -- database migrate
 # Build a sample crate to make sure it works

--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ cargo build
 # Start the external services
 docker-compose up -d db s3
 # anything that doesn't run via docker-compose needs the settings defined in 
-# .env. Either via `. .env` as below, or via any dotenv shell integration
-(dotenv, direnv, ...).
+# .env. Either via `. .env` as below, or via any dotenv shell integration.
 . .env
 # Setup the database you just created
 cargo run -- database migrate

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -16,8 +16,6 @@ use structopt::StructOpt;
 use strum::VariantNames;
 
 fn main() {
-    let _ = dotenv::dotenv();
-
     let _sentry_guard = if let Ok(sentry_dsn) = env::var("SENTRY_DSN") {
         rustwide::logging::init_with(SentryLogger::with_dest(logger_init()));
         Some(sentry::init((

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -19,8 +19,6 @@ use std::net::SocketAddr;
 use std::{panic, sync::Arc};
 
 pub(crate) fn wrapper(f: impl FnOnce(&TestEnvironment) -> Result<()>) {
-    let _ = dotenv::dotenv();
-
     let env = TestEnvironment::new();
     // if we didn't catch the panic, the server would hang forever
     let maybe_panic = panic::catch_unwind(panic::AssertUnwindSafe(|| f(&env)));


### PR DESCRIPTION
resolves #1811 

We need to add the config to the tests explicitly, which personally I like more than how it was done before. 

