### PR TITLE
Remove links that shouldn't be in the top navbar

### DIFF
--- a/templates/header/topbar_end.html
+++ b/templates/header/topbar_end.html
@@ -48,19 +48,6 @@
                             ) }}
 
                             {{ macros::menu_link(
-                                href="https://rust-lang-nursery.github.io/rust-cookbook/",
-                                text="Rust Cookbook",
-                                target="_blank",
-                                extra_classes="menu-item-divided"
-                            ) }}
-
-                            {{ macros::menu_link(
-                                href="https://crates.io",
-                                text="Crates.io",
-                                target="_blank"
-                            ) }}
-
-                            {{ macros::menu_link(
                                 href="http://doc.crates.io/guide.html",
                                 text="The Cargo Guide",
                                 target="_blank"


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/docs.rs/pull/1809#issuecomment-1232031749, some links shouldn't be in the docs.rs top navbar. The parameters are as follows:

 * Only official resources (it excludes the rust cookbook).
 * Only documentation (it excludes rust-lang.org and crates.io, and for the latter, we already link to it).

This is very much up-to-debate.