### PR TITLE
make AWS SDK retries configurable, add more retries to CDN invalidations

### DIFF
--- a/src/cdn.rs
+++ b/src/cdn.rs
@@ -35,7 +35,9 @@ impl CdnBackend {
             CdnKind::CloudFront => {
                 let shared_config = runtime.block_on(aws_config::load_from_env());
                 let config_builder = aws_sdk_cloudfront::config::Builder::from(&shared_config)
-                    .retry_config(RetryConfig::standard().with_max_attempts(3))
+                    .retry_config(
+                        RetryConfig::standard().with_max_attempts(config.aws_sdk_max_retries),
+                    )
                     .region(Region::new(config.s3_region.clone()));
 
                 Self::CloudFront {

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,9 @@ pub struct Config {
     // Storage params
     pub(crate) storage_backend: StorageKind,
 
+    // AWS SDK configuration
+    pub(crate) aws_sdk_max_retries: u32,
+
     // S3 params
     pub(crate) s3_bucket: String,
     pub(crate) s3_region: String,
@@ -122,6 +125,8 @@ impl Config {
             min_pool_idle: env("DOCSRS_MIN_POOL_IDLE", 10)?,
 
             storage_backend: env("DOCSRS_STORAGE_BACKEND", StorageKind::Database)?,
+
+            aws_sdk_max_retries: env("DOCSRS_AWS_SDK_MAX_RETRIES", 6)?,
 
             s3_bucket: env("DOCSRS_S3_BUCKET", "rust-docs-rs".to_string())?,
             s3_region: env("S3_REGION", "us-west-1".to_string())?,

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -37,7 +37,7 @@ impl S3Backend {
     ) -> Result<Self, Error> {
         let shared_config = runtime.block_on(aws_config::load_from_env());
         let mut config_builder = aws_sdk_s3::config::Builder::from(&shared_config)
-            .retry_config(RetryConfig::standard().with_max_attempts(6))
+            .retry_config(RetryConfig::standard().with_max_attempts(config.aws_sdk_max_retries))
             .region(Region::new(config.s3_region.clone()));
 
         if let Some(ref endpoint) = config.s3_endpoint {


### PR DESCRIPTION
This should help with https://sentry.io/organizations/rust-lang/issues/3750221523/ 

and make it configurable to be able to increase it further as needed. 