### PR TITLE
Left-align crate and release pages

### DIFF
--- a/templates/about-base.html
+++ b/templates/about-base.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+{%- block body_classes -%}
+centered
+{%- endblock body_classes -%}
+
 {% block header %}
     <div class="docsrs-package-container">
         <div class="container">

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -2,6 +2,10 @@
 
 {%- block title -%}Docs.rs{%- endblock title -%}
 
+{%- block body_classes -%}
+centered
+{%- endblock body_classes -%}
+
 {%- block body -%}
     <div class="container landing">
         <h1 class="brand">{{ "cubes" | fas(fw=true) }} Docs.rs</h1>

--- a/templates/style/style.scss
+++ b/templates/style/style.scss
@@ -211,13 +211,16 @@ pre {
 
 div.container {
     max-width: 1160px;
-    margin: 0 auto;
     text-align: left;
 
     > .chartjs-render-monitor {
         // This is to prevent the canvas text to go under the footer.
         padding-bottom: 35px;
     }
+}
+
+body.centered div.container {
+    margin: 0 auto;
 }
 
 div.landing {


### PR DESCRIPTION
To make them more similar to doc pages. Retain centered alignment for / and /about.

Since the crate page is navigated as part of a crate's documentation, it's jarring for it to have different alignment than the documentation itself.

We first [made this change in 2020](https://github.com/rust-lang/docs.rs/pull/1079) but [reverted it due to a regression](https://github.com/rust-lang/docs.rs/issues/1084): the about and home pages weren't supposed to change.

Now, homepage stays the same:

![image](https://user-images.githubusercontent.com/220205/213938521-9d49e47e-646f-4475-9815-8e3e885d85a9.png)

About stays the same:

![image](https://user-images.githubusercontent.com/220205/213938539-1731853f-6e04-407e-a61b-061f3454aee0.png)

Crate page is left aligned:

![image](https://user-images.githubusercontent.com/220205/213956985-266ca6fa-80dd-446c-a81e-5590cb5d63f8.png)

The doc page stays left aligned:
![image](https://user-images.githubusercontent.com/220205/213938552-3566bd19-bf7b-47d6-b9e7-51afc861b4b7.png)