### PR TITLE
remove unused `systemstat` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1458,7 +1458,6 @@ dependencies = [
  "string_cache_codegen",
  "strum",
  "syntect",
- "systemstat",
  "tempfile",
  "tera",
  "test-case",
@@ -4844,20 +4843,6 @@ dependencies = [
  "thiserror",
  "walkdir",
  "yaml-rust",
-]
-
-[[package]]
-name = "systemstat"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5158fd55089515c923306476aaf3fa8ffc29a902561bf0017166a93218831c"
-dependencies = [
- "bytesize",
- "lazy_static",
- "libc",
- "nom",
- "time",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ syntect = { version = "5.0.0", default-features = false, features = ["parsing", 
 toml = "0.5"
 schemamama = "0.3"
 schemamama_postgres = "0.3"
-systemstat = "0.2.0"
 prometheus = { version = "0.13.0", default-features = false }
 rustwide = { version = "0.15.0", features = ["unstable-toolchain-ci"] }
 mime_guess = "2"


### PR DESCRIPTION
`cargo udeps` gave me this output, I didn't find any usages of it in our codebase. 