### PR TITLE
Replace topbar dropdown menus working with JS by `<details>`

### DIFF
--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -991,7 +991,7 @@ mod tests {
 
             let platform_links: Vec<(String, String)> = kuchiki::parse_html()
                 .one(response.text()?)
-                .select(r#"a[aria-label="Platform"] + ul li a"#)
+                .select(r#"summary[aria-label="Platform"] + ul li a"#)
                 .expect("invalid selector")
                 .map(|el| {
                     let attributes = el.attributes.borrow();

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -952,7 +952,7 @@ mod test {
             let text = web.get("/foo/0.2.0/foo").send()?.text()?;
             let platform = kuchiki::parse_html()
                 .one(text)
-                .select(r#"ul > li > a[aria-label="Platform"]"#)
+                .select(r#"form.landing-search-form-nav details > summary[aria-label="Platform"]"#)
                 .unwrap()
                 .count();
             assert_eq!(platform, 1);

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -861,7 +861,7 @@ mod test {
         let dom = kuchiki::parse_html().one(data);
 
         if let Some(elem) = dom
-            .select("form > ul > li > a.warn")
+            .select("form.landing-search-form-nav > a.warn.pure-menu-item")
             .expect("invalid selector")
             .next()
         {
@@ -1257,7 +1257,7 @@ mod test {
             let data = web.get(path).send()?.text()?;
             Ok(kuchiki::parse_html()
                 .one(data)
-                .select("form > ul > li > .warn")
+                .select("form.landing-search-form-nav > .warn.pure-menu-item")
                 .expect("invalid selector")
                 .any(|el| el.text_contents().contains("yanked")))
         }
@@ -1502,7 +1502,7 @@ mod test {
             let data = web.get(path).send()?.text()?;
             let dom = kuchiki::parse_html().one(data);
             Ok(dom
-                .select(r#"a[aria-label="Platform"] + ul li a"#)
+                .select(r#"summary[aria-label="Platform"] + ul li a"#)
                 .expect("invalid selector")
                 .map(|el| {
                     let attributes = el.attributes.borrow();

--- a/static/menu.js
+++ b/static/menu.js
@@ -1,18 +1,15 @@
-const updateMenuPositionForSubMenu = (currentMenuSupplier) => {
-    const currentMenu = currentMenuSupplier();
-    const subMenu = currentMenu?.getElementsByClassName('pure-menu-children')?.[0];
-
-    subMenu?.style.setProperty('--menu-x', `${currentMenu.getBoundingClientRect().x}px`);
-}
-
-// Allow menus to be open and used by keyboard.
+// Improve interactions with dropdown menus.
 (function() {
-    var currentMenu;
-    var backdrop = document.createElement("div");
-    backdrop.style = "display:none;position:fixed;width:100%;height:100%;z-index:1";
-    document.documentElement.insertBefore(backdrop, document.querySelector("body"));
+    const OPEN_MENU_SELECTOR = ".nav-container details[open]";
 
-    addEventListener('resize', () => updateMenuPositionForSubMenu(() => currentMenu));
+    function updateMenuPositionForSubMenu() {
+        const currentMenu = document.querySelector(OPEN_MENU_SELECTOR);
+        const subMenu = currentMenu?.getElementsByClassName('pure-menu-children')?.[0];
+
+        subMenu?.style.setProperty('--menu-x', `${currentMenu.getBoundingClientRect().x}px`);
+    }
+
+    addEventListener('resize', updateMenuPositionForSubMenu);
 
     function previous(allItems, item) {
         var i = 1;
@@ -37,216 +34,43 @@ const updateMenuPositionForSubMenu = (currentMenuSupplier) => {
     function last(allItems) {
         return allItems[allItems.length - 1];
     }
-    function closeMenu() {
-        if (this === backdrop) {
-            document.documentElement.focus();
-        } else if (currentMenu.querySelector(".pure-menu-link:focus")) {
-            currentMenu.firstElementChild.focus();
+    function closeMenu(ignore) {
+        const menus = Array.prototype.slice.call(
+            document.querySelectorAll(OPEN_MENU_SELECTOR));
+        for (const menu of menus) {
+            if (menu !== ignore) {
+                menu.open = false;
+            }
         }
-        currentMenu.className = currentMenu.className.replace("pure-menu-active", "");
-        currentMenu = null;
-        backdrop.style.display = "none";
-    }
-    backdrop.onclick = closeMenu;
-    function openMenu(newMenu) {
-        updateMenuPositionForSubMenu(() => newMenu);
-        currentMenu = newMenu;
-        newMenu.className += " pure-menu-active";
-        backdrop.style.display = "block";
     }
     function menuOnClick(e) {
-        if (this.getAttribute("href") != "#") {
-            return;
-        }
-        if (this.parentNode === currentMenu) {
-            closeMenu();
-            this.blur();
+        if (!this.open) {
+            this.focus();
         } else {
-            if (currentMenu) closeMenu();
-
-            openMenu(this.parentNode);
+            closeMenu(this);
+            updateMenuPositionForSubMenu();
         }
-        e.preventDefault();
-        e.stopPropagation();
     };
     function menuKeyDown(e) {
-        if (currentMenu) {
-            var children = currentMenu.querySelector(".pure-menu-children");
-            var currentLink = children.querySelector(".pure-menu-link:focus");
-            var currentItem;
-            if (currentLink && currentLink.parentNode.className.indexOf("pure-menu-item") !== -1) {
-                currentItem = currentLink.parentNode;
-            }
-            var allItems = [];
-            if (children) {
-                allItems = children.querySelectorAll(".pure-menu-item .pure-menu-link");
-            }
-            var switchTo = null;
-            switch (e.key.toLowerCase()) {
-                case "escape":
-                case "esc":
-                    closeMenu();
-                    e.preventDefault();
-                    e.stopPropagation();
-                    return;
-                case "arrowdown":
-                case "down":
-                    if (currentLink) {
-                        // Arrow down when an item other than the last is focused: focus next item.
-                        // Arrow down when the last item is focused: jump to top.
-                        switchTo = (next(allItems, currentLink) || allItems[0]);
-                    } else {
-                        // Arrow down when a menu is open and nothing is focused: focus first item.
-                        switchTo = allItems[0];
-                    }
-                    break;
-                case "arrowup":
-                case "up":
-                    if (currentLink) {
-                        // Arrow up when an item other than the first is focused: focus previous item.
-                        // Arrow up when the first item is focused: jump to bottom.
-                        switchTo = (previous(allItems, currentLink) || last(allItems));
-                    } else {
-                        // Arrow up when a menu is open and nothing is focused: focus last item.
-                        switchTo = last(allItems);
-                    }
-                    break;
-                case "tab":
-                    if (!currentLink) {
-                        // if the menu is open, we should focus trap into it
-                        // this is the behavior of the WAI example
-                        // it is not the same as GitHub, but GitHub allows you to tab yourself out
-                        // of the menu without closing it (which is horrible behavior)
-                        switchTo = e.shiftKey ? last(allItems) : allItems[0];
-                    } else if (e.shiftKey && currentLink === allItems[0]) {
-                        // if you tab your way out of the menu, close it
-                        // this is neither what GitHub nor the WAI example do,
-                        // but is a rationalization of GitHub's behavior: we don't want users who know how to
-                        // use tab and enter, but don't know that they can close menus with Escape,
-                        // to find themselves completely trapped in the menu
-                        closeMenu();
-                        e.preventDefault();
-                        e.stopPropagation();
-                    } else if (!e.shiftKey && currentLink === last(allItems)) {
-                        // same as above.
-                        // if you tab your way out of the menu, close it
-                        closeMenu();
-                    }
-                    break;
-                case "enter":
-                case "return":
-                    // enter and return have the default browser behavior,
-                    // but they also close the menu
-                    // this behavior is identical between both the WAI example, and GitHub's
-                    setTimeout(function() {
-                        closeMenu();
-                    }, 100);
-                    break;
-                case "space":
-                case " ":
-                    // space closes the menu, and activates the current link
-                    // this behavior is identical between both the WAI example, and GitHub's
-                    if (document.activeElement instanceof HTMLAnchorElement && !document.activeElement.hasAttribute("aria-haspopup")) {
-                        // It's supposed to copy the behaviour of the WAI Menu Bar
-                        // page, and of GitHub's menus. I've been using these two
-                        // sources to judge what is basically "industry standard"
-                        // behaviour for menu keyboard activity on the web.
-                        //
-                        // On GitHub, here's what I notice:
-                        //
-                        // 1 If you click open a menu, the menu button remains
-                        //   focused. If, in this stage, I press space, the menu will
-                        //   close.
-                        //
-                        // 2 If I use the arrow keys to focus a menu item, and then
-                        //   press space, the menu item will be activated. For
-                        //   example, clicking "+", then pressing down, then pressing
-                        //   space will open the New Repository page.
-                        //
-                        // Behaviour 1 is why the
-                        // `!document.activeElement.hasAttribute("aria-haspopup")`
-                        // condition is there. It's to make sure the menu-link on
-                        // things like the About dropdown don't get activated.
-                        // Behaviour 2 is why this code is required at all; I want to
-                        // activate the currently highlighted menu item.
-                        document.activeElement.click();
-                    }
-                    setTimeout(function() {
-                        closeMenu();
-                    }, 100);
-                    e.preventDefault();
-                    e.stopPropagation();
-                    break;
-                case "home":
-                    // home: focus first menu item.
-                    // This is the behavior of WAI, while GitHub scrolls,
-                    // but it's unlikely that a user will try to scroll the page while the menu is open,
-                    // so they won't do it on accident.
-                    switchTo = allItems[0];
-                    break;
-                case "end":
-                    // end: focus last menu item.
-                    // This is the behavior of WAI, while GitHub scrolls,
-                    // but it's unlikely that a user will try to scroll the page while the menu is open,
-                    // so they won't do it on accident.
-                    switchTo = last(allItems);
-                    break;
-                case "pageup":
-                    // page up: jump five items up, stopping at the top
-                    // the number 5 is used so that we go one page in the
-                    // inner-scrolled Dependencies and Versions fields
-                    switchTo = currentItem || allItems[0];
-                    for (var n = 0; n < 5; ++n) {
-                        if (switchTo.previousElementSibling && switchTo.previousElementSibling.className == 'pure-menu-item') {
-                            switchTo = switchTo.previousElementSibling;
-                        }
-                    }
-                    break;
-                case "pagedown":
-                    // page down: jump five items down, stopping at the bottom
-                    // the number 5 is used so that we go one page in the
-                    // inner-scrolled Dependencies and Versions fields
-                    switchTo = currentItem || last(allItems);
-                    for (var n = 0; n < 5; ++n) {
-                        if (switchTo.nextElementSibling && switchTo.nextElementSibling.className == 'pure-menu-item') {
-                            switchTo = switchTo.nextElementSibling;
-                        }
-                    }
-                    break;
-            }
-            if (switchTo) {
-                var switchToLink = switchTo.querySelector("a");
-                if (switchToLink) {
-                    switchToLink.focus();
-                } else {
-                    switchTo.focus();
-                }
-                e.preventDefault();
-                e.stopPropagation();
-            }
-        } else if (e.target.parentNode.className && e.target.parentNode.className.indexOf("pure-menu-has-children") !== -1) {
-            switch (e.key.toLowerCase()) {
-                case "arrowdown":
-                case "down":
-                case "space":
-                case " ":
-                    openMenu(e.target.parentNode);
-                    e.preventDefault();
-                    e.stopPropagation();
-                    break;
-            }
+        const key = e.key.toLowerCase();
+        if ((key === "escape" || key === "esc") &&
+            document.querySelector(OPEN_MENU_SELECTOR) !== null)
+        {
+            closeMenu();
+            e.preventDefault();
+            e.stopPropagation();
+        }
+    }
+
+    const setEvents = (menus) => {
+        menus = Array.prototype.slice.call(menus);
+        for (const menu of menus) {
+            menu.addEventListener("toggle", menuOnClick);
+            menu.addEventListener("keydown", menuKeyDown);
         }
     };
-    var menus = Array.prototype.slice.call(document.querySelectorAll(".pure-menu-has-children"));
-    var menusLength = menus.length;
-    var menu;
-    for (var i = 0; i < menusLength; ++i) {
-        menu = menus[i];
-        menu.firstElementChild.setAttribute("aria-haspopup", "menu");
-        menu.firstElementChild.nextElementSibling.setAttribute("role", "menu");
-        menu.firstElementChild.addEventListener("click", menuOnClick);
-    }
-    document.documentElement.addEventListener("keydown", menuKeyDown);
+    setEvents(document.querySelectorAll(".nav-container details"));
+
     document.documentElement.addEventListener("keydown", function(ev) {
         if (ev.key == "y" && ev.target.tagName != "INPUT") {
             let permalink = document.getElementById("permalink");

--- a/templates/header/topbar_end.html
+++ b/templates/header/topbar_end.html
@@ -4,13 +4,12 @@
                 {# The global alert, if there is one #}
                 {% include "header/global_alert.html" -%}
 
-                <ul class="pure-menu-list">
-                    <li class="pure-menu-item pure-menu-has-children">
-                        <a href="#" class="pure-menu-link">
+                <div class="pure-menu-list">
+                    <details class="pure-menu-item" aria-haspopup="menu">
+                        <summary>
                             <span title="Releases">{{ "leaf" | fas }}</span>
                             <span class="title">Releases</span>
-                        </a>
-
+                        </summary>
                         <ul class="pure-menu-children">
                             {{ macros::menu_link(href="/releases", text="All Releases") }}
                             {{ macros::menu_link(href="/releases/stars", text="Releases by Stars") }}
@@ -18,11 +17,11 @@
                             {{ macros::menu_link(href="/releases/failures", text="Build Failures by Stars") }}
                             {{ macros::menu_link(href="/releases/activity", text="Release Activity") }}
                         </ul>
-                    </li>{#
+                    </details>{#
 
                     The Rust dropdown menu
-                    #}<li class="pure-menu-item pure-menu-has-children">
-                        <a href="#" class="pure-menu-link" aria-label="Rust">Rust</a>
+                    #}<details class="pure-menu-item" aria-haspopup="menu">
+                        <summary aria-label="Rust">Rust</summary>
                         <ul class="pure-menu-children">
                             {{ macros::menu_link(
                                 href="https://www.rust-lang.org/",
@@ -59,8 +58,8 @@
                                 target="_blank"
                             ) }}
                         </ul>
-                    </li>
-                </ul>
+                    </details>
+                </div>
                 {# The search bar #}
                 <div id="search-input-nav">
                     <label for="nav-search">

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -5,242 +5,233 @@
 
 {%- include "header/topbar_begin.html" -%}{#
 extra whitespace unremovable, need to use html tags unaffacted by whitespace T_T
-#}<ul class="pure-menu-list">
-    {%- if krate -%}
-        <li class="pure-menu-item pure-menu-has-children">
-            <a href="#" class="pure-menu-link crate-name" title="{{ krate.description }}">
-                {{ "cube" | fas }}
-                <span class="title">{{ krate.name }}-{{ krate.version }}</span>
-            </a>
+#}
+{%- if krate -%}
+    <details class="pure-menu-item">
+        <summary class="crate-name" title="{{ krate.description }}">
+            {{ "cube" | fas }}
+            <span class="title">{{ krate.name }}-{{ krate.version }}</span>
+        </summary>
 
-            {# Crate details #}
-            <div class="pure-menu-children package-details-menu">
-                {# Crate name, description and license #}
-                <ul class="pure-menu-list menu-item-divided">
-                    <li class="pure-menu-heading" id="crate-title">
-                        {{ krate.name }} {{ krate.version }}
-                        <span id="clipboard" class="fa-svg fa-svg-fw" title="Copy crate name and version information">{%- include "clipboard.svg" -%}</span>
-                    </li>
+        {# Crate details #}
+        <div class="pure-menu-children package-details-menu">
+            {# Crate name, description and license #}
+            <ul class="pure-menu-list menu-item-divided">
+                <li class="pure-menu-heading" id="crate-title">
+                    {{ krate.name }} {{ krate.version }}
+                    <span id="clipboard" class="fa-svg fa-svg-fw" title="Copy crate name and version information">{%- include "clipboard.svg" -%}</span>
+                </li>
 
-                    {%- if metadata.version_or_latest == "latest" -%}
-                    <li class="pure-menu-item">
-                        <a href="{{permalink_path | safe}}" class="pure-menu-link description" id="permalink" title="Get a link to this specific version">
-                            {{ "link" | fas }} Permalink
-                        </a>
-                    </li>
-                    {%- endif -%}
-
-                    <li class="pure-menu-item">
-                        <a href="{{ crate_url | safe }}" class="pure-menu-link description" title="See {{ krate.name }} in docs.rs">
-                            {{ "cube" | fas(fw=true) }} Docs.rs crate page
-                        </a>
-                    </li>
-
-                    <li class="pure-menu-item">
-                        <a href="{{ crate_url | safe }}" class="pure-menu-link">
-                            {{ "scale-unbalanced-flip" | fas(fw=true) }} {{ krate.license }}
-                        </a>
-                    </li>
-                </ul>
-
-                <div class="pure-g menu-item-divided">
-                    <div class="pure-u-1-2 right-border">
-                        <ul class="pure-menu-list">
-                            <li class="pure-menu-heading">Links</li>
-
-                            {# If the crate has a homepage, show a link to it #}
-                            {%- if krate.homepage_url -%}
-                                <li class="pure-menu-item">
-                                    <a href="{{ krate.homepage_url }}" class="pure-menu-link">
-                                        {{ "house" | fas(fw=true) }} Homepage
-                                    </a>
-                                </li>
-                            {%- endif -%}
-
-                            {# If the crate has external docs, show a link #}
-                            {%- if krate.documentation_url -%}
-                                <li class="pure-menu-item">
-                                    <a href="{{ krate.documentation_url }}" title="Canonical documentation" class="pure-menu-link">
-                                        {{ "file-lines" | far(fw=true) }} Documentation
-                                    </a>
-                                </li>
-                            {%- endif -%}
-
-                            {# If a the crate has a repo url, show it #}
-                            {%- if krate.repository_url -%}
-                                <li class="pure-menu-item">
-                                    <a href="{{ krate.repository_url }}" class="pure-menu-link">
-                                        {{ "code-branch" | fas(fw=true) }} Repository
-                                    </a>
-                                </li>
-                            {%- endif -%}
-
-                            <li class="pure-menu-item">
-                                <a href="https://crates.io/crates/{{ krate.name }}" class="pure-menu-link" title="See {{ krate.name }} in crates.io">
-                                    {{ "cube" | fas(fw=true) }} Crates.io
-                                </a>
-                            </li>
-
-                            {# A link to the release's source view #}
-                            <li class="pure-menu-item">
-                                <a href="{{ crate_url | safe }}/source/" title="Browse source of {{ metadata.name }}-{{ metadata.version }}" class="pure-menu-link">
-                                    {{ "folder-open" | fas(fw=true) }} Source
-                                </a>
-                            </li>
-                        </ul>
-                    </div>
-
-                    {# Show the crate owners #}
-                    <div class="pure-u-1-2">
-                        <ul class="pure-menu-list">
-                            <li class="pure-menu-heading">Owners</li>
-
-                            {%- for owner in krate.owners -%}
-                                <li class="pure-menu-item">
-                                    <a href="https://crates.io/users/{{ owner[0] }}" class="pure-menu-link">
-                                        {{ "user" | fas(fw=true) }} {{ owner[0] }}
-                                    </a>
-                                </li>
-                            {%- endfor -%}
-                        </ul>
-                    </div>
-                </div>
-
-                <div class="pure-g menu-item-divided">
-                    <div class="pure-u-1-2 right-border">
-                        <ul class="pure-menu-list">
-                            <li class="pure-menu-heading">Dependencies</li>
-
-                            {# Display all dependencies that the crate has #}
-                            <li class="pure-menu-item">
-                                <div class="pure-menu pure-menu-scrollable sub-menu" tabindex="-1">
-                                    <ul class="pure-menu-list">
-                                        {%- for dep in krate.dependencies -%}
-                                            <li class="pure-menu-item">
-                                                <a href="/{{ dep[0] }}/{{ dep[1] }}" class="pure-menu-link">
-                                                    {{ dep[0] }} {{ dep[1] }}
-                                                    <i class="dependencies {{ dep[2] | default(value='') }}">{{ dep[2] | default(value="") }}</i>
-                                                </a>
-                                            </li>
-                                        {%- endfor -%}
-                                    </ul>
-                                </div>
-                            </li>
-                        </ul>
-                    </div>
-
-                    <div class="pure-u-1-2">
-                        <ul class="pure-menu-list">
-                            <li class="pure-menu-heading">Versions</li>
-
-                            <li class="pure-menu-item">
-                                <div class="pure-menu pure-menu-scrollable sub-menu" tabindex="-1">
-                                    <ul class="pure-menu-list">
-                                        {# Display all releases of this crate #}
-                                        {{ macros::releases_list(name=krate.name, releases=krate.releases, target=target, inner_path=inner_path) }}
-                                    </ul>
-                                </div>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-                {%- if krate.documented_items and krate.total_items -%}
-                    {% set percent = krate.documented_items * 100 / krate.total_items %}
-                    <div class="pure-g">
-                        <div class="pure-u-1">
-                            <ul class="pure-menu-list">
-                                <li>
-                                    <a href="{{ crate_url | safe }}" class="pure-menu-link">
-                                        <b>{{ percent | round(precision=2) }}%</b>
-                                        of the crate is documented
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                {%- endif -%}
-            </div>
-        </li>
-    {%- else -%}
-        <li class="pure-menu-item">
-            <a href="{{ crate_url | safe }}" class="pure-menu-link crate-name" title="{{ metadata.description }}">
-                {{ "cube" | fas }}
-                <span class="title">{{ metadata.name }}-{{ metadata.version }}</span>
-            </a>
-        </li>
-    {%- endif -%}{#
-
-    If this is the latest release and it's been yanked, just display a warning #}
-    {%- if is_latest_version and metadata.yanked -%}
-        <li class="pure-menu-item">
-            <span class="pure-menu-link warn">
-                {{ "triangle-exclamation" | fas }}
-                <span class="title">This release has been yanked</span>
-            </span>
-        </li>{#
-
-    If this isn't the most recent stable release, offer a link to the latest #}
-    {%- elif not is_latest_version -%}
-        {%- if metadata.yanked -%}
-            {%- set tooltip = "You are seeing a yanked version of the " ~ metadata.name ~ " crate. Click here to go to the latest version." -%}
-            {%- set title = "This release has been yanked, go to latest version" -%}
-        {%- elif is_prerelease -%}
-            {%- set tooltip = "You are seeing a pre-release version of the " ~ metadata.name ~ " crate. Click here to go to the latest stable version." -%}
-            {%- set title = "Go to latest stable release" -%}
-        {%- else -%}
-            {%- set tooltip = "You are seeing an outdated version of the " ~ metadata.name ~ " crate. Click here to go to the latest version." -%}
-            {%- set title = "Go to latest version" -%}
-        {%- endif -%}
-
-        <li class="pure-menu-item">
-            <a href="{{ latest_path | safe }}" class="pure-menu-link warn"
-                data-fragment="retain"
-                title="{{ tooltip }}">
-                {{ "triangle-exclamation" | fas }}
-                <span class="title">{{ title }}</span>
-            </a>
-        </li>
-    {%- endif -%}
-
-    {# Display the platforms that the release has been built for #}
-    {%- if metadata.doc_targets -%}
-    <li class="pure-menu-item pure-menu-has-children">
-        <a href="#" class="pure-menu-link" aria-label="Platform">
-            {{ "gears" | fas }}
-            <span class="title">Platform</span>
-        </a>
-
-        {# Build the dropdown list showing available targets #}
-        <ul class="pure-menu-children">
-            {%- for target in metadata.doc_targets -%}
-                {#
-                    The crate-detail page is the only page where we want to allow google to follow
-                    the target-links. On that page we also don't have to use `/target-redirect/`
-                    because the documentation root page is guaranteed to exist for all targets.
-                #}
-                {%- if use_direct_platform_links -%}
-                    {%- set target_url = "/" ~ metadata.name ~ "/" ~ metadata.version_or_latest ~ "/" ~ target ~ "/" ~ inner_path -%}
-                    {%- set target_no_follow = "" -%}
-                {%- else -%}
-                    {%- set target_url = "/crate/" ~ metadata.name ~ "/" ~ metadata.version_or_latest ~ "/target-redirect/" ~ target ~ "/" ~ inner_path -%}
-                    {%- set target_no_follow = "nofollow" -%}
+                {%- if metadata.version_or_latest == "latest" -%}
+                <li class="pure-menu-item">
+                    <a href="{{permalink_path | safe}}" class="pure-menu-link description" id="permalink" title="Get a link to this specific version">
+                        {{ "link" | fas }} Permalink
+                    </a>
+                </li>
                 {%- endif -%}
 
                 <li class="pure-menu-item">
-                    <a href="{{ target_url | safe }}" class="pure-menu-link" data-fragment="retain" rel="{{ target_no_follow }}">
-                        {{- target -}}
+                    <a href="{{ crate_url | safe }}" class="pure-menu-link description" title="See {{ krate.name }} in docs.rs">
+                        {{ "cube" | fas(fw=true) }} Docs.rs crate page
                     </a>
                 </li>
-            {%- endfor -%}
-        </ul>
-    </li>{#
-    Display the features available in current build
-  #}<li class="pure-menu-item">
-        <a href="{{ crate_url | safe }}/features" title="Browse available feature flags of {{ metadata.name }}-{{ metadata.version }}" class="pure-menu-link">
-            {{ "flag" | fas }}
-            <span class="title">Feature flags</span>
-        </a>
-    </li>
-    {% endif %}
-</ul>
+
+                <li class="pure-menu-item">
+                    <a href="{{ crate_url | safe }}" class="pure-menu-link">
+                        {{ "scale-unbalanced-flip" | fas(fw=true) }} {{ krate.license }}
+                    </a>
+                </li>
+            </ul>
+
+            <div class="pure-g menu-item-divided">
+                <div class="pure-u-1-2 right-border">
+                    <ul class="pure-menu-list">
+                        <li class="pure-menu-heading">Links</li>
+
+                        {# If the crate has a homepage, show a link to it #}
+                        {%- if krate.homepage_url -%}
+                            <li class="pure-menu-item">
+                                <a href="{{ krate.homepage_url }}" class="pure-menu-link">
+                                    {{ "house" | fas(fw=true) }} Homepage
+                                </a>
+                            </li>
+                        {%- endif -%}
+
+                        {# If the crate has external docs, show a link #}
+                        {%- if krate.documentation_url -%}
+                            <li class="pure-menu-item">
+                                <a href="{{ krate.documentation_url }}" title="Canonical documentation" class="pure-menu-link">
+                                    {{ "file-lines" | far(fw=true) }} Documentation
+                                </a>
+                            </li>
+                        {%- endif -%}
+
+                        {# If a the crate has a repo url, show it #}
+                        {%- if krate.repository_url -%}
+                            <li class="pure-menu-item">
+                                <a href="{{ krate.repository_url }}" class="pure-menu-link">
+                                    {{ "code-branch" | fas(fw=true) }} Repository
+                                </a>
+                            </li>
+                        {%- endif -%}
+
+                        <li class="pure-menu-item">
+                            <a href="https://crates.io/crates/{{ krate.name }}" class="pure-menu-link" title="See {{ krate.name }} in crates.io">
+                                {{ "cube" | fas(fw=true) }} Crates.io
+                            </a>
+                        </li>
+
+                        {# A link to the release's source view #}
+                        <li class="pure-menu-item">
+                            <a href="{{ crate_url | safe }}/source/" title="Browse source of {{ metadata.name }}-{{ metadata.version }}" class="pure-menu-link">
+                                {{ "folder-open" | fas(fw=true) }} Source
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+
+                {# Show the crate owners #}
+                <div class="pure-u-1-2">
+                    <ul class="pure-menu-list">
+                        <li class="pure-menu-heading">Owners</li>
+
+                        {%- for owner in krate.owners -%}
+                            <li class="pure-menu-item">
+                                <a href="https://crates.io/users/{{ owner[0] }}" class="pure-menu-link">
+                                    {{ "user" | fas(fw=true) }} {{ owner[0] }}
+                                </a>
+                            </li>
+                        {%- endfor -%}
+                    </ul>
+                </div>
+            </div>
+
+            <div class="pure-g menu-item-divided">
+                <div class="pure-u-1-2 right-border">
+                    <ul class="pure-menu-list">
+                        <li class="pure-menu-heading">Dependencies</li>
+
+                        {# Display all dependencies that the crate has #}
+                        <li class="pure-menu-item">
+                            <div class="pure-menu pure-menu-scrollable sub-menu" tabindex="-1">
+                                <ul class="pure-menu-list">
+                                    {%- for dep in krate.dependencies -%}
+                                        <li class="pure-menu-item">
+                                            <a href="/{{ dep[0] }}/{{ dep[1] }}" class="pure-menu-link">
+                                                {{ dep[0] }} {{ dep[1] }}
+                                                <i class="dependencies {{ dep[2] | default(value='') }}">{{ dep[2] | default(value="") }}</i>
+                                            </a>
+                                        </li>
+                                    {%- endfor -%}
+                                </ul>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+
+                <div class="pure-u-1-2">
+                    <ul class="pure-menu-list">
+                        <li class="pure-menu-heading">Versions</li>
+
+                        <li class="pure-menu-item">
+                            <div class="pure-menu pure-menu-scrollable sub-menu" tabindex="-1">
+                                <ul class="pure-menu-list">
+                                    {# Display all releases of this crate #}
+                                    {{ macros::releases_list(name=krate.name, releases=krate.releases, target=target, inner_path=inner_path) }}
+                                </ul>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            {%- if krate.documented_items and krate.total_items -%}
+                {% set percent = krate.documented_items * 100 / krate.total_items %}
+                <div class="pure-g">
+                    <div class="pure-u-1">
+                        <ul class="pure-menu-list">
+                            <li>
+                                <a href="{{ crate_url | safe }}" class="pure-menu-link">
+                                    <b>{{ percent | round(precision=2) }}%</b>
+                                    of the crate is documented
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            {%- endif -%}
+        </div>
+    </details>
+{%- else -%}
+    <a href="{{ crate_url | safe }}" class="pure-menu-item pure-menu-link crate-name" title="{{ metadata.description }}">
+        {{ "cube" | fas }}
+        <span class="title">{{ metadata.name }}-{{ metadata.version }}</span>
+    </a>
+{%- endif -%}{#
+
+If this is the latest release and it's been yanked, just display a warning #}
+{%- if is_latest_version and metadata.yanked -%}
+    <span class="pure-menu-item pure-menu-link warn">
+        {{ "triangle-exclamation" | fas }}
+        <span class="title">This release has been yanked</span>
+    </span>{#
+
+If this isn't the most recent stable release, offer a link to the latest #}
+{%- elif not is_latest_version -%}
+    {%- if metadata.yanked -%}
+        {%- set tooltip = "You are seeing a yanked version of the " ~ metadata.name ~ " crate. Click here to go to the latest version." -%}
+        {%- set title = "This release has been yanked, go to latest version" -%}
+    {%- elif is_prerelease -%}
+        {%- set tooltip = "You are seeing a pre-release version of the " ~ metadata.name ~ " crate. Click here to go to the latest stable version." -%}
+        {%- set title = "Go to latest stable release" -%}
+    {%- else -%}
+        {%- set tooltip = "You are seeing an outdated version of the " ~ metadata.name ~ " crate. Click here to go to the latest version." -%}
+        {%- set title = "Go to latest version" -%}
+    {%- endif -%}
+
+    <a href="{{ latest_path | safe }}" class="pure-menu-item pure-menu-link warn"
+        data-fragment="retain"
+        title="{{ tooltip }}">
+        {{ "triangle-exclamation" | fas }}
+        <span class="title">{{ title }}</span>
+    </a>
+{%- endif -%}
+
+{# Display the platforms that the release has been built for #}
+{%- if metadata.doc_targets -%}
+<details class="pure-menu-item">
+    <summary class="pure-menu-link" aria-label="Platform">
+        {{ "gears" | fas }}
+        <span class="title">Platform</span>
+    </summary>
+
+    {# Build the dropdown list showing available targets #}
+    <ul class="pure-menu-children">
+        {%- for target in metadata.doc_targets -%}
+            {#
+                The crate-detail page is the only page where we want to allow google to follow
+                the target-links. On that page we also don't have to use `/target-redirect/`
+                because the documentation root page is guaranteed to exist for all targets.
+            #}
+            {%- if use_direct_platform_links -%}
+                {%- set target_url = "/" ~ metadata.name ~ "/" ~ metadata.version_or_latest ~ "/" ~ target ~ "/" ~ inner_path -%}
+                {%- set target_no_follow = "" -%}
+            {%- else -%}
+                {%- set target_url = "/crate/" ~ metadata.name ~ "/" ~ metadata.version_or_latest ~ "/target-redirect/" ~ target ~ "/" ~ inner_path -%}
+                {%- set target_no_follow = "nofollow" -%}
+            {%- endif -%}
+
+            <li class="pure-menu-item">
+                <a href="{{ target_url | safe }}" class="pure-menu-link" data-fragment="retain" rel="{{ target_no_follow }}">
+                    {{- target -}}
+                </a>
+            </li>
+        {%- endfor -%}
+    </ul>
+</details>{#
+Display the features available in current build
+#}<a href="{{ crate_url | safe }}/features" title="Browse available feature flags of {{ metadata.name }}-{{ metadata.version }}" class="pure-menu-item pure-menu-link">
+    {{ "flag" | fas }}
+    <span class="title">Feature flags</span>
+</a>
+{% endif %}
 {%- include "header/topbar_end.html" -%}

--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -34,25 +34,9 @@ div.nav-container {
         height: 100%;
     }
 
-    li {
-        border-left: 1px solid var(--color-border);
-    }
-
-    .pure-menu-has-children > .pure-menu-link {
-        background-color: var(--color-background);
-
-        &:hover {
-            background-color: var(--color-background);
-        }
-        &:after {
-            font-size: 12.8px;
-            content: "\25BC"
-        }
-    }
-
-    .pure-menu-has-children.pure-menu-active > .pure-menu-link {
-        &:after {
-            content:"\25B2";
+    .landing-search-form-nav {
+        > .pure-menu-item, li {
+            border-left: 1px solid var(--color-border);
         }
     }
 
@@ -156,6 +140,35 @@ div.nav-container {
 
         li {
             border-left: none;
+        }
+    }
+
+    details.pure-menu-item {
+        > summary::-webkit-details-marker,
+        > .dropdown > summary::marker {
+           display: none;
+        }
+
+        > summary {
+            padding: 6.4px 16px 6.4px 16px;
+            margin: 0;
+            font-size: 12.8px;
+            display: inline-block;
+            vertical-align: middle;
+            cursor: pointer;
+        }
+
+        > summary::after {
+            content: "▼";
+            padding-left: .5em;
+        }
+
+        &[open] > summary::after {
+            content: "▲";
+        }
+
+        .pure-menu-children {
+            display: block;
         }
     }
 


### PR DESCRIPTION
First, there should be no UI changes. I replaced the dropdown menus in the topbar with `<details>` instead which work nicely with keyboard events and don't require JS, hence why the JS reduced drastically. Another big advantage is that it'll be possible to collapse/expand menus even without JS (the position of the dropdown will be a bit less good but that's the only downside).

There is one notable change though: in the current version of my changes, the ESCAPE and arrow keys don't work anymore. To expand/collapse a menu entry, you'll need to click on it or press ENTER/SPACE when it's focused.

With these changes, the JS is only here to prevent having two menus expanded at the same time and to still have the dropdown menu position working smoothly.

cc @Nemo157 @jsha 