### PR TITLE
set AWS API region when creating invalidations

### DIFF
--- a/src/cdn.rs
+++ b/src/cdn.rs
@@ -2,7 +2,7 @@ use crate::Config;
 use anyhow::{Context, Error, Result};
 use aws_sdk_cloudfront::{
     model::{InvalidationBatch, Paths},
-    Client, RetryConfig,
+    Client, Region, RetryConfig,
 };
 use chrono::{DateTime, Utc};
 use serde::Serialize;
@@ -35,7 +35,8 @@ impl CdnBackend {
             CdnKind::CloudFront => {
                 let shared_config = runtime.block_on(aws_config::load_from_env());
                 let config_builder = aws_sdk_cloudfront::config::Builder::from(&shared_config)
-                    .retry_config(RetryConfig::standard().with_max_attempts(3));
+                    .retry_config(RetryConfig::standard().with_max_attempts(3))
+                    .region(Region::new(config.s3_region.clone()));
 
                 Self::CloudFront {
                     runtime: runtime.clone(),


### PR DESCRIPTION
to fix https://sentry.io/organizations/rust-lang/issues/3749747987/ 

I could reproduce the error after removing my local config, and it was fixed by this change. 