### PR TITLE
consistency check: update local crates.io index before querying it

### DIFF
--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -95,7 +95,9 @@ impl Index {
             .repository_url
             .as_deref()
             .unwrap_or("https://github.com/rust-lang/crates.io-index");
-        crates_index::Index::with_path(&self.path, repo_url).map_err(Into::into)
+        let mut index = crates_index::Index::with_path(&self.path, repo_url)?;
+        index.update()?;
+        Ok(index)
     }
 
     pub fn api(&self) -> &Api {


### PR DESCRIPTION
so, from a first digging surfaced
* `crates_index` uses `FETCH_HEAD` or `HEAD` to fetch the crates ( see [here](https://github.com/frewsxcv/rust-crates-index/blob/9b21638187728e151cabc392d110492bb49c26cb/src/bare_index.rs#L150-L154) )
* while `crates-index-diff` uses its own logic to get the local ref / branch to use as a head (see [here](https://github.com/Byron/crates-index-diff-rs/blob/7ea9dda2a9ca3702dbafbb2009c3c801bfb34669/src/index/diff/mod.rs#L176-L189) )

calling [`.update` on `crates_index.Index`](https://github.com/frewsxcv/rust-crates-index/blob/9b21638187728e151cabc392d110492bb49c26cb/src/bare_index.rs#L191-L217) solves the issue, from what I see without impacting what crates-index-diff does.

( I downloaded the index state from our server and tested this)