### PR TITLE
If static.files directory is present, use that

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -227,7 +227,23 @@ impl RustwideBuilder {
                         .tempdir()?;
                     copy_dir_all(source, &dest)?;
 
-                    add_path_into_database(&self.storage, RUSTDOC_STATIC_STORAGE_PREFIX, &dest)?;
+                    // One https://github.com/rust-lang/rust/pull/101702 lands, static files will be
+                    // put in their own directory, "static.files". To make sure those files are
+                    // available at --static-root-path, we add files from that subdirectory, if present.
+                    let static_files = dest.as_ref().join("static.files");
+                    if static_files.try_exists()? {
+                        add_path_into_database(
+                            &self.storage,
+                            RUSTDOC_STATIC_STORAGE_PREFIX,
+                            &static_files,
+                        )?;
+                    } else {
+                        add_path_into_database(
+                            &self.storage,
+                            RUSTDOC_STATIC_STORAGE_PREFIX,
+                            &dest,
+                        )?;
+                    }
 
                     set_config(
                         &mut conn,


### PR DESCRIPTION
This prepares for https://github.com/rust-lang/rust/pull/101702 by adding special handling of the static.files directory.

I still need to figure out how to get the rustwide builder to build based on my local toolchain in order to test this. I've gotten it working once before but I remember it was kinda complicated.