### PR TITLE
refactor redirects & canonical URL generation for path encoding

### DIFF
--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -318,8 +318,8 @@ pub(crate) async fn crate_details_handler(
 ) -> AxumResult<AxumResponse> {
     // this handler must always called with a crate name
     if params.version.is_none() {
-        return Ok(super::axum_cached_redirect(
-            &format!("/crate/{}/latest", params.name),
+        return Ok(super::internal_redirect(
+            format!("/crate/{}/latest", params.name),
             CachePolicy::ForeverInCdn,
         )?
         .into_response());
@@ -342,8 +342,8 @@ pub(crate) async fn crate_details_handler(
         MatchSemver::Exact((version, _)) => (version.clone(), version, false),
         MatchSemver::Latest((version, _)) => (version, "latest".to_string(), true),
         MatchSemver::Semver((version, _)) => {
-            return Ok(super::axum_cached_redirect(
-                &format!("/crate/{}/{}", &params.name, version),
+            return Ok(super::internal_redirect(
+                format!("/crate/{}/{}", &params.name, version),
                 CachePolicy::ForeverInCdn,
             )?
             .into_response());

--- a/src/web/features.rs
+++ b/src/web/features.rs
@@ -1,3 +1,4 @@
+use super::headers::CanonicalUrl;
 use super::MatchSemver;
 use crate::db::types::Feature;
 use crate::{
@@ -16,12 +17,12 @@ use std::collections::{HashMap, VecDeque};
 
 const DEFAULT_NAME: &str = "default";
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 struct FeaturesPage {
     metadata: MetaData,
     features: Option<Vec<Feature>>,
     default_len: usize,
-    canonical_url: String,
+    canonical_url: CanonicalUrl,
     is_latest_url: bool,
 }
 
@@ -47,8 +48,8 @@ pub(crate) async fn build_features_handler(
             MatchSemver::Latest((version, _)) => (version, "latest".to_string(), true),
 
             MatchSemver::Semver((version, _)) => {
-                return Ok(super::axum_cached_redirect(
-                    &format!("/crate/{}/{}/features", &name, version),
+                return Ok(super::internal_redirect(
+                    format!("/crate/{}/{}/features", &name, version),
                     CachePolicy::ForeverInCdn,
                 )?
                 .into_response());
@@ -87,7 +88,7 @@ pub(crate) async fn build_features_handler(
         features,
         default_len,
         is_latest_url,
-        canonical_url: format!("https://docs.rs/crate/{}/latest/features", &name),
+        canonical_url: CanonicalUrl::from_path(format!("/crate/{}/latest/features", &name))?,
     }
     .into_response())
 }

--- a/src/web/headers.rs
+++ b/src/web/headers.rs
@@ -22,8 +22,7 @@ impl CanonicalUrl {
             .authority("docs.rs")
             .path_and_query(self.0.clone())
             .build()
-            // this unwrap can't fail because PathAndQuery is valid
-            .unwrap()
+            .expect("this unwrap can't fail because PathAndQuery is valid")
     }
 }
 

--- a/src/web/headers.rs
+++ b/src/web/headers.rs
@@ -1,10 +1,31 @@
+use super::encode_path_for_uri;
+use anyhow::Result;
 use axum::{
     headers::{Header, HeaderName, HeaderValue},
-    http::uri::Uri,
+    http::uri::{PathAndQuery, Uri},
 };
+use serde::Serialize;
 
 /// simplified typed header for a `Link rel=canonical` header in the response.
-pub struct CanonicalUrl(pub Uri);
+/// Only takes the path to be used, url-encodes it and attaches domain & schema to it.
+#[derive(Debug, Clone)]
+pub struct CanonicalUrl(PathAndQuery);
+
+impl CanonicalUrl {
+    pub fn from_path<P: AsRef<str>>(path: P) -> Result<Self> {
+        Ok(Self(encode_path_for_uri(path)?))
+    }
+
+    fn build_full_uri(&self) -> Uri {
+        Uri::builder()
+            .scheme("https")
+            .authority("docs.rs")
+            .path_and_query(self.0.clone())
+            .build()
+            // this unwrap can't fail because PathAndQuery is valid
+            .unwrap()
+    }
+}
 
 impl Header for CanonicalUrl {
     fn name() -> &'static HeaderName {
@@ -22,9 +43,20 @@ impl Header for CanonicalUrl {
     where
         E: Extend<HeaderValue>,
     {
-        let value: HeaderValue = format!(r#"<{}>; rel="canonical""#, self.0).parse().unwrap();
+        let value: HeaderValue = format!(r#"<{}>; rel="canonical""#, self.build_full_uri())
+            .parse()
+            .unwrap();
 
         values.extend(std::iter::once(value));
+    }
+}
+
+impl Serialize for CanonicalUrl {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.build_full_uri().to_string())
     }
 }
 
@@ -36,9 +68,32 @@ mod tests {
     use axum::http::HeaderMap;
 
     #[test]
+    fn test_serialize_canonical() {
+        let url = CanonicalUrl::from_path("/some/path/").unwrap();
+
+        assert_eq!(
+            serde_json::to_string(&url).unwrap(),
+            "\"https://docs.rs/some/path/\""
+        );
+    }
+
+    #[test]
     fn test_encode_canonical() {
         let mut map = HeaderMap::new();
-        map.typed_insert(CanonicalUrl("http://something/".parse().unwrap()));
-        assert_eq!(map["link"], "<http://something/>; rel=\"canonical\"");
+        map.typed_insert(CanonicalUrl::from_path("/some/path/").unwrap());
+        assert_eq!(
+            map["link"],
+            "<https://docs.rs/some/path/>; rel=\"canonical\""
+        );
+    }
+
+    #[test]
+    fn test_encode_canonical_with_encoding() {
+        let mut map = HeaderMap::new();
+        map.typed_insert(CanonicalUrl::from_path("/some/äöü/").unwrap());
+        assert_eq!(
+            map["link"],
+            "<https://docs.rs/some/%C3%A4%C3%B6%C3%BC/>; rel=\"canonical\""
+        );
     }
 }

--- a/src/web/page/web_page.rs
+++ b/src/web/page/web_page.rs
@@ -84,17 +84,13 @@ macro_rules! impl_axum_webpage {
 
                 $(
                     let canonical_url = {
-                        let canonical_url: fn(&Self) -> Option<String> = $canonical_url;
+                        let canonical_url: fn(&Self) -> Option<$crate::web::headers::CanonicalUrl> = $canonical_url;
                         (canonical_url)(&self)
                     };
                     if let Some(canonical_url) = canonical_url {
                         use axum::headers::HeaderMapExt;
 
-                        response.headers_mut().typed_insert(
-                            $crate::web::headers::CanonicalUrl(
-                                canonical_url.parse().expect("invalid URL for canonical link")
-                            ),
-                        );
+                        response.headers_mut().typed_insert(canonical_url);
                     }
                 )?
 

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -4,12 +4,12 @@ use crate::{
     impl_axum_webpage,
     utils::{get_correct_docsrs_style_file, spawn_blocking},
     web::{
-        cache::CachePolicy, encode_url_path, error::AxumNope, file::File as DbFile,
-        headers::CanonicalUrl, MatchSemver, MetaData,
+        cache::CachePolicy, error::AxumNope, file::File as DbFile, headers::CanonicalUrl,
+        MatchSemver, MetaData,
     },
     Storage,
 };
-use anyhow::{Context as _, Result};
+use anyhow::Result;
 use axum::{extract::Path, headers::HeaderMapExt, response::IntoResponse, Extension};
 
 use postgres::Client;
@@ -163,13 +163,13 @@ impl FileList {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 struct SourcePage {
     file_list: FileList,
     show_parent_link: bool,
     file: Option<File>,
     file_content: Option<String>,
-    canonical_url: String,
+    canonical_url: CanonicalUrl,
     is_latest_url: bool,
 }
 
@@ -213,8 +213,8 @@ pub(crate) async fn source_browser_handler(
         MatchSemver::Latest((version, _)) => (version, "latest".to_string(), true),
         MatchSemver::Exact((version, _)) => (version.clone(), version, false),
         MatchSemver::Semver((version, _)) => {
-            return Ok(super::axum_cached_redirect(
-                &format!("/crate/{}/{}/source/{}", name, version, path),
+            return Ok(super::internal_redirect(
+                format!("/crate/{}/{}/source/{}", name, version, path),
                 CachePolicy::ForeverInCdn,
             )?
             .into_response());
@@ -253,20 +253,14 @@ pub(crate) async fn source_browser_handler(
     })
     .await?;
 
-    let canonical_url = format!(
-        "https://docs.rs/crate/{}/latest/source/{}",
-        name,
-        encode_url_path(&path),
-    );
+    let canonical_url = CanonicalUrl::from_path(format!("/crate/{}/latest/source/{}", name, path))?;
 
     let (file, file_content) = if let Some(blob) = blob {
         let is_text = blob.mime.starts_with("text") || blob.mime == "application/json";
         // serve the file with DatabaseFileHandler if file isn't text and not empty
         if !is_text && !blob.is_empty() {
             let mut response = DbFile(blob).into_response();
-            response.headers_mut().typed_insert(CanonicalUrl(
-                canonical_url.parse().context("invalid canonical url")?,
-            ));
+            response.headers_mut().typed_insert(canonical_url);
             response
                 .extensions_mut()
                 .insert(CachePolicy::ForeverInCdnAndStaleInBrowser);
@@ -325,7 +319,7 @@ pub(crate) async fn source_browser_handler(
 #[cfg(test)]
 mod tests {
     use crate::test::*;
-    use crate::web::{cache::CachePolicy, encode_url_path};
+    use crate::web::cache::CachePolicy;
     use kuchiki::traits::TendrilSink;
     use reqwest::StatusCode;
     use test_case::test_case;
@@ -346,7 +340,7 @@ mod tests {
     #[test_case(false)]
     fn fetch_source_file_utf8_path(archive_storage: bool) {
         wrapper(|env| {
-            let filename = "序列化工具简单测试结果.pdf";
+            let filename = "序.pdf";
 
             env.fake_release()
                 .archive_storage(archive_storage)
@@ -362,10 +356,7 @@ mod tests {
             assert!(response.status().is_success());
             assert_eq!(
                 response.headers().get("link").unwrap(),
-                &format!(
-                    "<https://docs.rs/crate/fake/latest/source/{}>; rel=\"canonical\"",
-                    encode_url_path(filename),
-                )
+                "<https://docs.rs/crate/fake/latest/source/%E5%BA%8F.pdf>; rel=\"canonical\"",
             );
             assert!(response.text()?.contains("some_random_content"));
             Ok(())


### PR DESCRIPTION
This is a potential fix for: 
- https://sentry.io/organizations/rust-lang/issues/3837812670/
- https://sentry.io/organizations/rust-lang/issues/3836548500/

plus trying to prevent the issue in other places. 

I'm happy to change things if there is a better design :) 