### PR TITLE
axum migration: migrate `releases_handler`

### DIFF
--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -234,6 +234,8 @@ impl IntoResponse for AxumNope {
     }
 }
 
+pub(crate) type WebResult<T> = Result<T, AxumNope>;
+
 #[cfg(test)]
 mod tests {
     use crate::test::wrapper;

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -61,6 +61,38 @@ pub(super) fn build_axum_routes() -> AxumRouter {
             "/about/builds",
             get_internal(super::sitemap::about_builds_handler),
         )
+        .route(
+            "/releases",
+            get_internal(super::releases::recent_releases_handler),
+        )
+        .route(
+            "/releases/recent/:page",
+            get_internal(super::releases::recent_releases_handler),
+        )
+        .route(
+            "/releases/stars",
+            get_internal(super::releases::releases_by_stars_handler),
+        )
+        .route(
+            "/releases/stars/:page",
+            get_internal(super::releases::releases_by_stars_handler),
+        )
+        .route(
+            "/releases/recent-failures",
+            get_internal(super::releases::releases_recent_failures_handler),
+        )
+        .route(
+            "/releases/recent-failures/:page",
+            get_internal(super::releases::releases_recent_failures_handler),
+        )
+        .route(
+            "/releases/failures",
+            get_internal(super::releases::releases_failures_by_stars_handler),
+        )
+        .route(
+            "/releases/failures/:page",
+            get_internal(super::releases::releases_failures_by_stars_handler),
+        )
 }
 
 // REFACTOR: Break this into smaller initialization functions
@@ -105,41 +137,12 @@ pub(super) fn build_routes() -> Routes {
     routes.internal_page("/about/metrics", super::metrics::metrics_handler);
     routes.internal_page("/about/:subpage", super::sitemap::about_handler);
 
-    routes.internal_page("/releases", super::releases::recent_releases_handler);
     routes.static_resource("/releases/feed", super::releases::releases_feed_handler);
     routes.internal_page("/releases/:owner", super::releases::owner_handler);
     routes.internal_page("/releases/:owner/:page", super::releases::owner_handler);
     routes.internal_page("/releases/activity", super::releases::activity_handler);
     routes.internal_page("/releases/search", super::releases::search_handler);
     routes.internal_page("/releases/queue", super::releases::build_queue_handler);
-    routes.internal_page(
-        "/releases/recent/:page",
-        super::releases::recent_releases_handler,
-    );
-    routes.internal_page(
-        "/releases/stars",
-        super::releases::releases_by_stars_handler,
-    );
-    routes.internal_page(
-        "/releases/stars/:page",
-        super::releases::releases_by_stars_handler,
-    );
-    routes.internal_page(
-        "/releases/recent-failures",
-        super::releases::releases_recent_failures_handler,
-    );
-    routes.internal_page(
-        "/releases/recent-failures/:page",
-        super::releases::releases_recent_failures_handler,
-    );
-    routes.internal_page(
-        "/releases/failures",
-        super::releases::releases_failures_by_stars_handler,
-    );
-    routes.internal_page(
-        "/releases/failures/:page",
-        super::releases::releases_failures_by_stars_handler,
-    );
 
     routes.internal_page("/crate/:name", super::crate_details::crate_details_handler);
     routes.internal_page(

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -3,7 +3,10 @@ use crate::{
     docbuilder::Limits,
     impl_axum_webpage, impl_webpage,
     utils::{get_config, ConfigName},
-    web::{error::AxumNope, page::WebPage},
+    web::{
+        error::{AxumNope, WebResult},
+        page::WebPage,
+    },
 };
 use anyhow::Context;
 use axum::{
@@ -53,7 +56,7 @@ impl_axum_webpage! {
 pub(crate) async fn sitemap_handler(
     Path(letter): Path<String>,
     Extension(pool): Extension<Pool>,
-) -> Result<impl IntoResponse, AxumNope> {
+) -> WebResult<impl IntoResponse> {
     if letter.len() != 1 {
         return Err(AxumNope::ResourceNotFound);
     } else if let Some(ch) = letter.chars().next() {
@@ -112,7 +115,7 @@ impl_axum_webpage!(AboutBuilds = "core/about/builds.html");
 
 pub(crate) async fn about_builds_handler(
     Extension(pool): Extension<Pool>,
-) -> Result<impl IntoResponse, AxumNope> {
+) -> WebResult<impl IntoResponse> {
     let rustc_version = spawn_blocking(move || -> anyhow::Result<_> {
         let mut conn = pool.get()?;
         get_config::<String>(&mut conn, ConfigName::RustcVersion)


### PR DESCRIPTION
ref #1900 

IMO this could be a next migration step, with some handlers with a little more traffic. 

( I'll definitely wait some days watching the current axum deploy before I'll merge & deploy this change here)