### PR TITLE
keep queries when doing lucky, `::` or crate-name searches

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -728,24 +728,24 @@ mod test {
         wrapper(|env| {
             let web = env.frontend();
             for krate in &["std", "alloc", "core", "proc_macro", "test"] {
-                let target = format!("https://doc.rust-lang.org/stable/{}/", krate);
+                let target = format!("https://doc.rust-lang.org/stable/{}/?", krate);
 
                 // with or without slash
                 assert_redirect(&format!("/{}", krate), &target, web)?;
                 assert_redirect(&format!("/{}/", krate), &target, web)?;
             }
 
-            let target = "https://doc.rust-lang.org/stable/proc_macro/";
+            let target = "https://doc.rust-lang.org/stable/proc_macro/?";
             // with or without slash
             assert_redirect("/proc-macro", target, web)?;
             assert_redirect("/proc-macro/", target, web)?;
 
-            let target = "https://doc.rust-lang.org/nightly/nightly-rustc/";
+            let target = "https://doc.rust-lang.org/nightly/nightly-rustc/?";
             // with or without slash
             assert_redirect("/rustc", target, web)?;
             assert_redirect("/rustc/", target, web)?;
 
-            let target = "https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc/";
+            let target = "https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc/?";
             // with or without slash
             assert_redirect("/rustdoc", target, web)?;
             assert_redirect("/rustdoc/", target, web)?;

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -584,17 +584,13 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
             let url = if matchver.rustdoc_status {
                 let target_name = matchver.target_name;
                 let path = format!("{base}/{krate}/{version}/{target_name}/");
-                if queries.is_empty() {
-                    ctry!(req, Url::parse(&path))
-                } else {
-                    ctry!(
+                ctry!(
+                    req,
+                    Url::from_generic_url(ctry!(
                         req,
-                        Url::from_generic_url(ctry!(
-                            req,
-                            iron::url::Url::parse_with_params(&path, queries)
-                        ))
-                    )
-                }
+                        iron::url::Url::parse_with_params(&path, queries)
+                    ))
+                )
             } else {
                 ctry!(req, Url::parse(&format!("{base}/crate/{krate}/{version}")))
             };
@@ -842,7 +838,7 @@ mod tests {
 
             assert_redirect(
                 "/releases/search?query=some_random_crate&i-am-feeling-lucky=1",
-                "/some_random_crate/1.0.0/some_random_crate/",
+                "/some_random_crate/1.0.0/some_random_crate/?",
                 web,
             )?;
             Ok(())

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -561,24 +561,22 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
             return redirect_to_random_crate(req, &mut conn);
         }
 
-        let (krate, mut query) = match query.split_once("::") {
-            Some((krate, query)) => (krate.to_string(), format!("?search={query}")),
-            None => (query.clone(), "".to_string()),
+        let mut queries = std::collections::BTreeMap::new();
+
+        let krate = match query.split_once("::") {
+            Some((krate, query)) => {
+                queries.insert("search", query);
+                krate.to_string()
+            }
+            None => query.clone(),
         };
 
-        for (k, v) in params
-            .iter()
-            .filter(|(k, _)| !matches!(k.as_ref(), "i-am-feeling-lucky" | "query"))
-        {
-            if query.is_empty() {
-                query.push('?');
-            } else {
-                query.push('&')
-            }
-            query.push_str(k);
-            query.push('=');
-            query.push_str(v);
-        }
+        queries.extend(
+            params
+                .iter()
+                .filter(|(k, _)| !matches!(k.as_ref(), "i-am-feeling-lucky" | "query"))
+                .map(|(k, v)| (k.as_ref(), v.as_ref())),
+        );
 
         // since we never pass a version into `match_version` here, we'll never get
         // `MatchVersion::Exact`, so the distinction between `Exact` and `Semver` doesn't
@@ -590,10 +588,18 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
             let base = redirect_base(req);
             let url = if matchver.rustdoc_status {
                 let target_name = matchver.target_name;
-                ctry!(
-                    req,
-                    Url::parse(&format!("{base}/{krate}/{version}/{target_name}/{query}"))
-                )
+                let path = format!("{base}/{krate}/{version}/{target_name}/");
+                if queries.is_empty() {
+                    ctry!(req, Url::parse(&path))
+                } else {
+                    ctry!(
+                        req,
+                        Url::from_generic_url(ctry!(
+                            req,
+                            iron::url::Url::parse_with_params(&path, queries)
+                        ))
+                    )
+                }
             } else {
                 ctry!(req, Url::parse(&format!("{base}/crate/{krate}/{version}")))
             };
@@ -891,7 +897,7 @@ mod tests {
             )?;
             assert_redirect(
                 "/releases/search?query=some_random_crate::some::path",
-                "/some_random_crate/1.0.0/some_random_crate/?search=some::path",
+                "/some_random_crate/1.0.0/some_random_crate/?search=some%3A%3Apath",
                 web,
             )?;
             Ok(())
@@ -906,7 +912,7 @@ mod tests {
 
             assert_redirect(
                 "/releases/search?query=some_random_crate::somepath&go_to_first=true",
-                "/some_random_crate/1.0.0/some_random_crate/?search=somepath&go_to_first=true",
+                "/some_random_crate/1.0.0/some_random_crate/?go_to_first=true&search=somepath",
                 web,
             )?;
             Ok(())

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -561,10 +561,24 @@ pub fn search_handler(req: &mut Request) -> IronResult<Response> {
             return redirect_to_random_crate(req, &mut conn);
         }
 
-        let (krate, query) = match query.split_once("::") {
+        let (krate, mut query) = match query.split_once("::") {
             Some((krate, query)) => (krate.to_string(), format!("?search={query}")),
             None => (query.clone(), "".to_string()),
         };
+
+        for (k, v) in params
+            .iter()
+            .filter(|(k, _)| !matches!(k.as_ref(), "i-am-feeling-lucky" | "query"))
+        {
+            if query.is_empty() {
+                query.push('?');
+            } else {
+                query.push('&')
+            }
+            query.push_str(k);
+            query.push('=');
+            query.push_str(v);
+        }
 
         // since we never pass a version into `match_version` here, we'll never get
         // `MatchVersion::Exact`, so the distinction between `Exact` and `Semver` doesn't
@@ -878,6 +892,21 @@ mod tests {
             assert_redirect(
                 "/releases/search?query=some_random_crate::some::path",
                 "/some_random_crate/1.0.0/some_random_crate/?search=some::path",
+                web,
+            )?;
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn search_coloncolon_path_redirects_to_crate_docs_and_keeps_query() {
+        wrapper(|env| {
+            let web = env.frontend();
+            env.fake_release().name("some_random_crate").create()?;
+
+            assert_redirect(
+                "/releases/search?query=some_random_crate::somepath&go_to_first=true",
+                "/some_random_crate/1.0.0/some_random_crate/?search=somepath&go_to_first=true",
                 web,
             )?;
             Ok(())


### PR DESCRIPTION
enables https://docs.rs/releases/search?query=tokio::spawn&i-am-feeling-lucky=1&go_to_first=true

to go to first result after redirect

useful for `%s` keyword search
