### PR TITLE
set platform in docker-compose file to builds work on M1 macs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
         build:
             context: .
             dockerfile: ./dockerfiles/Dockerfile
+        platform: "linux/amd64"
         depends_on:
             - db
             - s3


### PR DESCRIPTION
docker on mac has a new feature: 
<img width="711" alt="grafik" src="https://user-images.githubusercontent.com/540890/218250818-cdcc19d7-7089-428d-9678-f1afd79e4236.png">

Which makes the performance of the emulation actually useable. 

So before I can dig into how to make the build-server work on ARM linux, this helps. 

I could theoretically split the web/build server in the docker-compose file, but IMO this is OK for the use-case. 