### PR TITLE
upgrade to axum 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.5.17"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -563,8 +563,10 @@ dependencies = [
  "mime 0.3.16",
  "percent-encoding 2.2.0",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
@@ -576,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
+checksum = "79b8558f5a0581152dc94dcd289132a1d377494bdeafcd41869b3258e3e2ad92"
 dependencies = [
  "async-trait",
  "bytes",
@@ -586,6 +588,26 @@ dependencies = [
  "http",
  "http-body",
  "mime 0.3.16",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a320103719de37b7b4da4c8eb629d4573f6bcfd3dfe80d3208806895ccf81d"
+dependencies = [
+ "axum",
+ "bytes",
+ "futures-util",
+ "http",
+ "mime 0.3.16",
+ "pin-project-lite",
+ "tokio",
+ "tower",
+ "tower-http",
  "tower-layer",
  "tower-service",
 ]
@@ -1402,6 +1424,7 @@ dependencies = [
  "aws-smithy-http",
  "aws-smithy-types-convert",
  "axum",
+ "axum-extra",
  "backtrace",
  "base64 0.13.1",
  "bzip2",
@@ -3083,9 +3106,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "matchit"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "maybe-async"
@@ -4809,6 +4832,15 @@ checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa 1.0.4",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "184c643044780f7ceb59104cef98a5a6f12cb2288a7bc701ab93a362b49fd47d"
+dependencies = [
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,8 @@ iron = "0.6"
 router = "0.6"
 
 # axum dependencies
-axum = "0.5.17"
+axum = "0.6.1"
+axum-extra = "0.4.2"
 hyper = { version = "0.14.15", default-features = false }
 tower = "0.4.11"
 tower-service = "0.3.2"

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -587,7 +587,7 @@ impl TestFrontend {
                         .unwrap()
                         .serve(
                             axum_app
-                                .fallback(
+                                .fallback_service(
                                     build_strangler_service(iron_server.socket)
                                         .expect("could not build strangler service"),
                                 )

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -514,7 +514,7 @@ pub fn start_web_server(addr: Option<&str>, context: &dyn Context) -> Result<(),
         axum::Server::bind(&axum_addr)
             .serve(
                 build_axum_app(context, template_data)?
-                    .fallback(build_strangler_service(iron_server.socket)?)
+                    .fallback_service(build_strangler_service(iron_server.socket)?)
                     .into_make_service(),
             )
             .await?;

--- a/src/web/statics.rs
+++ b/src/web/statics.rs
@@ -30,11 +30,11 @@ pub(crate) async fn static_handler(Path(path): Path<String>) -> AxumResult<impl 
     let text_css: Mime = "text/css".parse().unwrap();
 
     Ok(match path.as_str() {
-        "/vendored.css" => build_response(VENDORED_CSS, text_css),
-        "/style.css" => build_response(STYLE_CSS, text_css),
-        "/rustdoc.css" => build_response(RUSTDOC_CSS, text_css),
-        "/rustdoc-2021-12-05.css" => build_response(RUSTDOC_2021_12_05_CSS, text_css),
-        file => match serve_file(&file[1..]).await {
+        "vendored.css" => build_response(VENDORED_CSS, text_css),
+        "style.css" => build_response(STYLE_CSS, text_css),
+        "rustdoc.css" => build_response(RUSTDOC_CSS, text_css),
+        "rustdoc-2021-12-05.css" => build_response(RUSTDOC_2021_12_05_CSS, text_css),
+        file => match serve_file(file).await {
             Ok(response) => response.into_response(),
             Err(err) => return Err(err),
         },


### PR DESCRIPTION
For the next set of routes I'm running into some routing problems, which are fixed with axum 0.6. 

Also the bug I reported ( https://github.com/tokio-rs/axum/issues/1605 ) was fixed ( in https://github.com/tokio-rs/axum/issues/1605 ) and released in `axum-extra==0.4.2`. 

The old router only does the trialing-slash-redirects for `internal_page` routes, so I'm doing that too, and don't redirect for trialing slashes for the other routes. 