### PR TITLE
encode redirect paths where they contain user-provided info or file paths

### DIFF
--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -6,6 +6,7 @@ use crate::{
     repositories::RepositoryStatsUpdater,
     web::{
         cache::CachePolicy,
+        encode_url_path,
         error::{AxumNope, AxumResult},
     },
 };
@@ -319,7 +320,7 @@ pub(crate) async fn crate_details_handler(
     // this handler must always called with a crate name
     if params.version.is_none() {
         return Ok(super::axum_cached_redirect(
-            &format!("/crate/{}/latest", params.name),
+            encode_url_path(&format!("/crate/{}/latest", params.name)),
             CachePolicy::ForeverInCdn,
         )?
         .into_response());

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -7,7 +7,7 @@ use crate::{
     impl_axum_webpage,
     utils::{report_error, spawn_blocking},
     web::{
-        axum_parse_uri_with_params, axum_redirect,
+        axum_parse_uri_with_params, axum_redirect, encode_url_path,
         error::{AxumNope, AxumResult},
         match_version_axum,
     },
@@ -412,7 +412,7 @@ pub(crate) async fn releases_failures_by_stars_handler(
 pub(crate) async fn owner_handler(Path(owner): Path<String>) -> AxumResult<impl IntoResponse> {
     axum_redirect(format!(
         "https://crates.io/users/{}",
-        owner.strip_prefix('@').unwrap_or(&owner)
+        encode_url_path(owner.strip_prefix('@').unwrap_or(&owner))
     ))
     .map_err(|_| AxumNope::OwnerNotFound)
 }


### PR DESCRIPTION
This would be the "simple" approach to solve only _the current_ URI encoding errors:
- https://sentry.io/organizations/rust-lang/issues/3836548500/
- https://sentry.io/organizations/rust-lang/issues/3837812670/

as alternative to #1983. 
The reason for the big implementation #1983 was to prevent future contributors to forget the path encoding, 
though I also feel the PR has too many changes for what it tries to do. 

So I would be happy just having this PR to fix the actual encoding errors we have in sentry. 