### PR TITLE
refactor canonical URL generation to they are always correctly encoded

### DIFF
--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -1,4 +1,4 @@
-use super::{cache::CachePolicy, MatchSemver};
+use super::{cache::CachePolicy, headers::CanonicalUrl, MatchSemver};
 use crate::{
     db::Pool,
     docbuilder::Limits,
@@ -25,12 +25,12 @@ pub(crate) struct Build {
     build_time: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 struct BuildsPage {
     metadata: MetaData,
     builds: Vec<Build>,
     limits: Limits,
-    canonical_url: String,
+    canonical_url: CanonicalUrl,
 }
 
 impl_axum_webpage! {
@@ -74,7 +74,7 @@ pub(crate) async fn build_list_handler(
         metadata,
         builds,
         limits,
-        canonical_url: format!("https://docs.rs/crate/{}/latest/builds", name),
+        canonical_url: CanonicalUrl::from_path(format!("/crate/{}/latest/builds", name)),
     }
     .into_response())
 }

--- a/src/web/features.rs
+++ b/src/web/features.rs
@@ -1,3 +1,4 @@
+use super::headers::CanonicalUrl;
 use super::MatchSemver;
 use crate::db::types::Feature;
 use crate::{
@@ -16,12 +17,12 @@ use std::collections::{HashMap, VecDeque};
 
 const DEFAULT_NAME: &str = "default";
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 struct FeaturesPage {
     metadata: MetaData,
     features: Option<Vec<Feature>>,
     default_len: usize,
-    canonical_url: String,
+    canonical_url: CanonicalUrl,
     is_latest_url: bool,
 }
 
@@ -87,7 +88,7 @@ pub(crate) async fn build_features_handler(
         features,
         default_len,
         is_latest_url,
-        canonical_url: format!("https://docs.rs/crate/{}/latest/features", &name),
+        canonical_url: CanonicalUrl::from_path(format!("/crate/{}/latest/features", &name)),
     }
     .into_response())
 }

--- a/src/web/headers.rs
+++ b/src/web/headers.rs
@@ -1,10 +1,34 @@
+use super::encode_url_path;
+use anyhow::Result;
 use axum::{
     headers::{Header, HeaderName, HeaderValue},
-    http::uri::Uri,
+    http::uri::{PathAndQuery, Uri},
 };
+use serde::Serialize;
 
 /// simplified typed header for a `Link rel=canonical` header in the response.
-pub struct CanonicalUrl(pub Uri);
+/// Only takes the path to be used, url-encodes it and attaches domain & schema to it.
+#[derive(Debug, Clone)]
+pub struct CanonicalUrl(PathAndQuery);
+
+impl CanonicalUrl {
+    pub fn from_path<P: AsRef<str>>(path: P) -> Self {
+        Self(
+            encode_url_path(path.as_ref())
+                .try_into()
+                .expect("invalid URI path characters even after encoding them"),
+        )
+    }
+
+    fn build_full_uri(&self) -> Uri {
+        Uri::builder()
+            .scheme("https")
+            .authority("docs.rs")
+            .path_and_query(self.0.clone())
+            .build()
+            .expect("this unwrap can't fail because PathAndQuery is valid")
+    }
+}
 
 impl Header for CanonicalUrl {
     fn name() -> &'static HeaderName {
@@ -22,9 +46,20 @@ impl Header for CanonicalUrl {
     where
         E: Extend<HeaderValue>,
     {
-        let value: HeaderValue = format!(r#"<{}>; rel="canonical""#, self.0).parse().unwrap();
+        let value: HeaderValue = format!(r#"<{}>; rel="canonical""#, self.build_full_uri())
+            .parse()
+            .unwrap();
 
         values.extend(std::iter::once(value));
+    }
+}
+
+impl Serialize for CanonicalUrl {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.build_full_uri().to_string())
     }
 }
 
@@ -36,9 +71,32 @@ mod tests {
     use axum::http::HeaderMap;
 
     #[test]
+    fn test_serialize_canonical() {
+        let url = CanonicalUrl::from_path("/some/path/");
+
+        assert_eq!(
+            serde_json::to_string(&url).unwrap(),
+            "\"https://docs.rs/some/path/\""
+        );
+    }
+
+    #[test]
     fn test_encode_canonical() {
         let mut map = HeaderMap::new();
-        map.typed_insert(CanonicalUrl("http://something/".parse().unwrap()));
-        assert_eq!(map["link"], "<http://something/>; rel=\"canonical\"");
+        map.typed_insert(CanonicalUrl::from_path("/some/path/"));
+        assert_eq!(
+            map["link"],
+            "<https://docs.rs/some/path/>; rel=\"canonical\""
+        );
+    }
+
+    #[test]
+    fn test_encode_canonical_with_encoding() {
+        let mut map = HeaderMap::new();
+        map.typed_insert(CanonicalUrl::from_path("/some/äöü/"));
+        assert_eq!(
+            map["link"],
+            "<https://docs.rs/some/%C3%A4%C3%B6%C3%BC/>; rel=\"canonical\""
+        );
     }
 }

--- a/src/web/page/web_page.rs
+++ b/src/web/page/web_page.rs
@@ -84,17 +84,13 @@ macro_rules! impl_axum_webpage {
 
                 $(
                     let canonical_url = {
-                        let canonical_url: fn(&Self) -> Option<String> = $canonical_url;
+                        let canonical_url: fn(&Self) -> Option<$crate::web::headers::CanonicalUrl> = $canonical_url;
                         (canonical_url)(&self)
                     };
                     if let Some(canonical_url) = canonical_url {
                         use axum::headers::HeaderMapExt;
 
-                        response.headers_mut().typed_insert(
-                            $crate::web::headers::CanonicalUrl(
-                                canonical_url.parse().expect("invalid URL for canonical link")
-                            ),
-                        );
+                        response.headers_mut().typed_insert(canonical_url);
                     }
                 )?
 


### PR DESCRIPTION
This splts out the canonical-url part from #1983 , hopefully in isolation easier to understand & review. 