### PR TITLE
Optimize loading docs.rs-specific javascript

### DIFF
--- a/templates/rustdoc/body.html
+++ b/templates/rustdoc/body.html
@@ -1,4 +1,4 @@
-<script type="text/javascript" src="/-/static/menu.js?{{ docsrs_version() | slugify }}"></script>
-<script type="text/javascript" src="/-/static/index.js?{{ docsrs_version() | slugify }}"></script>
+<script async src="/-/static/menu.js?{{ docsrs_version() | slugify }}"></script>
+<script async src="/-/static/index.js?{{ docsrs_version() | slugify }}"></script>
 {# see comment in ../storage-change-detection.html for details #}
 <iframe loading="lazy" src="/-/storage-change-detection.html" width="0" height="0" style="display: none"></iframe>


### PR DESCRIPTION
This removes the [type] attribute, which is not recommended by MDN since JavaScript is the default anyway, and loads it [async] instead of blocking.

[type]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type
[async]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-async