### PR TITLE
perf: change the link in the topbar to avoid a redirect

### DIFF
--- a/templates/header/topbar_end.html
+++ b/templates/header/topbar_end.html
@@ -48,7 +48,7 @@
                             ) }}
 
                             {{ macros::menu_link(
-                                href="http://doc.crates.io/guide.html",
+                                href="https://doc.rust-lang.org/cargo/guide/",
                                 text="The Cargo Guide",
                                 target="_blank"
                             ) }}


### PR DESCRIPTION
Hi! I'm new, it's my first contribution.
It's a small change for me but it's a start of a lot more I hope. 🙂
Solve issue #1727

Just change the link to avoid a redirect.