### PR TITLE
show pending CDN invalidations on queue page

### DIFF
--- a/src/cdn.rs
+++ b/src/cdn.rs
@@ -144,7 +144,7 @@ pub(crate) struct CrateInvalidation {
 /// Return fake active cloudfront invalidations.
 /// CloudFront invalidations can take up to 15 minutes. Until we have
 /// live queries of the invalidation status we just assume it's fine
-/// latest 20 minutes after the build.
+/// 20 minutes after the build.
 /// TODO: should be replaced be keeping track or querying the active invalidation from CloudFront
 pub(crate) fn active_crate_invalidations(
     conn: &mut postgres::Client,

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -38,6 +38,7 @@ pub(crate) struct FakeRelease<'a> {
 pub(crate) struct FakeBuild {
     s3_build_log: Option<String>,
     db_build_log: Option<String>,
+    build_time: Option<DateTime<Utc>>,
     result: BuildResult,
 }
 
@@ -458,6 +459,12 @@ impl FakeGithubStats {
 }
 
 impl FakeBuild {
+    pub(crate) fn build_time(self, build_time: impl Into<DateTime<Utc>>) -> Self {
+        Self {
+            build_time: Some(build_time.into()),
+            ..self
+        }
+    }
     pub(crate) fn rustc_version(self, rustc_version: impl Into<String>) -> Self {
         Self {
             result: BuildResult {
@@ -525,6 +532,13 @@ impl FakeBuild {
             )?;
         }
 
+        if let Some(build_time) = self.build_time.as_ref() {
+            conn.query(
+                "UPDATE builds SET build_time = $2 WHERE id = $1",
+                &[&build_id, &build_time],
+            )?;
+        }
+
         if let Some(s3_build_log) = self.s3_build_log.as_deref() {
             let path = format!("build-logs/{}/{}.txt", build_id, default_target);
             storage.store_one(path, s3_build_log)?;
@@ -539,6 +553,7 @@ impl Default for FakeBuild {
         Self {
             s3_build_log: Some("It works!".into()),
             db_build_log: None,
+            build_time: None,
             result: BuildResult {
                 rustc_version: "rustc 2.0.0-nightly (000000000 1970-01-01)".into(),
                 docsrs_version: "docs.rs 1.0.0 (000000000 1970-01-01)".into(),

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,5 +1,5 @@
 <div class="docs-rs-footer">
     <a href="/about">About docs.rs</a>
     <a href="https://foundation.rust-lang.org/policies/privacy-policy/#docs.rs">Privacy policy</a>
-    <a href="/releases/queue">Build queue</a>
+    <a href="/releases/queue">Queue</a>
 </div>

--- a/templates/releases/build_queue.html
+++ b/templates/releases/build_queue.html
@@ -1,37 +1,64 @@
 {%- extends "base.html" -%}
 {%- import "releases/header.html" as release_macros -%}
 
-{%- block title -%}Build Queue - Docs.rs{%- endblock title -%}
+{%- block title -%}Queue - Docs.rs{%- endblock title -%}
 
 {%- block header -%}
-    {{ release_macros::header(title="Build Queue", description=description, tab="queue") }}
+    {{ release_macros::header(title="Queue", description=description, tab="queue") }}
 {%- endblock header -%}
 
 {%- block body -%}
     <div class="container">
         <div class="recent-releases-container">
+            {%- if active_deployments %}
+                <div class="release">
+                    <strong>active CDN deployments</strong>
+                </div>
+
+                <div class = "pure-g">
+                    <div class="pure-u-1-2">
+                        <ol class="queue-list">
+                            {% for invalidation in active_deployments -%}
+                                <li>
+                                    <a href="https://docs.rs/{{ invalidation.name }}">
+                                        {{ invalidation.name }}
+                                    </a>
+                                </li>
+                            {%- endfor %}
+                        </ol>
+                    </div>
+                    <div class="pure-u-1-2">
+                        <div class="about">
+                            <p>
+                                After the build finishes it may take up to 20 minutes for all documentation
+                                pages to be up-to-date and available to everybody.
+                            </p>
+                            <p>Especially <code>/latest/</code> URLs might be affected.</p>
+                        </div>
+                    </div>
+                </div>
+            {%- endif %}
 
             <div class="release">
-                {% set queue_length = queue | length -%}
-                {%- if queue_length == 0  -%}
-                    <strong>There is nothing in the queue</strong>
-                {%- else -%}
-                    <strong>Queue</strong>
-                {%- endif %}
+                <strong>Build Queue</strong>
             </div>
 
             <ol class="queue-list">
-                {% for crate in queue -%}
-                    <li>
-                        <a href="https://crates.io/crates/{{ crate.name }}">
-                            {{ crate.name }} {{ crate.version }}
-                        </a>
+                {%- if queue -%}
+                    {% for crate in queue -%}
+                        <li>
+                            <a href="https://crates.io/crates/{{ crate.name }}">
+                                {{ crate.name }} {{ crate.version }}
+                            </a>
 
-                        {% if crate.priority != 0 -%}
-                            (priority: {{ crate.priority }})
-                        {%- endif %}
-                    </li>
-                {%- endfor %}
+                            {% if crate.priority != 0 -%}
+                                (priority: {{ crate.priority }})
+                            {%- endif %}
+                        </li>
+                    {%- endfor %}
+                {%- else %}
+                    <strong>There is nothing in the queue</strong>
+                {%- endif %}
             </ol>
         </div>
     </div>


### PR DESCRIPTION
Since #1880 raised some more open questions, here a simple addition to the queue page. I'll finish up #1880 separately, same for actually querying the cloudfront API to get the invalidations. 

This is IMO the last piece missing to really enable #1552 in the CDN configuration. 