### PR TITLE
Set X-Robots-Tag: noindex for nonlatest rustdoc

### DIFF
--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -246,11 +246,6 @@ impl<'a> FakeRelease<'a> {
         self
     }
 
-    pub(crate) fn documentation_url(mut self, documentation: Option<String>) -> Self {
-        self.package.documentation = documentation;
-        self
-    }
-
     /// Returns the release_id
     pub(crate) fn create(mut self) -> Result<i32> {
         use std::fs;

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -332,10 +332,9 @@ impl RustdocPage {
             result => result.context("error rewriting HTML")?,
         };
 
-        let robots = if is_latest_url { "" } else { "noindex" };
         Ok((
             StatusCode::OK,
-            [("X-Robots-Tag", robots)],
+            (!is_latest_url).then_some([("X-Robots-Tag", "noindex")]),
             Extension(if is_latest_url {
                 CachePolicy::ForeverInCdn
             } else {

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -2397,15 +2397,12 @@ mod test {
                 .unwrap()
                 .contains("noindex"));
 
-            assert!(!web
+            assert!(web
                 .get("/dummy/latest/dummy/")
                 .send()?
                 .headers()
                 .get("x-robots-tag")
-                .unwrap_or_default()
-                .to_str()
-                .unwrap()
-                .contains("noindex"));
+                .is_none());
             Ok(())
         })
     }

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -2402,7 +2402,7 @@ mod test {
                 .send()?
                 .headers()
                 .get("x-robots-tag")
-                .unwrap()
+                .unwrap_or_default()
                 .to_str()
                 .unwrap()
                 .contains("noindex"));

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -24,7 +24,7 @@ use anyhow::{anyhow, Context as _};
 use axum::{
     extract::{Extension, Path, Query},
     http::{StatusCode, Uri},
-    response::{AppendHeaders, Html, IntoResponse, Response as AxumResponse},
+    response::{Html, IntoResponse, Response as AxumResponse},
 };
 use lol_html::errors::RewritingError;
 use once_cell::sync::Lazy;
@@ -335,7 +335,7 @@ impl RustdocPage {
         let robots = if is_latest_url { "" } else { "noindex" };
         Ok((
             StatusCode::OK,
-            AppendHeaders([("X-Robots-Tag", robots)]),
+            [("X-Robots-Tag", robots)],
             Extension(if is_latest_url {
                 CachePolicy::ForeverInCdn
             } else {


### PR DESCRIPTION
We want /latest/ URLs to be indexed, but not /1.2.3/ URLs, because the latter compete for pagerank with /latest/ and aren't usually what people want.

This replaces the previous canonical URL header. Canonical URLs were doing some good, but did not work in all cases. In particular, if some older version of a crate's documentation was very different than the latest version, Google would not accept the canonicalization. This would sometimes result in the old version still showing up in the search results instead of /latest/.