### PR TITLE
Upload docker image to dev ecr repo

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,27 @@
+name: Deploy Dev
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker:
+    name: Build and upload docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build the Docker image
+        run: docker build -t docs-rs -f dockerfiles/Dockerfile . --target=web-server
+
+      - name: Upload the Docker image to ECR (dev)
+        uses: rust-lang/simpleinfra/github-actions/upload-docker-image@master
+        with:
+          image: docs-rs-web
+          repository: docs-rs-web
+          region: us-east-1
+          aws_access_key_id: "${{ secrets.dev_aws_access_key_id }}"
+          aws_secret_access_key: "${{ secrets.dev_aws_secret_access_key }}"
+          redeploy_ecs_cluster: docs-rs-staging
+          redeploy_ecs_service: docs-rs-web

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Build the Docker image
         run: docker build -t docs-rs-web -f dockerfiles/Dockerfile --target web-server .
 
-      - name: Upload the Docker image to ECR
+      - name: Upload the Docker image to ECR (production)
         uses: rust-lang/simpleinfra/github-actions/upload-docker-image@master
         with:
           image: docs-rs-web

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,6 @@
 name: Docker
 
-on:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   docker:
@@ -13,15 +10,4 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build the Docker image
-        run: docker build -t docs-rs -f dockerfiles/Dockerfile . --target=web-server
-
-      - name: Upload the Docker image to ECR (dev)
-        uses: rust-lang/simpleinfra/github-actions/upload-docker-image@master
-        with:
-          image: docs-rs-web
-          repository: docs-rs-web
-          region: us-east-1
-          aws_access_key_id: "${{ secrets.dev_aws_access_key_id }}"
-          aws_secret_access_key: "${{ secrets.dev_aws_secret_access_key }}"
-          redeploy_ecs_cluster: docs-rs-staging
-          redeploy_ecs_service: docs-rs-web
+        run: docker build -t docs-rs -f dockerfiles/Dockerfile .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,9 @@
 name: Docker
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   docker:
@@ -10,4 +13,15 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build the Docker image
-        run: docker build -t docs-rs -f dockerfiles/Dockerfile .
+        run: docker build -t docs-rs -f dockerfiles/Dockerfile . --target=web-server
+
+      - name: Upload the Docker image to ECR (dev)
+        uses: rust-lang/simpleinfra/github-actions/upload-docker-image@master
+        with:
+          image: docs-rs-web
+          repository: docs-rs-web
+          region: us-east-1
+          aws_access_key_id: "${{ secrets.dev_aws_access_key_id }}"
+          aws_secret_access_key: "${{ secrets.dev_aws_secret_access_key }}"
+          redeploy_ecs_cluster: docs-rs-staging
+          redeploy_ecs_service: docs-rs-web


### PR DESCRIPTION
With the creation of the docs-rs-staging environment, we can now deploy master to the environment. We may want to be a bit smarter about this to allow for more targeted testing, but for now this can let me test that the environment works. 