### PR TITLE
Only inject the vendored css once with the new /-/rustdoc.static/ paths

### DIFF
--- a/src/utils/html.rs
+++ b/src/utils/html.rs
@@ -68,8 +68,18 @@ pub(crate) fn rewrite_lol(
             element!("body", body_handler),
             // Append `vendored.css` before `rustdoc.css`, so that the duplicate copy of
             // `normalize.css` will be overridden by the later version.
+            //
+            // Later rustdoc has `#mainThemeStyle` that could be used, but pre-2018 docs
+            // don't have this:
+            //
+            // https://github.com/rust-lang/rust/commit/003b2bc1c65251ec2fc80b78ed91c43fb35402ec
+            //
+            // Pre-2018 rustdoc also didn't have the resource suffix, but docs.rs was using a fork
+            // that had implemented it already then, so we can assume the css files are
+            // `<some path>/rustdoc-<some suffix>.css` and use the `-` to distinguish from the
+            // `rustdoc.static` path.
             element!(
-                "link[rel='stylesheet'][href*='rustdoc']",
+                "link[rel='stylesheet'][href*='rustdoc-']",
                 |rustdoc_css: &mut Element| {
                     rustdoc_css.before(&tera_vendored_css, ContentType::Html);
                     Ok(())
@@ -94,4 +104,51 @@ pub(crate) fn rewrite_lol(
     writer.end()?;
 
     Ok(buffer)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::test::wrapper;
+
+    #[test]
+    fn rewriting_only_injects_css_once() {
+        wrapper(|env| {
+            env.fake_release()
+                .name("testing")
+                .version("0.1.0")
+                // A somewhat representative rustdoc html file from 2016
+                .rustdoc_file_with("2016/index.html", br#"
+                    <html>
+                        <head>
+                            <meta charset="utf-8">
+                            <link rel="stylesheet" type="text/css" href="../../../rustdoc-20160728-1.12.0-nightly-54c0dcfd6.css">
+                            <link rel="stylesheet" type="text/css" href="../../../main-20160728-1.12.0-nightly-54c0dcfd6.css">
+                        </head>
+                    </html>
+                "#)
+                // A somewhat representative rustdoc html file from late 2022
+                .rustdoc_file_with("2022/index.html", br#"
+                    <html>
+                        <head>
+                            <meta charset="utf-8">
+                            <link rel="preload" as="font" type="font/woff2" crossorigin="" href="/-/rustdoc.static/SourceSerif4-Regular-1f7d512b176f0f72.ttf.woff2">
+                            <link rel="stylesheet" href="/-/rustdoc.static/normalize-76eba96aa4d2e634.css">
+                            <link rel="stylesheet" href="/-/rustdoc.static/rustdoc-eabf764633b9d7be.css" id="mainThemeStyle">
+                            <link rel="stylesheet" disabled="" href="/-/rustdoc.static/dark-e2f4109f2e82e3af.css">
+                            <script src="/-/rustdoc.static/storage-d43fa987303ecbbb.js"></script>
+                            <noscript><link rel="stylesheet" href="/-/rustdoc.static/noscript-13285aec31fa243e.css"></noscript>
+                        </head>
+                    </html>
+                "#)
+                .create()?;
+
+            let output = env.frontend().get("/testing/0.1.0/2016/").send()?.text()?;
+            assert_eq!(output.matches(r#"href="/-/static/vendored.css"#).count(), 1);
+
+            let output = env.frontend().get("/testing/0.1.0/2022/").send()?.text()?;
+            assert_eq!(output.matches(r#"href="/-/static/vendored.css"#).count(), 1);
+
+            Ok(())
+        });
+    }
 }


### PR DESCRIPTION
fixes #1907