### PR TITLE
Add cli interface to sandbox limit overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,6 +1441,7 @@ dependencies = [
  "grass",
  "hostname",
  "http",
+ "humantime",
  "hyper",
  "indoc",
  "itertools",
@@ -2632,6 +2633,12 @@ name = "humansize"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ chrono = { version = "0.4.11", default-features = false, features = ["clock", "s
 
 # Transitive dependencies we don't use directly but need to have specific versions of
 thread_local = "1.1.3"
+humantime = "2.1.0"
 
 [dependencies.postgres]
 version = "0.19"

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,18 +1,22 @@
 //! Database operations
 
-pub use self::add_package::update_crate_data_in_database;
 pub(crate) use self::add_package::{
     add_build_into_database, add_doc_coverage, add_package_into_database,
 };
-pub use self::delete::{delete_crate, delete_version};
-pub use self::file::{add_path_into_database, add_path_into_remote_archive};
-pub use self::migrate::migrate;
-pub use self::pool::{Pool, PoolClient, PoolError};
+pub use self::{
+    add_package::update_crate_data_in_database,
+    delete::{delete_crate, delete_version},
+    file::{add_path_into_database, add_path_into_remote_archive},
+    migrate::migrate,
+    overrides::Overrides,
+    pool::{Pool, PoolClient, PoolError},
+};
 
 mod add_package;
 pub mod blacklist;
 pub mod delete;
 pub(crate) mod file;
 mod migrate;
+mod overrides;
 mod pool;
 pub(crate) mod types;

--- a/src/db/overrides.rs
+++ b/src/db/overrides.rs
@@ -1,0 +1,129 @@
+use crate::error::Result;
+use postgres::Client;
+use std::time::Duration;
+
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub struct Overrides {
+    pub memory: Option<usize>,
+    pub targets: Option<usize>,
+    pub timeout: Option<Duration>,
+}
+
+impl Overrides {
+    pub fn all(conn: &mut Client) -> Result<Vec<(String, Self)>> {
+        Ok(conn
+            .query("SELECT * FROM sandbox_overrides", &[])?
+            .into_iter()
+            .map(|row| (row.get("crate_name"), Self::from_row(row)))
+            .collect())
+    }
+
+    pub fn for_crate(conn: &mut Client, krate: &str) -> Result<Option<Self>> {
+        Ok(conn
+            .query_opt(
+                "SELECT * FROM sandbox_overrides WHERE crate_name = $1",
+                &[&krate],
+            )?
+            .map(Self::from_row))
+    }
+
+    fn from_row(row: postgres::Row) -> Self {
+        Self {
+            memory: row
+                .get::<_, Option<i64>>("max_memory_bytes")
+                .map(|i| i as usize),
+            targets: row.get::<_, Option<i32>>("max_targets").map(|i| i as usize),
+            timeout: row
+                .get::<_, Option<i32>>("timeout_seconds")
+                .map(|i| Duration::from_secs(i as u64)),
+        }
+    }
+
+    pub fn save(conn: &mut Client, krate: &str, overrides: Self) -> Result<()> {
+        if overrides.timeout.is_some() && overrides.targets.is_none() {
+            tracing::warn!("setting `Overrides::timeout` implies a default `Overrides::targets = 1`, prefer setting this explicitly");
+        }
+        conn.execute(
+            "
+                INSERT INTO sandbox_overrides (
+                    crate_name, max_memory_bytes, max_targets, timeout_seconds
+                )
+                VALUES ($1, $2, $3, $4)
+                ON CONFLICT (crate_name) DO UPDATE
+                    SET
+                        max_memory_bytes = $2,
+                        max_targets = $3,
+                        timeout_seconds = $4
+                ",
+            &[
+                &krate,
+                &overrides.memory.map(|i| i as i64),
+                &overrides.targets.map(|i| i as i32),
+                &overrides.timeout.map(|d| d.as_secs() as i32),
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn remove(conn: &mut Client, krate: &str) -> Result<()> {
+        conn.execute(
+            "DELETE FROM sandbox_overrides WHERE crate_name = $1",
+            &[&krate],
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{db::Overrides, test::*};
+    use std::time::Duration;
+
+    #[test]
+    fn retrieve_overrides() {
+        wrapper(|env| {
+            let db = env.db();
+
+            let krate = "hexponent";
+
+            // no overrides
+            let actual = Overrides::for_crate(&mut db.conn(), krate)?;
+            assert_eq!(actual, None);
+
+            // add partial overrides
+            let expected = Overrides {
+                targets: Some(1),
+                ..Overrides::default()
+            };
+            Overrides::save(&mut db.conn(), krate, expected)?;
+            let actual = Overrides::for_crate(&mut db.conn(), krate)?;
+            assert_eq!(actual, Some(expected));
+
+            // overwrite with full overrides
+            let expected = Overrides {
+                memory: Some(100_000),
+                targets: Some(1),
+                timeout: Some(Duration::from_secs(300)),
+            };
+            Overrides::save(&mut db.conn(), krate, expected)?;
+            let actual = Overrides::for_crate(&mut db.conn(), krate)?;
+            assert_eq!(actual, Some(expected));
+
+            // overwrite with partial overrides
+            let expected = Overrides {
+                memory: Some(1),
+                ..Overrides::default()
+            };
+            Overrides::save(&mut db.conn(), krate, expected)?;
+            let actual = Overrides::for_crate(&mut db.conn(), krate)?;
+            assert_eq!(actual, Some(expected));
+
+            // remove overrides
+            Overrides::remove(&mut db.conn(), krate)?;
+            let actual = Overrides::for_crate(&mut db.conn(), krate)?;
+            assert_eq!(actual, None);
+
+            Ok(())
+        });
+    }
+}

--- a/src/db/overrides.rs
+++ b/src/db/overrides.rs
@@ -43,6 +43,14 @@ impl Overrides {
         if overrides.timeout.is_some() && overrides.targets.is_none() {
             tracing::warn!("setting `Overrides::timeout` implies a default `Overrides::targets = 1`, prefer setting this explicitly");
         }
+
+        if conn
+            .query_opt("SELECT id FROM crates WHERE crates.name = $1", &[&krate])?
+            .is_none()
+        {
+            tracing::warn!("setting overrides for unknown crate `{krate}`");
+        }
+
         conn.execute(
             "
                 INSERT INTO sandbox_overrides (


### PR DESCRIPTION
I went to do #2032 and realised we still had no way to do it other than editing the database directly. I think it's worth trying to expose all the semi-regular operations in the CLI so we don't need to remember how to edit the schema.