### PR TITLE
remove `oldtime` feature from `chrono` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ tera = { version = "1.5.0", features = ["builtins"] }
 walkdir = "2"
 
 # Date and Time utilities
-chrono = { version = "0.4.11", features = ["serde"] }
+chrono = { version = "0.4.11", default-features = false, features = ["clock", "serde"] }
 time = "0.1" # TODO: Remove once `iron` is removed
 
 # Transitive dependencies we don't use directly but need to have specific versions of


### PR DESCRIPTION
I checked why after #1963 we still have a dependency to time@0.1. 

Chrono actually tried to stay backwards-compatible and introduced an `oldtime` feature, which is default. 

Removing it also removes the depdency to the old time crate. 

Checking the other dependencies: 
```
$ cargo tree -i time@0.1.45
time v0.1.45
├── chrono v0.4.23
│   ├── aws-smithy-types-convert v0.51.0
│   │   └── docs-rs v0.6.0 (/Users/syphar/src/rust-lang/docs.rs)
│   ├── chrono-tz v0.6.3
│   │   └── tera v1.17.1
│   │       └── docs-rs v0.6.0 (/Users/syphar/src/rust-lang/docs.rs)
│   ├── docs-rs v0.6.0 (/Users/syphar/src/rust-lang/docs.rs)
│   ├── postgres-types v0.2.4
│   │   ├── docs-rs v0.6.0 (/Users/syphar/src/rust-lang/docs.rs)
│   │   └── tokio-postgres v0.7.7
│   │       └── postgres v0.19.4
│   │           ├── docs-rs v0.6.0 (/Users/syphar/src/rust-lang/docs.rs)
│   │           ├── r2d2_postgres v0.18.1
│   │           │   └── docs-rs v0.6.0 (/Users/syphar/src/rust-lang/docs.rs)
│   │           └── schemamama_postgres v0.3.0
│   │               └── docs-rs v0.6.0 (/Users/syphar/src/rust-lang/docs.rs)
│   └── tera v1.17.1 (*)
├── docs-rs v0.6.0 (/Users/syphar/src/rust-lang/docs.rs)
└── hyper v0.10.16
    └── iron v0.6.1
        ├── docs-rs v0.6.0 (/Users/syphar/src/rust-lang/docs.rs)
        └── router v0.6.0
            └── docs-rs v0.6.0 (/Users/syphar/src/rust-lang/docs.rs)
```

They _all_ changed to dropping the `oldtime` feature in recent releases. 

So when this PRs is merged, and these: 
- #1971
- #1970
- #1963 

then we can drop the audit-ignore for the `time` and `chrono` `localtime_r` rustsec entries. 