### PR TITLE
re-add using the env-filter for tracing/log messages in tests

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -17,7 +17,7 @@ use reqwest::{
     blocking::{Client, ClientBuilder, RequestBuilder, Response},
     Method,
 };
-use std::{fs, net::SocketAddr, panic, sync::Arc, time::Duration};
+use std::{fs, net::SocketAddr, panic, str::FromStr, sync::Arc, time::Duration};
 use tokio::runtime::Runtime;
 use tracing::{debug, error};
 
@@ -206,9 +206,16 @@ pub(crate) struct TestEnvironment {
 }
 
 pub(crate) fn init_logger() {
+    use tracing_subscriber::{filter::Directive, EnvFilter};
+
     rustwide::logging::init_with(tracing_log::LogTracer::new());
     let subscriber = tracing_subscriber::FmtSubscriber::builder()
-        .with_max_level(tracing::Level::DEBUG)
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(Directive::from_str("docs_rs=info").unwrap())
+                .with_env_var("DOCSRS_LOG")
+                .from_env_lossy(),
+        )
         .with_test_writer()
         .finish();
     let _ = tracing::subscriber::set_global_default(subscriber);


### PR DESCRIPTION
after 86dd1661b0a5a9bd9fbf9c3663ead5ac5646cd08 many log/tracing messages appeared in failing test results, which made debugging these hard. 

Now we respect the `DOCSRS_LOG` env, the same way as we did before. 