### PR TITLE
Improve instructions a bit for bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ cargo build
 docker-compose up -d db s3
 # anything that doesn't run via docker-compose needs the settings defined in
 # .env. Either via `. ./.env` as below, or via any dotenv shell integration.
+# If using bash, you need to run instead:
+# `set -o allexport && . ./env && set +o allexport` otherwise they won't be
+# saved in your environment.
 . ./.env
 # Setup the database you just created
 cargo run -- database migrate


### PR DESCRIPTION
Took me a while to understand why `source` wasn't working. It's because it doesn't export variables defined in a script into the environment by default. To do so, we need to use `set -o allexport` or `set -a`. Since I think some others might have the same issue, I updated the README a bit to include this command.