### PR TITLE
Use header for canonical URLs on source pages

### DIFF
--- a/src/web/page/web_page.rs
+++ b/src/web/page/web_page.rs
@@ -61,11 +61,11 @@ macro_rules! impl_webpage {
 
 #[macro_export]
 macro_rules! impl_axum_webpage {
-    ($page:ty = $template:literal $(, status = $status:expr)? $(, content_type = $content_type:expr)? $(, canonical_url = $canonical_url:expr)? $(,)?) => {
-        $crate::impl_axum_webpage!($page = |_| ::std::borrow::Cow::Borrowed($template) $(, status = $status)? $(, content_type = $content_type)?  $(, canonical_url = $canonical_url:expr)?);
+    ($page:ty = $template:literal $(, status = $status:expr)? $(, content_type = $content_type:expr)? $(,)?) => {
+        $crate::impl_axum_webpage!($page = |_| ::std::borrow::Cow::Borrowed($template) $(, status = $status)? $(, content_type = $content_type)?);
     };
 
-    ($page:ty = $template:expr $(, status = $status:expr)? $(, content_type = $content_type:expr)? $(, canonical_url = $canonical_url:expr)? $(,)?) => {
+    ($page:ty = $template:expr $(, status = $status:expr)? $(, content_type = $content_type:expr)? $(,)?) => {
         impl axum::response::IntoResponse for $page
         {
             fn into_response(self) -> ::axum::response::Response {

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -171,6 +171,7 @@ struct SourcePage {
 
 impl_webpage! {
     SourcePage = "crate/source.html",
+    canonical_url = |page| Some(page.canonical_url.clone()),
 }
 
 pub fn source_browser_handler(req: &mut Request) -> IronResult<Response> {

--- a/templates/crate/source.html
+++ b/templates/crate/source.html
@@ -5,10 +5,6 @@
     {{ macros::doc_title(name=file_list.metadata.name, version=file_list.metadata.version) }}
 {%- endblock title -%}
 
-{%- block meta -%}
-    <link rel="canonical" href="{{ canonical_url | safe }}" />
-{%- endblock -%}
-
 {%- block topbar -%}
   {%- set metadata = file_list.metadata -%}
   {%- set latest_version = "" -%}


### PR DESCRIPTION
Since source pages can contain arbitrary files, and those files are auto-assigned content-types, they sometimes serve PDF files. Google considers those to be pages so they are subject to canonicalization; but we can't use the `<link rel="canonical">` method because they are PDFs. The header should work for all file types.

Related to #1926