### PR TITLE
fix rustdoc caching tests

### DIFF
--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -912,14 +912,21 @@ mod test {
                 .archive_storage(true)
                 .rustdoc_file("dummy/index.html")
                 .create()?;
-            let resp = env.frontend().get("/dummy/latest/dummy/").send()?;
-            assert_eq!(resp.headers().get("Cache-Control").unwrap(), &"max-age=0");
 
-            let resp = env.frontend().get("/dummy/0.1.0/dummy/").send()?;
-            assert_eq!(
-                resp.headers().get("Cache-Control").unwrap(),
-                &"stale-while-revalidate=2592000, max-age=600"
-            );
+            let web = env.frontend();
+
+            {
+                let resp = web.get("/dummy/latest/dummy/").send()?;
+                assert_eq!(resp.headers().get("Cache-Control").unwrap(), &"max-age=0");
+            }
+
+            {
+                let resp = web.get("/dummy/0.1.0/dummy/").send()?;
+                assert_eq!(
+                    resp.headers().get("Cache-Control").unwrap(),
+                    &"stale-while-revalidate=2592000, max-age=600"
+                );
+            }
             Ok(())
         })
     }


### PR DESCRIPTION
After #1569 the tests failed, first because of 2db2d767d7aefe5369e333642befa9eb0e55b0ab, then because of something else. 

I don't know _why_ this is breaking, didn't have more time to dig this evening, but this fixes the test. 

cc @jsha 