### PR TITLE
Start axum migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,6 +543,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper 0.14.23",
+ "itoa 1.0.4",
+ "matchit",
+ "memchr",
+ "mime 0.3.16",
+ "percent-encoding 2.2.0",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime 0.3.16",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,6 +1375,7 @@ dependencies = [
  "aws-smithy-client",
  "aws-smithy-http",
  "aws-smithy-types-convert",
+ "axum",
  "backtrace",
  "base64 0.13.1",
  "bzip2",
@@ -1348,12 +1396,14 @@ dependencies = [
  "grass",
  "hostname",
  "http",
+ "hyper 0.14.23",
  "indoc",
  "iron",
  "kuchiki",
  "log 0.4.17",
  "lol_html",
  "memmap2",
+ "mime 0.3.16",
  "mime_guess 2.0.4",
  "mockito",
  "once_cell",
@@ -1376,6 +1426,7 @@ dependencies = [
  "sentry",
  "sentry-anyhow",
  "sentry-panic",
+ "sentry-tower",
  "sentry-tracing",
  "serde",
  "serde_cbor",
@@ -1395,6 +1446,9 @@ dependencies = [
  "time 0.3.17",
  "tokio",
  "toml",
+ "tower",
+ "tower-http",
+ "tower-service",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -2473,6 +2527,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2938,6 +2998,12 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "matchit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "maybe-async"
@@ -4529,6 +4595,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sentry-tower"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "359fdd1be4c5ecf03ffa7b21bc865836159590d0f6d114bbabd1e9c9be4c513e"
+dependencies = [
+ "http",
+ "pin-project",
+ "sentry-core",
+ "tower-layer",
+ "tower-service",
+ "url 2.3.1",
+]
+
+[[package]]
 name = "sentry-tracing"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4843,6 +4923,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
 name = "synstructure"
@@ -5207,6 +5293,26 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ consistency_check = ["crates-index", "rayon"]
 sentry = "0.27.0"
 sentry-panic = "0.27.0"
 sentry-tracing = "0.27.0"
+sentry-tower = { version = "0.27.0", features = ["http"] }
 sentry-anyhow = { version = "0.27.0", features = ["backtrace"] }
 log = "0.4"
 tracing = "0.1.37"
@@ -88,6 +89,14 @@ memmap2 = "0.5.0"
 # iron dependencies
 iron = "0.6"
 router = "0.6"
+
+# axum dependencies
+axum = "0.5.17"
+hyper = { version = "0.14.15", default-features = false }
+tower = "0.4.11"
+tower-service = "0.3.2"
+tower-http = { version = "0.3.4", features = ["trace"] }
+mime = "0.3.16"
 
 # NOTE: if you change this, also double-check that the comment in `queue_builder::remove_tempdirs` is still accurate.
 tempfile = "3.1.0"

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -3,7 +3,6 @@ use std::{path::PathBuf, process::Command};
 
 use anyhow::Context;
 use crates_index_diff::git;
-use tracing::debug;
 use url::Url;
 
 use self::api::Api;
@@ -90,6 +89,7 @@ impl Index {
 
     #[cfg(feature = "consistency_check")]
     pub(crate) fn crates(&self) -> Result<crates_index::Index> {
+        use tracing::debug;
         // First ensure the index is up to date, peeking will pull the latest changes without
         // affecting anything else.
         debug!("Updating index");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub use self::docbuilder::RustwideBuilder;
 pub use self::index::Index;
 pub use self::metrics::Metrics;
 pub use self::storage::Storage;
-pub use self::web::Server;
+pub use self::web::start_web_server;
 
 mod build_queue;
 pub mod cdn;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -573,7 +573,7 @@ impl TestFrontend {
                             axum_app
                                 .fallback(
                                     build_strangler_service(iron_server.socket)
-                                        .expect("cloud not build strangler service"),
+                                        .expect("could not build strangler service"),
                                 )
                                 .into_make_service(),
                         )
@@ -606,7 +606,7 @@ impl TestFrontend {
         trace!("joining axum server thread");
         self.axum_server_thread
             .join()
-            .expect("could not join axum background thread error");
+            .expect("could not join axum background thread");
 
         trace!("forgetting about iron");
         // Iron is bugged, and it never closes the server even when the listener is dropped. To

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -124,7 +124,7 @@ pub fn start_daemon<C: Context + Send + Clone + 'static>(
 
     start_background_repository_stats_updater(&context)?;
 
-    // NOTE: if a anyhow occurred earlier in `start_daemon`, the server will _not_ be joined -
+    // NOTE: if a error occurred earlier in `start_daemon`, the server will _not_ be joined -
     // instead it will get killed when the process exits.
     webserver_thread
         .join()

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -128,7 +128,7 @@ pub fn start_daemon<C: Context + Send + Clone + 'static>(
     // instead it will get killed when the process exits.
     webserver_thread
         .join()
-        .map_err(|_| anyhow!("web server panicked"))?
+        .map_err(|err| anyhow!("web server panicked: {:?}", err))?
 }
 
 pub(crate) fn cron<F>(name: &'static str, interval: Duration, exec: F) -> Result<(), Error>

--- a/src/web/csp.rs
+++ b/src/web/csp.rs
@@ -172,9 +172,9 @@ pub(crate) async fn csp_middleware<B>(mut req: AxumHttpRequest<B>, next: Next<B>
             // actually enforcing them. This is useful to check if the CSP works without
             // impacting production traffic.
             if csp_report_only {
-                "Content-Security-Policy-Report-Only"
+                http::header::CONTENT_SECURITY_POLICY_REPORT_ONLY
             } else {
-                "Content-Security-Policy"
+                http::header::CONTENT_SECURITY_POLICY
             },
             rendered
                 .parse()

--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{
     db::PoolError,
     web::{page::WebPage, releases::Search, AxumErrorPage, ErrorPage},
@@ -149,8 +151,8 @@ pub enum AxumNope {
     OwnerNotFound,
     #[error("Requested crate does not have specified version")]
     VersionNotFound,
-    #[error("Search yielded no results")]
-    NoResults,
+    // #[error("Search yielded no results")]
+    // NoResults,
     #[error("Internal server error")]
     InternalServerError,
     #[error("internal error")]
@@ -166,7 +168,7 @@ impl IntoResponse for AxumNope {
                 // user tried to navigate to a resource (doc page/file) that doesn't exist
                 AxumErrorPage {
                     title: "Requested resource does not exist",
-                    message: Some("no such resource".into()),
+                    message: "no such resource".into(),
                     status: StatusCode::NOT_FOUND,
                 }
                 .into_response()
@@ -174,7 +176,7 @@ impl IntoResponse for AxumNope {
 
             AxumNope::BuildNotFound => AxumErrorPage {
                 title: "The requested build does not exist",
-                message: Some("no such build".into()),
+                message: "no such build".into(),
                 status: StatusCode::NOT_FOUND,
             }
             .into_response(),
@@ -184,7 +186,7 @@ impl IntoResponse for AxumNope {
                 // TODO: Display the attempted crate and a link to a search for said crate
                 AxumErrorPage {
                     title: "The requested crate does not exist",
-                    message: Some("no such crate".into()),
+                    message: "no such crate".into(),
                     status: StatusCode::NOT_FOUND,
                 }
                 .into_response()
@@ -192,7 +194,7 @@ impl IntoResponse for AxumNope {
 
             AxumNope::OwnerNotFound => AxumErrorPage {
                 title: "The requested owner does not exist",
-                message: Some("no such owner".into()),
+                message: "no such owner".into(),
                 status: StatusCode::NOT_FOUND,
             }
             .into_response(),
@@ -202,19 +204,19 @@ impl IntoResponse for AxumNope {
                 // TODO: Display the attempted crate and version
                 AxumErrorPage {
                     title: "The requested version does not exist",
-                    message: Some("no such version for this crate".into()),
+                    message: "no such version for this crate".into(),
                     status: StatusCode::NOT_FOUND,
                 }
                 .into_response()
             }
-            AxumNope::NoResults => {
-                todo!("to be implemented when search-handler is migrated to axum")
-            }
+            // AxumNope::NoResults => {
+            //     todo!("to be implemented when search-handler is migrated to axum")
+            // }
             AxumNope::InternalServerError => {
                 // something went wrong, details should have been logged
                 AxumErrorPage {
                     title: "Internal server error",
-                    message: Some("internal server error".into()),
+                    message: "internal server error".into(),
                     status: StatusCode::INTERNAL_SERVER_ERROR,
                 }
                 .into_response()
@@ -230,8 +232,8 @@ fn generate_internal_error_page<E: Into<anyhow::Error>>(error: E) -> impl IntoRe
 
     let web_error = crate::web::AxumErrorPage {
         title: "Internal Server Error",
-        message: ::std::option::Option::Some(::std::borrow::Cow::Owned(error.to_string())),
-        status: ::http::StatusCode::INTERNAL_SERVER_ERROR,
+        message: Cow::Owned(error.to_string()),
+        status: StatusCode::INTERNAL_SERVER_ERROR,
     };
 
     // TODO: check: does the sentry tower layer add the request as context?

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -447,7 +447,8 @@ pub(crate) fn build_axum_app(
             .layer(middleware::from_fn(csp::csp_middleware))
             .layer(middleware::from_fn(
                 page::web_page::render_templates_middleware,
-            )),
+            ))
+            .layer(middleware::from_fn(cache::cache_middleware)),
     ))
 }
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -668,7 +668,7 @@ pub(crate) struct AxumErrorPage {
     /// The title of the page
     pub title: &'static str,
     /// The error message, displayed as a description
-    pub message: Option<Cow<'static, str>>,
+    pub message: Cow<'static, str>,
     #[serde(skip)]
     pub status: StatusCode,
 }

--- a/src/web/page/mod.rs
+++ b/src/web/page/mod.rs
@@ -1,5 +1,5 @@
 mod templates;
-mod web_page;
+pub(crate) mod web_page;
 
 pub(crate) use templates::TemplateData;
 pub(super) use web_page::WebPage;

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -42,7 +42,7 @@ fn load_rustc_resource_suffix(conn: &mut Client) -> Result<String> {
     anyhow::bail!("failed to parse the rustc version");
 }
 
-pub(super) fn load_templates(conn: &mut Client) -> Result<Tera> {
+fn load_templates(conn: &mut Client) -> Result<Tera> {
     // This uses a custom function to find the templates in the filesystem instead of Tera's
     // builtin way (passing a glob expression to Tera::new), speeding up the startup of the
     // application and running the tests.

--- a/src/web/page/web_page.rs
+++ b/src/web/page/web_page.rs
@@ -1,12 +1,20 @@
 use super::TemplateData;
 use crate::{
     ctry,
-    web::{cache::CachePolicy, csp::Csp},
+    web::{cache::CachePolicy, csp::Csp, error::AxumNope},
 };
+use anyhow::anyhow;
+use axum::{
+    body::{boxed, Body},
+    http::Request as AxumRequest,
+    middleware::Next,
+    response::{IntoResponse, Response as AxumResponse},
+};
+use http::header::CONTENT_LENGTH;
 use iron::{headers::ContentType, response::Response, status::Status, IronResult, Request};
 use serde::Serialize;
-use std::borrow::Cow;
-use tera::Context;
+use std::{borrow::Cow, sync::Arc};
+use tera::{Context, Tera};
 
 /// When making using a custom status, use a closure that coerces to a `fn(&Self) -> Status`
 #[macro_export]
@@ -34,6 +42,56 @@ macro_rules! impl_webpage {
                     $content_type
                 }
             )?
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_axum_webpage {
+    ($page:ty = $template:literal $(, status = $status:expr)? $(, cache_control = $cache_control:expr)? $(, content_type = $content_type:expr)? $(,)?) => {
+        $crate::impl_axum_webpage!($page = |_| ::std::borrow::Cow::Borrowed($template) $(, status = $status)? $(, content_type = $content_type)?);
+    };
+
+    ($page:ty = $template:expr $(, status = $status:expr)? $(, cache_control = $cache_control:expr)? $(, content_type = $content_type:expr)? $(,)?) => {
+        impl axum::response::IntoResponse for $page
+        {
+            fn into_response(self) -> ::axum::response::Response {
+                // set a default content type, eventually override from the page
+                #[allow(unused_mut, unused_assignments)]
+                let mut ct: &'static str = ::mime::TEXT_HTML_UTF_8.as_ref();
+                $(
+                    ct = $content_type;
+                )?
+
+                let mut response = ::axum::http::Response::builder()
+                    .header(::axum::http::header::CONTENT_TYPE, ct)
+                    $(
+                        .status({
+                            let status: fn(&$page) -> ::axum::http::StatusCode = $status;
+                            (status)(&self)
+                        })
+                    )?
+                    $(
+                        .header(
+                            ::axum::http::header::CACHE_CONTROL,
+                            ::axum::http::HeaderValue::from_str($cache_control).unwrap(),
+                        )
+                    )?
+                    // this empty body will be replaced in `render_templates_middleware` using
+                    // the data from `DelayedTemplateRender` below.
+                    .body(::axum::body::boxed(::axum::body::Body::empty()))
+                    .unwrap();
+
+                response.extensions_mut().insert($crate::web::page::web_page::DelayedTemplateRender {
+                    context: ::tera::Context::from_serialize(&self)
+                        .expect("could not create tera context from web-page"),
+                    template: {
+                        let template: fn(&Self) -> ::std::borrow::Cow<'static, str> = $template;
+                        template(&self).to_string()
+                    },
+                });
+                response
+            }
         }
     };
 }
@@ -104,4 +162,63 @@ pub trait WebPage: Serialize + Sized {
     fn cache_policy() -> Option<CachePolicy> {
         None
     }
+}
+
+/// adding this to the axum response extensions will lead
+/// to the template being rendered, adding the csp_nonce to
+/// the context.
+pub(crate) struct DelayedTemplateRender {
+    pub template: String,
+    pub context: Context,
+}
+
+fn render_response(mut response: AxumResponse, templates: &Tera, csp_nonce: &str) -> AxumResponse {
+    if let Some(render) = response.extensions().get::<DelayedTemplateRender>() {
+        let mut context = render.context.clone();
+        context.insert("csp_nonce", &csp_nonce);
+
+        let rendered = match templates.render(&render.template, &context) {
+            Ok(content) => content,
+            Err(err) => {
+                if response.status().is_server_error() {
+                    // avoid infinite loop if error.html somehow fails to load
+                    panic!("error while serving error page: {:?}", err);
+                } else {
+                    return render_response(
+                        AxumNope::InternalError(anyhow!(err)).into_response(),
+                        templates,
+                        csp_nonce,
+                    );
+                }
+            }
+        };
+        let content_length = rendered.len();
+        *response.body_mut() = boxed(Body::from(rendered));
+        response
+            .headers_mut()
+            .insert(CONTENT_LENGTH, content_length.into());
+        response
+    } else {
+        response
+    }
+}
+
+pub(crate) async fn render_templates_middleware<B>(
+    req: AxumRequest<B>,
+    next: Next<B>,
+) -> AxumResponse {
+    let templates: Arc<TemplateData> = req
+        .extensions()
+        .get::<Arc<TemplateData>>()
+        .expect("template data request extension not found")
+        .clone();
+
+    let csp_nonce = req
+        .extensions()
+        .get::<Arc<Csp>>()
+        .expect("csp request extension not found")
+        .nonce()
+        .to_owned();
+
+    render_response(next.run(req).await, &templates.templates, &csp_nonce)
 }

--- a/src/web/page/web_page.rs
+++ b/src/web/page/web_page.rs
@@ -48,11 +48,11 @@ macro_rules! impl_webpage {
 
 #[macro_export]
 macro_rules! impl_axum_webpage {
-    ($page:ty = $template:literal $(, status = $status:expr)? $(, cache_control = $cache_control:expr)? $(, content_type = $content_type:expr)? $(,)?) => {
+    ($page:ty = $template:literal $(, status = $status:expr)? $(, content_type = $content_type:expr)? $(,)?) => {
         $crate::impl_axum_webpage!($page = |_| ::std::borrow::Cow::Borrowed($template) $(, status = $status)? $(, content_type = $content_type)?);
     };
 
-    ($page:ty = $template:expr $(, status = $status:expr)? $(, cache_control = $cache_control:expr)? $(, content_type = $content_type:expr)? $(,)?) => {
+    ($page:ty = $template:expr $(, status = $status:expr)? $(, content_type = $content_type:expr)? $(,)?) => {
         impl axum::response::IntoResponse for $page
         {
             fn into_response(self) -> ::axum::response::Response {
@@ -70,12 +70,6 @@ macro_rules! impl_axum_webpage {
                             let status: fn(&$page) -> ::axum::http::StatusCode = $status;
                             (status)(&self)
                         })
-                    )?
-                    $(
-                        .header(
-                            ::axum::http::header::CACHE_CONTROL,
-                            ::axum::http::HeaderValue::from_str($cache_control).unwrap(),
-                        )
                     )?
                     // this empty body will be replaced in `render_templates_middleware` using
                     // the data from `DelayedTemplateRender` below.

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -5,6 +5,7 @@ use crate::{
     utils::{get_config, ConfigName},
     web::{error::AxumNope, page::WebPage},
 };
+use anyhow::Context;
 use axum::{
     extract::{Extension, Path},
     response::IntoResponse,
@@ -91,7 +92,8 @@ pub(crate) async fn sitemap_handler(
             })
             .collect())
     })
-    .await??;
+    .await
+    .context("failed to join thread")??;
 
     Ok(SitemapXml { releases })
 }
@@ -115,7 +117,8 @@ pub(crate) async fn about_builds_handler(
         let mut conn = pool.get()?;
         get_config::<String>(&mut conn, ConfigName::RustcVersion)
     })
-    .await??;
+    .await
+    .context("failed to join thread")??;
 
     Ok(AboutBuilds {
         rustc_version,

--- a/src/web/strangler.rs
+++ b/src/web/strangler.rs
@@ -92,7 +92,7 @@ async fn forward_call_to_strangled(
     inner: Arc<InnerStranglerService>,
     req: axum::http::Request<axum::body::Body>,
 ) -> Result<axum::response::Response, Infallible> {
-    tracing::info!("handling a request");
+    tracing::debug!("handling a request");
     let mut request_parts = RequestParts::new(req);
     let req: Result<axum::http::Request<axum::body::Body>, _> = request_parts.extract().await;
     let mut req = req.unwrap();

--- a/src/web/strangler.rs
+++ b/src/web/strangler.rs
@@ -1,0 +1,258 @@
+/// This implements a simplified strangler-service,
+/// using code from
+/// https://github.com/MidasLamb/axum-strangler/
+///
+/// because
+/// * axum-strangler breaks redirects in our current implementation:
+///   https://github.com/MidasLamb/axum-strangler/issues/4
+/// * it adds quite some dependencies it only needs for supporting WebSockets (which we don't
+///   need).
+/// * it has more dependencies itself doesn't need (reqwest)
+///
+/// We might be able to switch back to using the library when
+/// * the host/redirect problem is fixed
+/// * websocket suport is hidden behind a feature
+use std::{
+    convert::Infallible,
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use axum::{
+    extract::RequestParts,
+    http::{uri::Authority, Uri},
+};
+use tower_service::Service;
+
+/// Service that forwards all requests to another service
+/// ```ignore
+/// #[tokio::main]
+/// async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+///     let strangler_svc = StranglerService::new(
+///         axum::http::uri::Authority::from_static("127.0.0.1:3333"),
+///     );
+///     let router = axum::Router::new().fallback(strangler_svc);
+///     axum::Server::bind(&"127.0.0.1:0".parse()?)
+///         .serve(router.into_make_service())
+///         # .with_graceful_shutdown(async {
+///         # // Shut down immediately
+///         # })
+///         .await?;
+///     Ok(())
+/// }
+/// ```
+#[derive(Clone)]
+pub struct StranglerService {
+    http_client: hyper::Client<hyper::client::HttpConnector>,
+    inner: Arc<InnerStranglerService>,
+}
+
+impl StranglerService {
+    /// Construct a new `StranglerService`.
+    /// The `strangled_authority` is the host & port of the service to be strangled.
+    pub fn new(strangled_authority: Authority) -> Self {
+        Self {
+            http_client: hyper::Client::new(),
+            inner: Arc::new(InnerStranglerService {
+                strangled_authority,
+            }),
+        }
+    }
+}
+
+struct InnerStranglerService {
+    strangled_authority: axum::http::uri::Authority,
+}
+
+impl Service<axum::http::Request<axum::body::Body>> for StranglerService {
+    type Response = axum::response::Response;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: axum::http::Request<axum::body::Body>) -> Self::Future {
+        let http_client = self.http_client.clone();
+        let inner = self.inner.clone();
+
+        let fut = forward_call_to_strangled(http_client, inner, req);
+        Box::pin(fut)
+    }
+}
+
+#[tracing::instrument(skip_all, fields(req.path = %req.uri()))] // Note that we set the path to the
+                                                                // "full" uri, as host etc gets
+                                                                // removed by axum already.
+async fn forward_call_to_strangled(
+    http_client: hyper::Client<hyper::client::HttpConnector>,
+    inner: Arc<InnerStranglerService>,
+    req: axum::http::Request<axum::body::Body>,
+) -> Result<axum::response::Response, Infallible> {
+    tracing::info!("handling a request");
+    let mut request_parts = RequestParts::new(req);
+    let req: Result<axum::http::Request<axum::body::Body>, _> = request_parts.extract().await;
+    let mut req = req.unwrap();
+
+    let uri: Uri = {
+        // Not really anything to do, because this could just not be a websocket
+        // request.
+        let strangled_authority = inner.strangled_authority.clone();
+        let strangled_scheme = axum::http::uri::Scheme::HTTP;
+        Uri::builder()
+            .authority(strangled_authority)
+            .scheme(strangled_scheme)
+            .path_and_query(req.uri().path_and_query().cloned().unwrap())
+            .build()
+            .unwrap()
+    };
+
+    *req.uri_mut() = uri;
+
+    let r = http_client.request(req).await.unwrap();
+
+    let mut response_builder = axum::response::Response::builder();
+    response_builder = response_builder.status(r.status());
+
+    if let Some(headers) = response_builder.headers_mut() {
+        *headers = r.headers().clone();
+    }
+
+    let response = response_builder
+        .body(axum::body::boxed(r))
+        .map_err(|_| axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+
+    match response {
+        Ok(response) => Ok(response),
+        Err(_) => todo!(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use axum::{http::uri::Authority, routing::get, Extension, Router};
+
+    /// Create a mock service that's not connecting to anything.
+    fn make_svc() -> StranglerService {
+        StranglerService::new(Authority::from_static("127.0.0.1:0"))
+    }
+
+    #[tokio::test]
+    async fn can_be_used_as_fallback() {
+        let router = Router::new().fallback(make_svc());
+        axum::Server::bind(&"0.0.0.0:0".parse().unwrap()).serve(router.into_make_service());
+    }
+
+    #[tokio::test]
+    async fn can_be_used_for_a_route() {
+        let router = Router::new().route("/api", make_svc());
+        axum::Server::bind(&"0.0.0.0:0".parse().unwrap()).serve(router.into_make_service());
+    }
+
+    #[derive(Clone)]
+    struct StopChannel(Arc<tokio::sync::broadcast::Sender<()>>);
+
+    struct StartupHelper {
+        strangler_port: u16,
+        strangler_joinhandle: tokio::task::JoinHandle<()>,
+        stranglee_joinhandle: tokio::task::JoinHandle<()>,
+    }
+
+    async fn start_up_strangler_and_strangled(strangled_router: Router) -> StartupHelper {
+        let (tx, mut rx_1) = tokio::sync::broadcast::channel::<()>(1);
+        let mut rx_2 = tx.subscribe();
+        let tx_arc = Arc::new(tx);
+        let stop_channel = StopChannel(tx_arc);
+
+        let stranglee_tcp = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let stranglee_port = stranglee_tcp.local_addr().unwrap().port();
+
+        let strangler_tcp = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let strangler_port = strangler_tcp.local_addr().unwrap().port();
+
+        let client = hyper::Client::new();
+        let strangler_svc = StranglerService {
+            http_client: client,
+            inner: Arc::new(InnerStranglerService {
+                strangled_authority: axum::http::uri::Authority::try_from(format!(
+                    "127.0.0.1:{}",
+                    stranglee_port
+                ))
+                .unwrap(),
+            }),
+        };
+
+        let background_stranglee_handle = tokio::spawn(async move {
+            axum::Server::from_tcp(stranglee_tcp)
+                .unwrap()
+                .serve(
+                    strangled_router
+                        .layer(axum::Extension(stop_channel))
+                        .into_make_service(),
+                )
+                .with_graceful_shutdown(async {
+                    rx_1.recv().await.ok();
+                })
+                .await
+                .unwrap();
+        });
+
+        let background_strangler_handle = tokio::spawn(async move {
+            let router = Router::new().fallback(strangler_svc);
+            axum::Server::from_tcp(strangler_tcp)
+                .unwrap()
+                .serve(router.into_make_service())
+                .with_graceful_shutdown(async {
+                    rx_2.recv().await.ok();
+                })
+                .await
+                .unwrap();
+        });
+
+        StartupHelper {
+            strangler_port,
+            strangler_joinhandle: background_strangler_handle,
+            stranglee_joinhandle: background_stranglee_handle,
+        }
+    }
+
+    #[tokio::test]
+    async fn proxies_strangled_http_service() {
+        let router = Router::new().route(
+            "/api/something",
+            get(
+                |Extension(StopChannel(tx_arc)): Extension<StopChannel>| async move {
+                    tx_arc.send(()).unwrap();
+                    "I'm being strangled"
+                },
+            ),
+        );
+
+        let StartupHelper {
+            strangler_port,
+            strangler_joinhandle,
+            stranglee_joinhandle,
+        } = start_up_strangler_and_strangled(router).await;
+
+        let c = reqwest::Client::new();
+        let r = c
+            .get(format!("http://127.0.0.1:{}/api/something", strangler_port))
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+
+        assert_eq!(r, "I'm being strangled");
+
+        stranglee_joinhandle.await.unwrap();
+        strangler_joinhandle.await.unwrap();
+    }
+}


### PR DESCRIPTION
This starts the migration from iron to axum (see #1900 ) 

We're using a strangler-fig pattern, so we're running the old iron server in the background, which will be called when we don't find a route in axum. The service is based on adapted code from [`axum-strangler`](https://github.com/MidasLamb/axum-strangler).

I migrated some handlers from `web::sitemap` and some static redirects, especially to show how I thing we should do: 
- template rendering 
- CSP 
- error handling without `ctry`, `cexpect` or `.unwrap`/`.expect`
- request metrics  recorder
- cache middleware

especially the combination of template rendering and CSP took some thinking, but IMO this is a good approach. 

There is some duplication (`impl_webpage` + `impl_axum_webpage`, `AxumNope` + `Nope`, `AxumErrorPage` + `ErrorPage`), which was easier to do than figuring out how to design for both Iron & Axum in these structs. And since at some point Iron will be gone, we're fine IMO. 

I tried to do most of the change in our `TestFrontend` so the tests just run as they are, so we're sure everything is fine. 

### other things that will come / are good to know
( see also https://github.com/rust-lang/docs.rs/compare/master...syphar:docs.rs:new-web-axum )
- in `web::routes` -> a `get_rustdoc` will also inject a prefix-blocking middleware 
- the old shared-resources handler will also be a middleware, if the rebuild isn't finished until then and we can replace it with a handler.
- trailing-slash handling is done by default in the axum router
- axum/tower graceful shutdown will be added when iron is gone

### pending manual test 
- [x] do redirects include https, coming from cloudfront? ( see `redirect_base`)
- [x] are request metrics recorded correctly?
- [x] sentry error reporting / trace

which specifics are not covered with tests good enough? 