### PR TITLE
Serve rustdoc static files from /-/rustdoc.static/

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -11,6 +11,7 @@ use crate::storage::{rustdoc_archive_path, source_archive_path};
 use crate::utils::{
     copy_dir_all, parse_rustc_version, queue_builder, set_config, CargoMetadata, ConfigName,
 };
+use crate::RUSTDOC_STATIC_STORAGE_PREFIX;
 use crate::{db::blacklist::is_blacklisted, utils::MetadataPackage};
 use crate::{Config, Context, Index, Metrics, Storage};
 use anyhow::{anyhow, bail, Error};
@@ -225,7 +226,8 @@ impl RustwideBuilder {
                         .prefix("essential-files")
                         .tempdir()?;
                     copy_dir_all(source, &dest)?;
-                    add_path_into_database(&self.storage, "", &dest)?;
+
+                    add_path_into_database(&self.storage, RUSTDOC_STATIC_STORAGE_PREFIX, &dest)?;
 
                     set_config(
                         &mut conn,
@@ -710,7 +712,7 @@ impl RustwideBuilder {
 
         #[rustfmt::skip]
         const UNCONDITIONAL_ARGS: &[&str] = &[
-            "--static-root-path", "/",
+            "--static-root-path", "/-/rustdoc.static/",
             "--cap-lints", "warn",
             "--disable-per-crate-search",
             "--extern-html-root-takes-precedence",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,3 +55,6 @@ pub const BUILD_VERSION: &str = concat!(
     " ",
     include_str!(concat!(env!("OUT_DIR"), "/git_version"))
 );
+
+/// Where rustdoc's static files are stored in S3.
+pub const RUSTDOC_STATIC_STORAGE_PREFIX: &str = "/rustdoc-static/";

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -31,6 +31,11 @@ pub(super) fn build_routes() -> Routes {
 
     routes.static_resource("/-/static/:single", super::statics::static_handler);
     routes.static_resource("/-/static/*", super::statics::static_handler);
+    routes.internal_page(
+        "/-/rustdoc.static/:single",
+        super::rustdoc::static_asset_handler,
+    );
+    routes.internal_page("/-/rustdoc.static/*", super::rustdoc::static_asset_handler);
     routes.internal_page("/-/storage-change-detection.html", {
         #[derive(Debug, serde::Serialize)]
         struct StorageChangeDetection {}
@@ -356,6 +361,8 @@ fn calculate_id(pattern: &str) -> String {
 #[cfg(test)]
 mod tests {
     use crate::test::*;
+    use crate::web::cache::CachePolicy;
+    use reqwest::StatusCode;
 
     #[test]
     fn test_root_redirects() {
@@ -376,5 +383,42 @@ mod tests {
 
             Ok(())
         });
+    }
+
+    #[test]
+    fn serve_rustdoc_content_not_found() {
+        wrapper(|env| {
+            let response = env.frontend().get("/-/rustdoc-static/style.css").send()?;
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+            assert_cache_control(&response, CachePolicy::NoCaching, &env.config());
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn serve_rustdoc_content() {
+        wrapper(|env| {
+            let web = env.frontend();
+            env.storage().store_one("style.css", *b"content")?;
+            env.storage()
+                .store_one("will_not/be_found.css", *b"something")?;
+
+            let response = web.get("/-/rustdoc-static/style.css").send()?;
+            assert_cache_control(
+                &response,
+                CachePolicy::ForeverInCdnAndBrowser,
+                &env.config(),
+            );
+            assert!(response.status().is_success());
+            assert_eq!(response.text()?, "content");
+
+            assert_eq!(
+                web.get("/-/rustdoc-static/will_not/be_found.css")
+                    .send()?
+                    .status(),
+                StatusCode::NOT_FOUND
+            );
+            Ok(())
+        })
     }
 }


### PR DESCRIPTION
Fixes #1869 

This changes the `--static-root-path` we pass to rustdoc, so it generates HTML that looks for files in the new location. It also changes where the shared static files are uploaded to in storage. They are uploaded to a matching path (`/-/rustdoc.static/`).

Files under this path can be served from an ordinary route. After this change, the special logic in SharedResourceHandler (ignore request path, serve file from storage root) will only be needed when serving documentation built prior to this PR being deployed. As such, I've renamed SharedResourceHandler to LegacySharedResourceHandler, and named the new handler SharedResourceHandler.

Note: this does not depend on https://github.com/rust-lang/rust/pull/101702.