### PR TITLE
add `#[track_caller]` to test wrapper

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -20,6 +20,7 @@ use reqwest::{
 use std::{fs, net::SocketAddr, panic, sync::Arc, time::Duration};
 use tokio::runtime::Runtime;
 
+#[track_caller]
 pub(crate) fn wrapper(f: impl FnOnce(&TestEnvironment) -> Result<()>) {
     let env = TestEnvironment::new();
     // if we didn't catch the panic, the server would hang forever


### PR DESCRIPTION
this makes it easier to identify what test failed, pointing to the caller of wrapper instead of the wrapper fn

```
panicked at 'the test failed', src/web/rustdoc.rs:line:col
```
