### PR TITLE
new cache-policy & cache middleware structure to support full page caching

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -61,7 +61,6 @@ pub struct Config {
     // If both are absent, don't generate the header. If only one is present,
     // generate just that directive. Values are in seconds.
     pub(crate) cache_control_stale_while_revalidate: Option<u32>,
-    pub(crate) cache_control_max_age: Option<u32>,
 
     pub(crate) cdn_backend: CdnKind,
 
@@ -145,7 +144,6 @@ impl Config {
             cache_control_stale_while_revalidate: maybe_env(
                 "CACHE_CONTROL_STALE_WHILE_REVALIDATE",
             )?,
-            cache_control_max_age: maybe_env("CACHE_CONTROL_MAX_AGE")?,
 
             cdn_backend: env("DOCSRS_CDN_BACKEND", CdnKind::Dummy)?,
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -164,7 +164,8 @@ pub(crate) fn assert_redirect(path: &str, expected_target: &str, web: &TestFront
     Ok(())
 }
 
-/// Make sure that a URL redirects to a specific page, and that the target exists and is not another redirect
+/// Make sure that a URL redirects to a specific page, and that the target exists and is not another redirect.
+/// Also verifies that the redirect's cache-control header matches the provided cache policy.
 #[context("expected redirect from {path} to {expected_target}")]
 pub(crate) fn assert_redirect_cached(
     path: &str,

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -263,7 +263,7 @@ impl TestEnvironment {
         config.local_archive_cache_path =
             std::env::temp_dir().join(format!("docsrs-test-index-{}", rand::random::<u64>()));
 
-        // set stale content serving so Cache::ForeverOnlyInCdn and Cache::ForeverInCdnAndStaleInBrowser
+        // set stale content serving so Cache::ForeverInCdn and Cache::ForeverInCdnAndStaleInBrowser
         // are actually different.
         config.cache_control_stale_while_revalidate = Some(86400);
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -60,12 +60,17 @@ pub(crate) fn assert_cache_control(
     config: &Config,
 ) {
     assert!(config.cache_control_stale_while_revalidate.is_some());
-    assert_eq!(
-        res.headers()
-            .get("Cache-Control")
-            .expect("missing cache-control header"),
-        &CacheControl(cache_policy.render(config)).to_string()
-    );
+    let cache_control = res.headers().get("Cache-Control");
+
+    let expected_directives = cache_policy.render(config);
+    if expected_directives.is_empty() {
+        assert!(cache_control.is_none());
+    } else {
+        assert_eq!(
+            cache_control.expect("missing cache-control header"),
+            &CacheControl(expected_directives).to_string()
+        );
+    }
 }
 
 /// Make sure that a URL returns a status code between 200-299

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -6,15 +6,16 @@ use crate::db::{Pool, PoolClient};
 use crate::error::Result;
 use crate::repositories::RepositoryStatsUpdater;
 use crate::storage::{Storage, StorageKind};
-use crate::web::Server;
+use crate::web::{cache, Server};
 use crate::{BuildQueue, Config, Context, Index, Metrics};
 use anyhow::Context as _;
 use fn_error_context::context;
+use iron::headers::CacheControl;
 use log::error;
 use once_cell::unsync::OnceCell;
 use postgres::Client as Connection;
 use reqwest::{
-    blocking::{Client, ClientBuilder, RequestBuilder},
+    blocking::{Client, ClientBuilder, RequestBuilder, Response},
     Method,
 };
 use std::{fs, net::SocketAddr, panic, sync::Arc, time::Duration};
@@ -42,6 +43,31 @@ pub(crate) fn wrapper(f: impl FnOnce(&TestEnvironment) -> Result<()>) {
     }
 }
 
+/// check a request if the cache control header matches NoCache
+pub(crate) fn assert_no_cache(res: &Response) {
+    assert_eq!(
+        res.headers()
+            .get("Cache-Control")
+            .expect("missing cache-control header"),
+        cache::NO_CACHE,
+    );
+}
+
+/// check a request if the cache control header matches the given cache config.
+pub(crate) fn assert_cache_control(
+    res: &Response,
+    cache_policy: cache::CachePolicy,
+    config: &Config,
+) {
+    assert!(config.cache_control_stale_while_revalidate.is_some());
+    assert_eq!(
+        res.headers()
+            .get("Cache-Control")
+            .expect("missing cache-control header"),
+        &CacheControl(cache_policy.render(config)).to_string()
+    );
+}
+
 /// Make sure that a URL returns a status code between 200-299
 pub(crate) fn assert_success(path: &str, web: &TestFrontend) -> Result<()> {
     let status = web.get(path).send()?.status();
@@ -49,14 +75,42 @@ pub(crate) fn assert_success(path: &str, web: &TestFrontend) -> Result<()> {
     Ok(())
 }
 
-/// Make sure that a URL returns a 404
-pub(crate) fn assert_not_found(path: &str, web: &TestFrontend) -> Result<()> {
-    let status = web.get(path).send()?.status();
-    assert_eq!(status, 404, "GET {} should have been a 404", path);
+/// Make sure that a URL returns a status code between 200-299,
+/// also check the cache-control headers.
+pub(crate) fn assert_success_cached(
+    path: &str,
+    web: &TestFrontend,
+    cache_policy: cache::CachePolicy,
+    config: &Config,
+) -> Result<()> {
+    let response = web.get(path).send()?;
+    assert_cache_control(&response, cache_policy, config);
+    let status = response.status();
+    assert!(status.is_success(), "failed to GET {}: {}", path, status);
     Ok(())
 }
 
-fn assert_redirect_common(path: &str, expected_target: &str, web: &TestFrontend) -> Result<()> {
+/// Make sure that a URL returns a 404
+pub(crate) fn assert_not_found(path: &str, web: &TestFrontend) -> Result<()> {
+    let response = web.get(path).send()?;
+
+    // for now, 404s should always have `no-cache`
+    assert_no_cache(&response);
+
+    assert_eq!(
+        response.status(),
+        404,
+        "GET {} should have been a 404",
+        path
+    );
+    Ok(())
+}
+
+fn assert_redirect_common(
+    path: &str,
+    expected_target: &str,
+    web: &TestFrontend,
+) -> Result<Response> {
     let response = web.get_no_redirect(path).send()?;
     let status = response.status();
     if !status.is_redirection() {
@@ -83,7 +137,7 @@ fn assert_redirect_common(path: &str, expected_target: &str, web: &TestFrontend)
         anyhow::bail!("got redirect to {redirect_target}");
     }
 
-    Ok(())
+    Ok(response)
 }
 
 /// Makes sure that a URL redirects to a specific page, but doesn't check that the target exists
@@ -93,13 +147,34 @@ pub(crate) fn assert_redirect_unchecked(
     expected_target: &str,
     web: &TestFrontend,
 ) -> Result<()> {
-    assert_redirect_common(path, expected_target, web)
+    assert_redirect_common(path, expected_target, web).map(|_| ())
 }
 
 /// Make sure that a URL redirects to a specific page, and that the target exists and is not another redirect
 #[context("expected redirect from {path} to {expected_target}")]
 pub(crate) fn assert_redirect(path: &str, expected_target: &str, web: &TestFrontend) -> Result<()> {
     assert_redirect_common(path, expected_target, web)?;
+
+    let response = web.get_no_redirect(expected_target).send()?;
+    let status = response.status();
+    if !status.is_success() {
+        anyhow::bail!("failed to GET {expected_target}: {status}");
+    }
+
+    Ok(())
+}
+
+/// Make sure that a URL redirects to a specific page, and that the target exists and is not another redirect
+#[context("expected redirect from {path} to {expected_target}")]
+pub(crate) fn assert_redirect_cached(
+    path: &str,
+    expected_target: &str,
+    cache_policy: cache::CachePolicy,
+    web: &TestFrontend,
+    config: &Config,
+) -> Result<()> {
+    let redirect_response = assert_redirect_common(path, expected_target, web)?;
+    assert_cache_control(&redirect_response, cache_policy, config);
 
     let response = web.get_no_redirect(expected_target).send()?;
     let status = response.status();
@@ -186,6 +261,10 @@ impl TestEnvironment {
 
         config.local_archive_cache_path =
             std::env::temp_dir().join(format!("docsrs-test-index-{}", rand::random::<u64>()));
+
+        // set stale content serving so Cache::ForeverOnlyInCdn and Cache::ForeverInCdnAndStaleInBrowser
+        // are actually different.
+        config.cache_control_stale_while_revalidate = Some(86400);
 
         config
     }

--- a/src/web/cache.rs
+++ b/src/web/cache.rs
@@ -6,7 +6,7 @@ use iron::{
 };
 
 #[cfg(test)]
-pub const NO_CACHE: &str = "no-cache, max-age=0";
+pub const NO_CACHE: &str = "max-age=0";
 
 /// defines the wanted caching behaviour for a web response.
 pub enum CachePolicy {
@@ -40,7 +40,7 @@ impl CachePolicy {
     pub fn render(&self, config: &Config) -> Vec<CacheDirective> {
         match *self {
             CachePolicy::NoCaching => {
-                vec![CacheDirective::NoCache, CacheDirective::MaxAge(0)]
+                vec![CacheDirective::MaxAge(0)]
             }
             CachePolicy::NoStoreMustRevalidate => {
                 vec![
@@ -118,7 +118,7 @@ mod tests {
     use iron::headers::CacheControl;
     use test_case::test_case;
 
-    #[test_case(CachePolicy::NoCaching, "no-cache, max-age=0")]
+    #[test_case(CachePolicy::NoCaching, "max-age=0")]
     #[test_case(
         CachePolicy::NoStoreMustRevalidate,
         "no-cache, no-store, must-revalidate, max-age=0"

--- a/src/web/cache.rs
+++ b/src/web/cache.rs
@@ -51,10 +51,7 @@ impl CachePolicy {
                 ]
             }
             CachePolicy::ForeverInCdnAndBrowser => {
-                vec![
-                    CacheDirective::Public,
-                    CacheDirective::MaxAge(STATIC_FILE_CACHE_DURATION as u32),
-                ]
+                vec![CacheDirective::MaxAge(STATIC_FILE_CACHE_DURATION as u32)]
             }
             CachePolicy::ForeverInCdn => {
                 // A missing `max-age` or `s-maxage` in the Cache-Control header will lead to
@@ -62,7 +59,7 @@ impl CachePolicy {
                 // This means we can have the CDN caching the documentation while just
                 // issuing a purge after a build.
                 // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html#ExpirationDownloadDist
-                vec![CacheDirective::Public]
+                vec![]
             }
             CachePolicy::ForeverInCdnAndStaleInBrowser => {
                 let mut directives = CachePolicy::ForeverInCdn.render(config);
@@ -124,11 +121,11 @@ mod tests {
         CachePolicy::NoStoreMustRevalidate,
         "no-cache, no-store, must-revalidate, max-age=0"
     )]
-    #[test_case(CachePolicy::ForeverInCdnAndBrowser, "public, max-age=31104000")]
-    #[test_case(CachePolicy::ForeverInCdn, "public")]
+    #[test_case(CachePolicy::ForeverInCdnAndBrowser, "max-age=31104000")]
+    #[test_case(CachePolicy::ForeverInCdn, "")]
     #[test_case(
         CachePolicy::ForeverInCdnAndStaleInBrowser,
-        "public, stale-while-revalidate=86400"
+        "stale-while-revalidate=86400"
     )]
     fn render(cache: CachePolicy, expected: &str) {
         wrapper(|env| {
@@ -148,7 +145,7 @@ mod tests {
             assert_eq!(
                 CacheControl(CachePolicy::ForeverInCdnAndStaleInBrowser.render(&env.config()))
                     .to_string(),
-                "public"
+                ""
             );
             Ok(())
         });
@@ -163,7 +160,7 @@ mod tests {
             assert_eq!(
                 CacheControl(CachePolicy::ForeverInCdnAndStaleInBrowser.render(&env.config()))
                     .to_string(),
-                "public, stale-while-revalidate=666"
+                "stale-while-revalidate=666"
             );
             Ok(())
         });

--- a/src/web/cache.rs
+++ b/src/web/cache.rs
@@ -102,7 +102,7 @@ impl AfterMiddleware for CacheMiddleware {
 
         if cfg!(test) {
             assert!(
-                !res.headers.has::<CacheControl>(), 
+                !res.headers.has::<CacheControl>(),
                 "handlers should never set their own caching headers and only use CachePolicy to control caching."
             );
         }

--- a/src/web/cache.rs
+++ b/src/web/cache.rs
@@ -101,9 +101,10 @@ impl AfterMiddleware for CacheMiddleware {
             .unwrap_or(&CachePolicy::NoCaching);
 
         if cfg!(test) {
-            // handlers should never set their own caching headers and
-            // only use the caching header templates above.
-            assert!(!res.headers.has::<CacheControl>());
+            assert!(
+                !res.headers.has::<CacheControl>(), 
+                "handlers should never set their own caching headers and only use CachePolicy to control caching."
+            );
         }
 
         res.headers.set(CacheControl(cache.render(config)));

--- a/src/web/cache.rs
+++ b/src/web/cache.rs
@@ -1,0 +1,170 @@
+use super::STATIC_FILE_CACHE_DURATION;
+use crate::config::Config;
+use iron::{
+    headers::{CacheControl, CacheDirective},
+    AfterMiddleware, IronResult, Request, Response,
+};
+
+#[cfg(test)]
+pub const NO_CACHE: &str = "no-cache, max-age=0";
+
+/// defines the wanted caching behaviour for a web response.
+pub enum CachePolicy {
+    /// no browser or CDN caching.
+    /// In some cases the browser might still use cached content,
+    /// for example when using the "back" button or when it can't
+    /// connect to the server.
+    NoCaching,
+    /// don't cache, plus
+    /// * enforce revalidation
+    /// * never store
+    NoStoreMustRevalidate,
+    /// cache forever in browser & CDN.  
+    /// Valid when you have hashed / versioned filenames and every rebuild would
+    /// change the filename.
+    ForeverInCdnAndBrowser,
+    /// cache forever in CDN, but not in the browser.
+    /// Since we control the CDN we can actively purge content that is cached like
+    /// this, for example after building a crate.
+    /// Example usage: `/latest/` rustdoc pages and their redirects.
+    ForeverOnlyInCdn,
+    /// cache forver in the CDN, but allow stale content in the browser.
+    /// Example: rustdoc pages with the version in their URL.
+    /// A browser will show the stale content while getting the up-to-date
+    /// version from the origin server in the background.
+    /// This helps building a PWA.
+    ForeverInCdnAndStaleInBrowser,
+}
+
+impl CachePolicy {
+    pub fn render(&self, config: &Config) -> Vec<CacheDirective> {
+        match *self {
+            CachePolicy::NoCaching => {
+                vec![CacheDirective::NoCache, CacheDirective::MaxAge(0)]
+            }
+            CachePolicy::NoStoreMustRevalidate => {
+                vec![
+                    CacheDirective::NoCache,
+                    CacheDirective::NoStore,
+                    CacheDirective::MustRevalidate,
+                    CacheDirective::MaxAge(0),
+                ]
+            }
+            CachePolicy::ForeverInCdnAndBrowser => {
+                vec![
+                    CacheDirective::Public,
+                    CacheDirective::MaxAge(STATIC_FILE_CACHE_DURATION as u32),
+                ]
+            }
+            CachePolicy::ForeverOnlyInCdn => {
+                // A missing `max-age` or `s-maxage` in the Cache-Control header will lead to
+                // CloudFront using the default TTL, while the browser not seeing any caching header.
+                // This means we can have the CDN caching the documentation while just
+                // issuing a purge after a build.
+                // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html#ExpirationDownloadDist
+                vec![CacheDirective::Public]
+            }
+            CachePolicy::ForeverInCdnAndStaleInBrowser => {
+                let mut directives = CachePolicy::ForeverOnlyInCdn.render(config);
+                if let Some(seconds) = config.cache_control_stale_while_revalidate {
+                    directives.push(CacheDirective::Extension(
+                        "stale-while-revalidate".to_string(),
+                        Some(seconds.to_string()),
+                    ));
+                }
+                directives
+            }
+        }
+    }
+}
+
+impl iron::typemap::Key for CachePolicy {
+    type Value = CachePolicy;
+}
+
+/// Middleware to ensure a correct cache-control header.
+/// The default is an explicit "never cache" header, which
+/// can be adapted via:
+/// ```ignore
+///  resp.extensions.insert::<CachePolicy>(CachePolicy::ForeverOnlyInCdn);
+///  # change Cache::ForeverOnlyInCdn into the cache polity you want to have
+/// ```
+/// in a handler function.
+pub(super) struct CacheMiddleware;
+
+impl AfterMiddleware for CacheMiddleware {
+    fn after(&self, req: &mut Request, mut res: Response) -> IronResult<Response> {
+        let config = req.extensions.get::<Config>().expect("missing config");
+        let cache = res
+            .extensions
+            .get::<CachePolicy>()
+            .unwrap_or(&CachePolicy::NoCaching);
+
+        if cfg!(test) {
+            // handlers should never set their own caching headers and
+            // only use the caching header templates above.
+            assert!(!res.headers.has::<CacheControl>());
+        }
+
+        res.headers.set(CacheControl(cache.render(config)));
+        Ok(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::wrapper;
+    use iron::headers::CacheControl;
+    use test_case::test_case;
+
+    #[test_case(CachePolicy::NoCaching, "no-cache, max-age=0")]
+    #[test_case(
+        CachePolicy::NoStoreMustRevalidate,
+        "no-cache, no-store, must-revalidate, max-age=0"
+    )]
+    #[test_case(CachePolicy::ForeverInCdnAndBrowser, "public, max-age=31104000")]
+    #[test_case(CachePolicy::ForeverOnlyInCdn, "public")]
+    #[test_case(
+        CachePolicy::ForeverInCdnAndStaleInBrowser,
+        "public, stale-while-revalidate=86400"
+    )]
+    fn render(cache: CachePolicy, expected: &str) {
+        wrapper(|env| {
+            assert_eq!(
+                CacheControl(cache.render(&env.config())).to_string(),
+                expected
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn render_stale_without_config() {
+        wrapper(|env| {
+            env.override_config(|config| config.cache_control_stale_while_revalidate = None);
+
+            assert_eq!(
+                CacheControl(CachePolicy::ForeverInCdnAndStaleInBrowser.render(&env.config()))
+                    .to_string(),
+                "public"
+            );
+            Ok(())
+        });
+    }
+    #[test]
+    fn render_stale_with_config() {
+        wrapper(|env| {
+            env.override_config(|config| {
+                config.cache_control_stale_while_revalidate = Some(666);
+            });
+
+            assert_eq!(
+                CacheControl(CachePolicy::ForeverInCdnAndStaleInBrowser.render(&env.config()))
+                    .to_string(),
+                "public, stale-while-revalidate=666"
+            );
+            Ok(())
+        });
+    }
+}

--- a/src/web/cache.rs
+++ b/src/web/cache.rs
@@ -104,7 +104,10 @@ impl AfterMiddleware for CacheMiddleware {
             );
         }
 
-        res.headers.set(CacheControl(cache.render(config)));
+        let directives = cache.render(config);
+        if !directives.is_empty() {
+            res.headers.set(CacheControl(directives))
+        }
         Ok(res)
     }
 }

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -308,7 +308,7 @@ pub fn crate_details_handler(req: &mut Request) -> IronResult<Response> {
             req,
             Url::parse(&format!("{}/crate/{}/latest", redirect_base(req), name,)),
         );
-        return Ok(super::cached_redirect(url, CachePolicy::ForeverOnlyInCdn));
+        return Ok(super::cached_redirect(url, CachePolicy::ForeverInCdn));
     }
 
     let mut conn = extension!(req, Pool).get()?;
@@ -329,7 +329,7 @@ pub fn crate_details_handler(req: &mut Request) -> IronResult<Response> {
                 )),
             );
 
-            return Ok(super::cached_redirect(url, CachePolicy::ForeverOnlyInCdn));
+            return Ok(super::cached_redirect(url, CachePolicy::ForeverInCdn));
         }
     };
 
@@ -350,7 +350,7 @@ pub fn crate_details_handler(req: &mut Request) -> IronResult<Response> {
 
     let mut res = CrateDetailsPage { details }.into_response(req)?;
     res.extensions.insert::<CachePolicy>(if is_latest_url {
-        CachePolicy::ForeverOnlyInCdn
+        CachePolicy::ForeverInCdn
     } else {
         CachePolicy::ForeverInCdnAndStaleInBrowser
     });
@@ -1027,7 +1027,7 @@ mod tests {
 
             let resp = env.frontend().get("/crate/dummy/latest").send()?;
             assert!(resp.status().is_success());
-            assert_cache_control(&resp, CachePolicy::ForeverOnlyInCdn, &env.config());
+            assert_cache_control(&resp, CachePolicy::ForeverInCdn, &env.config());
             assert!(resp.url().as_str().ends_with("/crate/dummy/latest"));
             let body = String::from_utf8(resp.bytes().unwrap().to_vec()).unwrap();
             assert!(body.contains("<a href=\"/crate/dummy/latest/features\""));
@@ -1045,7 +1045,7 @@ mod tests {
             assert_redirect_cached(
                 "/crate/dummy",
                 "/crate/dummy/latest",
-                CachePolicy::ForeverOnlyInCdn,
+                CachePolicy::ForeverInCdn,
                 web,
                 &env.config(),
             )?;

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -1,6 +1,11 @@
 use super::{match_version, redirect_base, render_markdown, MatchSemver, MetaData};
 use crate::utils::{get_correct_docsrs_style_file, report_error};
-use crate::{db::Pool, impl_webpage, repositories::RepositoryStatsUpdater, web::page::WebPage};
+use crate::{
+    db::Pool,
+    impl_webpage,
+    repositories::RepositoryStatsUpdater,
+    web::{cache::CachePolicy, page::WebPage},
+};
 use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use iron::prelude::*;
@@ -303,16 +308,16 @@ pub fn crate_details_handler(req: &mut Request) -> IronResult<Response> {
             req,
             Url::parse(&format!("{}/crate/{}/latest", redirect_base(req), name,)),
         );
-        return Ok(super::redirect(url));
+        return Ok(super::cached_redirect(url, CachePolicy::ForeverOnlyInCdn));
     }
 
     let mut conn = extension!(req, Pool).get()?;
 
     let found_version =
         match_version(&mut conn, name, req_version).and_then(|m| m.assume_exact())?;
-    let (version, version_or_latest) = match found_version {
-        MatchSemver::Exact((version, _)) => (version.clone(), version),
-        MatchSemver::Latest((version, _)) => (version, "latest".to_string()),
+    let (version, version_or_latest, is_latest_url) = match found_version {
+        MatchSemver::Exact((version, _)) => (version.clone(), version, false),
+        MatchSemver::Latest((version, _)) => (version, "latest".to_string(), true),
         MatchSemver::Semver((version, _)) => {
             let url = ctry!(
                 req,
@@ -324,7 +329,7 @@ pub fn crate_details_handler(req: &mut Request) -> IronResult<Response> {
                 )),
             );
 
-            return Ok(super::redirect(url));
+            return Ok(super::cached_redirect(url, CachePolicy::ForeverOnlyInCdn));
         }
     };
 
@@ -343,14 +348,20 @@ pub fn crate_details_handler(req: &mut Request) -> IronResult<Response> {
         )
     );
 
-    CrateDetailsPage { details }.into_response(req)
+    let mut res = CrateDetailsPage { details }.into_response(req)?;
+    res.extensions.insert::<CachePolicy>(if is_latest_url {
+        CachePolicy::ForeverOnlyInCdn
+    } else {
+        CachePolicy::ForeverInCdnAndStaleInBrowser
+    });
+    Ok(res)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::index::api::CrateOwner;
-    use crate::test::{assert_redirect, wrapper, TestDatabase};
+    use crate::test::{assert_cache_control, assert_redirect_cached, wrapper, TestDatabase};
     use anyhow::{Context, Error};
     use kuchiki::traits::TendrilSink;
     use std::collections::HashMap;
@@ -581,11 +592,14 @@ mod tests {
             env.fake_release().name("foo").version("0.0.1").create()?;
             env.fake_release().name("foo").version("0.0.2").create()?;
 
-            let web = env.frontend();
+            let response = env.frontend().get("/crate/foo/0.0.1").send()?;
+            assert_cache_control(
+                &response,
+                CachePolicy::ForeverInCdnAndStaleInBrowser,
+                &env.config(),
+            );
 
-            assert!(web
-                .get("/crate/foo/0.0.1")
-                .send()?
+            assert!(response
                 .text()?
                 .contains("rel=\"canonical\" href=\"https://docs.rs/crate/foo/latest"));
 
@@ -1013,6 +1027,7 @@ mod tests {
 
             let resp = env.frontend().get("/crate/dummy/latest").send()?;
             assert!(resp.status().is_success());
+            assert_cache_control(&resp, CachePolicy::ForeverOnlyInCdn, &env.config());
             assert!(resp.url().as_str().ends_with("/crate/dummy/latest"));
             let body = String::from_utf8(resp.bytes().unwrap().to_vec()).unwrap();
             assert!(body.contains("<a href=\"/crate/dummy/latest/features\""));
@@ -1020,8 +1035,20 @@ mod tests {
             assert!(body.contains("<a href=\"/crate/dummy/latest/source/\""));
             assert!(body.contains("<a href=\"/crate/dummy/latest\""));
 
-            assert_redirect("/crate/dummy/latest/", "/crate/dummy/latest", web)?;
-            assert_redirect("/crate/dummy", "/crate/dummy/latest", web)?;
+            assert_redirect_cached(
+                "/crate/dummy/latest/",
+                "/crate/dummy/latest",
+                CachePolicy::NoCaching,
+                web,
+                &env.config(),
+            )?;
+            assert_redirect_cached(
+                "/crate/dummy",
+                "/crate/dummy/latest",
+                CachePolicy::ForeverOnlyInCdn,
+                web,
+                &env.config(),
+            )?;
 
             let resp_json = env
                 .frontend()

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -74,6 +74,7 @@ macro_rules! extension {
 
 mod build_details;
 mod builds;
+pub(crate) mod cache;
 pub(crate) mod crate_details;
 mod csp;
 mod error;
@@ -128,6 +129,7 @@ impl MainHandler {
 
         chain.link_before(CspMiddleware);
         chain.link_after(CspMiddleware);
+        chain.link_after(cache::CacheMiddleware);
 
         chain
     }
@@ -485,7 +487,12 @@ fn duration_to_str(init: DateTime<Utc>) -> String {
 fn redirect(url: Url) -> Response {
     let mut resp = Response::with((status::Found, Redirect(url)));
     resp.headers.set(Expires(HttpDate(time::now())));
+    resp
+}
 
+fn cached_redirect(url: Url, cache_policy: cache::CachePolicy) -> Response {
+    let mut resp = Response::with((status::Found, Redirect(url)));
+    resp.extensions.insert::<cache::CachePolicy>(cache_policy);
     resp
 }
 

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -1,11 +1,8 @@
 use crate::web::page::WebPage;
 
-use super::metrics::RequestRecorder;
+use super::{cache::CachePolicy, metrics::RequestRecorder};
 use ::std::borrow::Cow;
-use iron::{
-    headers::{CacheControl, CacheDirective},
-    middleware::Handler,
-};
+use iron::middleware::Handler;
 use router::Router;
 use std::collections::HashSet;
 
@@ -42,8 +39,8 @@ pub(super) fn build_routes() -> Routes {
             fn template(&self) -> Cow<'static, str> {
                 "storage-change-detection.html".into()
             }
-            fn cache_control() -> CacheControl {
-                CacheControl(vec![CacheDirective::MaxAge(604800)])
+            fn cache_policy() -> Option<CachePolicy> {
+                Some(CachePolicy::ForeverInCdnAndBrowser)
             }
         }
         fn storage_change_detection(req: &mut iron::Request) -> iron::IronResult<iron::Response> {

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -1778,10 +1778,7 @@ mod test {
             let url = format!("http://{}/dummy", web.server_addr());
             let resp = client.get(url).send()?;
             assert_eq!(resp.status(), StatusCode::FOUND);
-            assert_eq!(
-                resp.headers().get("Cache-Control").unwrap(),
-                reqwest::header::HeaderValue::from_str("public").unwrap()
-            );
+            assert!(resp.headers().get("Cache-Control").unwrap().is_empty());
             assert!(resp
                 .headers()
                 .get("Location")

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -54,12 +54,7 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
         }
         queries.extend(req.url.as_ref().query_pairs());
         let url = ctry!(req, parse_url_with_params(&url_str, queries));
-        let status = if matches!(cache_policy, CachePolicy::ForeverInCdnAndBrowser) {
-            status::MovedPermanently
-        } else {
-            status::Found
-        };
-        let mut resp = Response::with((status, Redirect(url)));
+        let mut resp = Response::with((status::Found, Redirect(url)));
         resp.extensions.insert::<CachePolicy>(cache_policy);
         Ok(resp)
     }
@@ -195,7 +190,7 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
         };
 
         let cache = if version == "latest" {
-            CachePolicy::ForeverInCdnAndBrowser
+            CachePolicy::ForeverInCdn
         } else {
             CachePolicy::ForeverInCdnAndStaleInBrowser
         };
@@ -1772,7 +1767,7 @@ mod test {
     }
 
     #[test]
-    fn test_redirect_to_latest_301() {
+    fn test_redirect_to_latest_302() {
         wrapper(|env| {
             env.fake_release().name("dummy").version("1.0.0").create()?;
             let web = env.frontend();
@@ -1782,10 +1777,10 @@ mod test {
                 .unwrap();
             let url = format!("http://{}/dummy", web.server_addr());
             let resp = client.get(url).send()?;
-            assert_eq!(resp.status(), StatusCode::MOVED_PERMANENTLY);
+            assert_eq!(resp.status(), StatusCode::FOUND);
             assert_eq!(
                 resp.headers().get("Cache-Control").unwrap(),
-                reqwest::header::HeaderValue::from_str("public, max-age=31104000").unwrap()
+                reqwest::header::HeaderValue::from_str("public").unwrap()
             );
             assert!(resp
                 .headers()

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -5,19 +5,16 @@ use crate::{
     repositories::RepositoryStatsUpdater,
     utils,
     web::{
-        crate_details::CrateDetails, csp::Csp, error::Nope, file::File, match_version,
-        metrics::RenderingTimesRecorder, parse_url_with_params, redirect_base, MatchSemver,
-        MetaData,
+        cache::CachePolicy, crate_details::CrateDetails, csp::Csp, error::Nope, file::File,
+        match_version, metrics::RenderingTimesRecorder, parse_url_with_params, redirect_base,
+        MatchSemver, MetaData,
     },
     Config, Metrics, Storage,
 };
 use anyhow::{anyhow, Context};
 use iron::{
-    headers::{CacheControl, CacheDirective, Expires, HttpDate},
-    modifiers::Redirect,
-    status,
-    url::percent_encoding::percent_decode,
-    Handler, IronResult, Request, Response, Url,
+    modifiers::Redirect, status, url::percent_encoding::percent_decode, Handler, IronResult,
+    Request, Response, Url,
 };
 use lol_html::errors::RewritingError;
 use once_cell::sync::Lazy;
@@ -48,7 +45,7 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
     fn redirect_to_doc(
         req: &Request,
         url_str: String,
-        permanent: bool,
+        cache_policy: CachePolicy,
         path_in_crate: Option<&str>,
     ) -> IronResult<Response> {
         let mut queries = BTreeMap::new();
@@ -57,14 +54,8 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
         }
         queries.extend(req.url.as_ref().query_pairs());
         let url = ctry!(req, parse_url_with_params(&url_str, queries));
-        let (status_code, max_age) = if permanent {
-            (status::MovedPermanently, 86400)
-        } else {
-            (status::Found, 0)
-        };
-        let mut resp = Response::with((status_code, Redirect(url)));
-        resp.headers
-            .set(CacheControl(vec![CacheDirective::MaxAge(max_age)]));
+        let mut resp = Response::with((status::Found, Redirect(url)));
+        resp.extensions.insert::<CachePolicy>(cache_policy);
         Ok(resp)
     }
 
@@ -75,8 +66,8 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
         );
 
         let mut resp = Response::with((status::Found, Redirect(url)));
-        resp.headers.set(Expires(HttpDate(time::now())));
-
+        resp.extensions
+            .insert::<CachePolicy>(CachePolicy::ForeverOnlyInCdn);
         Ok(resp)
     }
 
@@ -141,7 +132,12 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
 
     if let Some(inner_path) = DOC_RUST_LANG_ORG_REDIRECTS.get(crate_name.as_str()) {
         let url = format!("https://doc.rust-lang.org/{inner_path}/");
-        return redirect_to_doc(req, url, false, path_in_crate.as_deref());
+        return redirect_to_doc(
+            req,
+            url,
+            CachePolicy::ForeverInCdnAndStaleInBrowser,
+            path_in_crate.as_deref(),
+        );
     }
 
     let req_version = router.find("version");
@@ -193,7 +189,13 @@ pub fn rustdoc_redirector_handler(req: &mut Request) -> IronResult<Response> {
             format!("{base}/{crate_name}/{version}/{target_name}/")
         };
 
-        redirect_to_doc(req, url_str, version == "latest", path_in_crate.as_deref())
+        let cache = if version == "latest" {
+            CachePolicy::ForeverOnlyInCdn
+        } else {
+            CachePolicy::ForeverInCdnAndStaleInBrowser
+        };
+
+        redirect_to_doc(req, url_str, cache, path_in_crate.as_deref())
     } else {
         rendering_time.step("redirect to crate");
         redirect_to_crate(req, &crate_name, &version)
@@ -260,28 +262,11 @@ impl RustdocPage {
 
         let mut response = Response::with((Status::Ok, html));
         response.headers.set(ContentType::html());
-
-        if is_latest_url {
-            response
-                .headers
-                .set(CacheControl(vec![CacheDirective::MaxAge(0)]));
+        response.extensions.insert::<CachePolicy>(if is_latest_url {
+            CachePolicy::ForeverOnlyInCdn
         } else {
-            let mut directives = vec![];
-            if let Some(seconds) = config.cache_control_stale_while_revalidate {
-                directives.push(CacheDirective::Extension(
-                    "stale-while-revalidate".to_string(),
-                    Some(format!("{}", seconds)),
-                ));
-            }
-
-            if let Some(seconds) = config.cache_control_max_age {
-                directives.push(CacheDirective::MaxAge(seconds));
-            }
-
-            if !directives.is_empty() {
-                response.headers.set(CacheControl(directives));
-            }
-        }
+            CachePolicy::ForeverInCdnAndStaleInBrowser
+        });
         Ok(response)
     }
 }
@@ -319,7 +304,11 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
     req_path.drain(..2).for_each(drop);
 
     // Convenience closure to allow for easy redirection
-    let redirect = |name: &str, vers: &str, path: &[&str]| -> IronResult<Response> {
+    let redirect = |name: &str,
+                    vers: &str,
+                    path: &[&str],
+                    cache_policy: CachePolicy|
+     -> IronResult<Response> {
         // Format and parse the redirect url
         let redirect_path = format!(
             "{}/{}/{}/{}",
@@ -330,7 +319,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
         );
         let url = ctry!(req, Url::parse(&redirect_path));
 
-        Ok(super::redirect(url))
+        Ok(super::cached_redirect(url, cache_policy))
     };
 
     rendering_time.step("match version");
@@ -343,23 +332,23 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
     // * If there is a semver (but not exact) match, redirect to the exact version.
     let release_found = match_version(&mut conn, &name, url_version)?;
 
-    let (version, version_or_latest) = match release_found.version {
+    let (version, version_or_latest, is_latest_url) = match release_found.version {
         MatchSemver::Exact((version, _)) => {
             // Redirect when the requested crate name isn't correct
             if let Some(name) = release_found.corrected_name {
-                return redirect(&name, &version, &req_path);
+                return redirect(&name, &version, &req_path, CachePolicy::NoCaching);
             }
 
-            (version.clone(), version)
+            (version.clone(), version, false)
         }
 
         MatchSemver::Latest((version, _)) => {
             // Redirect when the requested crate name isn't correct
             if let Some(name) = release_found.corrected_name {
-                return redirect(&name, "latest", &req_path);
+                return redirect(&name, "latest", &req_path, CachePolicy::NoCaching);
             }
 
-            (version, "latest".to_string())
+            (version, "latest".to_string(), true)
         }
 
         // Redirect when the requested version isn't correct
@@ -367,7 +356,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
             // to prevent cloudfront caching the wrong artifacts on URLs with loose semver
             // versions, redirect the browser to the returned version instead of loading it
             // immediately
-            return redirect(&name, &v, &req_path);
+            return redirect(&name, &v, &req_path, CachePolicy::ForeverOnlyInCdn);
         }
     };
 
@@ -394,7 +383,12 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
     // if visiting the full path to the default target, remove the target from the path
     // expects a req_path that looks like `[/:target]/.*`
     if req_path.first().copied() == Some(&krate.metadata.default_target) {
-        return redirect(&name, &version_or_latest, &req_path[1..]);
+        return redirect(
+            &name,
+            &version_or_latest,
+            &req_path[1..],
+            CachePolicy::ForeverOnlyInCdn,
+        );
     }
 
     // Create the path to access the file from
@@ -429,7 +423,12 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
                 req,
                 storage.rustdoc_file_exists(&name, &version, &path, krate.archive_storage)
             ) {
-                redirect(&name, &version_or_latest, &req_path)
+                redirect(
+                    &name,
+                    &version_or_latest,
+                    &req_path,
+                    CachePolicy::ForeverOnlyInCdn,
+                )
             } else if req_path.first().map_or(false, |p| p.contains('-')) {
                 // This is a target, not a module; it may not have been built.
                 // Redirect to the default target and show a search page instead of a hard 404.
@@ -437,6 +436,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
                     &format!("/crate/{}", name),
                     &format!("{}/target-redirect", version),
                     &req_path,
+                    CachePolicy::ForeverOnlyInCdn,
                 )
             } else {
                 Err(Nope::ResourceNotFound.into())
@@ -448,7 +448,19 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
     if !path.ends_with(".html") {
         rendering_time.step("serve asset");
 
-        return Ok(File(blob).serve());
+        let mut response = File(blob).serve();
+        // default asset caching behaviour is `Cache::ForeverInCdnAndBrowser`.
+        // We don't want to cache invocation specific assets in the browser
+        // but only in the CDN so we can invalidate these after a build.
+        // For CDN caching the same rules should apply as for HTML files,
+        // which means we cache slightly different for `/latest/` and
+        // URLs with versions.
+        response.extensions.insert::<CachePolicy>(if is_latest_url {
+            CachePolicy::ForeverOnlyInCdn
+        } else {
+            CachePolicy::ForeverInCdnAndStaleInBrowser
+        });
+        return Ok(response);
     }
 
     rendering_time.step("find latest path");
@@ -549,7 +561,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
         target,
         inner_path,
         is_latest_version,
-        is_latest_url: version_or_latest == "latest",
+        is_latest_url,
         is_prerelease,
         metadata: krate.metadata.clone(),
         krate,
@@ -630,9 +642,9 @@ pub fn target_redirect_handler(req: &mut Request) -> IronResult<Response> {
 
     let release_found = match_version(&mut conn, name, Some(version))?;
 
-    let (version, version_or_latest) = match release_found.version {
-        MatchSemver::Exact((version, _)) => (version.clone(), version),
-        MatchSemver::Latest((version, _)) => (version, "latest".to_string()),
+    let (version, version_or_latest, is_latest_url) = match release_found.version {
+        MatchSemver::Exact((version, _)) => (version.clone(), version, false),
+        MatchSemver::Latest((version, _)) => (version, "latest".to_string(), true),
         // semver matching not supported here
         MatchSemver::Semver(_) => return Err(Nope::VersionNotFound.into()),
     };
@@ -688,8 +700,11 @@ pub fn target_redirect_handler(req: &mut Request) -> IronResult<Response> {
 
     let url = ctry!(req, Url::parse(&url));
     let mut resp = Response::with((status::Found, Redirect(url)));
-    resp.headers.set(Expires(HttpDate(time::now())));
-
+    resp.extensions.insert::<CachePolicy>(if is_latest_url {
+        CachePolicy::ForeverOnlyInCdn
+    } else {
+        CachePolicy::ForeverInCdnAndStaleInBrowser
+    });
     Ok(resp)
 }
 
@@ -706,7 +721,10 @@ pub fn badge_handler(req: &mut Request) -> IronResult<Response> {
     let name = cexpect!(req, extension!(req, Router).find("crate"));
     let url = format!("https://img.shields.io/docsrs/{}/{}", name, version);
     let url = ctry!(req, Url::parse(&url));
-    Ok(Response::with((status::MovedPermanently, Redirect(url))))
+    let mut res = Response::with((status::MovedPermanently, Redirect(url)));
+    res.extensions
+        .insert::<CachePolicy>(CachePolicy::ForeverInCdnAndBrowser);
+    Ok(res)
 }
 
 /// Serves shared web resources used by rustdoc-generated documentation.
@@ -741,7 +759,7 @@ impl Handler for SharedResourceHandler {
 
 #[cfg(test)]
 mod test {
-    use crate::test::*;
+    use crate::{test::*, web::cache::CachePolicy, Config};
     use anyhow::Context;
     use kuchiki::traits::TendrilSink;
     use reqwest::{blocking::ClientBuilder, redirect, StatusCode};
@@ -751,9 +769,16 @@ mod test {
     fn try_latest_version_redirect(
         path: &str,
         web: &TestFrontend,
+        config: &Config,
     ) -> Result<Option<String>, anyhow::Error> {
         assert_success(path, web)?;
-        let data = web.get(path).send()?.text()?;
+        let response = web.get(path).send()?;
+        assert_cache_control(
+            &response,
+            CachePolicy::ForeverInCdnAndStaleInBrowser,
+            config,
+        );
+        let data = response.text()?;
         log::info!("fetched path {} and got content {}\nhelp: if this is missing the header, remember to add <html><head></head><body></body></html>", path, data);
         let dom = kuchiki::parse_html().one(data);
 
@@ -763,15 +788,19 @@ mod test {
             .next()
         {
             let link = elem.attributes.borrow().get("href").unwrap().to_string();
-            assert_success(&link, web)?;
+            assert_success_cached(&link, web, CachePolicy::ForeverOnlyInCdn, config)?;
             Ok(Some(link))
         } else {
             Ok(None)
         }
     }
 
-    fn latest_version_redirect(path: &str, web: &TestFrontend) -> Result<String, anyhow::Error> {
-        try_latest_version_redirect(path, web)?
+    fn latest_version_redirect(
+        path: &str,
+        web: &TestFrontend,
+        config: &Config,
+    ) -> Result<String, anyhow::Error> {
+        try_latest_version_redirect(path, web, config)?
             .with_context(|| anyhow::anyhow!("no redirect found for {}", path))
     }
 
@@ -799,14 +828,49 @@ mod test {
                 .build_result_failed()
                 .create()?;
             let web = env.frontend();
-            assert_success("/", web)?;
-            assert_success("/crate/buggy/0.1.0/", web)?;
-            assert_success("/buggy/0.1.0/directory_1/index.html", web)?;
-            assert_success("/buggy/0.1.0/directory_2.html/index.html", web)?;
-            assert_success("/buggy/0.1.0/directory_3/.gitignore", web)?;
-            assert_success("/buggy/0.1.0/settings.html", web)?;
-            assert_success("/buggy/0.1.0/all.html", web)?;
-            assert_success("/buggy/0.1.0/directory_4/empty_file_no_ext", web)?;
+            assert_success_cached("/", web, CachePolicy::NoCaching, &env.config())?;
+            assert_success_cached(
+                "/crate/buggy/0.1.0/",
+                web,
+                CachePolicy::ForeverInCdnAndStaleInBrowser,
+                &env.config(),
+            )?;
+            assert_success_cached(
+                "/buggy/0.1.0/directory_1/index.html",
+                web,
+                CachePolicy::ForeverInCdnAndStaleInBrowser,
+                &env.config(),
+            )?;
+            assert_success_cached(
+                "/buggy/0.1.0/directory_2.html/index.html",
+                web,
+                CachePolicy::ForeverInCdnAndStaleInBrowser,
+                &env.config(),
+            )?;
+            assert_success_cached(
+                "/buggy/0.1.0/directory_3/.gitignore",
+                web,
+                CachePolicy::ForeverInCdnAndStaleInBrowser,
+                &env.config(),
+            )?;
+            assert_success_cached(
+                "/buggy/0.1.0/settings.html",
+                web,
+                CachePolicy::ForeverInCdnAndStaleInBrowser,
+                &env.config(),
+            )?;
+            assert_success_cached(
+                "/buggy/0.1.0/all.html",
+                web,
+                CachePolicy::ForeverInCdnAndStaleInBrowser,
+                &env.config(),
+            )?;
+            assert_success_cached(
+                "/buggy/0.1.0/directory_4/empty_file_no_ext",
+                web,
+                CachePolicy::ForeverInCdnAndStaleInBrowser,
+                &env.config(),
+            )?;
             Ok(())
         });
     }
@@ -825,8 +889,19 @@ mod test {
             let web = env.frontend();
             // no explicit default-target
             let base = "/dummy/0.1.0/dummy/";
-            assert_success(base, web)?;
-            assert_redirect("/dummy/0.1.0/x86_64-unknown-linux-gnu/dummy/", base, web)?;
+            assert_success_cached(
+                base,
+                web,
+                CachePolicy::ForeverInCdnAndStaleInBrowser,
+                &env.config(),
+            )?;
+            assert_redirect_cached(
+                "/dummy/0.1.0/x86_64-unknown-linux-gnu/dummy/",
+                base,
+                CachePolicy::ForeverOnlyInCdn,
+                web,
+                &env.config(),
+            )?;
 
             assert_success("/dummy/latest/dummy/", web)?;
 
@@ -879,6 +954,7 @@ mod test {
                 .create()?;
 
             let resp = env.frontend().get("/dummy/latest/dummy/").send()?;
+            assert_cache_control(&resp, CachePolicy::ForeverOnlyInCdn, &env.config());
             assert!(resp.url().as_str().ends_with("/dummy/latest/dummy/"));
             let body = String::from_utf8(resp.bytes().unwrap().to_vec()).unwrap();
             assert!(body.contains("<a href=\"/crate/dummy/latest/source/\""));
@@ -892,7 +968,6 @@ mod test {
     fn cache_headers_on_version() {
         wrapper(|env| {
             env.override_config(|config| {
-                config.cache_control_max_age = Some(600);
                 config.cache_control_stale_while_revalidate = Some(2592000);
             });
 
@@ -907,14 +982,15 @@ mod test {
 
             {
                 let resp = web.get("/dummy/latest/dummy/").send()?;
-                assert_eq!(resp.headers().get("Cache-Control").unwrap(), &"max-age=0");
+                assert_cache_control(&resp, CachePolicy::ForeverOnlyInCdn, &env.config());
             }
 
             {
                 let resp = web.get("/dummy/0.1.0/dummy/").send()?;
-                assert_eq!(
-                    resp.headers().get("Cache-Control").unwrap(),
-                    &"stale-while-revalidate=2592000, max-age=600"
+                assert_cache_control(
+                    &resp,
+                    CachePolicy::ForeverInCdnAndStaleInBrowser,
+                    &env.config(),
                 );
             }
             Ok(())
@@ -944,27 +1020,31 @@ mod test {
             let web = env.frontend();
 
             // check it works at all
-            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/", web)?;
+            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/", web, &env.config())?;
             assert_eq!(
                 redirect,
                 "/crate/dummy/latest/target-redirect/x86_64-unknown-linux-gnu/dummy/index.html"
             );
 
             // check it keeps the subpage
-            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/blah/", web)?;
+            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/blah/", web, &env.config())?;
             assert_eq!(
                 redirect,
                 "/crate/dummy/latest/target-redirect/x86_64-unknown-linux-gnu/dummy/blah/index.html"
             );
-            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/blah/blah.html", web)?;
+            let redirect =
+                latest_version_redirect("/dummy/0.1.0/dummy/blah/blah.html", web, &env.config())?;
             assert_eq!(
                 redirect,
                 "/crate/dummy/latest/target-redirect/x86_64-unknown-linux-gnu/dummy/blah/blah.html"
             );
 
             // check it also works for deleted pages
-            let redirect =
-                latest_version_redirect("/dummy/0.1.0/dummy/struct.will-be-deleted.html", web)?;
+            let redirect = latest_version_redirect(
+                "/dummy/0.1.0/dummy/struct.will-be-deleted.html",
+                web,
+                &env.config(),
+            )?;
             assert_eq!(redirect, "/crate/dummy/latest/target-redirect/x86_64-unknown-linux-gnu/dummy/struct.will-be-deleted.html");
 
             Ok(())
@@ -991,15 +1071,21 @@ mod test {
 
             let web = env.frontend();
 
-            let redirect =
-                latest_version_redirect("/dummy/0.1.0/x86_64-pc-windows-msvc/dummy", web)?;
+            let redirect = latest_version_redirect(
+                "/dummy/0.1.0/x86_64-pc-windows-msvc/dummy",
+                web,
+                &env.config(),
+            )?;
             assert_eq!(
                 redirect,
                 "/crate/dummy/latest/target-redirect/x86_64-pc-windows-msvc/dummy/index.html"
             );
 
-            let redirect =
-                latest_version_redirect("/dummy/0.1.0/x86_64-pc-windows-msvc/dummy/", web)?;
+            let redirect = latest_version_redirect(
+                "/dummy/0.1.0/x86_64-pc-windows-msvc/dummy/",
+                web,
+                &env.config(),
+            )?;
             assert_eq!(
                 redirect,
                 "/crate/dummy/latest/target-redirect/x86_64-pc-windows-msvc/dummy/index.html"
@@ -1008,6 +1094,7 @@ mod test {
             let redirect = latest_version_redirect(
                 "/dummy/0.1.0/x86_64-pc-windows-msvc/dummy/struct.Blah.html",
                 web,
+                &env.config(),
             )?;
             assert_eq!(
                 redirect,
@@ -1036,7 +1123,7 @@ mod test {
                 .create()?;
 
             let web = env.frontend();
-            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/", web)?;
+            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/", web, &env.config())?;
             assert_eq!(redirect, "/crate/dummy/latest");
 
             Ok(())
@@ -1068,13 +1155,13 @@ mod test {
                 .create()?;
 
             let web = env.frontend();
-            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/", web)?;
+            let redirect = latest_version_redirect("/dummy/0.1.0/dummy/", web, &env.config())?;
             assert_eq!(
                 redirect,
                 "/crate/dummy/latest/target-redirect/x86_64-unknown-linux-gnu/dummy/index.html"
             );
 
-            let redirect = latest_version_redirect("/dummy/0.2.1/dummy/", web)?;
+            let redirect = latest_version_redirect("/dummy/0.2.1/dummy/", web, &env.config())?;
             assert_eq!(
                 redirect,
                 "/crate/dummy/latest/target-redirect/x86_64-unknown-linux-gnu/dummy/index.html"
@@ -1154,6 +1241,11 @@ mod test {
             }
             println!("({} -> {})", last_url, current_url);
             assert_eq!(response.status(), StatusCode::MOVED_PERMANENTLY);
+            assert_cache_control(
+                &response,
+                CachePolicy::ForeverInCdnAndBrowser,
+                &env.config(),
+            );
             assert_eq!(
                 current_url.as_str(),
                 "https://img.shields.io/docsrs/zstd/latest"
@@ -1343,7 +1435,6 @@ mod test {
                 })
                 .collect())
         }
-
         fn assert_platform_links(
             web: &TestFrontend,
             path: &str,
@@ -1676,7 +1767,7 @@ mod test {
     }
 
     #[test]
-    fn test_redirect_to_latest_301() {
+    fn test_redirect_to_latest_302() {
         wrapper(|env| {
             env.fake_release().name("dummy").version("1.0.0").create()?;
             let web = env.frontend();
@@ -1686,10 +1777,10 @@ mod test {
                 .unwrap();
             let url = format!("http://{}/dummy", web.server_addr());
             let resp = client.get(url).send()?;
-            assert_eq!(resp.status(), StatusCode::MOVED_PERMANENTLY);
+            assert_eq!(resp.status(), StatusCode::FOUND);
             assert_eq!(
                 resp.headers().get("Cache-Control").unwrap(),
-                reqwest::header::HeaderValue::from_str("max-age=86400").unwrap()
+                reqwest::header::HeaderValue::from_str("public").unwrap()
             );
             assert!(resp
                 .headers()
@@ -1929,7 +2020,8 @@ mod test {
             assert_eq!(
                 latest_version_redirect(
                     "/tungstenite/0.10.0/tungstenite/?search=String%20-%3E%20Message",
-                    env.frontend()
+                    env.frontend(),
+                    &env.config()
                 )?,
                 "/crate/tungstenite/latest/target-redirect/x86_64-unknown-linux-gnu/tungstenite/index.html?search=String%20-%3E%20Message",
             );
@@ -1952,7 +2044,8 @@ mod test {
             assert_eq!(
                 latest_version_redirect(
                     "/pyo3/0.2.7/src/pyo3/objects/exc.rs.html",
-                    env.frontend()
+                    env.frontend(),
+                    &env.config(),
                 )?,
                 target_redirect
             );

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -1769,7 +1769,7 @@ mod test {
             let url = format!("http://{}/dummy", web.server_addr());
             let resp = client.get(url).send()?;
             assert_eq!(resp.status(), StatusCode::FOUND);
-            assert!(resp.headers().get("Cache-Control").unwrap().is_empty());
+            assert!(resp.headers().get("Cache-Control").is_none());
             assert!(resp
                 .headers()
                 .get("Location")

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -450,8 +450,8 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
 
         let mut response = File(blob).serve();
         // default asset caching behaviour is `Cache::ForeverInCdnAndBrowser`.
-        // We don't want to cache invocation specific assets in the browser
-        // but only in the CDN so we can invalidate these after a build.
+        // We want invocation specific assets cached in the CDN but not in the browser.
+        // That way we can invalidate the CDN cache after a build.
         // For CDN caching the same rules should apply as for HTML files,
         // which means we cache slightly different for `/latest/` and
         // URLs with versions.


### PR DESCRIPTION
Resolves #1552 

This is the implementation of #1552 , following the idea in https://github.com/rust-lang/docs.rs/issues/1552#issuecomment-1253165340. 

Basically: 
- set a _default TTL_ in cloudfront. 
- always set `no-cache` headers by default in all pages, 
- override with longer caching times where useful,  
- remove the TTL for the _default TTL_ to take effect. 

This enables us to have things cached for longer in the CDN and just invalidating the needed paths when the content changes, without having to think about browser caches or other proxies / CDNs. 

Invalidation after build was added in #1825. 

For now I only focused on rustdoc pages and their redirects, and putting the policy structure & safeguard middleware into place. Some other pages I added it too. 

Around CSP we believe that we can cache pages, even with nonces ( see https://github.com/rust-lang/docs.rs/pull/1569#issuecomment-984072156 ), online I can find sources that support both claims (see also https://serverfault.com/a/1064775/549071 ). To keep in mind too: for rustdoc pages we don't add CSP nonces yet, so the biggest part of the new caching is for now not affected by this caching change. 

The only option to combine random CSP nonces & CDN caching would be to use edge workers to rewrite the HTML and update the nonce in the header. ( with fastly or cloudflare we could even do this in rust ;) ). 