### PR TITLE
Add environment check to test_build_crate

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -867,6 +867,11 @@ mod tests {
                 .map(|v| v.as_str().unwrap().to_owned())
                 .collect();
             targets.sort();
+            assert_ne!(
+                std::env::var("DOCSRS_INCLUDE_DEFAULT_TARGETS").unwrap(),
+                "false",
+                "This test requires setting $DOCSRS_INCLUDE_DEFAULT_TARGETS to true"
+            );
             assert_eq!(
                 targets,
                 vec![


### PR DESCRIPTION
If $DOCSRS_INCLUDE_DEFAULT_TARGETS == false, this test fails when checking the list of built targets; better to provide a more useful error message.