### PR TITLE
Fix weird menu bug when using down-arrow to open a menu

### DIFF
--- a/static/menu.js
+++ b/static/menu.js
@@ -49,6 +49,7 @@ const updateMenuPositionForSubMenu = (currentMenuSupplier) => {
     }
     backdrop.onclick = closeMenu;
     function openMenu(newMenu) {
+        updateMenuPositionForSubMenu(() => newMenu);
         currentMenu = newMenu;
         newMenu.className += " pure-menu-active";
         backdrop.style.display = "block";
@@ -62,8 +63,6 @@ const updateMenuPositionForSubMenu = (currentMenuSupplier) => {
             this.blur();
         } else {
             if (currentMenu) closeMenu();
-
-            updateMenuPositionForSubMenu(() => this.parentNode);
 
             openMenu(this.parentNode);
         }


### PR DESCRIPTION
To reproduce this problem, use the <kbd>Tab</kbd> key to navigate to a drop-down menu, then press the <kbd>↓</kbd> on the keyboard to open it (because pressing <kbd>Enter</kbd> dispatches a "click" event, this problem never occured for that key).

## Before

![image](https://user-images.githubusercontent.com/1593513/190712224-6df0ec82-7ad3-4de4-b55a-69a39517ac71.png)

## After

![image](https://user-images.githubusercontent.com/1593513/190712295-337bfbc8-5e7c-4c02-a43a-429117223d39.png)
