### PR TITLE
upgrade crates-index-diff & git-repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,14 +1054,18 @@ dependencies = [
 
 [[package]]
 name = "crates-index-diff"
-version = "13.0.3"
+version = "15.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab591cfff8e7a1b0dbd5362f2d9d1ce8fc090226912fca28c7965ed63c630f5"
+checksum = "7febea16145828bf66a7e12e7c85555ddf488ed7b8a98035ef4a594d2cf28c3c"
 dependencies = [
+ "ahash 0.8.2",
  "bstr 1.0.1",
- "git-repository 0.28.0",
+ "git-repository",
+ "hashbrown 0.13.1",
+ "hex",
  "serde",
  "serde_json",
+ "smartstring",
  "thiserror",
 ]
 
@@ -1390,7 +1394,7 @@ dependencies = [
  "font-awesome-as-a-crate",
  "futures-util",
  "getrandom 0.2.8",
- "git-repository 0.27.0",
+ "git-repository",
  "grass",
  "hostname",
  "http",
@@ -1786,9 +1790,9 @@ checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "git-actor"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d4ce09c0a6c71c044700e5932877667f427f007b77e6c39ab49aebc4719e25"
+checksum = "ac9fb99c934ed45a62d9ae1e7b21949f2d869d1b82a07dcbf16ed61daa665870"
 dependencies = [
  "bstr 1.0.1",
  "btoi",
@@ -1800,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "git-attributes"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c62e66a042c6b39c6dbfa3be37d134900d99ff9c54bbe489ed560a573895d5d"
+checksum = "82e98446a2bf0eb5c8f29fa828d6529510a6fadeb59ce14ca98e58fa7e1e0199"
 dependencies = [
  "bstr 1.0.1",
  "compact_str",
@@ -1816,64 +1820,43 @@ dependencies = [
 
 [[package]]
 name = "git-bitmap"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327098a7ad27ae298d7e71602dbd4375cc828d755d10a720e4be0be1b4ec38f0"
+checksum = "44304093ac66a0ada1b243c15c3a503a165a1d0f50bec748f4e5a9b84a0d0722"
 dependencies = [
  "quick-error",
 ]
 
 [[package]]
 name = "git-chunk"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b2bc1635b660ad6e30379a84a4946590a3c124b747107c2cca1d9dbb98f588"
+checksum = "3090baa2f4a3fe488a9b3e31090b83259aaf930bf0634af34c18117274f8f1a8"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "git-command"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e4b01997b6551554fdac6f02277d0d04c3e869daa649bedd06d38c86f11dc42"
+checksum = "a6b98a6312fef79b326c0a6e15d576c2bd30f7f9d0b7964998d166049e0d7b9e"
 dependencies = [
  "bstr 1.0.1",
 ]
 
 [[package]]
 name = "git-config"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8603e953bd4c9bf310e74e43697400f5542f1cc75fad46fbd7427135a9534f"
+checksum = "bd1d13179bcf3dd68e83404f91a8d01c618f54eb97ef36c68ee5e6f30183a681"
 dependencies = [
  "bstr 1.0.1",
  "git-config-value",
  "git-features",
  "git-glob",
  "git-path",
- "git-ref 0.18.0",
- "git-sec",
- "memchr",
- "nom",
- "once_cell",
- "smallvec",
- "thiserror",
- "unicode-bom",
-]
-
-[[package]]
-name = "git-config"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0484e654521f4e0d5937a99b80bca25d450a4ce2150c1f54e6bae975c44cb74"
-dependencies = [
- "bstr 1.0.1",
- "git-config-value",
- "git-features",
- "git-glob",
- "git-path",
- "git-ref 0.19.0",
+ "git-ref",
  "git-sec",
  "memchr",
  "nom",
@@ -1885,9 +1868,9 @@ dependencies = [
 
 [[package]]
 name = "git-config-value"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f276bfe5806b414915112f1eec0f006206cdf5b8cc9bbb44ef7e52286dc3eb"
+checksum = "64561e9700f1fc737fa3c1c4ea55293be70dba98e45c54cf3715cb180f37a566"
 dependencies = [
  "bitflags",
  "bstr 1.0.1",
@@ -1898,9 +1881,9 @@ dependencies = [
 
 [[package]]
 name = "git-credentials"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f540186ea56fd075ba2b923180ebf4318e66ceaeac0a2a518e75dab8517d339"
+checksum = "621dd60288ae7b8f80bb0704f46d4d2b76fc1ec980a7804e48b02d94a927e331"
 dependencies = [
  "bstr 1.0.1",
  "git-command",
@@ -1914,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "git-date"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37881e9725df41e15d16216d3a0cee251fd8a39d425f75b389112df5c7f20f3d"
+checksum = "e33db9f4462b565a33507aee113f3383bf16b988d2c573f07691e34302b7aa0a"
 dependencies = [
  "bstr 1.0.1",
  "itoa 1.0.4",
@@ -1926,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "git-diff"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4c61358be0a961adf3ebc9a9e126678d98a906a293959847f0b7f3b580c21c"
+checksum = "82f77407381267be95f1b26acfb32007258af342ee61729bb4271b1869bf5bb2"
 dependencies = [
  "git-hash",
  "git-object",
@@ -1938,37 +1921,23 @@ dependencies = [
 
 [[package]]
 name = "git-discover"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881e4136d5599cfdb79d8ef60d650823d1a563589fa493d8e4961e64d78a79f2"
+checksum = "2c2cfd1272824b126c6997ef479a71288d00fae14dc5144dfc48658f4dd24fbe"
 dependencies = [
  "bstr 1.0.1",
  "git-hash",
  "git-path",
- "git-ref 0.18.0",
- "git-sec",
- "thiserror",
-]
-
-[[package]]
-name = "git-discover"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a027ba1f15bee27f4fce92870fed4322c83f9a3efc39422ab5481477544bc1b"
-dependencies = [
- "bstr 1.0.1",
- "git-hash",
- "git-path",
- "git-ref 0.19.0",
+ "git-ref",
  "git-sec",
  "thiserror",
 ]
 
 [[package]]
 name = "git-features"
-version = "0.23.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be88ae837674c71b30c6517c6f5f1335f8135bb8a9ffef20000d211933bed08"
+checksum = "d7bdbe755d2129bc609437b6b18af1116f146128dda6070c15c0aa50201ac17c"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1988,9 +1957,9 @@ dependencies = [
 
 [[package]]
 name = "git-glob"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d756430237112f8c89049236f60fdcdb0005127b1f7e531d40984e4fe7daa90"
+checksum = "ef858611602fce54b51e45671ca72f07fe6a3c0e24a0539c66b75dfd4d84bd77"
 dependencies = [
  "bitflags",
  "bstr 1.0.1",
@@ -1998,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "git-hash"
-version = "0.9.11"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d46e6c2d1e8da4438a87bf516a6761b300964a353541fea61e96b3c7b34554"
+checksum = "d74d271e8194956dcb6f8bf94b6bc1f403acf34c81d9371c15e4145e6d059795"
 dependencies = [
  "hex",
  "thiserror",
@@ -2008,31 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "git-index"
-version = "0.7.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821583c2d12b1e864694eb0bf1cca10ff6a3f45966f5f834e0f921b496dbe7cb"
-dependencies = [
- "atoi",
- "bitflags",
- "bstr 1.0.1",
- "filetime",
- "git-bitmap",
- "git-features",
- "git-hash",
- "git-lock",
- "git-object",
- "git-traverse",
- "itoa 1.0.4",
- "memmap2",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "git-index"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a0010457804e8e7918bfc37870c532ee7ab93bca4be94d5e7875390997caa3"
+checksum = "a87c32d2e012ee316d4037b2151e5893599379ff1fc2c6adb36d2d4d1c461e2c"
 dependencies = [
  "atoi",
  "bitflags",
@@ -2052,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "git-lock"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0fe10bf961f62b1335b4c07785e64fb4d86c5ed367dc7cd9360f13c3eb7c78"
+checksum = "89e4f05b8a68c3a5dd83a6651c76be384e910fe283072184fdab9d77f87ccec2"
 dependencies = [
  "fastrand",
  "git-tempfile",
@@ -2063,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "git-mailmap"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb3f85ce84b2328aeb3124a809f7b3a63e59c4d63c227dba7a9cdf6fca6c0987"
+checksum = "480eecdfaf1bfd05973678520d182dc07afa25b133db18c52575fb65b782b7ba"
 dependencies = [
  "bstr 1.0.1",
  "git-actor",
@@ -2074,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "git-object"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9469a8c00d8bb500ee76a12e455bb174b4ddf71674713335dd1a84313723f7b3"
+checksum = "ce0f14f9cd8f0782e843898a2fb7b0c2f5a6e37bd4cdff4409bb8ec698597dad"
 dependencies = [
  "bstr 1.0.1",
  "btoi",
@@ -2093,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "git-odb"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76eb64cf37326fccda46fee6dc6c8c39d2e8b03f13031cb094a928d61c97b95c"
+checksum = "13493da6cf0326454215414d29f933a1e26bdba3b9b60ad8cdcbe06f0639584b"
 dependencies = [
  "arc-swap",
  "git-features",
@@ -2111,9 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "git-pack"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f385ab95e01ecface60658b0d0f1181f51e114213e584bb7a16c5af47d653f"
+checksum = "fa8391cbf293f0f8ffbb5e324f25741f5e1e2d35fb87b89ab222a025661e0454"
 dependencies = [
  "bytesize",
  "clru",
@@ -2136,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "git-packetline"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23284ba3ede7849f70d4f20766868fc90aab420730bdbf5e7932de72aa84e3ce"
+checksum = "1e6351b197bb99597f0983f1972108b2ebe8f42e38c3e052d77b3df10b37842f"
 dependencies = [
  "bstr 1.0.1",
  "hex",
@@ -2147,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "git-path"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "425dc1022690be13e6c5bde4b7e04d9504d323605ec314cd367cebf38a812572"
+checksum = "5f60cbc13bc0fdd95df5f4b80437197e2853116792894b1bf38d1a6b4a64f8c9"
 dependencies = [
  "bstr 1.0.1",
  "thiserror",
@@ -2157,9 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "git-prompt"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6947935c0671342277bc883ff0687978477b570c1ffe2200b9ba5ac8afdd9f"
+checksum = "21c6aaeb3f0f8de91f5e0eb950282c6508e05babcedef768db5a6f085d6e5242"
 dependencies = [
  "git-command",
  "git-config-value",
@@ -2170,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "git-protocol"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "275203dad7f0d1efa775552b283f7567d06086d1e7032044c4065ff5b78c5e6b"
+checksum = "127fef6ec65a0d86c2406ca79b8740408b66af70eb31ed0aa98527650a33a92a"
 dependencies = [
  "bstr 1.0.1",
  "btoi",
@@ -2187,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "git-quote"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea17931d07cbe447f371bbdf45ff03c30ea86db43788166655a5302df87ecfc"
+checksum = "1dd11f4e7f251ab297545faa4c5a4517f4985a43b9c16bf96fa49107f58e837f"
 dependencies = [
  "bstr 1.0.1",
  "btoi",
@@ -2198,28 +2145,9 @@ dependencies = [
 
 [[package]]
 name = "git-ref"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "638c9e454bacb2965a43f05b4a383c8f66dc64f3a770bd0324b221c2a20e121d"
-dependencies = [
- "git-actor",
- "git-features",
- "git-hash",
- "git-lock",
- "git-object",
- "git-path",
- "git-tempfile",
- "git-validate",
- "memmap2",
- "nom",
- "thiserror",
-]
-
-[[package]]
-name = "git-ref"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de7085a883068565623fdb4d1c6790c63ca3a57479387ba1584916df74b3c3a4"
+checksum = "22484043921e699edc170415789f1b882c8f3546e1fbbc447a0043ef07e088c4"
 dependencies = [
  "git-actor",
  "git-features",
@@ -2236,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "git-refspec"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9497af773538ae8cfda053ff7dd0a9e6c28d333ba653040f54b8b4ee32f14187"
+checksum = "ac2e8f36e7d5d48903b60051dfb75aedfc4ea9ba66bdffa7a9081e8d276b0107"
 dependencies = [
  "bstr 1.0.1",
  "git-hash",
@@ -2250,66 +2178,23 @@ dependencies = [
 
 [[package]]
 name = "git-repository"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e2c5e4611c366b025c4501677e2077d1fba1d365f9e211398d4426f482e204"
+checksum = "a89cec253dd3fba44694f7468d907506a52d0055850ecd7d84f4bac07f00e73f"
 dependencies = [
  "byte-unit",
  "clru",
  "git-actor",
  "git-attributes",
- "git-config 0.10.0",
+ "git-config",
  "git-credentials",
  "git-date",
  "git-diff",
- "git-discover 0.7.0",
+ "git-discover",
  "git-features",
  "git-glob",
  "git-hash",
- "git-index 0.7.1",
- "git-lock",
- "git-mailmap",
- "git-object",
- "git-odb",
- "git-pack",
- "git-path",
- "git-prompt",
- "git-ref 0.18.0",
- "git-refspec",
- "git-revision",
- "git-sec",
- "git-tempfile",
- "git-traverse",
- "git-url",
- "git-validate",
- "git-worktree 0.7.0",
- "log 0.4.17",
- "once_cell",
- "signal-hook",
- "smallvec",
- "thiserror",
- "unicode-normalization",
-]
-
-[[package]]
-name = "git-repository"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ffe7749cc0191b8410b6191acdc8d2dea390995d132840642d619c10aeba15"
-dependencies = [
- "byte-unit",
- "clru",
- "git-actor",
- "git-attributes",
- "git-config 0.11.0",
- "git-credentials",
- "git-date",
- "git-diff",
- "git-discover 0.8.0",
- "git-features",
- "git-glob",
- "git-hash",
- "git-index 0.8.0",
+ "git-index",
  "git-lock",
  "git-mailmap",
  "git-object",
@@ -2318,7 +2203,7 @@ dependencies = [
  "git-path",
  "git-prompt",
  "git-protocol",
- "git-ref 0.19.0",
+ "git-ref",
  "git-refspec",
  "git-revision",
  "git-sec",
@@ -2327,7 +2212,7 @@ dependencies = [
  "git-traverse",
  "git-url",
  "git-validate",
- "git-worktree 0.8.0",
+ "git-worktree",
  "log 0.4.17",
  "once_cell",
  "signal-hook",
@@ -2338,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "git-revision"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efd31c63c3745b5dba5ec7109eec41a9c717f4e1e797fe0ef93098f33f31b25"
+checksum = "e629289b0d7f7f2f2e46248527f5cac838e6a7cb9507eab06fc8473082db6cb6"
 dependencies = [
  "bstr 1.0.1",
  "git-date",
@@ -2352,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "git-sec"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c79769f6546814d0774db7295c768441016b7e40bdd414fa8dfae2c616a1892"
+checksum = "1ecb370efde58da72827909292284b5c5b885e0621a342515a36976b0b3bf660"
 dependencies = [
  "bitflags",
  "dirs",
@@ -2365,9 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "git-tempfile"
-version = "2.0.6"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d23bc6129de3cbd81e6c9d0d685b5540c6b41bd9fa0cc38f381bc300743d708"
+checksum = "a6bb4dee86c8cae5a078cfaac3b004ef99c31548ed86218f23a7ff9b4b74f3be"
 dependencies = [
  "dashmap",
  "libc",
@@ -2379,9 +2264,9 @@ dependencies = [
 
 [[package]]
 name = "git-transport"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a1cff8c310d13240f0c48653d1e10320db6fd32243b7afa39213f2be5445534"
+checksum = "69e32879c8bfacdf3bc43bcffacad456f722f06b6e9335e9e2990c281d4f6622"
 dependencies = [
  "base64 0.13.1",
  "bstr 1.0.1",
@@ -2395,9 +2280,9 @@ dependencies = [
 
 [[package]]
 name = "git-traverse"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0c4dd773c69f294f43ace8373d48eb770129791f104c6857fa8cac0505af89"
+checksum = "2d2746935c92d252e24f9d345e0a981510596faceb7edae821b9e4c8c35c285b"
 dependencies = [
  "git-hash",
  "git-object",
@@ -2407,9 +2292,9 @@ dependencies = [
 
 [[package]]
 name = "git-url"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b7f8323196840e7932f5b60e1d9c1d6c140fd806bc512f8beedc3f990a1f81"
+checksum = "7dbd91c55b1b03a833ff8278776fed272918cd61cd48efe9a97ad1fea7ef93ec"
 dependencies = [
  "bstr 1.0.1",
  "git-features",
@@ -2421,44 +2306,26 @@ dependencies = [
 
 [[package]]
 name = "git-validate"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5439d6aa0de838dfadd74a71e97a9e23ebc719fd11a9ab6788b835b112c8c3d"
-dependencies = [
- "bstr 1.0.1",
- "thiserror",
-]
-
-[[package]]
-name = "git-worktree"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bcc69c36a29cfa283710b7901877ab251d658935f5a41ed824416af500e0ed"
+checksum = "cdf83bae632fc064ca938ebfb987364d9083b7f98b1476805f0a2d5eebb48686"
 dependencies = [
  "bstr 1.0.1",
- "git-attributes",
- "git-features",
- "git-glob",
- "git-hash",
- "git-index 0.7.1",
- "git-object",
- "git-path",
- "io-close",
  "thiserror",
 ]
 
 [[package]]
 name = "git-worktree"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e39b730ab111ae1f98ce15774b7e6ad7eb0433dba580698aa2f7fd6956a9884b"
+checksum = "2eae0e0b1050208e611d5fac0d8366b29ef3f83849767ff9c4bcf570f0d5dc2b"
 dependencies = [
  "bstr 1.0.1",
  "git-attributes",
  "git-features",
  "git-glob",
  "git-hash",
- "git-index 0.8.0",
+ "git-index",
  "git-object",
  "git-path",
  "io-close",
@@ -2568,6 +2435,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+dependencies = [
+ "ahash 0.8.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,6 +1124,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,6 +1169,16 @@ dependencies = [
  "crossbeam-utils",
  "memoffset 0.7.1",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1605,6 +1629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
+ "libz-sys",
  "miniz_oxide 0.6.2",
 ]
 
@@ -1945,12 +1970,14 @@ dependencies = [
  "crossbeam-utils",
  "flate2",
  "git-hash",
+ "jwalk",
  "libc",
  "num_cpus",
  "once_cell",
  "parking_lot",
  "prodash",
  "quick-error",
+ "sha1",
  "sha1_smol",
  "walkdir",
 ]
@@ -2840,6 +2867,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jwalk"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "172752e853a067cbce46427de8470ddf308af7fd8ceaf9b682ef31a5021b6bb9"
+dependencies = [
+ "crossbeam",
+ "rayon",
 ]
 
 [[package]]
@@ -4805,6 +4842,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+ "sha1-asm",
+]
+
+[[package]]
+name = "sha1-asm"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563d4f7100bc3fce234e5f37bbf63dc2752558964505ba6ac3f7204bdc59eaac"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ regex = "1"
 clap = { version = "4.0.22", features = [ "derive" ] }
 crates-index = { version = "0.18.5", optional = true }
 rayon = { version = "1", optional = true }
-crates-index-diff = "15.0.1"
+crates-index-diff = { version = "15.0.1", features = [ "max-performance" ]}
 reqwest = { version = "0.11", features = ["blocking", "json"] } # TODO: Remove blocking when async is ready
 semver = { version = "1.0.4", features = ["serde"] }
 slug = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ regex = "1"
 clap = { version = "4.0.22", features = [ "derive" ] }
 crates-index = { version = "0.18.5", optional = true }
 rayon = { version = "1", optional = true }
-crates-index-diff = "13.0.2"
+crates-index-diff = "15.0.1"
 reqwest = { version = "0.11", features = ["blocking", "json"] } # TODO: Remove blocking when async is ready
 semver = { version = "1.0.4", features = ["serde"] }
 slug = "0.1.1"
@@ -134,7 +134,7 @@ indoc = "1.0.7"
 
 [build-dependencies]
 time = "0.3"
-git-repository = { version = "0.27.0", default-features = false }
+git-repository = { version = "0.29.0", default-features = false }
 string_cache_codegen = "0.5.1"
 walkdir = "2"
 anyhow = { version = "1.0.42", features = ["backtrace"] }

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -302,7 +302,7 @@ impl BuildQueue {
     pub fn get_new_crates(&self, index: &Index) -> Result<usize> {
         let mut conn = self.db.get()?;
         let diff = index.diff()?;
-        let (mut changes, oid) = diff.peek_changes()?;
+        let (mut changes, oid) = diff.peek_changes_ordered()?;
         let mut crates_added = 0;
 
         // I believe this will fix ordering of queue if we get more than one crate from changes

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -313,7 +313,7 @@ impl BuildQueue {
                     .with_context(|| format!("failed to delete crate {}", krate))
                 {
                     Ok(_) => info!(
-                        "crate {} was deleted from the index and will be deleted from the database",
+                        "crate {} was deleted from the index and the database",
                         krate
                     ),
                     Err(err) => report_error(&err),


### PR DESCRIPTION
This updates the crates-index-diff crates, including thread-names for all the threads that crates-index-diff spawns, to get visibility into our CPU-load problem. 

related release notes: 
- https://github.com/Byron/crates-index-diff-rs/releases/tag/v14.0.0
- https://github.com/Byron/crates-index-diff-rs/releases/tag/v15.0.0
- https://github.com/Byron/crates-index-diff-rs/releases/tag/v15.0.1
- https://github.com/Byron/gitoxide/releases/tag/git-features-v0.24.1 (named threads)
- https://github.com/Byron/gitoxide/releases/tag/git-index-v0.9.1 (named threads)

Also: 
- handling the new `AddedAndYanked` change as currently just `Added`
- adding an error message when we try to yank/unyank a release that doesn't exist (yet), see also #1934. 