### PR TITLE
set up dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
see also https://github.com/rust-lang/docs.rs/pull/1891#issuecomment-1297003073

Caveat: 
dependabot will change the version references from major versions to patch versions. 

The amount of PRs still should be manageable, but it's definitely more than just major version upgrades. 