### PR TITLE
fix performance regression after 644ebfd3 and 3868e79

### DIFF
--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -843,6 +843,11 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> crate::error::Res
             "ALTER TABLE builds ADD COLUMN build_server TEXT NOT NULL DEFAULT '';",
             "ALTER TABLE builds DROP COLUMN build_server;",
         ),
+        sql_migration!(
+            context, 34, "add index on builds.rid",
+            "CREATE INDEX builds_release_id_idx ON builds (rid);",
+            "DROP INDEX builds_release_id_idx;",
+        ),
 
     ];
 


### PR DESCRIPTION
After merging #1835 the homepage and release-views felt oddly slow, which lead me to digging into this. 

I found two issues: 
- after #1491 we actually forgot adding an index to `builds.rid`, which slowed down the join 
- having the condition the join on `releases` instead of using the `WHERE` condition is actually much faster. 