### PR TITLE
Retain queries and convert `::` paths on redirects to rust-lang.org

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -750,6 +750,13 @@ mod test {
             assert_redirect("/rustdoc", target, web)?;
             assert_redirect("/rustdoc/", target, web)?;
 
+            // queries are supported
+            assert_redirect(
+                "/std?search=foobar",
+                "https://doc.rust-lang.org/stable/std/?search=foobar",
+                web,
+            )?;
+
             Ok(())
         })
     }

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -9,9 +9,6 @@ use iron::{
 use router::Router;
 use std::collections::HashSet;
 
-pub(super) const DOC_RUST_LANG_ORG_REDIRECTS: &[&str] =
-    &["alloc", "core", "proc_macro", "std", "test"];
-
 // REFACTOR: Break this into smaller initialization functions
 pub(super) fn build_routes() -> Routes {
     let mut routes = Routes::new();
@@ -166,44 +163,6 @@ pub(super) fn build_routes() -> Routes {
     routes.rustdoc_page(
         "/:crate/:version/:target/*.html",
         super::rustdoc::rustdoc_html_server_handler,
-    );
-
-    for redirect in DOC_RUST_LANG_ORG_REDIRECTS {
-        routes.internal_page(
-            &format!("/{}", redirect),
-            super::rustdoc::RustLangRedirector::new("stable", redirect),
-        );
-        routes.internal_page(
-            &format!("/{}/", redirect),
-            super::rustdoc::RustLangRedirector::new("stable", redirect),
-        );
-    }
-    // redirect proc-macro to proc_macro
-    routes.internal_page(
-        "/proc-macro",
-        super::rustdoc::RustLangRedirector::new("stable", "proc_macro"),
-    );
-    routes.internal_page(
-        "/proc-macro/",
-        super::rustdoc::RustLangRedirector::new("stable", "proc_macro"),
-    );
-    // redirect rustc to nightly rustc docs
-    routes.internal_page(
-        "/rustc",
-        super::rustdoc::RustLangRedirector::new("nightly", "nightly-rustc"),
-    );
-    routes.internal_page(
-        "/rustc/",
-        super::rustdoc::RustLangRedirector::new("nightly", "nightly-rustc"),
-    );
-    // redirect rustdoc to nightly rustdoc docs
-    routes.internal_page(
-        "/rustdoc",
-        super::rustdoc::RustLangRedirector::new("nightly", "nightly-rustc/rustdoc"),
-    );
-    routes.internal_page(
-        "/rustdoc/",
-        super::rustdoc::RustLangRedirector::new("nightly", "nightly-rustc/rustdoc"),
     );
 
     routes


### PR DESCRIPTION
fixes #751, but using `::` separated paths instead of the `/` ones mentioned in the issue.