### PR TITLE
Use header for canonical URLs on rustdoc pages

### DIFF
--- a/templates/rustdoc/head.html
+++ b/templates/rustdoc/head.html
@@ -3,6 +3,4 @@
 
         <link rel="search" href="/-/static/opensearch.xml" type="application/opensearchdescription+xml" title="Docs.rs" />
 
-        <link rel="canonical" href="{{canonical_url | safe}}" />
-
         <script type="text/javascript">{%- include "theme.js" -%}</script>


### PR DESCRIPTION
Since the header on rustdoc pages is partly user-controlled, the user can inadvertantly break parsing such that Google doesn't see the `<link>` tag. Putting it in the header ensures it is reliably parsed.