### PR TITLE
add download endpoint for rustdoc archive

### DIFF
--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -580,10 +580,6 @@ mod tests {
                             "distribution_id_static".into(),
                             "/rustdoc/will_succeed*".into()
                         ),
-                        (
-                            "distribution_id_static".into(),
-                            "/sources/will_succeed*".into()
-                        ),
                     ]
                 );
             }
@@ -603,19 +599,11 @@ mod tests {
                             "distribution_id_static".into(),
                             "/rustdoc/will_succeed*".into()
                         ),
-                        (
-                            "distribution_id_static".into(),
-                            "/sources/will_succeed*".into()
-                        ),
                         ("distribution_id_web".into(), "/will_fail*".into()),
                         ("distribution_id_web".into(), "/crate/will_fail*".into()),
                         (
                             "distribution_id_static".into(),
                             "/rustdoc/will_fail*".into()
-                        ),
-                        (
-                            "distribution_id_static".into(),
-                            "/sources/will_fail*".into()
                         ),
                     ]
                 );

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -550,7 +550,8 @@ mod tests {
     fn test_invalidate_cdn_after_build_and_error() {
         crate::test::wrapper(|env| {
             env.override_config(|config| {
-                config.cloudfront_distribution_id_web = Some("distribution_id".into());
+                config.cloudfront_distribution_id_web = Some("distribution_id_web".into());
+                config.cloudfront_distribution_id_static = Some("distribution_id_static".into());
             });
 
             let queue = env.build_queue();
@@ -573,8 +574,16 @@ mod tests {
                 assert_eq!(
                     *ir,
                     [
-                        ("distribution_id".into(), "/will_succeed*".into()),
-                        ("distribution_id".into(), "/crate/will_succeed*".into()),
+                        ("distribution_id_web".into(), "/will_succeed*".into()),
+                        ("distribution_id_web".into(), "/crate/will_succeed*".into()),
+                        (
+                            "distribution_id_static".into(),
+                            "/rustdoc/will_succeed*".into()
+                        ),
+                        (
+                            "distribution_id_static".into(),
+                            "/sources/will_succeed*".into()
+                        ),
                     ]
                 );
             }
@@ -588,10 +597,26 @@ mod tests {
                 assert_eq!(
                     *ir,
                     [
-                        ("distribution_id".into(), "/will_succeed*".into()),
-                        ("distribution_id".into(), "/crate/will_succeed*".into()),
-                        ("distribution_id".into(), "/will_fail*".into()),
-                        ("distribution_id".into(), "/crate/will_fail*".into()),
+                        ("distribution_id_web".into(), "/will_succeed*".into()),
+                        ("distribution_id_web".into(), "/crate/will_succeed*".into()),
+                        (
+                            "distribution_id_static".into(),
+                            "/rustdoc/will_succeed*".into()
+                        ),
+                        (
+                            "distribution_id_static".into(),
+                            "/sources/will_succeed*".into()
+                        ),
+                        ("distribution_id_web".into(), "/will_fail*".into()),
+                        ("distribution_id_web".into(), "/crate/will_fail*".into()),
+                        (
+                            "distribution_id_static".into(),
+                            "/rustdoc/will_fail*".into()
+                        ),
+                        (
+                            "distribution_id_static".into(),
+                            "/sources/will_fail*".into()
+                        ),
                     ]
                 );
             }

--- a/src/cdn.rs
+++ b/src/cdn.rs
@@ -126,14 +126,8 @@ pub(crate) fn invalidate_crate(config: &Config, cdn: &CdnBackend, name: &str) ->
         .context("error creating web CDN invalidation")?;
     }
     if let Some(distribution_id) = config.cloudfront_distribution_id_static.as_ref() {
-        cdn.create_invalidation(
-            distribution_id,
-            &[
-                &format!("/rustdoc/{}*", name),
-                &format!("/sources/{}*", name),
-            ],
-        )
-        .context("error creating static CDN invalidation")?;
+        cdn.create_invalidation(distribution_id, &[&format!("/rustdoc/{}*", name)])
+            .context("error creating static CDN invalidation")?;
     }
 
     Ok(())
@@ -196,7 +190,6 @@ mod tests {
                         ("distribution_id_web".into(), "/krate*".into()),
                         ("distribution_id_web".into(), "/crate/krate*".into()),
                         ("distribution_id_static".into(), "/rustdoc/krate*".into()),
-                        ("distribution_id_static".into(), "/sources/krate*".into()),
                     ]
                 );
             }

--- a/src/cdn.rs
+++ b/src/cdn.rs
@@ -123,7 +123,17 @@ pub(crate) fn invalidate_crate(config: &Config, cdn: &CdnBackend, name: &str) ->
             distribution_id,
             &[&format!("/{}*", name), &format!("/crate/{}*", name)],
         )
-        .context("error creating CDN invalidation")?;
+        .context("error creating web CDN invalidation")?;
+    }
+    if let Some(distribution_id) = config.cloudfront_distribution_id_static.as_ref() {
+        cdn.create_invalidation(
+            distribution_id,
+            &[
+                &format!("/rustdoc/{}*", name),
+                &format!("/sources/{}*", name),
+            ],
+        )
+        .context("error creating static CDN invalidation")?;
     }
 
     Ok(())
@@ -166,6 +176,32 @@ mod tests {
 
             Ok(())
         })
+    }
+
+    #[test]
+    fn invalidate_a_crate() {
+        crate::test::wrapper(|env| {
+            env.override_config(|config| {
+                config.cloudfront_distribution_id_web = Some("distribution_id_web".into());
+                config.cloudfront_distribution_id_static = Some("distribution_id_static".into());
+            });
+            invalidate_crate(&*env.config(), &*env.cdn(), "krate")?;
+
+            assert!(matches!(*env.cdn(), CdnBackend::Dummy(_)));
+            if let CdnBackend::Dummy(ref invalidation_requests) = *env.cdn() {
+                let ir = invalidation_requests.lock().unwrap();
+                assert_eq!(
+                    *ir,
+                    [
+                        ("distribution_id_web".into(), "/krate*".into()),
+                        ("distribution_id_web".into(), "/crate/krate*".into()),
+                        ("distribution_id_static".into(), "/rustdoc/krate*".into()),
+                        ("distribution_id_static".into(), "/sources/krate*".into()),
+                    ]
+                );
+            }
+            Ok(())
+        });
     }
 
     async fn get_mock_config() -> aws_sdk_cloudfront::Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,7 @@ pub struct Config {
 
     // CloudFront domain which we can access
     // public S3 files through
-    pub(crate) s3_static_domain: String,
+    pub(crate) s3_static_root_path: String,
 
     // Github authentication
     pub(crate) github_accesstoken: Option<String>,
@@ -131,7 +131,7 @@ impl Config {
             #[cfg(test)]
             s3_bucket_is_temporary: false,
 
-            s3_static_domain: env("S3_STATIC_DOMAIN", "https://static.docs.rs".to_string())?,
+            s3_static_root_path: env("S3_STATIC_ROOT_PATH", "https://static.docs.rs".to_string())?,
 
             github_accesstoken: maybe_env("DOCSRS_GITHUB_ACCESSTOKEN")?,
             github_updater_min_rate_limit: env("DOCSRS_GITHUB_UPDATER_MIN_RATE_LIMIT", 2500)?,

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,10 @@ pub struct Config {
     #[cfg(test)]
     pub(crate) s3_bucket_is_temporary: bool,
 
+    // CloudFront domain which we can access
+    // public S3 files through
+    pub(crate) s3_static_domain: String,
+
     // Github authentication
     pub(crate) github_accesstoken: Option<String>,
     pub(crate) github_updater_min_rate_limit: u32,
@@ -67,6 +71,8 @@ pub struct Config {
     // CloudFront distribution ID for the web server.
     // Will be used for invalidation-requests.
     pub cloudfront_distribution_id_web: Option<String>,
+    /// same for the `static.docs.rs` distribution
+    pub cloudfront_distribution_id_static: Option<String>,
 
     // Build params
     pub(crate) build_attempts: u16,
@@ -125,6 +131,8 @@ impl Config {
             #[cfg(test)]
             s3_bucket_is_temporary: false,
 
+            s3_static_domain: env("S3_STATIC_DOMAIN", "https://static.docs.rs".to_string())?,
+
             github_accesstoken: maybe_env("DOCSRS_GITHUB_ACCESSTOKEN")?,
             github_updater_min_rate_limit: env("DOCSRS_GITHUB_UPDATER_MIN_RATE_LIMIT", 2500)?,
 
@@ -148,6 +156,7 @@ impl Config {
             cdn_backend: env("DOCSRS_CDN_BACKEND", CdnKind::Dummy)?,
 
             cloudfront_distribution_id_web: maybe_env("CLOUDFRONT_DISTRIBUTION_ID_WEB")?,
+            cloudfront_distribution_id_static: maybe_env("CLOUDFRONT_DISTRIBUTION_ID_STATIC")?,
 
             local_archive_cache_path: env(
                 "DOCSRS_ARCHIVE_INDEX_CACHE_PATH",

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,7 +131,10 @@ impl Config {
             #[cfg(test)]
             s3_bucket_is_temporary: false,
 
-            s3_static_root_path: env("S3_STATIC_ROOT_PATH", "https://static.docs.rs".to_string())?,
+            s3_static_root_path: env(
+                "DOCSRS_S3_STATIC_ROOT_PATH",
+                "https://static.docs.rs".to_string(),
+            )?,
 
             github_accesstoken: maybe_env("DOCSRS_GITHUB_ACCESSTOKEN")?,
             github_updater_min_rate_limit: env("DOCSRS_GITHUB_UPDATER_MIN_RATE_LIMIT", 2500)?,

--- a/src/db/file.rs
+++ b/src/db/file.rs
@@ -38,8 +38,12 @@ pub fn add_path_into_remote_archive<P: AsRef<Path>>(
     storage: &Storage,
     archive_path: &str,
     path: P,
+    public_access: bool,
 ) -> Result<(Value, CompressionAlgorithm)> {
     let (file_list, algorithm) = storage.store_all_in_archive(archive_path, path.as_ref())?;
+    if public_access {
+        storage.set_public_access(archive_path, true)?;
+    }
     Ok((
         file_list_to_json(file_list.into_iter().collect()),
         algorithm,

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -848,6 +848,11 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> crate::error::Res
             "CREATE INDEX builds_release_id_idx ON builds (rid);",
             "DROP INDEX builds_release_id_idx;",
         ),
+        sql_migration!(
+            context, 35, "add public visibility to files table",
+            "ALTER TABLE files ADD COLUMN public BOOL NOT NULL DEFAULT FALSE;",
+            "ALTER TABLE files DROP COLUMN public;"
+        ),
 
     ];
 

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -410,6 +410,7 @@ impl RustwideBuilder {
                             &self.storage,
                             &rustdoc_archive_path(name, version),
                             local_storage.path(),
+                            true,
                         )?;
                         algs.insert(new_alg);
                     };
@@ -421,6 +422,7 @@ impl RustwideBuilder {
                             &self.storage,
                             &source_archive_path(name, version),
                             build.host_source_dir(),
+                            false,
                         )?;
                         algs.insert(new_alg);
                         files_list

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -140,6 +140,20 @@ impl Storage {
         }
     }
 
+    pub(crate) fn get_public_access(&self, path: &str) -> Result<bool> {
+        match &self.backend {
+            StorageBackend::Database(db) => db.get_public_access(path),
+            StorageBackend::S3(s3) => s3.get_public_access(path),
+        }
+    }
+
+    pub(crate) fn set_public_access(&self, path: &str, public: bool) -> Result<()> {
+        match &self.backend {
+            StorageBackend::Database(db) => db.set_public_access(path, public),
+            StorageBackend::S3(s3) => s3.set_public_access(path, public),
+        }
+    }
+
     fn max_file_size_for(&self, path: &str) -> usize {
         if path.ends_with(".html") {
             self.config.max_file_size_html
@@ -620,9 +634,38 @@ mod backend_tests {
         Ok(())
     }
 
+    fn test_set_public(storage: &Storage) -> Result<()> {
+        let path: &str = "foo/bar.txt";
+
+        storage.store_blobs(vec![Blob {
+            path: path.into(),
+            mime: "text/plain".into(),
+            date_updated: Utc::now(),
+            compression: None,
+            content: b"test content\n".to_vec(),
+        }])?;
+
+        assert!(!storage.get_public_access(path)?);
+        storage.set_public_access(path, true)?;
+        assert!(storage.get_public_access(path)?);
+        storage.set_public_access(path, false)?;
+        assert!(!storage.get_public_access(path)?);
+
+        for path in &["bar.txt", "baz.txt", "foo/baz.txt"] {
+            assert!(storage
+                .set_public_access(path, true)
+                .unwrap_err()
+                .downcast_ref::<PathNotFoundError>()
+                .is_some());
+        }
+
+        Ok(())
+    }
+
     fn test_get_object(storage: &Storage) -> Result<()> {
+        let path: &str = "foo/bar.txt";
         let blob = Blob {
-            path: "foo/bar.txt".into(),
+            path: path.into(),
             mime: "text/plain".into(),
             date_updated: Utc::now(),
             compression: None,
@@ -631,13 +674,22 @@ mod backend_tests {
 
         storage.store_blobs(vec![blob.clone()])?;
 
-        let found = storage.get("foo/bar.txt", std::usize::MAX)?;
+        let found = storage.get(path, std::usize::MAX)?;
         assert_eq!(blob.mime, found.mime);
         assert_eq!(blob.content, found.content);
+
+        // default visibility is private
+        assert!(!storage.get_public_access(path)?);
 
         for path in &["bar.txt", "baz.txt", "foo/baz.txt"] {
             assert!(storage
                 .get(path, std::usize::MAX)
+                .unwrap_err()
+                .downcast_ref::<PathNotFoundError>()
+                .is_some());
+
+            assert!(storage
+                .get_public_access(path)
                 .unwrap_err()
                 .downcast_ref::<PathNotFoundError>()
                 .is_some());
@@ -1028,6 +1080,7 @@ mod backend_tests {
             test_delete_prefix_without_matches,
             test_delete_percent,
             test_exists_without_remote_archive,
+            test_set_public,
         }
 
         tests_with_metrics {

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -316,13 +316,21 @@ impl<'a> FakeRelease<'a> {
                 source_directory.display()
             );
             if archive_storage {
-                let archive = match kind {
-                    FileKind::Rustdoc => rustdoc_archive_path(&package.name, &package.version),
-                    FileKind::Sources => source_archive_path(&package.name, &package.version),
+                let (archive, public) = match kind {
+                    FileKind::Rustdoc => {
+                        (rustdoc_archive_path(&package.name, &package.version), true)
+                    }
+                    FileKind::Sources => {
+                        (source_archive_path(&package.name, &package.version), false)
+                    }
                 };
                 log::debug!("store in archive: {:?}", archive);
-                let (files_list, new_alg) =
-                    crate::db::add_path_into_remote_archive(&storage, &archive, source_directory)?;
+                let (files_list, new_alg) = crate::db::add_path_into_remote_archive(
+                    &storage,
+                    &archive,
+                    source_directory,
+                    public,
+                )?;
                 let mut hm = HashSet::new();
                 hm.insert(new_alg);
                 Ok((files_list, hm))

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -101,6 +101,10 @@ pub(super) fn build_routes() -> Routes {
         "/crate/:name/:version/builds",
         super::builds::build_list_handler,
     );
+    routes.internal_page(
+        "/crate/:name/:version/download",
+        super::rustdoc::download_handler,
+    );
     routes.static_resource(
         "/crate/:name/:version/builds.json",
         super::builds::build_list_handler,

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -761,7 +761,7 @@ pub fn download_handler(req: &mut Request) -> IronResult<Response> {
 
     Ok(super::redirect(ctry!(
         req,
-        Url::parse(&format!("{}/{}", config.s3_static_domain, archive_path))
+        Url::parse(&format!("{}/{}", config.s3_static_root_path, archive_path))
     )))
 }
 

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -140,7 +140,7 @@ pub fn about_handler(req: &mut Request) -> IronResult<Response> {
 
     let name = match *req.url.path().last().expect("iron is broken") {
         "about" | "index" => "index",
-        x @ "badges" | x @ "metadata" | x @ "redirections" => x,
+        x @ "badges" | x @ "metadata" | x @ "redirections" | x @ "download" => x,
         _ => {
             let msg = "This /about page does not exist. \
                 Perhaps you are interested in <a href=\"https://github.com/rust-lang/docs.rs/tree/master/templates/core/about\">creating</a> it?";

--- a/templates/about-base.html
+++ b/templates/about-base.html
@@ -26,6 +26,10 @@
                         {% set text = "road" | fas(fw=true) %}
                         {% set text = text ~ ' <span class="title">Shorthand URLs</span>' %}
                         {{ macros::active_link(expected="redirections", href="/about/redirections", text=text) }}
+
+                        {% set text = "download" | fas(fw=true) %}
+                        {% set text = text ~ ' <span class="title">Download</span>' %}
+                        {{ macros::active_link(expected="download", href="/about/download", text=text) }}
                     </ul>
                 </div>
             </div>

--- a/templates/core/about/download.html
+++ b/templates/core/about/download.html
@@ -1,0 +1,62 @@
+{% extends "about-base.html" -%}
+
+{%- block title -%} Download {%- endblock title -%}
+
+{%- block body -%}
+    <h1>Documentation download</h1>
+
+    <div class="about-page">
+        <div class="container pure-u-5-6 about">
+            <p>
+                docs.rs stores the <code>rustdoc</code> output in a ZIP file.
+            </p>
+            <p>
+                These archives can be used as a base for further processing of
+                the documentation for offline readers like Dash or Zeal.
+                <b>They are not directly usable for offline documentation.</b>
+            </p>
+            <h2>URLs</h2>
+            <p>
+                The download is possible for specific or semantic versions:
+                <ul>
+                    <li>
+                        <a href="https://docs.rs/crate/clap/4.0.4/download">
+                            docs.rs/crate/clap/4.0.4/download
+                        </a>
+                    </li>
+                    <li>
+                        <a href="https://docs.rs/crate/clap/%7E4/download">
+                            docs.rs/crate/clap/~4/download
+                        </a>
+                    </li>
+                </ul>
+
+                But also via <a href="https://docs.rs/crate/clap/latest/download">
+                    docs.rs/crate/clap/latest/download
+                </a> to get the latest version.
+            </p>
+            <h2>processing / caveats</h2>
+            <p>
+                To unpack the ZIP file you need any zip utility that supports
+                PKZIP version 4.6 and BZIP2 compression.
+            </p>
+            <p>
+                The archives will contain all the documentation HTML files for all
+                targets and CSS/JS assets that are specific to the build. The default
+                target will be found at the root, and other targets each in its own
+                subfolder.
+            </p>
+            <p>
+                Docs.rs is running rustdoc with <code>--static-root-path "/"</code>,
+                which leads to all references to static assets breaking if they are not
+                available under that path.
+            </p>
+            <p>
+                Since we're also adding <code>--emit=invocation-specific</code> to our build
+                the archives will <i>not</i> contain any static assets that are specific to the
+                toolchain. For now these will have to be downloaded file-by-file directly
+                from docs.rs.
+            </p>
+        </div>
+    </div>
+{%- endblock body %}


### PR DESCRIPTION
This resolves #174 for offline documentation readers. 

The tag specifications & static domain were already set up with @Mark-Simulacrum , see [here](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/docs.2Ers.20.2F.20downloadable.20docs/near/300674444). 

A working download can be seen [here](https://static.docs.rs/rustdoc/verify-call/0.1.1.zip), while other crates / versions would get a 403 / forbidden error. 


### note for deploy: 
we need to check with @pietroalbini if the access key on the docs.rs server has the needed permissions: 
- `s3:PutObjectTagging` on the bucket 
- create-invalidation for the `static.docs.rs` cloudfront distribution
