### PR TITLE
migrate to using tracing instead of log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,7 +1169,6 @@ dependencies = [
  "criterion",
  "dashmap",
  "docsrs-metadata",
- "env_logger",
  "failure",
  "fn-error-context",
  "font-awesome-as-a-crate",
@@ -1205,8 +1204,8 @@ dependencies = [
  "semver",
  "sentry",
  "sentry-anyhow",
- "sentry-log",
  "sentry-panic",
+ "sentry-tracing",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -1225,6 +1224,9 @@ dependencies = [
  "time 0.3.15",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
  "url 2.3.1",
  "uuid",
  "walkdir",
@@ -1276,19 +1278,6 @@ name = "entities"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
-
-[[package]]
-name = "env_logger"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
-dependencies = [
- "atty",
- "humantime",
- "log 0.4.17",
- "regex",
- "termcolor",
-]
 
 [[package]]
 name = "errno"
@@ -1778,12 +1767,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.10.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2179,6 +2162,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,6 +2352,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2503,6 +2505,12 @@ checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -3300,6 +3308,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3702,16 +3719,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sentry-log"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a76b41861ebde9b0a689fa13080ad5508583e094c48acad461eec5acd7fc5f"
-dependencies = [
- "log 0.4.17",
- "sentry-core",
-]
-
-[[package]]
 name = "sentry-panic"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3719,6 +3726,17 @@ checksum = "696c74c5882d5a0d5b4a31d0ff3989b04da49be7983b7f52a52c667da5b480bf"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea50bcf843510179a7ba41c9fe4d83a8958e9f8adf707ec731ff999297536344"
+dependencies = [
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3821,6 +3839,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -4405,6 +4432,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log 0.4.17",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]
@@ -4642,6 +4697,12 @@ dependencies = [
  "getrandom 0.2.7",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,13 @@ consistency_check = ["crates-index", "rayon"]
 
 [dependencies]
 sentry = "0.27.0"
-sentry-log = "0.27.0"
 sentry-panic = "0.27.0"
+sentry-tracing = "0.27.0"
 sentry-anyhow = { version = "0.27.0", features = ["backtrace"] }
 log = "0.4"
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", default-features = false, features = ["ansi", "fmt", "env-filter"] }
+tracing-log = "0.1.3"
 regex = "1"
 structopt = "0.3"
 crates-index = { version = "0.18.5", optional = true }
@@ -32,7 +35,6 @@ crates-index-diff = "10.0.0"
 reqwest = { version = "0.11", features = ["blocking", "json"] } # TODO: Remove blocking when async is ready
 semver = { version = "1.0.4", features = ["serde"] }
 slug = "0.1.1"
-env_logger = "0.9.0"
 r2d2 = "0.8"
 r2d2_postgres = "0.18"
 # iron needs url@1, but it reexports it as iron::url, so we can start using

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -8,7 +8,7 @@ use crate::{Config, Index, Metrics, RustwideBuilder};
 use anyhow::Context;
 
 use crates_index_diff::Change;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use git2::Oid;
 use std::sync::Arc;
@@ -239,11 +239,9 @@ fn retry<T>(mut f: impl FnMut() -> Result<T>, max_attempts: u32) -> Result<T> {
                     return Err(err);
                 } else {
                     let sleep_for = 2u32.pow(attempt);
-                    tracing::warn!(
+                    warn!(
                         "got error on attempt {}, will try again after {}s:\n{:?}",
-                        attempt,
-                        sleep_for,
-                        err
+                        attempt, sleep_for, err
                     );
                     thread::sleep(Duration::from_secs(sleep_for as u64));
                 }

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -8,7 +8,7 @@ use crate::{Config, Index, Metrics, RustwideBuilder};
 use anyhow::Context;
 
 use crates_index_diff::Change;
-use log::{debug, info};
+use tracing::{debug, info};
 
 use git2::Oid;
 use std::sync::Arc;
@@ -239,7 +239,7 @@ fn retry<T>(mut f: impl FnMut() -> Result<T>, max_attempts: u32) -> Result<T> {
                     return Err(err);
                 } else {
                     let sleep_for = 2u32.pow(attempt);
-                    log::warn!(
+                    tracing::warn!(
                         "got error on attempt {}, will try again after {}s:\n{:?}",
                         attempt,
                         sleep_for,

--- a/src/config.rs
+++ b/src/config.rs
@@ -205,7 +205,7 @@ where
             .map(Some)
             .with_context(|| format!("failed to parse configuration variable {}", var))?),
         Err(VarError::NotPresent) => {
-            log::trace!("optional configuration variable {} is not set", var);
+            tracing::trace!("optional configuration variable {} is not set", var);
             Ok(None)
         }
         Err(VarError::NotUnicode(_)) => Err(anyhow!("configuration variable {} is not UTF-8", var)),

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use std::env::VarError;
 use std::error::Error;
 use std::path::PathBuf;
 use std::str::FromStr;
+use tracing::trace;
 
 #[derive(Debug)]
 pub struct Config {
@@ -205,7 +206,7 @@ where
             .map(Some)
             .with_context(|| format!("failed to parse configuration variable {}", var))?),
         Err(VarError::NotPresent) => {
-            tracing::trace!("optional configuration variable {} is not set", var);
+            trace!("optional configuration variable {} is not set", var);
             Ok(None)
         }
         Err(VarError::NotUnicode(_)) => Err(anyhow!("configuration variable {} is not UTF-8", var)),

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -8,7 +8,6 @@ use crate::{
     web::crate_details::CrateDetails,
 };
 use anyhow::{anyhow, Context};
-use log::{debug, info};
 use postgres::Client;
 use serde_json::Value;
 use slug::slugify;
@@ -18,6 +17,7 @@ use std::{
     io::{BufRead, BufReader},
     path::Path,
 };
+use tracing::{debug, info};
 
 /// Adds a package into database.
 ///

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -1,9 +1,9 @@
 use crate::metrics::Metrics;
 use crate::Config;
-use log::debug;
 use postgres::{Client, NoTls};
 use r2d2_postgres::PostgresConnectionManager;
 use std::sync::Arc;
+use tracing::debug;
 
 pub type PoolClient = r2d2::PooledConnection<PostgresConnectionManager<NoTls>>;
 

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -160,8 +160,8 @@ impl RustwideBuilder {
         // NOTE: this ignores the error so that you can still run a build without rustfmt.
         // This should only happen if you run a build for the first time when rustfmt isn't available.
         if let Err(err) = self.toolchain.add_component(&self.workspace, "rustfmt") {
-            tracing::warn!("failed to install rustfmt: {}", err);
-            tracing::info!("continuing anyway, since this must be the first build");
+            warn!("failed to install rustfmt: {}", err);
+            info!("continuing anyway, since this must be the first build");
         }
 
         self.rustc_version = self.detect_rustc_version()?;
@@ -486,7 +486,7 @@ impl RustwideBuilder {
                         // won't lead to non-existing docs.
                         for prefix in &["rustdoc", "sources"] {
                             let prefix = format!("{}/{}/{}/", prefix, name, version);
-                            tracing::debug!("cleaning old storage folder {}", prefix);
+                            debug!("cleaning old storage folder {}", prefix);
                             self.storage.delete_prefix(&prefix)?;
                         }
                     }
@@ -615,8 +615,8 @@ impl RustwideBuilder {
         let doc_coverage = match self.get_coverage(target, build, metadata, limits) {
             Ok(cov) => cov,
             Err(err) => {
-                tracing::info!("error when trying to get coverage: {}", err);
-                tracing::info!("continuing anyways.");
+                info!("error when trying to get coverage: {}", err);
+                info!("continuing anyways.");
                 None
             }
         };

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -90,9 +90,9 @@ impl Index {
     pub(crate) fn crates(&self) -> Result<crates_index::Index> {
         // First ensure the index is up to date, peeking will pull the latest changes without
         // affecting anything else.
-        log::debug!("Updating index");
+        tracing::debug!("Updating index");
         self.diff()?.peek_changes()?;
-        log::debug!("Opening with `crates_index`");
+        tracing::debug!("Opening with `crates_index`");
         // crates_index requires the repo url to match the existing origin or it tries to reinitialize the repo
         let repo_url = self
             .repository_url

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1,6 +1,7 @@
 use std::{path::PathBuf, process::Command};
 
 use anyhow::Context;
+use tracing::debug;
 use url::Url;
 
 use self::api::Api;
@@ -90,9 +91,9 @@ impl Index {
     pub(crate) fn crates(&self) -> Result<crates_index::Index> {
         // First ensure the index is up to date, peeking will pull the latest changes without
         // affecting anything else.
-        tracing::debug!("Updating index");
+        debug!("Updating index");
         self.diff()?.peek_changes()?;
-        tracing::debug!("Opening with `crates_index`");
+        debug!("Opening with `crates_index`");
         // crates_index requires the repo url to match the existing origin or it tries to reinitialize the repo
         let repo_url = self
             .repository_url

--- a/src/repositories/github.rs
+++ b/src/repositories/github.rs
@@ -1,12 +1,12 @@
 use crate::error::Result;
 use crate::Config;
 use chrono::{DateTime, Utc};
-use log::{trace, warn};
 use reqwest::{
     blocking::Client as HttpClient,
     header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT},
 };
 use serde::Deserialize;
+use tracing::{trace, warn};
 
 use crate::repositories::{
     FetchRepositoriesResult, RateLimitReached, Repository, RepositoryForge, RepositoryName,

--- a/src/repositories/gitlab.rs
+++ b/src/repositories/gitlab.rs
@@ -1,6 +1,5 @@
 use crate::error::Result;
 use chrono::{DateTime, Utc};
-use log::warn;
 use reqwest::{
     blocking::Client as HttpClient,
     header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT},
@@ -8,6 +7,7 @@ use reqwest::{
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::str::FromStr;
+use tracing::warn;
 
 use crate::repositories::{
     FetchRepositoriesResult, RateLimitReached, Repository, RepositoryForge, RepositoryName,

--- a/src/repositories/updater.rs
+++ b/src/repositories/updater.rs
@@ -3,12 +3,12 @@ use crate::repositories::{GitHub, GitLab, RateLimitReached};
 use crate::utils::MetadataPackage;
 use crate::{db::Pool, Config};
 use chrono::{DateTime, Utc};
-use log::{debug, info, trace, warn};
 use once_cell::sync::Lazy;
 use postgres::Client;
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use tracing::{debug, info, trace, warn};
 
 pub trait RepositoryForge {
     /// Result used both as the `host` column in the DB and to match repository URLs during

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -261,7 +261,7 @@ impl<'a> StorageTransaction for S3StorageTransaction<'a> {
                                 self.s3.metrics.uploaded_files_total.inc();
                             })
                             .map_err(|err| {
-                                log::warn!("Failed to upload blob to S3: {:?}", err);
+                                tracing::warn!("Failed to upload blob to S3: {:?}", err);
                                 // Reintroduce failed blobs for a retry
                                 blob
                             }),
@@ -324,7 +324,7 @@ impl<'a> StorageTransaction for S3StorageTransaction<'a> {
 
                     if let Some(errs) = resp.errors {
                         for err in &errs {
-                            log::error!("error deleting file from s3: {:?}", err);
+                            tracing::error!("error deleting file from s3: {:?}", err);
                         }
 
                         anyhow::bail!("deleting from s3 failed");

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -303,14 +303,14 @@ impl<'a> FakeRelease<'a> {
                         .with_context(|| format!("failed to create {}", path.display()))?;
                 }
                 let file = base_path.join(&path);
-                log::debug!("writing file {}", file.display());
+                tracing::debug!("writing file {}", file.display());
                 fs::write(file, data)?;
             }
             Ok(())
         };
 
         let upload_files = |kind: FileKind, source_directory: &Path| {
-            log::debug!(
+            tracing::debug!(
                 "adding directory {:?} from {}",
                 kind,
                 source_directory.display()
@@ -324,7 +324,7 @@ impl<'a> FakeRelease<'a> {
                         (source_archive_path(&package.name, &package.version), false)
                     }
                 };
-                log::debug!("store in archive: {:?}", archive);
+                tracing::debug!("store in archive: {:?}", archive);
                 let (files_list, new_alg) = crate::db::add_path_into_remote_archive(
                     &storage,
                     &archive,
@@ -347,11 +347,11 @@ impl<'a> FakeRelease<'a> {
             }
         };
 
-        log::debug!("before upload source");
+        tracing::debug!("before upload source");
         let source_tmp = create_temp_dir();
         store_files_into(&self.source_files, source_tmp.path())?;
         let (source_meta, algs) = upload_files(FileKind::Sources, source_tmp.path())?;
-        log::debug!("added source files {}", source_meta);
+        tracing::debug!("added source files {}", source_meta);
 
         // If the test didn't add custom builds, inject a default one
         if self.builds.is_empty() {
@@ -370,7 +370,7 @@ impl<'a> FakeRelease<'a> {
 
             // store default target files
             store_files_into(&rustdoc_files, rustdoc_path)?;
-            log::debug!("added rustdoc files");
+            tracing::debug!("added rustdoc files");
 
             for target in &package.targets[1..] {
                 let platform = target.src_path.as_ref().unwrap();
@@ -378,11 +378,11 @@ impl<'a> FakeRelease<'a> {
                 fs::create_dir(&platform_dir)?;
 
                 store_files_into(&rustdoc_files, &platform_dir)?;
-                log::debug!("added platform files for {}", platform);
+                tracing::debug!("added platform files for {}", platform);
             }
 
             let (rustdoc_meta, _) = upload_files(FileKind::Rustdoc, rustdoc_path)?;
-            log::debug!("uploaded rustdoc files: {}", rustdoc_meta);
+            tracing::debug!("uploaded rustdoc files: {}", rustdoc_meta);
         }
 
         let repository = match self.github_stats {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -19,7 +19,7 @@ use reqwest::{
 };
 use std::{fs, net::SocketAddr, panic, sync::Arc, time::Duration};
 use tokio::runtime::Runtime;
-use tracing::error;
+use tracing::{debug, error};
 
 #[track_caller]
 pub(crate) fn wrapper(f: impl FnOnce(&TestEnvironment) -> Result<()>) {
@@ -536,13 +536,13 @@ impl TestFrontend {
 
     pub(crate) fn get(&self, url: &str) -> RequestBuilder {
         let url = self.build_url(url);
-        tracing::debug!("getting {url}");
+        debug!("getting {url}");
         self.client.request(Method::GET, url)
     }
 
     pub(crate) fn get_no_redirect(&self, url: &str) -> RequestBuilder {
         let url = self.build_url(url);
-        tracing::debug!("getting {url} (no redirects)");
+        debug!("getting {url} (no redirects)");
         self.client_no_redirect.request(Method::GET, url)
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -11,7 +11,6 @@ use crate::{BuildQueue, Config, Context, Index, Metrics};
 use anyhow::Context as _;
 use fn_error_context::context;
 use iron::headers::CacheControl;
-use log::error;
 use once_cell::unsync::OnceCell;
 use postgres::Client as Connection;
 use reqwest::{
@@ -20,6 +19,7 @@ use reqwest::{
 };
 use std::{fs, net::SocketAddr, panic, sync::Arc, time::Duration};
 use tokio::runtime::Runtime;
+use tracing::error;
 
 #[track_caller]
 pub(crate) fn wrapper(f: impl FnOnce(&TestEnvironment) -> Result<()>) {
@@ -206,13 +206,12 @@ pub(crate) struct TestEnvironment {
 }
 
 pub(crate) fn init_logger() {
-    // initializing rustwide logging also sets the global logger
-    rustwide::logging::init_with(
-        env_logger::Builder::from_env(env_logger::Env::default().filter("DOCSRS_LOG"))
-            .format_timestamp_millis()
-            .is_test(true)
-            .build(),
-    );
+    rustwide::logging::init_with(tracing_log::LogTracer::new());
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_test_writer()
+        .finish();
+    let _ = tracing::subscriber::set_global_default(subscriber);
 }
 
 impl TestEnvironment {
@@ -537,13 +536,13 @@ impl TestFrontend {
 
     pub(crate) fn get(&self, url: &str) -> RequestBuilder {
         let url = self.build_url(url);
-        log::debug!("getting {url}");
+        tracing::debug!("getting {url}");
         self.client.request(Method::GET, url)
     }
 
     pub(crate) fn get_no_redirect(&self, url: &str) -> RequestBuilder {
         let url = self.build_url(url);
-        log::debug!("getting {url} (no redirects)");
+        tracing::debug!("getting {url} (no redirects)");
         self.client_no_redirect.request(Method::GET, url)
     }
 }

--- a/src/utils/consistency/mod.rs
+++ b/src/utils/consistency/mod.rs
@@ -1,6 +1,7 @@
 use self::diff::{Diff, Diffable};
 use crate::Index;
 use anyhow::Context;
+use tracing::info;
 
 mod data;
 mod db;
@@ -16,17 +17,17 @@ pub fn run_check(
         anyhow::bail!("TODO: only a --dry-run synchronization is supported currently");
     }
 
-    tracing::info!("Loading data from database...");
+    info!("Loading data from database...");
     let timer = std::time::Instant::now();
     let db_data =
         self::db::load(conn).context("Loading crate data from database for consistency check")?;
-    tracing::info!("...loaded in {:?}", timer.elapsed());
+    info!("...loaded in {:?}", timer.elapsed());
 
     tracing::info!("Loading data from index...");
     let timer = std::time::Instant::now();
     let index_data =
         self::index::load(index).context("Loading crate data from index for consistency check")?;
-    tracing::info!("...loaded in {:?}", timer.elapsed());
+    info!("...loaded in {:?}", timer.elapsed());
 
     let diff = db_data.diff(index_data);
 

--- a/src/utils/consistency/mod.rs
+++ b/src/utils/consistency/mod.rs
@@ -16,17 +16,17 @@ pub fn run_check(
         anyhow::bail!("TODO: only a --dry-run synchronization is supported currently");
     }
 
-    log::info!("Loading data from database...");
+    tracing::info!("Loading data from database...");
     let timer = std::time::Instant::now();
     let db_data =
         self::db::load(conn).context("Loading crate data from database for consistency check")?;
-    log::info!("...loaded in {:?}", timer.elapsed());
+    tracing::info!("...loaded in {:?}", timer.elapsed());
 
-    log::info!("Loading data from index...");
+    tracing::info!("Loading data from index...");
     let timer = std::time::Instant::now();
     let index_data =
         self::index::load(index).context("Loading crate data from index for consistency check")?;
-    log::info!("...loaded in {:?}", timer.elapsed());
+    tracing::info!("...loaded in {:?}", timer.elapsed());
 
     let diff = db_data.diff(index_data);
 

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Context as _, Error};
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
-use tracing::{debug, info};
+use tracing::{debug, error, info};
 
 /// Run the registry watcher
 /// NOTE: this should only be run once, otherwise crates would be added
@@ -30,7 +30,7 @@ pub fn watch_registry(
         }
         Ok(None) => {}
         Err(err) => {
-            tracing::error!(
+            error!(
                 "queue locked because of invalid last_seen_index_reference in database: {:?}",
                 err
             );

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -7,10 +7,10 @@ use crate::{
     BuildQueue, Config, Context, Index, RustwideBuilder,
 };
 use anyhow::{anyhow, Context as _, Error};
-use log::{debug, info};
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
+use tracing::{debug, info};
 
 /// Run the registry watcher
 /// NOTE: this should only be run once, otherwise crates would be added
@@ -30,7 +30,7 @@ pub fn watch_registry(
         }
         Ok(None) => {}
         Err(err) => {
-            log::error!(
+            tracing::error!(
                 "queue locked because of invalid last_seen_index_reference in database: {:?}",
                 err
             );

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -37,7 +37,7 @@ pub(crate) fn report_error(err: &anyhow::Error) {
         sentry_anyhow::capture_anyhow(err);
     } else {
         // Debug-format for anyhow errors includes context & backtrace
-        log::error!("{:?}", err);
+        tracing::error!("{:?}", err);
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -24,6 +24,7 @@ use anyhow::Result;
 use postgres::Client;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use tracing::error;
 pub(crate) mod sized_buffer;
 
 pub(crate) const APP_USER_AGENT: &str = concat!(
@@ -37,7 +38,7 @@ pub(crate) fn report_error(err: &anyhow::Error) {
         sentry_anyhow::capture_anyhow(err);
     } else {
         // Debug-format for anyhow errors includes context & backtrace
-        tracing::error!("{:?}", err);
+        error!("{:?}", err);
     }
 }
 

--- a/src/utils/queue_builder.rs
+++ b/src/utils/queue_builder.rs
@@ -1,10 +1,10 @@
 use crate::{docbuilder::RustwideBuilder, utils::report_error, BuildQueue};
 use anyhow::{Context, Error};
-use log::{debug, error, warn};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 use std::time::Duration;
 use std::{fs, io, thread};
+use tracing::{debug, error, warn};
 
 pub(crate) const TEMPDIR_PREFIX: &str = "docsrs-docs";
 

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -6,6 +6,8 @@ use iron::prelude::*;
 use iron::status::Status;
 use prometheus::{Encoder, HistogramVec, TextEncoder};
 use std::time::{Duration, Instant};
+#[cfg(test)]
+use tracing::debug;
 
 pub(super) fn metrics_handler(req: &mut Request) -> IronResult<Response> {
     let metrics = extension!(req, Metrics);
@@ -93,7 +95,7 @@ impl<'a> RenderingTimesRecorder<'a> {
     fn record_current(&mut self) {
         if let Some(current) = self.current.take() {
             #[cfg(test)]
-            tracing::debug!(
+            debug!(
                 "rendering time - {}: {:?}",
                 current.step,
                 current.start.elapsed()

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -93,7 +93,7 @@ impl<'a> RenderingTimesRecorder<'a> {
     fn record_current(&mut self) {
         if let Some(current) = self.current.take() {
             #[cfg(test)]
-            log::debug!(
+            tracing::debug!(
                 "rendering time - {}: {:?}",
                 current.step,
                 current.start.elapsed()

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -5,8 +5,8 @@ pub(crate) mod page;
 use crate::utils::get_correct_docsrs_style_file;
 use crate::utils::report_error;
 use anyhow::anyhow;
-use log::info;
 use serde_json::Value;
+use tracing::info;
 
 /// ctry! (cratesfyitry) is extremely similar to try! and itry!
 /// except it returns an error page response instead of plain Err.
@@ -363,7 +363,7 @@ fn match_version(
         VersionReq::STAR
     } else {
         VersionReq::parse(&req_version).map_err(|err| {
-            log::info!(
+            tracing::info!(
                 "could not parse version requirement \"{}\": {:?}",
                 req_version,
                 err

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -363,10 +363,9 @@ fn match_version(
         VersionReq::STAR
     } else {
         VersionReq::parse(&req_version).map_err(|err| {
-            tracing::info!(
+            info!(
                 "could not parse version requirement \"{}\": {:?}",
-                req_version,
-                err
+                req_version, err
             );
             Nope::VersionNotFound
         })?

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -9,6 +9,7 @@ use postgres::Client;
 use serde_json::Value;
 use std::{collections::HashMap, fmt, path::PathBuf};
 use tera::{Result as TeraResult, Tera};
+use tracing::{error, trace};
 use walkdir::WalkDir;
 
 const TEMPLATES_DIRECTORY: &str = "templates";
@@ -21,13 +22,13 @@ pub(crate) struct TemplateData {
 
 impl TemplateData {
     pub(crate) fn new(conn: &mut Client) -> Result<Self> {
-        tracing::trace!("Loading templates");
+        trace!("Loading templates");
 
         let data = Self {
             templates: load_templates(conn)?,
         };
 
-        tracing::trace!("Finished loading templates");
+        trace!("Finished loading templates");
 
         Ok(data)
     }
@@ -84,7 +85,7 @@ pub(super) fn load_templates(conn: &mut Client) -> Result<Tera> {
         &mut tera,
         "rustc_resource_suffix",
         Value::String(load_rustc_resource_suffix(conn).unwrap_or_else(|err| {
-            tracing::error!("Failed to load rustc resource suffix: {:?}", err);
+            error!("Failed to load rustc resource suffix: {:?}", err);
             // This is not fatal because the server might be started before essential files are
             // generated during development. Returning "???" provides a degraded UX, but allows the
             // server to start every time.

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -21,13 +21,13 @@ pub(crate) struct TemplateData {
 
 impl TemplateData {
     pub(crate) fn new(conn: &mut Client) -> Result<Self> {
-        log::trace!("Loading templates");
+        tracing::trace!("Loading templates");
 
         let data = Self {
             templates: load_templates(conn)?,
         };
 
-        log::trace!("Finished loading templates");
+        tracing::trace!("Finished loading templates");
 
         Ok(data)
     }
@@ -84,7 +84,7 @@ pub(super) fn load_templates(conn: &mut Client) -> Result<Tera> {
         &mut tera,
         "rustc_resource_suffix",
         Value::String(load_rustc_resource_suffix(conn).unwrap_or_else(|err| {
-            log::error!("Failed to load rustc resource suffix: {:?}", err);
+            tracing::error!("Failed to load rustc resource suffix: {:?}", err);
             // This is not fatal because the server might be started before essential files are
             // generated during development. Returning "???" provides a degraded UX, but allows the
             // server to start every time.

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -16,12 +16,12 @@ use iron::{
     modifiers::Redirect,
     status, IronError, IronResult, Request, Response, Url,
 };
-use log::{debug, warn};
 use postgres::Client;
 use router::Router;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::str;
+use tracing::{debug, warn};
 use url::form_urlencoded;
 
 /// Number of release in home page

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -414,7 +414,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
             if !matches!(err.downcast_ref(), Some(Nope::ResourceNotFound))
                 && !matches!(err.downcast_ref(), Some(crate::storage::PathNotFoundError))
             {
-                log::debug!("got error serving {}: {}", path, err);
+                tracing::debug!("got error serving {}: {}", path, err);
             }
             // If it fails, we try again with /index.html at the end
             path.to_mut().push_str("/index.html");
@@ -817,7 +817,7 @@ mod test {
             config,
         );
         let data = response.text()?;
-        log::info!("fetched path {} and got content {}\nhelp: if this is missing the header, remember to add <html><head></head><body></body></html>", path, data);
+        tracing::info!("fetched path {} and got content {}\nhelp: if this is missing the header, remember to add <html><head></head><body></body></html>", path, data);
         let dom = kuchiki::parse_html().one(data);
 
         if let Some(elem) = dom

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -26,6 +26,7 @@ use std::{
     fmt::Write,
     path::Path,
 };
+use tracing::debug;
 
 static DOC_RUST_LANG_ORG_REDIRECTS: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
     HashMap::from([
@@ -414,7 +415,7 @@ pub fn rustdoc_html_server_handler(req: &mut Request) -> IronResult<Response> {
             if !matches!(err.downcast_ref(), Some(Nope::ResourceNotFound))
                 && !matches!(err.downcast_ref(), Some(crate::storage::PathNotFoundError))
             {
-                tracing::debug!("got error serving {}: {}", path, err);
+                debug!("got error serving {}: {}", path, err);
             }
             // If it fails, we try again with /index.html at the end
             path.to_mut().push_str("/index.html");
@@ -803,6 +804,7 @@ mod test {
     use reqwest::{blocking::ClientBuilder, redirect, StatusCode};
     use std::collections::BTreeMap;
     use test_case::test_case;
+    use tracing::info;
 
     fn try_latest_version_redirect(
         path: &str,
@@ -817,7 +819,7 @@ mod test {
             config,
         );
         let data = response.text()?;
-        tracing::info!("fetched path {} and got content {}\nhelp: if this is missing the header, remember to add <html><head></head><body></body></html>", path, data);
+        info!("fetched path {} and got content {}\nhelp: if this is missing the header, remember to add <html><head></head><body></body></html>", path, data);
         let dom = kuchiki::parse_html().one(data);
 
         if let Some(elem) = dom


### PR DESCRIPTION
in preparation for the async web framework migration ( and sqlx) this migrates our logging to tracing. 

Currently not changing any log-message, the key-value and `#[instrument]` awesomeness can be added step by step in later PRs. 

