### PR TITLE
don't report error on unknown mime type from S3

### DIFF
--- a/src/web/file.rs
+++ b/src/web/file.rs
@@ -4,10 +4,9 @@ use super::cache::CachePolicy;
 use crate::{
     error::Result,
     storage::{Blob, Storage},
-    utils::report_error,
     Config,
 };
-use anyhow::anyhow;
+
 use axum::{
     extract::Extension,
     http::{
@@ -36,10 +35,11 @@ impl File {
 
 impl IntoResponse for File {
     fn into_response(self) -> AxumResponse {
-        let content_type: Mime = self.0.mime.parse::<Mime>().unwrap_or_else(|e| {
-            report_error(&anyhow!(e).context("could not parse mime from storage object"));
-            mime::APPLICATION_OCTET_STREAM
-        });
+        let content_type: Mime = self
+            .0
+            .mime
+            .parse::<Mime>()
+            .unwrap_or(mime::APPLICATION_OCTET_STREAM);
 
         (
             StatusCode::OK,


### PR DESCRIPTION
I saw [this sentry error](https://rust-lang.sentry.io/issues/3918886192/), 

from (for example) serving `http://docs.rs/crate/mach_object/0.1.3/source/test/helloworld.universal`, which raises the error "could not parse mime from storage object". 

IMO we don't need this error, defaulting to `application/octet-stream` is totally fine. 