### PR TITLE
Add canonical link for crate pages

### DIFF
--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -576,6 +576,24 @@ mod tests {
     }
 
     #[test]
+    fn test_canonical_url() {
+        wrapper(|env| {
+            env.fake_release().name("foo").version("0.0.1").create()?;
+            env.fake_release().name("foo").version("0.0.2").create()?;
+
+            let web = env.frontend();
+
+            assert!(web
+                .get("/crate/foo/0.0.1")
+                .send()?
+                .text()?
+                .contains("rel=\"canonical\" href=\"https://docs.rs/crate/foo/latest"));
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_latest_version() {
         wrapper(|env| {
             let db = env.db();

--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -5,6 +5,10 @@
     {{ macros::doc_title(name=details.name, version=details.version) }}
 {%- endblock title -%}
 
+{%- block meta -%}
+    <link rel="canonical" href="https://docs.rs/crate/{{ details.name }}/latest" />
+{%- endblock meta -%}
+
 {%- block topbar -%}
   {%- set metadata = details.metadata -%}
   {%- set latest_version = "" -%}


### PR DESCRIPTION
Part of #74

Note: the "Source", "Builds", and "Feature Flags" pages will also need this treatment, but I didn't see any easy way to cover them all at one go so I figured I'd do the crate page first, and the other tabs as I have time.