### PR TITLE
Add a route for scrape-examples-help.html. Fixes #1960.

### DIFF
--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -260,6 +260,10 @@ pub(super) fn build_routes() -> Routes {
         super::rustdoc::rustdoc_html_server_handler,
     );
     routes.rustdoc_page(
+        "/:crate/:version/scrape-examples-help.html",
+        super::rustdoc::rustdoc_html_server_handler,
+    );
+    routes.rustdoc_page(
         "/:crate/:version/all.html",
         super::rustdoc::rustdoc_html_server_handler,
     );

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -933,6 +933,7 @@ mod test {
                 .version("0.1.0")
                 .archive_storage(archive_storage)
                 .rustdoc_file("settings.html")
+                .rustdoc_file("scrape-examples-help.html")
                 .rustdoc_file("directory_1/index.html")
                 .rustdoc_file("directory_2.html/index.html")
                 .rustdoc_file("all.html")
@@ -973,6 +974,12 @@ mod test {
             )?;
             assert_success_cached(
                 "/buggy/0.1.0/settings.html",
+                web,
+                CachePolicy::ForeverInCdnAndStaleInBrowser,
+                &env.config(),
+            )?;
+            assert_success_cached(
+                "/buggy/0.1.0/scrape-examples-help.html",
                 web,
                 CachePolicy::ForeverInCdnAndStaleInBrowser,
                 &env.config(),


### PR DESCRIPTION
This PR adds a route for the new `scrape-examples-help.html` file generated by Rustdoc. I also updated one of the tests to verify that the file is generated / served.