### PR TITLE
Eliminate (most of) GHA warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - id: install
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        run: |
+          rustup override set stable
+          rustup update stable
 
       - name: restore build & cargo cache
         uses: Swatinem/rust-cache@v1
@@ -129,16 +128,12 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - id: install
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: rustfmt
+        run: |
+          rustup override set stable
+          rustup update stable
+          rustup component add rustfmt
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+      - run: cargo fmt -- --check
 
   clippy:
     name: Clippy
@@ -147,16 +142,12 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - id: install
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: clippy
+        run: |
+          rustup override set stable
+          rustup update stable
+          rustup component add clippy
 
       - name: restore build & cargo cache
         uses: Swatinem/rust-cache@v1
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --all-targets --workspace --locked -- -D warnings
+      - run: cargo clippy --all-features --all-targets --workspace --locked -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: get test binaries from cache
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: test-binaries-${{ github.sha }}
           path: ./test-binaries/
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: get test binaries from cache
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: test-binaries-${{ github.sha }}
           path: ./test-binaries/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           rustup update stable
 
       - name: restore build & cargo cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Build
         run: cargo build --workspace --locked
@@ -148,6 +148,6 @@ jobs:
           rustup component add clippy
 
       - name: restore build & cargo cache
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - run: cargo clippy --all-features --all-targets --workspace --locked -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - id: install
         run: |
           rustup override set stable
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
 
       - name: get test binaries from cache
         uses: actions/download-artifact@v3
@@ -89,7 +89,7 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
 
       - name: get test binaries from cache
         uses: actions/download-artifact@v3
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - id: install
         run: |
           rustup override set stable
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - id: install
         run: |
           rustup override set stable

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ jobs:
     name: Build and upload docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
 
       - name: Build the Docker image
         run: docker build -t docs-rs -f dockerfiles/Dockerfile .


### PR DESCRIPTION
GHA on this repo currently emits a lot of warnings: https://github.com/rust-lang/docs.rs/actions/runs/3309175135
It means GHA will stop the work if we don't take any action by the next year, see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ and https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.
This PR tries to eliminate most of them by updating some actions and removing the use of actions-rs' actions (as the author is currently inactive and these haven't been updated for a while. I sent an email to them but there's no response as of now).
One remaining thing is actions-rs/audit. We could just replace it with a `cargo install` way but it wouldn't show a summary on GHA. Rustsec forked and updated it but it isn't updated much and still depends on actions-rs code: https://github.com/rustsec/audit-check
We have some options here:
- use another third-party action
- install it directly
- any other way?

Let me know your preference!

Signed-off-by: Yuki Okushi <jtitor@2k36.org>