### PR TITLE
Add -Zrustdoc-scrape-examples to default Cargo args

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -736,6 +736,9 @@ impl RustwideBuilder {
                 r#"--config=doc.extern-map.registries.crates-io="https://docs.rs/{{pkg_name}}/{{version}}/{}""#,
                 target
             ),
+            // Enables the unstable rustdoc-scrape-examples feature. We are "soft launching" this feature on
+            // docs.rs, but once it's stable we can remove this flag.
+            "-Zrustdoc-scrape-examples".into(),
         ];
         if let Some(cpu_limit) = self.config.build_cpu_limit {
             cargo_args.push(format!("-j{}", cpu_limit));


### PR DESCRIPTION
This PR adds `-Zrustdoc-scrape-examples` to the set of default arguments passed to `cargo doc`. This (finally!) enables the scrape-examples feature to be enabled by default for all readers of docs.rs. 

After extensive work within Cargo (rust-lang/cargo#10343, rust-lang/cargo#10533, rust-lang/cargo#10549, rust-lang/cargo#11430, rust-lang/cargo#11450), this option is now robust enough to avoid breaking any existing build. Any crate that documented before will still document with `-Zrustdoc-scrape-examples`. The core issue that was addressed is to not require dev-dependencies if they weren't already needed.

I have verified that `-Zrustdoc-scrape-examples` does not introduce breakage in a recent Crater run: <https://crater-reports.s3.amazonaws.com/scrape-examples/index.html>
(Note there are regressions, but they appear to be spurious and not related to the scrape-examples feature.)

~~This PR is currently a draft because I am waiting on rust-lang/cargo#11450 to reach nightly in a few days. But I wanted to put it up before then to provide room for discussion if someone is not comfortable enabling this flag.~~

cc @jyn514 @GuillaumeGomez @jsha 