### PR TITLE
upgrade metadata & font-awesome to edition 2021, fix new clippy lints

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -91,7 +91,7 @@ fn write_git_version(out_dir: &Path) -> Result<()> {
 
     std::fs::write(
         out_dir.join("git_version"),
-        format!("({} {})", git_hash, build_date),
+        format!("({git_hash} {build_date})"),
     )?;
 
     Ok(())

--- a/crates/font-awesome-as-a-crate/Cargo.toml
+++ b/crates/font-awesome-as-a-crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "font-awesome-as-a-crate"
 version = "0.3.0"
-edition = "2018"
+edition = "2021"
 license = "CC-BY-4.0 AND MIT"
 description = "Font Awesome Free, packaged as a crate"
 repository = "https://github.com/rust-lang/docs.rs"

--- a/crates/font-awesome-as-a-crate/build.rs
+++ b/crates/font-awesome-as-a-crate/build.rs
@@ -30,7 +30,7 @@ fn write_fontawesome_sprite() {
             file.read_to_string(&mut data)
                 .expect("fontawesome file read");
             // if this assert goes off, add more hashes here and in the format! below
-            assert!(!data.contains("###"), "file {} breaks raw string", filename);
+            assert!(!data.contains("###"), "file {filename} breaks raw string");
             dest_file
                 .write_all(
                     format!(

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -2,7 +2,7 @@
 name = "docsrs-metadata"
 version = "0.1.0"
 authors = ["Joshua Nelson <jyn514@gmail.com>", "The Rust Project Developers"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 repository = "https://github.com/rust-lang/docs.rs"
 description = "Document crates the same way docs.rs would"

--- a/crates/metadata/lib.rs
+++ b/crates/metadata/lib.rs
@@ -280,18 +280,18 @@ impl Metadata {
             cargo_args.push("--config".into());
             let rustflags =
                 toml::to_string(&self.rustc_args).expect("serializing a string should never fail");
-            cargo_args.push(format!("build.rustflags={}", rustflags));
+            cargo_args.push(format!("build.rustflags={rustflags}"));
             cargo_args.push("-Zhost-config".into());
             cargo_args.push("-Ztarget-applies-to-host".into());
             cargo_args.push("--config".into());
-            cargo_args.push(format!("host.rustflags={}", rustflags));
+            cargo_args.push(format!("host.rustflags={rustflags}"));
         }
 
         if !all_rustdoc_args.is_empty() {
             cargo_args.push("--config".into());
             let rustdocflags =
                 toml::to_string(&all_rustdoc_args).expect("serializing a string should never fail");
-            cargo_args.push(format!("build.rustdocflags={}", rustdocflags));
+            cargo_args.push(format!("build.rustdocflags={rustdocflags}"));
         }
 
         cargo_args.extend(additional_args.iter().map(|s| s.to_owned()));
@@ -645,7 +645,7 @@ mod test_targets {
             other_targets: others,
             ..
         } = metadata.targets(false);
-        assert!(others.is_empty(), "{:?}", others);
+        assert!(others.is_empty(), "{others:?}");
     }
 }
 

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -52,15 +52,15 @@ fn main() {
     };
 
     if let Err(err) = CommandLine::parse().handle_args() {
-        let mut msg = format!("Error: {}", err);
+        let mut msg = format!("Error: {err}");
         for cause in err.chain() {
-            write!(msg, "\n\nCaused by:\n    {}", cause).unwrap();
+            write!(msg, "\n\nCaused by:\n    {cause}").unwrap();
         }
-        eprintln!("{}", msg);
+        eprintln!("{msg}");
 
         let backtrace = err.backtrace().to_string();
         if !backtrace.is_empty() {
-            eprintln!("\nStack backtrace:\n{}", backtrace);
+            eprintln!("\nStack backtrace:\n{backtrace}");
         }
 
         // we need to drop the sentry guard here so all unsent
@@ -254,7 +254,7 @@ impl PrioritySubcommand {
                 if let Some(priority) = remove_crate_priority(&mut *ctx.conn()?, &pattern)
                     .context("Could not remove pattern's priority")?
                 {
-                    println!("Removed pattern with priority {}", priority);
+                    println!("Removed pattern with priority {priority}");
                 } else {
                     println!("Pattern did not exist and so was not removed");
                 }

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -300,7 +300,7 @@ impl BuildQueue {
         for change in &changes {
             if let Some((ref krate, ..)) = change.deleted() {
                 match delete_crate(&mut conn, &self.storage, &self.config, krate)
-                    .with_context(|| format!("failed to delete crate {}", krate))
+                    .with_context(|| format!("failed to delete crate {krate}"))
                 {
                     Ok(_) => info!(
                         "crate {} was deleted from the index and the database",

--- a/src/cdn.rs
+++ b/src/cdn.rs
@@ -415,12 +415,12 @@ pub(crate) fn queue_crate_invalidation(
     if let Some(distribution_id) = config.cloudfront_distribution_id_web.as_ref() {
         add(
             distribution_id,
-            &[&format!("/{}*", name), &format!("/crate/{}*", name)],
+            &[&format!("/{name}*"), &format!("/crate/{name}*")],
         )
         .context("error enqueueing web CDN invalidation")?;
     }
     if let Some(distribution_id) = config.cloudfront_distribution_id_static.as_ref() {
-        add(distribution_id, &[&format!("/rustdoc/{}*", name)])
+        add(distribution_id, &[&format!("/rustdoc/{name}*")])
             .context("error enqueueing static CDN invalidation")?;
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -209,7 +209,7 @@ where
         Ok(content) => Ok(content
             .parse::<T>()
             .map(Some)
-            .with_context(|| format!("failed to parse configuration variable {}", var))?),
+            .with_context(|| format!("failed to parse configuration variable {var}"))?),
         Err(VarError::NotPresent) => {
             trace!("optional configuration variable {} is not set", var);
             Ok(None)

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -669,8 +669,8 @@ mod test {
 
             let new_owners: Vec<CrateOwner> = (1..5)
                 .map(|i| CrateOwner {
-                    login: format!("login{}", i),
-                    avatar: format!("avatar{}", i),
+                    login: format!("login{i}"),
+                    avatar: format!("avatar{i}"),
                 })
                 .collect();
 

--- a/src/index/api.rs
+++ b/src/index/api.rs
@@ -72,7 +72,7 @@ impl Api {
     pub fn get_crate_data(&self, name: &str) -> Result<CrateData> {
         let owners = self
             .get_owners(name)
-            .context(format!("Failed to get owners for {}", name))?;
+            .context(format!("Failed to get owners for {name}"))?;
 
         Ok(CrateData { owners })
     }
@@ -80,7 +80,7 @@ impl Api {
     pub(crate) fn get_release_data(&self, name: &str, version: &str) -> Result<ReleaseData> {
         let (release_time, yanked, downloads) = self
             .get_release_time_yanked_downloads(name, version)
-            .context(format!("Failed to get crate data for {}-{}", name, version))?;
+            .context(format!("Failed to get crate data for {name}-{version}"))?;
 
         Ok(ReleaseData {
             release_time,

--- a/src/repositories/github.rs
+++ b/src/repositories/github.rs
@@ -58,7 +58,7 @@ impl GitHub {
         if let Some(ref token) = config.github_accesstoken {
             headers.insert(
                 AUTHORIZATION,
-                HeaderValue::from_str(&format!("token {}", token))?,
+                HeaderValue::from_str(&format!("token {token}"))?,
             );
         } else {
             warn!("did not collect `github.com` stats as no token was provided");
@@ -277,7 +277,7 @@ mod tests {
 
             match updater.fetch_repositories(&[String::new()]) {
                 Err(e) if e.downcast_ref::<RateLimitReached>().is_some() => {}
-                x => panic!("Expected Err(RateLimitReached), found: {:?}", x),
+                x => panic!("Expected Err(RateLimitReached), found: {x:?}"),
             }
             Ok(())
         });
@@ -297,7 +297,7 @@ mod tests {
 
             match updater.fetch_repositories(&[String::new()]) {
                 Err(e) if e.downcast_ref::<RateLimitReached>().is_some() => {}
-                x => panic!("Expected Err(RateLimitReached), found: {:?}", x),
+                x => panic!("Expected Err(RateLimitReached), found: {x:?}"),
             }
             Ok(())
         });
@@ -323,7 +323,7 @@ mod tests {
                     assert_eq!(res.missing, vec![String::new()]);
                     assert_eq!(res.present.len(), 0);
                 }
-                x => panic!("Failed: {:?}", x),
+                x => panic!("Failed: {x:?}"),
             }
             Ok(())
         });

--- a/src/repositories/gitlab.rs
+++ b/src/repositories/gitlab.rs
@@ -54,7 +54,7 @@ impl GitLab {
         if let Some(token) = access_token {
             headers.insert(
                 AUTHORIZATION,
-                HeaderValue::from_str(&format!("Bearer {}", token))?,
+                HeaderValue::from_str(&format!("Bearer {token}"))?,
             );
         } else {
             warn!(
@@ -268,11 +268,11 @@ mod tests {
             &repository_name("https://gitlab.com/foo/bar").expect("repository_name failed"),
         ) {
             Err(e) if e.downcast_ref::<RateLimitReached>().is_some() => {}
-            x => panic!("Expected Err(RateLimitReached), found: {:?}", x),
+            x => panic!("Expected Err(RateLimitReached), found: {x:?}"),
         }
         match updater.fetch_repositories(&[String::new()]) {
             Err(e) if e.downcast_ref::<RateLimitReached>().is_some() => {}
-            x => panic!("Expected Err(RateLimitReached), found: {:?}", x),
+            x => panic!("Expected Err(RateLimitReached), found: {x:?}"),
         }
     }
 
@@ -290,7 +290,7 @@ mod tests {
                 assert_eq!(res.missing, vec![String::new()]);
                 assert_eq!(res.present.len(), 0);
             }
-            x => panic!("Failed: {:?}", x),
+            x => panic!("Failed: {x:?}"),
         }
     }
 

--- a/src/storage/compression.rs
+++ b/src/storage/compression.rs
@@ -105,7 +105,7 @@ mod tests {
     fn test_compression() {
         let orig = "fn main() {}";
         for alg in CompressionAlgorithm::AVAILABLE {
-            println!("testing algorithm {}", alg);
+            println!("testing algorithm {alg}");
 
             let data = compress(orig.as_bytes(), *alg).unwrap();
             assert_eq!(

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -185,7 +185,7 @@ impl Storage {
                 fetch_time.step("fetch from storage");
             }
             // Add rustdoc prefix, name and version to the path for accessing the file stored in the database
-            let remote_path = format!("rustdoc/{}/{}/{}", name, version, path);
+            let remote_path = format!("rustdoc/{name}/{version}/{path}");
             self.get(&remote_path, self.max_file_size_for(path))?
         })
     }
@@ -205,7 +205,7 @@ impl Storage {
                 None,
             )?
         } else {
-            let remote_path = format!("sources/{}/{}/{}", name, version, path);
+            let remote_path = format!("sources/{name}/{version}/{path}");
             self.get(&remote_path, self.max_file_size_for(path))?
         })
     }
@@ -221,7 +221,7 @@ impl Storage {
             self.exists_in_archive(&rustdoc_archive_path(name, version), path)?
         } else {
             // Add rustdoc prefix, name and version to the path for accessing the file stored in the database
-            let remote_path = format!("rustdoc/{}/{}/{}", name, version, path);
+            let remote_path = format!("rustdoc/{name}/{version}/{path}");
             self.exists(&remote_path)?
         })
     }
@@ -274,7 +274,7 @@ impl Storage {
 
     fn get_index_filename(&self, archive_path: &str) -> Result<PathBuf> {
         // remote/folder/and/x.zip.index
-        let remote_index_path = format!("{}.index", archive_path);
+        let remote_index_path = format!("{archive_path}.index");
         let local_index_path = self
             .config
             .local_archive_cache_path
@@ -320,7 +320,7 @@ impl Storage {
         assert_eq!(blob.compression, None);
 
         Ok(Blob {
-            path: format!("{}/{}", archive_path, path),
+            path: format!("{archive_path}/{path}"),
             mime: detect_mime(path).into(),
             date_updated: blob.date_updated,
             content: blob.content,
@@ -568,11 +568,11 @@ fn detect_mime(file_path: impl AsRef<Path>) -> &'static str {
 }
 
 pub(crate) fn rustdoc_archive_path(name: &str, version: &str) -> String {
-    format!("rustdoc/{0}/{1}.zip", name, version)
+    format!("rustdoc/{name}/{version}.zip")
 }
 
 pub(crate) fn source_archive_path(name: &str, version: &str) -> String {
-    format!("sources/{0}/{1}.zip", name, version)
+    format!("sources/{name}/{version}.zip")
 }
 
 #[cfg(test)]
@@ -932,11 +932,11 @@ mod backend_tests {
         let now = Utc::now();
         let uploads: Vec<_> = (0..=MAX_CONCURRENT_UPLOADS + 1)
             .map(|i| {
-                let content = format!("const IDX: usize = {};", i).as_bytes().to_vec();
+                let content = format!("const IDX: usize = {i};").as_bytes().to_vec();
                 Blob {
                     mime: "text/rust".into(),
                     content,
-                    path: format!("{}.rs", i),
+                    path: format!("{i}.rs"),
                     date_updated: now,
                     compression: None,
                 }

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -110,7 +110,7 @@ impl<'a> FakeRelease<'a> {
 
     pub(crate) fn name(mut self, new: &str) -> Self {
         self.package.name = new.into();
-        self.package.id = format!("{}-id", new);
+        self.package.id = format!("{new}-id");
         self.package.targets[0].name = new.into();
         self
     }
@@ -439,7 +439,7 @@ impl FakeGithubStats {
         let existing_count: i64 = conn
             .query_one("SELECT COUNT(*) FROM repositories;", &[])?
             .get(0);
-        let host_id = base64::encode(format!("FAKE ID {}", existing_count));
+        let host_id = base64::encode(format!("FAKE ID {existing_count}"));
 
         let data = conn.query_one(
             "INSERT INTO repositories (host, host_id, name, description, last_commit, stars, forks, issues, updated_at)
@@ -521,7 +521,7 @@ impl FakeBuild {
         }
 
         if let Some(s3_build_log) = self.s3_build_log.as_deref() {
-            let path = format!("build-logs/{}/{}.txt", build_id, default_target);
+            let path = format!("build-logs/{build_id}/{default_target}.txt");
             storage.store_one(path, s3_build_log)?;
         }
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -41,9 +41,9 @@ pub(crate) fn wrapper(f: impl FnOnce(&TestEnvironment) -> Result<()>) {
     };
 
     if let Err(err) = result {
-        eprintln!("the test failed: {}", err);
+        eprintln!("the test failed: {err}");
         for cause in err.chain() {
-            eprintln!("  caused by: {}", cause);
+            eprintln!("  caused by: {cause}");
         }
 
         eprintln!("{}", err.backtrace());
@@ -84,7 +84,7 @@ pub(crate) fn assert_cache_control(
 /// Make sure that a URL returns a status code between 200-299
 pub(crate) fn assert_success(path: &str, web: &TestFrontend) -> Result<()> {
     let status = web.get(path).send()?.status();
-    assert!(status.is_success(), "failed to GET {}: {}", path, status);
+    assert!(status.is_success(), "failed to GET {path}: {status}");
     Ok(())
 }
 
@@ -98,7 +98,7 @@ pub(crate) fn assert_success_cached(
 ) -> Result<()> {
     let response = web.get(path).send()?;
     let status = response.status();
-    assert!(status.is_success(), "failed to GET {}: {}", path, status);
+    assert!(status.is_success(), "failed to GET {path}: {status}");
     assert_cache_control(&response, cache_policy, config);
     Ok(())
 }
@@ -110,12 +110,7 @@ pub(crate) fn assert_not_found(path: &str, web: &TestFrontend) -> Result<()> {
     // for now, 404s should always have `no-cache`
     assert_no_cache(&response);
 
-    assert_eq!(
-        response.status(),
-        404,
-        "GET {} should have been a 404",
-        path
-    );
+    assert_eq!(response.status(), 404, "GET {path} should have been a 404");
     Ok(())
 }
 
@@ -473,10 +468,9 @@ impl TestDatabase {
         let mut conn = Connection::connect(&config.database_url, postgres::NoTls)?;
         conn.batch_execute(&format!(
             "
-                CREATE SCHEMA {0};
-                SET search_path TO {0}, public;
-            ",
-            schema
+                CREATE SCHEMA {schema};
+                SET search_path TO {schema}, public;
+            "
         ))?;
         crate::db::migrate(None, &mut conn)?;
 
@@ -498,7 +492,7 @@ impl TestDatabase {
             .enumerate()
             .map(|(i, sequence): (_, String)| {
                 let offset = (i + 1) * 10000;
-                format!(r#"ALTER SEQUENCE "{}" RESTART WITH {};"#, sequence, offset)
+                format!(r#"ALTER SEQUENCE "{sequence}" RESTART WITH {offset};"#)
             })
             .collect();
         conn.batch_execute(&query)?;

--- a/src/utils/consistency/mod.rs
+++ b/src/utils/consistency/mod.rs
@@ -127,7 +127,7 @@ where
             }
             diff::Difference::ReleaseYank(name, version, yanked) => {
                 if !dry_run {
-                    if let Err(err) = build_queue::set_yanked(&mut conn, name, version, *yanked) {
+                    if let Err(err) = build_queue.set_yanked(&mut conn, name, version, *yanked) {
                         warn!("{:?}", err);
                     }
                 }

--- a/src/utils/consistency/mod.rs
+++ b/src/utils/consistency/mod.rs
@@ -1,4 +1,4 @@
-use crate::{build_queue, db::delete, Context};
+use crate::{db::delete, Context};
 use anyhow::{Context as _, Result};
 use itertools::Itertools;
 use tracing::{info, warn};
@@ -50,7 +50,7 @@ pub fn run_check(ctx: &dyn Context, dry_run: bool) -> Result<()> {
         diff::Difference::ReleaseNotInDb(_, _) => "ReleaseNotInDb",
         diff::Difference::ReleaseYank(_, _, _) => "ReleaseYank",
     }) {
-        println!("{:17} => {:4}", key, count);
+        println!("{key:17} => {count:4}");
     }
 
     println!("============");

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -172,7 +172,7 @@ where
         .spawn(move || loop {
             thread::sleep(interval);
             if let Err(err) =
-                exec().with_context(|| format!("failed to run scheduled task '{}'", name))
+                exec().with_context(|| format!("failed to run scheduled task '{name}'"))
             {
                 report_error(&err);
             }

--- a/src/web/build_details.rs
+++ b/src/web/build_details.rs
@@ -68,7 +68,7 @@ pub(crate) async fn build_details_handler(
             output
         } else {
             let target: String = row.get("default_target");
-            let path = format!("build-logs/{}/{}.txt", id, target);
+            let path = format!("build-logs/{id}/{target}.txt");
             let file = File::from_path(&storage, &path, &config)?;
             String::from_utf8(file.0.content)?
         };
@@ -204,7 +204,7 @@ mod tests {
 
             let res = env
                 .frontend()
-                .get(&format!("/crate/foo/0.1.0/builds/{}", build_id))
+                .get(&format!("/crate/foo/0.1.0/builds/{build_id}"))
                 .send()?;
             assert_eq!(res.status(), 404);
             assert!(res.text()?.contains("no such build"));

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -50,7 +50,7 @@ pub(crate) async fn build_list_handler(
 
         MatchSemver::Semver((version, _)) => {
             return Ok(super::axum_cached_redirect(
-                &format!("/crate/{}/{}/builds", name, version),
+                &format!("/crate/{name}/{version}/builds"),
                 CachePolicy::ForeverInCdn,
             )?
             .into_response());
@@ -74,7 +74,7 @@ pub(crate) async fn build_list_handler(
         metadata,
         builds,
         limits,
-        canonical_url: CanonicalUrl::from_path(format!("/crate/{}/latest/builds", name)),
+        canonical_url: CanonicalUrl::from_path(format!("/crate/{name}/latest/builds")),
     }
     .into_response())
 }
@@ -90,7 +90,7 @@ pub(crate) async fn build_list_json_handler(
         MatchSemver::Exact((version, _)) | MatchSemver::Latest((version, _)) => version,
         MatchSemver::Semver((version, _)) => {
             return Ok(super::axum_cached_redirect(
-                &format!("/crate/{}/{}/builds.json", name, version),
+                &format!("/crate/{name}/{version}/builds.json"),
                 CachePolicy::ForeverInCdn,
             )?
             .into_response());

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -282,8 +282,7 @@ pub(crate) fn releases_for_crate(
                 }),
                 Err(err) => {
                     report_error(&anyhow!(err).context(format!(
-                        "invalid semver in database for crate {}: {}",
-                        crate_id, version
+                        "invalid semver in database for crate {crate_id}: {version}"
                     )));
                     None
                 }

--- a/src/web/file.rs
+++ b/src/web/file.rs
@@ -120,7 +120,7 @@ mod tests {
             let file = |path| {
                 File::from_path(
                     &env.storage(),
-                    &format!("rustdoc/dummy/0.1.0/{}", path),
+                    &format!("rustdoc/dummy/0.1.0/{path}"),
                     &env.config(),
                 )
             };

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -212,17 +212,16 @@ mod tests {
                     assert_eq!(labels.len(), 1); // not sure when this would be false
                     let route = labels[0].get_value();
                     let count = metric.get_counter().get_value();
-                    format!("{}: {}", route, count)
+                    format!("{route}: {count}")
                 })
                 .collect();
-            println!("routes: {:?}", routes_visited_pretty);
+            println!("routes: {routes_visited_pretty:?}");
 
             for (label, count) in expected.iter() {
                 assert_eq!(
                     metrics.routes_visited.with_label_values(&[*label]).get(),
                     *count,
-                    "routes_visited metrics for {} are incorrect",
-                    label,
+                    "routes_visited metrics for {label} are incorrect",
                 );
                 assert_eq!(
                     metrics
@@ -230,8 +229,7 @@ mod tests {
                         .with_label_values(&[*label])
                         .get_sample_count(),
                     *count,
-                    "response_time metrics for {} are incorrect",
-                    label,
+                    "response_time metrics for {label} are incorrect",
                 );
             }
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -339,16 +339,16 @@ fn duration_to_str(init: DateTime<Utc>) -> String {
 
     match delta {
         (days, ..) if days > 5 => format!("{}", init.format("%b %d, %Y")),
-        (days @ 2..=5, ..) => format!("{} days ago", days),
+        (days @ 2..=5, ..) => format!("{days} days ago"),
         (1, ..) => "one day ago".to_string(),
 
-        (_, hours, ..) if hours > 1 => format!("{} hours ago", hours),
+        (_, hours, ..) if hours > 1 => format!("{hours} hours ago"),
         (_, 1, ..) => "an hour ago".to_string(),
 
-        (_, _, minutes, _) if minutes > 1 => format!("{} minutes ago", minutes),
+        (_, _, minutes, _) if minutes > 1 => format!("{minutes} minutes ago"),
         (_, _, 1, _) => "one minute ago".to_string(),
 
-        (_, _, _, seconds) if seconds > 0 => format!("{} seconds ago", seconds),
+        (_, _, _, seconds) if seconds > 0 => format!("{seconds} seconds ago"),
         _ => "just now".to_string(),
     }
 }
@@ -410,7 +410,7 @@ where
         let query_params: String = form_urlencoded::Serializer::new(String::new())
             .extend_pairs(queries)
             .finish();
-        format!("{uri}?{}", query_params)
+        format!("{uri}?{query_params}")
             .parse::<http::Uri>()
             .context("error parsing URL")
     } else {
@@ -637,11 +637,11 @@ mod test {
         wrapper(|env| {
             let web = env.frontend();
             for krate in &["std", "alloc", "core", "proc_macro", "test"] {
-                let target = format!("https://doc.rust-lang.org/stable/{}/", krate);
+                let target = format!("https://doc.rust-lang.org/stable/{krate}/");
 
                 // with or without slash
-                assert_redirect(&format!("/{}", krate), &target, web)?;
-                assert_redirect(&format!("/{}/", krate), &target, web)?;
+                assert_redirect(&format!("/{krate}"), &target, web)?;
+                assert_redirect(&format!("/{krate}/"), &target, web)?;
             }
 
             let target = "https://doc.rust-lang.org/stable/proc_macro/";

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -54,17 +54,10 @@ fn load_templates(conn: &mut Client) -> Result<Tera> {
     //
     // TODO: remove this when https://github.com/Gilnaa/globwalk/issues/29 is fixed
     let mut tera = Tera::default();
-    let template_files = find_templates_in_filesystem(TEMPLATES_DIRECTORY).with_context(|| {
-        format!(
-            "failed to search {:?} for tera templates",
-            TEMPLATES_DIRECTORY
-        )
-    })?;
+    let template_files = find_templates_in_filesystem(TEMPLATES_DIRECTORY)
+        .with_context(|| format!("failed to search {TEMPLATES_DIRECTORY:?} for tera templates"))?;
     tera.add_template_files(template_files).with_context(|| {
-        format!(
-            "failed while loading tera templates in {:?}",
-            TEMPLATES_DIRECTORY
-        )
+        format!("failed while loading tera templates in {TEMPLATES_DIRECTORY:?}")
     })?;
 
     // This function will return any global alert, if present.
@@ -174,12 +167,12 @@ fn timeformat(value: &Value, args: &HashMap<String, Value>) -> TeraResult<Value>
         }
 
         // TODO: This formatting section can be optimized, two string allocations aren't needed
-        let mut value = format!("{:.1}", value);
+        let mut value = format!("{value:.1}");
         if value.ends_with(".0") {
             value.truncate(value.len() - 2);
         }
 
-        format!("{} {}", value, chosen_time)
+        format!("{value} {chosen_time}")
     };
 
     Ok(Value::String(fmt))
@@ -188,7 +181,7 @@ fn timeformat(value: &Value, args: &HashMap<String, Value>) -> TeraResult<Value>
 /// Print a tera value to stdout
 #[allow(clippy::unnecessary_wraps)]
 fn dbg(value: &Value, _args: &HashMap<String, Value>) -> TeraResult<Value> {
-    println!("{:?}", value);
+    println!("{value:?}");
 
     Ok(value.clone())
 }

--- a/src/web/page/web_page.rs
+++ b/src/web/page/web_page.rs
@@ -158,7 +158,7 @@ fn render_response(
                 Err(err) => {
                     if response.status().is_server_error() {
                         // avoid infinite loop if error.html somehow fails to load
-                        panic!("error while serving error page: {:?}", err);
+                        panic!("error while serving error page: {err:?}");
                     } else {
                         return render_response(
                             AxumNope::InternalError(err).into_response(),

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -163,7 +163,7 @@ async fn get_search_results(pool: Pool, query_params: &str) -> Result<SearchResu
     #[cfg(test)]
     let host = mockito::server_url();
 
-    let url = url::Url::parse(&format!("{}/api/v1/crates{}", host, query_params))?;
+    let url = url::Url::parse(&format!("{host}/api/v1/crates{query_params}"))?;
     debug!("fetching search results from {}", url);
 
     // extract the query from the query args.
@@ -494,10 +494,7 @@ async fn redirect_to_random_crate(
 
         metrics.im_feeling_lucky_searches.inc();
 
-        Ok(axum_redirect(format!(
-            "/{}/{}/{}/",
-            name, version, target_name
-        ))?)
+        Ok(axum_redirect(format!("/{name}/{version}/{target_name}/"))?)
     } else {
         report_error(&anyhow!("found no result in random crate search"));
         Err(AxumNope::NoResults)
@@ -601,9 +598,9 @@ pub(crate) async fn search_handler(
     let executed_query = search_result.executed_query.unwrap_or_default();
 
     let title = if search_result.results.is_empty() {
-        format!("No results found for '{}'", executed_query)
+        format!("No results found for '{executed_query}'")
     } else {
-        format!("Search results for '{}'", executed_query)
+        format!("Search results for '{executed_query}'")
     };
 
     Ok(Search {
@@ -984,7 +981,7 @@ mod tests {
                 .send()?;
             assert_eq!(response.status(), 500);
 
-            assert!(response.text()?.contains(&format!("{}", status)));
+            assert!(response.text()?.contains(&format!("{status}")));
             Ok(())
         })
     }
@@ -1447,7 +1444,7 @@ mod tests {
                 if let Some(priority) = expected.2 {
                     assert!(li
                         .text_contents()
-                        .contains(&format!("priority: {}", priority)));
+                        .contains(&format!("priority: {priority}")));
                 }
             }
 
@@ -1495,7 +1492,7 @@ mod tests {
                         web.get(&url).send()?
                     };
                 let status = resp.status();
-                assert!(status.is_success(), "failed to GET {}: {}", url, status);
+                assert!(status.is_success(), "failed to GET {url}: {status}");
             }
 
             Ok(())
@@ -1533,10 +1530,7 @@ mod tests {
                     let found = not_matching.iter().map(|(a, _)| a).collect::<Vec<_>>();
                     assert!(
                         not_matching.is_empty(),
-                        "Titles did not match for URL `{}`: not found: {:?}, found: {:?}",
-                        url,
-                        not_found,
-                        found,
+                        "Titles did not match for URL `{url}`: not found: {not_found:?}, found: {found:?}",
                     );
                 }
             };

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -75,7 +75,7 @@ pub(crate) async fn sitemap_handler(
                 crates.name ILIKE $1 
              GROUP BY crates.name, releases.target_name
              ",
-            &[&format!("{}%", letter)],
+            &[&format!("{letter}%")],
         )?;
 
         Ok(query
@@ -155,7 +155,7 @@ pub(crate) async fn about_handler(subpage: Option<Path<String>>) -> AxumResult<i
             return Ok(page.into_response());
         }
     };
-    let template = format!("core/about/{}.html", name);
+    let template = format!("core/about/{name}.html");
     Ok(AboutPage {
         template,
         active_tab: name,
@@ -183,9 +183,9 @@ mod tests {
 
             // everything not length=1 and ascii-lowercase should fail
             for invalid_letter in &["1", "aa", "A", ""] {
-                println!("trying to fail letter {}", invalid_letter);
+                println!("trying to fail letter {invalid_letter}");
                 assert_eq!(
-                    web.get(&format!("/-/sitemap/{}/sitemap.xml", invalid_letter))
+                    web.get(&format!("/-/sitemap/{invalid_letter}/sitemap.xml"))
                         .send()?
                         .status(),
                     StatusCode::NOT_FOUND
@@ -202,7 +202,7 @@ mod tests {
 
             // letter-sitemaps always work, even without crates & releases
             for letter in 'a'..='z' {
-                assert_success(&format!("/-/sitemap/{}/sitemap.xml", letter), web)?;
+                assert_success(&format!("/-/sitemap/{letter}/sitemap.xml"), web)?;
             }
 
             env.fake_release().name("some_random_crate").create()?;
@@ -222,7 +222,7 @@ mod tests {
             // and not in the others
             for letter in ('a'..='z').filter(|&c| c != 's') {
                 let response = web
-                    .get(&format!("/-/sitemap/{}/sitemap.xml", letter))
+                    .get(&format!("/-/sitemap/{letter}/sitemap.xml"))
                     .send()?;
 
                 assert!(response.status().is_success());
@@ -267,7 +267,7 @@ mod tests {
                     continue;
                 }
                 let filename = file_path.file_stem().unwrap().to_str().unwrap();
-                let path = format!("/about/{}", filename);
+                let path = format!("/about/{filename}");
                 assert_success(&path, web)?;
             }
             assert_success("/about", web)

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -214,7 +214,7 @@ pub(crate) async fn source_browser_handler(
         MatchSemver::Exact((version, _)) => (version.clone(), version, false),
         MatchSemver::Semver((version, _)) => {
             return Ok(super::axum_cached_redirect(
-                &format!("/crate/{}/{}/source/{}", name, version, path),
+                &format!("/crate/{name}/{version}/source/{path}"),
                 CachePolicy::ForeverInCdn,
             )?
             .into_response());
@@ -253,7 +253,7 @@ pub(crate) async fn source_browser_handler(
     })
     .await?;
 
-    let canonical_url = CanonicalUrl::from_path(format!("/crate/{}/latest/source/{}", name, path));
+    let canonical_url = CanonicalUrl::from_path(format!("/crate/{name}/latest/source/{path}"));
 
     let (file, file_content) = if let Some(blob) = blob {
         let is_text = blob.mime.starts_with("text") || blob.mime == "application/json";

--- a/src/web/statics.rs
+++ b/src/web/statics.rs
@@ -197,13 +197,12 @@ mod tests {
                     let url = format!("/-/static/{}", file.to_str().unwrap());
                     let resp = web.get(&url).send()?;
 
-                    assert!(resp.status().is_success(), "failed to fetch {:?}", url);
+                    assert!(resp.status().is_success(), "failed to fetch {url:?}");
                     assert_cache_control(&resp, CachePolicy::ForeverInCdnAndBrowser, &env.config());
                     assert_eq!(
                         resp.bytes()?,
                         fs::read(path).unwrap(),
-                        "failed to fetch {:?}",
-                        url,
+                        "failed to fetch {url:?}",
                     );
                 }
             }
@@ -231,14 +230,13 @@ mod tests {
             let files = &[("vendored.css", "text/css")];
 
             for (file, mime) in files {
-                let url = format!("/-/static/{}", file);
+                let url = format!("/-/static/{file}");
                 let resp = web.get(&url).send()?;
 
                 assert_eq!(
                     resp.headers().get("Content-Type"),
                     Some(&mime.parse().unwrap()),
-                    "{:?} has an incorrect content type",
-                    url,
+                    "{url:?} has an incorrect content type",
                 );
             }
 
@@ -265,8 +263,7 @@ mod tests {
             // to a framework that doesn't include builtin protection in the future.
             assert!(
                 matches!(serve_file(path).await, Err(AxumNope::ResourceNotFound)),
-                "{} did not return a 404",
-                path
+                "{path} did not return a 404"
             );
         }
     }


### PR DESCRIPTION
The edition-upgrade is needed because otherwise the fixed `assert!` format will lead to another clippy warning. 

The clippy changes themselves were 100% done by `clippy --fix` 