### PR TITLE
Include slash at the end of sitemap URLs

### DIFF
--- a/templates/core/sitemap.xml
+++ b/templates/core/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% for release in releases -%}
         <url>
-            <loc>https://docs.rs/{{ release.crate_name }}/latest/{{ release.target_name }}</loc>
+            <loc>https://docs.rs/{{ release.crate_name }}/latest/{{ release.target_name }}/</loc>
             <lastmod>{{ release.last_modified | escape_xml }}</lastmod>
         </url>
     {%- endfor %}


### PR DESCRIPTION
Without the slash, these URLs get immediately redirected to the version with the slash. We should skip the redirect.