### PR TITLE
extend about/download page with new static root

### DIFF
--- a/templates/core/about/download.html
+++ b/templates/core/about/download.html
@@ -47,9 +47,10 @@
                 subfolder.
             </p>
             <p>
-                Docs.rs is running rustdoc with <code>--static-root-path "/"</code>,
+                Docs.rs is running rustdoc with <code>--static-root-path "/-/rustdoc.static/"</code>,
                 which leads to all references to static assets breaking if they are not
-                available under that path.
+                available under that path. Older builds used <code>--static-root-path "/"</code>, which 
+                means you will have to handle both.
             </p>
             <p>
                 Since we're also adding <code>--emit=invocation-specific</code> to our build


### PR DESCRIPTION
After https://github.com/rust-lang/docs.rs/pull/1885 the update to this page was missing. 