### PR TITLE
Remove `type="text/css"` from stylesheet links

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,8 +10,8 @@
         {%- block meta -%}{%- endblock meta -%}
 
         {# Docs.rs styles #}
-        <link rel="stylesheet" href="/-/static/vendored.css?{{ docsrs_version() | slugify }}" type="text/css" media="all" />
-        <link rel="stylesheet" href="/-/static/style.css?{{ docsrs_version() | slugify }}" type="text/css" media="all" />
+        <link rel="stylesheet" href="/-/static/vendored.css?{{ docsrs_version() | slugify }}" media="all" />
+        <link rel="stylesheet" href="/-/static/style.css?{{ docsrs_version() | slugify }}" media="all" />
 
         <link rel="search" href="/-/static/opensearch.xml" type="application/opensearchdescription+xml" title="Docs.rs" />
 

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -42,7 +42,6 @@
         var link = document.createElement("link");
         link.rel = "stylesheet";
         link.href = stylesheet;
-        link.type = "text/css";
         link.media = "all";
         document.head.appendChild(link);
     </script>

--- a/templates/rustdoc/head.html
+++ b/templates/rustdoc/head.html
@@ -1,5 +1,5 @@
 {%- import "macros.html" as macros -%}
-        <link rel="stylesheet" href="/-/static/{{metadata.rustdoc_css_file}}?{{ docsrs_version() | slugify }}" type="text/css" media="all" />
+        <link rel="stylesheet" href="/-/static/{{metadata.rustdoc_css_file}}?{{ docsrs_version() | slugify }}" media="all" />
 
         <link rel="search" href="/-/static/opensearch.xml" type="application/opensearchdescription+xml" title="Docs.rs" />
 

--- a/templates/rustdoc/vendored.html
+++ b/templates/rustdoc/vendored.html
@@ -1,2 +1,2 @@
-<link rel="stylesheet" href="/-/static/vendored.css?{{ docsrs_version() | slugify }}" type="text/css" media="all" />
+<link rel="stylesheet" href="/-/static/vendored.css?{{ docsrs_version() | slugify }}" media="all" />
 


### PR DESCRIPTION
MDN directly recommends this in <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link>, since "CSS is the only stylesheet language used on the web."

Like <https://github.com/rust-lang/rust/pull/101023>, but for docs.rs.