### PR TITLE
Remove Releases menu in favor of /about.

### DIFF
--- a/templates/core/about/index.html
+++ b/templates/core/about/index.html
@@ -37,6 +37,9 @@
         <h3 id="version"> <a href="#version">Version</a> </h3>
         <p>Currently running Docs.rs version is: <strong>{{ docsrs_version() }}</strong></p>
 
+        <h3 id="builds"> <a href="#builds">Version</a> </h3>
+        <p>Summaries of the documentation build processes <a href="/releases">are available at /releases/</a>.</p>
+
         <h3 id="contact"> <a href="#contact">Contact</a> </h3>
         {%- set governance_link = "https://www.rust-lang.org/governance/teams/dev-tools#docs-rs" -%}
         <p>

--- a/templates/header/topbar_end.html
+++ b/templates/header/topbar_end.html
@@ -5,21 +5,7 @@
                 {% include "header/global_alert.html" -%}
 
                 <ul class="pure-menu-list">
-                    <li class="pure-menu-item pure-menu-has-children">
-                        <a href="#" class="pure-menu-link">
-                            <span title="Releases">{{ "leaf" | fas }}</span>
-                            <span class="title">Releases</span>
-                        </a>
-
-                        <ul class="pure-menu-children">
-                            {{ macros::menu_link(href="/releases", text="All Releases") }}
-                            {{ macros::menu_link(href="/releases/stars", text="Releases by Stars") }}
-                            {{ macros::menu_link(href="/releases/recent-failures", text="Recent Build Failures") }}
-                            {{ macros::menu_link(href="/releases/failures", text="Build Failures by Stars") }}
-                            {{ macros::menu_link(href="/releases/activity", text="Release Activity") }}
-                        </ul>
-                    </li>{#
-
+                    {#
                     The Rust dropdown menu
                     #}<li class="pure-menu-item pure-menu-has-children">
                         <a href="#" class="pure-menu-link" aria-label="Rust">Rust</a>


### PR DESCRIPTION
The Releases menu offered pages that were mainly of use to docs.rs developers, not general documentation readers. It also duplicated the contents of the /releases page. By removing, and adding a link to /releases on the /about page, we simplify the topbar while retaining the same functionality.

[Originally proposed on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/356853-t-docs-rs/topic/proposal.3A.20remove.20.22Releases.22.20menu).