### PR TITLE
fix add-essential-files  command

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -219,6 +219,7 @@ impl RustwideBuilder {
     }
 
     pub fn add_essential_files(&mut self) -> Result<()> {
+        self.rustc_version = self.detect_rustc_version()?;
         let rustc_version = parse_rustc_version(&self.rustc_version)?;
 
         info!("building a dummy crate to get essential files");


### PR DESCRIPTION
when working on making the local build work on my ARM, I stumbled on this issue where running `cratesfyi build add-essential-files` won't work any more. 

This could be a regression from #1892 , though I don't fully understand why the change was made in that PR. 

Any insight? @jsha @jyn514 