### PR TITLE
add simple "deployment pending" marker 20 minutes after a build

### DIFF
--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -39,6 +39,8 @@ pub struct Release {
     description: Option<String>,
     target_name: Option<String>,
     rustdoc_status: bool,
+    build_status: bool,
+    is_library: bool,
     deployment_pending: bool,
     pub(crate) build_time: DateTime<Utc>,
     stars: i32,
@@ -83,7 +85,9 @@ pub(crate) fn get_releases(
             releases.target_name,
             releases.rustdoc_status,
             builds.build_time,
-            repositories.stars
+            repositories.stars,
+            releases.build_status,
+            releases.is_library
         FROM crates
         {1}
         INNER JOIN builds ON releases.id = builds.rid
@@ -115,6 +119,8 @@ pub(crate) fn get_releases(
             build_time: row.get(5),
             deployment_pending: crate_invalidation_pending(&row.get(5)),
             stars: row.get::<_, Option<i32>>(6).unwrap_or(0),
+            build_status: row.get(7),
+            is_library: row.get(8),
         })
         .collect()
 }
@@ -206,7 +212,9 @@ fn get_search_results(
                 builds.build_time,
                 releases.target_name,
                 releases.rustdoc_status,
-                repositories.stars
+                repositories.stars,
+                releases.build_status,
+                releases.is_library
 
             FROM crates
             INNER JOIN releases ON crates.latest_version_id = releases.id
@@ -231,6 +239,8 @@ fn get_search_results(
                     target_name: row.get("target_name"),
                     rustdoc_status: row.get("rustdoc_status"),
                     stars: stars.unwrap_or(0),
+                    build_status: row.get("build_status"),
+                    is_library: row.get("is_library"),
                 },
             )
         })

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     build_queue::QueuedCrate,
+    cdn::crate_invalidation_pending,
     db::{Pool, PoolClient},
     impl_webpage,
     utils::report_error,
@@ -38,6 +39,7 @@ pub struct Release {
     description: Option<String>,
     target_name: Option<String>,
     rustdoc_status: bool,
+    deployment_pending: bool,
     pub(crate) build_time: DateTime<Utc>,
     stars: i32,
 }
@@ -109,6 +111,7 @@ pub(crate) fn get_releases(
             target_name: row.get(3),
             rustdoc_status: row.get(4),
             build_time: row.get(5),
+            deployment_pending: crate_invalidation_pending(&row.get(5)),
             stars: row.get::<_, Option<i32>>(6).unwrap_or(0),
         })
         .collect()
@@ -222,6 +225,7 @@ fn get_search_results(
                     version: row.get("version"),
                     description: row.get("description"),
                     build_time: row.get("build_time"),
+                    deployment_pending: crate_invalidation_pending(&row.get("build_time")),
                     target_name: row.get("target_name"),
                     rustdoc_status: row.get("rustdoc_status"),
                     stars: stars.unwrap_or(0),

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -47,7 +47,7 @@
                                 <div class="pure-u-1 pure-u-sm-6-24 pure-u-md-5-24 name">
                                     {{ release.name }}-{{ release.version }}
                                 </div>
-                                <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description">
+                                <div class="pure-u-1 pure-u-sm-13-24 pure-u-md-15-24 description">
                                     {{ release.description }}
                                 </div>
 
@@ -60,6 +60,17 @@
                                     <div class="pure-u-1 pure-u-sm-4-24 pure-u-md-3-24 date"
                                         title="{{ release.build_time | date(format='%FT%TZ') }}">
                                         {{ release.build_time | timeformat(relative=true) }}
+                                    </div>
+                                {%- endif -%}
+                                {% if release.deployment_pending -%}
+                                    <div class="pure-u-1 pure-u-sm-1-24 pure-u-md-1-24 deploymentstatus"
+                                        title="deployment pending, some pages might be outdated">
+                                        {{ "spinner" | fas }}
+                                    </div>
+                                {%- else -%}
+                                    <div class="pure-u-1 pure-u-sm-1-24 pure-u-md-1-24 deploymentstatus"
+                                        title="deployment finished">
+                                        {{ "check" | fas }}
                                     </div>
                                 {%- endif -%}
                             </div>

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -64,7 +64,7 @@
                                 {%- endif -%}
                                 {% if release.deployment_pending -%}
                                     <div class="pure-u-1 pure-u-sm-1-24 pure-u-md-1-24 deploymentstatus"
-                                        title="deployment pending, some pages might be outdated">
+                                        title="deployment pending, it may take up to 20 minutes for this version to be visible to everybody">
                                         {{ "spinner" | fas }}
                                     </div>
                                 {%- else -%}

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -47,7 +47,7 @@
                                 <div class="pure-u-1 pure-u-sm-6-24 pure-u-md-5-24 name">
                                     {{ release.name }}-{{ release.version }}
                                 </div>
-                                <div class="pure-u-1 pure-u-sm-13-24 pure-u-md-15-24 description">
+                                <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description">
                                     {{ release.description }}
                                 </div>
 
@@ -60,17 +60,6 @@
                                     <div class="pure-u-1 pure-u-sm-4-24 pure-u-md-3-24 date"
                                         title="{{ release.build_time | date(format='%FT%TZ') }}">
                                         {{ release.build_time | timeformat(relative=true) }}
-                                    </div>
-                                {%- endif -%}
-                                {% if release.deployment_pending -%}
-                                    <div class="pure-u-1 pure-u-sm-1-24 pure-u-md-1-24 deploymentstatus"
-                                        title="deployment pending, it may take up to 20 minutes for this version to be visible to everybody">
-                                        {{ "spinner" | fas }}
-                                    </div>
-                                {%- else -%}
-                                    <div class="pure-u-1 pure-u-sm-1-24 pure-u-md-1-24 deploymentstatus"
-                                        title="deployment finished">
-                                        {{ "check" | fas }}
                                     </div>
                                 {%- endif -%}
                             </div>

--- a/templates/releases/releases.html
+++ b/templates/releases/releases.html
@@ -52,7 +52,7 @@
                                 {%- endif %}
                                 {% if release.deployment_pending -%}
                                     <div class="pure-u-1 pure-u-sm-1-24 pure-u-md-1-24 deploymentstatus"
-                                        title="deployment pending, some pages might be outdated">
+                                        title="deployment pending, it may take up to 20 minutes for this version to be visible to everybody">
                                         {{ "spinner" | fas }}
                                     </div>
                                 {%- else -%}

--- a/templates/releases/releases.html
+++ b/templates/releases/releases.html
@@ -50,15 +50,22 @@
                                         {{ release.build_time | timeformat(relative=true) }}
                                     </div>
                                 {%- endif %}
-                                {% if release.deployment_pending -%}
-                                    <div class="pure-u-1 pure-u-sm-1-24 pure-u-md-1-24 deploymentstatus"
-                                        title="deployment pending, it may take up to 20 minutes for this version to be visible to everybody">
-                                        {{ "spinner" | fas }}
-                                    </div>
+                                {%- if release.rustdoc_status -%}
+                                    {%- if release.deployment_pending -%}
+                                        <div class="pure-u-1 pure-u-sm-1-24 pure-u-md-1-24 deploymentstatus"
+                                            title="deployment pending, it may take up to 20 minutes for this version to be visible to everybody">
+                                            {{ "spinner" | fas }}
+                                        </div>
+                                    {%- else -%}
+                                        <div class="pure-u-1 pure-u-sm-1-24 pure-u-md-1-24 deploymentstatus"
+                                            title="deployment finished">
+                                            {{ "check" | fas }}
+                                        </div>
+                                    {%- endif -%}
                                 {%- else -%}
                                     <div class="pure-u-1 pure-u-sm-1-24 pure-u-md-1-24 deploymentstatus"
-                                        title="deployment finished">
-                                        {{ "check" | fas }}
+                                        title="build error">
+                                        {{ "triangle-exclamation" | fas(fw=true) }}
                                     </div>
                                 {%- endif -%}
                             </div>

--- a/templates/releases/releases.html
+++ b/templates/releases/releases.html
@@ -62,7 +62,7 @@
                                             {{ "check" | fas }}
                                         </div>
                                     {%- endif -%}
-                                {%- else -%}
+                                {%- elif release.is_library and not release.build_status -%}
                                     <div class="pure-u-1 pure-u-sm-1-24 pure-u-md-1-24 deploymentstatus"
                                         title="build error">
                                         {{ "triangle-exclamation" | fas(fw=true) }}

--- a/templates/releases/releases.html
+++ b/templates/releases/releases.html
@@ -53,7 +53,7 @@
                                 {%- if release.rustdoc_status -%}
                                     {%- if release.deployment_pending -%}
                                         <div class="pure-u-1 pure-u-sm-1-24 pure-u-md-1-24 deploymentstatus"
-                                            title="deployment pending, it may take up to 20 minutes for this version to be visible to everybody">
+                                             title="deployment pending, it may take up to 20 minutes for this version to be visible to everybody and on all pages. Especially `/latest/` URLs might be affected.">
                                             {{ "spinner" | fas }}
                                         </div>
                                     {%- else -%}

--- a/templates/releases/releases.html
+++ b/templates/releases/releases.html
@@ -34,7 +34,7 @@
                                     {{ release.name }}-{{ release.version }}
                                 </div>
 
-                                <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description">
+                                <div class="pure-u-1 pure-u-sm-13-24 pure-u-md-15-24 description">
                                     {{ release.description }}
                                 </div>
 
@@ -50,6 +50,17 @@
                                         {{ release.build_time | timeformat(relative=true) }}
                                     </div>
                                 {%- endif %}
+                                {% if release.deployment_pending -%}
+                                    <div class="pure-u-1 pure-u-sm-1-24 pure-u-md-1-24 deploymentstatus"
+                                        title="deployment pending, some pages might be outdated">
+                                        {{ "spinner" | fas }}
+                                    </div>
+                                {%- else -%}
+                                    <div class="pure-u-1 pure-u-sm-1-24 pure-u-md-1-24 deploymentstatus"
+                                        title="deployment finished">
+                                        {{ "check" | fas }}
+                                    </div>
+                                {%- endif -%}
                             </div>
                         </a>
                     </li>

--- a/templates/style/style.scss
+++ b/templates/style/style.scss
@@ -364,6 +364,14 @@ div.recent-releases-container {
         }
     }
 
+    .deploymentstatus {
+        font-weight: normal;
+
+        @media #{$media-sm} {
+            text-align: right;
+        }
+    }
+
     div.pagination {
         text-align: center;
         margin: 1em;


### PR DESCRIPTION
This is the first workaround for #1877 , showing what I imagined as a visible marker shortly after a build. 

Looks like this when all is fine: 
<img width="1251" alt="grafik" src="https://user-images.githubusercontent.com/540890/195881813-08945a55-0070-4492-82f5-aba7a5a6b3ad.png">

And like this when the deployment is too recent: 
<img width="396" alt="grafik" src="https://user-images.githubusercontent.com/540890/195881958-11444eb0-a45e-4e6f-8914-e8ab499a646b.png">
