### PR TITLE
migrate homepage, release-lists & search to axum

### DIFF
--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -78,6 +78,7 @@ pub(super) fn build_axum_routes() -> AxumRouter {
             "/about/:subpage",
             get_internal(super::sitemap::about_handler),
         )
+        .route("/", get_internal(super::releases::home_page))
         .route(
             "/releases",
             get_internal(super::releases::recent_releases_handler),
@@ -118,6 +119,30 @@ pub(super) fn build_axum_routes() -> AxumRouter {
             "/crate/:name/:version",
             get_internal(super::crate_details::crate_details_handler),
         )
+        .route(
+            "/releases/feed",
+            get_static(super::releases::releases_feed_handler),
+        )
+        .route(
+            "/releases/:owner",
+            get_internal(super::releases::owner_handler),
+        )
+        .route(
+            "/releases/:owner/:page",
+            get_internal(super::releases::owner_handler),
+        )
+        .route(
+            "/releases/activity",
+            get_internal(super::releases::activity_handler),
+        )
+        .route(
+            "/releases/search",
+            get_internal(super::releases::search_handler),
+        )
+        .route(
+            "/releases/queue",
+            get_internal(super::releases::build_queue_handler),
+        )
 }
 
 // REFACTOR: Break this into smaller initialization functions
@@ -146,15 +171,6 @@ pub(super) fn build_routes() -> Routes {
         }
         storage_change_detection
     });
-
-    routes.internal_page("/", super::releases::home_page);
-
-    routes.static_resource("/releases/feed", super::releases::releases_feed_handler);
-    routes.internal_page("/releases/:owner", super::releases::owner_handler);
-    routes.internal_page("/releases/:owner/:page", super::releases::owner_handler);
-    routes.internal_page("/releases/activity", super::releases::activity_handler);
-    routes.internal_page("/releases/search", super::releases::search_handler);
-    routes.internal_page("/releases/queue", super::releases::build_queue_handler);
 
     routes.internal_page(
         "/crate/:name/:version/builds",

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -54,6 +54,10 @@ pub(super) fn build_axum_routes() -> AxumRouter {
             get_static(super::statics::static_handler),
         )
         .route(
+            "/opensearch.xml",
+            get_static(|| async { Redirect::permanent("/-/static/opensearch.xml") }),
+        )
+        .route(
             "/sitemap.xml",
             get_internal(super::sitemap::sitemapindex_handler),
         )
@@ -119,13 +123,6 @@ pub(super) fn build_axum_routes() -> AxumRouter {
 // REFACTOR: Break this into smaller initialization functions
 pub(super) fn build_routes() -> Routes {
     let mut routes = Routes::new();
-
-    // This should not need to be served from the root as we reference the inner path in links,
-    // but clients might have cached the url and need to update it.
-    routes.static_resource(
-        "/opensearch.xml",
-        PermanentRedirect("/-/static/opensearch.xml"),
-    );
 
     routes.internal_page(
         "/-/rustdoc.static/:single",


### PR DESCRIPTION
This block of pages might get more requests, but the kind of request (DB queries + template rendering) matches other handlers that are already live. 

Only more complex change is the search-handler, its request to crates.io, and the search-behaviour in general. 


This changes the `axum_redirect` method that is introduced in #1925, I'll fix the conflicts when #1925 is merged. 