### PR TITLE
Update Discord invite link on about page

### DIFF
--- a/templates/core/about/index.html
+++ b/templates/core/about/index.html
@@ -41,7 +41,7 @@
         {%- set governance_link = "https://www.rust-lang.org/governance/teams/dev-tools#docs-rs" -%}
         <p>
             Docs.rs is run and maintained by the <a href="{{ governance_link | safe }}">Docs.rs team</a>.
-            You can find us in #docs-rs on <a href="https://discordapp.com/invite/f7mTXPW/">Discord</a>.
+            You can find us in #docs-rs on <a href="https://discord.gg/f7mTXPW">Discord</a>.
         </p>
 
     </div>


### PR DESCRIPTION
The invite link on https://docs.rs/about is outdated, this PR updates it to be the same as in README.md (which works, just tested).