### PR TITLE
URL-encode canonical URLs when they can include UTF8 characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,6 +1448,7 @@ dependencies = [
  "mockito",
  "once_cell",
  "path-slash",
+ "percent-encoding 2.2.0",
  "postgres",
  "postgres-types",
  "procfs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ tower-service = "0.3.2"
 tower-http = { version = "0.3.4", features = ["trace"] }
 mime = "0.3.16"
 httpdate = "1.0.2"
+percent-encoding = "2.2.0"
 
 # NOTE: if you change this, also double-check that the comment in `queue_builder::remove_tempdirs` is still accurate.
 tempfile = "3.1.0"

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -115,6 +115,7 @@ use iron::{
     Chain, Handler, Iron, IronError, IronResult, Listening, Request, Response, Url,
 };
 use page::TemplateData;
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use postgres::Client;
 use router::{NoRoute, TrailingSlash};
 use semver::{Version, VersionReq};
@@ -125,6 +126,15 @@ use strangler::StranglerService;
 use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
 use url::form_urlencoded;
+
+// from https://github.com/servo/rust-url/blob/master/url/src/parser.rs
+// and https://github.com/tokio-rs/axum/blob/main/axum-extra/src/lib.rs
+const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`');
+const PATH: &AsciiSet = &FRAGMENT.add(b'#').add(b'?').add(b'{').add(b'}');
+
+pub(crate) fn encode_url_path(path: &str) -> String {
+    utf8_percent_encode(path, PATH).to_string()
+}
 
 /// Duration of static files for staticfile and DatabaseFileHandler (in seconds)
 const STATIC_FILE_CACHE_DURATION: u64 = 60 * 60 * 24 * 30 * 12; // 12 months


### PR DESCRIPTION
This fixes https://sentry.io/organizations/rust-lang/issues/3825062048/ 

( the error only means we had invalid canonical URLs before, these only weren't validated yet)