### PR TITLE
migrate statics-handler to axum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,6 +1422,7 @@ dependencies = [
  "grass",
  "hostname",
  "http",
+ "httpdate",
  "hyper 0.14.23",
  "indoc",
  "iron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ tower = "0.4.11"
 tower-service = "0.3.2"
 tower-http = { version = "0.3.4", features = ["trace"] }
 mime = "0.3.16"
+httpdate = "1.0.2"
 
 # NOTE: if you change this, also double-check that the comment in `queue_builder::remove_tempdirs` is still accurate.
 tempfile = "3.1.0"

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -50,6 +50,10 @@ pub(super) fn build_axum_routes() -> AxumRouter {
             get_static(|| async { Redirect::permanent("/-/static/favicon.ico") }),
         )
         .route(
+            "/-/static/*path",
+            get_static(super::statics::static_handler),
+        )
+        .route(
             "/sitemap.xml",
             get_internal(super::sitemap::sitemapindex_handler),
         )
@@ -123,8 +127,6 @@ pub(super) fn build_routes() -> Routes {
         PermanentRedirect("/-/static/opensearch.xml"),
     );
 
-    routes.static_resource("/-/static/:single", super::statics::static_handler);
-    routes.static_resource("/-/static/*", super::statics::static_handler);
     routes.internal_page(
         "/-/rustdoc.static/:single",
         super::rustdoc::static_asset_handler,


### PR DESCRIPTION
This probably can be optimized using [`ServeDir` from `tower_http`](https://docs.rs/tower-http/latest/tower_http/services/fs/struct.ServeDir.html),  but I wanted to keep the change small until we fully migrated. 