### PR TITLE
Use --offline when building docs

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -673,6 +673,7 @@ impl RustwideBuilder {
 
         // Add docs.rs specific arguments
         let mut cargo_args = vec![
+            "--offline".into(),
             // We know that `metadata` unconditionally passes `-Z rustdoc-map`.
             // Don't copy paste this, since that fact is not stable and may change in the future.
             "-Zunstable-options".into(),


### PR DESCRIPTION
This reflects the intent of the command, since containers are isolated from the network. And it provides a clearer error message in case there is some problem and cargo would try to make a network request.

When building with (e.g.) CARGO_UNSTABLE_SPARSE_REGISTRY=true on the host, this produces errors like this:
```
2022/10/15 01:57:02 [INFO] rustwide::cmd: [stderr] error: failed to download `autocfg v1.1.0`
2022/10/15 01:57:02 [INFO] rustwide::cmd: [stderr]
2022/10/15 01:57:02 [INFO] rustwide::cmd: [stderr] Caused by:
2022/10/15 01:57:02 [INFO] rustwide::cmd: [stderr]   attempting to make an HTTP request, but --offline was specified
```

Related: #1881