### PR TITLE
implement CDN invalidation queue & background worker

### DIFF
--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -859,7 +859,29 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> crate::error::Res
             ALTER TABLE owners ADD COLUMN name VARCHAR(255);
             ",
         ),
-
+        sql_migration!(
+            context, 37, "add cdn-invalidation-queue table",
+            " 
+            CREATE TABLE cdn_invalidation_queue (
+                id BIGSERIAL,
+                crate VARCHAR(255) NOT NULL,
+                cdn_distribution_id VARCHAR(255) NOT NULL,
+                path_pattern text NOT NULL,
+                queued TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                created_in_cdn TIMESTAMP WITH TIME ZONE,
+                cdn_reference VARCHAR(255)
+            );
+            CREATE INDEX cdn_invalidation_queue_crate_idx ON cdn_invalidation_queue (crate);
+            CREATE INDEX cdn_invalidation_queue_cdn_reference_idx ON cdn_invalidation_queue (cdn_reference);
+            CREATE INDEX cdn_invalidation_queue_created_in_cdn_idx ON cdn_invalidation_queue (created_in_cdn);
+            ",
+            "
+            DROP INDEX cdn_invalidation_queue_crate_idx;
+            DROP INDEX cdn_invalidation_queue_cdn_reference_idx;
+            DROP INDEX cdn_invalidation_queue_created_in_cdn_idx;
+            DROP TABLE cdn_invalidation_queue;
+            "
+        ),
     ];
 
     for migration in migrations {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub mod db;
 mod docbuilder;
 mod error;
 pub mod index;
-mod metrics;
+pub mod metrics;
 pub mod repositories;
 pub mod storage;
 #[cfg(test)]

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -38,7 +38,6 @@ pub(crate) struct FakeRelease<'a> {
 pub(crate) struct FakeBuild {
     s3_build_log: Option<String>,
     db_build_log: Option<String>,
-    build_time: Option<DateTime<Utc>>,
     result: BuildResult,
 }
 
@@ -459,12 +458,6 @@ impl FakeGithubStats {
 }
 
 impl FakeBuild {
-    pub(crate) fn build_time(self, build_time: impl Into<DateTime<Utc>>) -> Self {
-        Self {
-            build_time: Some(build_time.into()),
-            ..self
-        }
-    }
     pub(crate) fn rustc_version(self, rustc_version: impl Into<String>) -> Self {
         Self {
             result: BuildResult {
@@ -532,13 +525,6 @@ impl FakeBuild {
             )?;
         }
 
-        if let Some(build_time) = self.build_time.as_ref() {
-            conn.query(
-                "UPDATE builds SET build_time = $2 WHERE id = $1",
-                &[&build_id, &build_time],
-            )?;
-        }
-
         if let Some(s3_build_log) = self.s3_build_log.as_deref() {
             let path = format!("build-logs/{}/{}.txt", build_id, default_target);
             storage.store_one(path, s3_build_log)?;
@@ -553,7 +539,6 @@ impl Default for FakeBuild {
         Self {
             s3_build_log: Some("It works!".into()),
             db_build_log: None,
-            build_time: None,
             result: BuildResult {
                 rustc_version: "rustc 2.0.0-nightly (000000000 1970-01-01)".into(),
                 docsrs_version: "docs.rs 1.0.0 (000000000 1970-01-01)".into(),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -321,7 +321,6 @@ impl TestEnvironment {
                     self.db().pool(),
                     self.metrics(),
                     self.config(),
-                    self.cdn(),
                     self.storage(),
                 ))
             })

--- a/templates/releases/build_queue.html
+++ b/templates/releases/build_queue.html
@@ -18,10 +18,10 @@
                 <div class = "pure-g">
                     <div class="pure-u-1-2">
                         <ol class="queue-list">
-                            {% for invalidation in active_deployments -%}
+                            {% for krate in active_deployments -%}
                                 <li>
-                                    <a href="https://docs.rs/{{ invalidation.name }}">
-                                        {{ invalidation.name }}
+                                    <a href="https://docs.rs/{{ krate }}">
+                                        {{ krate }}
                                     </a>
                                 </li>
                             {%- endfor %}


### PR DESCRIPTION
To work around the Cloudfront limit (max 15 active wildcard invalidations), this implements a queue & batching for CDN invalidations. 

- this would solve https://sentry.io/organizations/rust-lang/issues/3749747987/ 
- the list of active invalidations on our build queue page will then also be based on actual data from cloudfront. 
- Since we only queue the invalidation, we might wait up to a minute to actually hand it over to cloudfront. 

So when we get a bunch of changes at once (many small builds, many failed builds, ....) these would be queued and executed over time. 

I was also thinking about adding invalidation-related metrics, but then decided to move this to a later point when we have this code running for some time. 

When the invalidations work reliably we can finally slowly introduce the full page caching for our docs. 