### PR TITLE
Rely on cargo adding features for optional dependencies

### DIFF
--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -697,25 +697,25 @@ mod test {
     #[test_case(
         r#"
             [features]
-            foo = []
+            bar = []
         "#,
-        [Feature::new("foo".into(), vec![])]
+        [Feature::new("bar".into(), vec![])]
     )]
     #[test_case(
         r#"
             [dependencies]
-            base64 = { optional = true, version = "=0.13.1" }
+            bar = { optional = true, path = "bar" }
         "#,
-        [Feature::new("base64".into(), vec!["dep:base64".into()])]
+        [Feature::new("bar".into(), vec!["dep:bar".into()])]
     )]
     #[test_case(
         r#"
             [dependencies]
-            base64 = { optional = true, version = "=0.13.1" }
+            bar = { optional = true, path = "bar" }
             [features]
-            not-base64 = ["dep:base64"]
+            not-bar = ["dep:bar"]
         "#,
-        [Feature::new("not-base64".into(), vec!["dep:base64".into()])]
+        [Feature::new("not-bar".into(), vec!["dep:bar".into()])]
     )]
     fn test_get_features(extra: &str, expected: impl AsRef<[Feature]>) -> Result<()> {
         let dir = tempfile::tempdir()?;
@@ -723,9 +723,22 @@ mod test {
         std::fs::create_dir(dir.path().join("src"))?;
         std::fs::write(dir.path().join("src/lib.rs"), "")?;
 
+        std::fs::create_dir(dir.path().join("bar"))?;
+        std::fs::create_dir(dir.path().join("bar/src"))?;
+        std::fs::write(dir.path().join("bar/src/lib.rs"), "")?;
+
+        std::fs::write(
+            dir.path().join("bar/Cargo.toml"),
+            r#"
+                [package]
+                name = "bar"
+                version = "0.0.0"
+            "#,
+        )?;
+
         let base = r#"
             [package]
-            name = "test"
+            name = "foo"
             version = "0.0.0"
         "#;
 

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -861,7 +861,7 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> crate::error::Res
         ),
         sql_migration!(
             context, 37, "add cdn-invalidation-queue table",
-            " 
+            "
             CREATE TABLE cdn_invalidation_queue (
                 id BIGSERIAL,
                 crate VARCHAR(255) NOT NULL,
@@ -881,6 +881,13 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> crate::error::Res
             DROP INDEX cdn_invalidation_queue_created_in_cdn_idx;
             DROP TABLE cdn_invalidation_queue;
             "
+        ),
+        sql_migration!(
+            context,
+            38,
+            "Remove mark for features that are derived from optional dependencies",
+            "ALTER TYPE feature DROP ATTRIBUTE optional_dependency;",
+            "ALTER TYPE feature ADD ATTRIBUTE optional_dependency BOOL;"
         ),
     ];
 

--- a/src/db/types.rs
+++ b/src/db/types.rs
@@ -6,17 +6,11 @@ use serde::Serialize;
 pub struct Feature {
     pub(crate) name: String,
     pub(crate) subfeatures: Vec<String>,
-    /// [`None`] when this crate was built before optional dependencies were tracked
-    pub(crate) optional_dependency: Option<bool>,
 }
 
 impl Feature {
-    pub fn new(name: String, subfeatures: Vec<String>, optional_dependency: bool) -> Self {
-        Feature {
-            name,
-            subfeatures,
-            optional_dependency: Some(optional_dependency),
-        }
+    pub fn new(name: String, subfeatures: Vec<String>) -> Self {
+        Feature { name, subfeatures }
     }
 
     pub fn is_private(&self) -> bool {

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -311,8 +311,8 @@ impl RustwideBuilder {
 
     pub fn build_local_package(&mut self, path: &Path) -> Result<bool> {
         self.update_toolchain()?;
-        let metadata =
-            CargoMetadata::load(&self.workspace, &self.toolchain, path).map_err(|err| {
+        let metadata = CargoMetadata::load_from_rustwide(&self.workspace, &self.toolchain, path)
+            .map_err(|err| {
                 err.context(format!("failed to load local package {}", path.display()))
             })?;
         let package = metadata.root();
@@ -646,8 +646,11 @@ impl RustwideBuilder {
         metadata: &Metadata,
         create_essential_files: bool,
     ) -> Result<FullBuildResult> {
-        let cargo_metadata =
-            CargoMetadata::load(&self.workspace, &self.toolchain, &build.host_source_dir())?;
+        let cargo_metadata = CargoMetadata::load_from_rustwide(
+            &self.workspace,
+            &self.toolchain,
+            &build.host_source_dir(),
+        )?;
 
         let mut rustdoc_flags = vec![if create_essential_files {
             "--emit=unversioned-shared-resources,toolchain-shared-resources"

--- a/src/utils/cargo_metadata.rs
+++ b/src/utils/cargo_metadata.rs
@@ -34,7 +34,8 @@ impl CargoMetadata {
             .output()?;
         let status = res.status;
         if !status.success() {
-            bail!("error returned by `cargo metadata`: {status}")
+            let stderr = std::str::from_utf8(&res.stderr).unwrap_or("");
+            bail!("error returned by `cargo metadata`: {status}\n{stderr}")
         }
         Self::load_from_metadata(std::str::from_utf8(&res.stdout)?)
     }

--- a/src/web/features.rs
+++ b/src/web/features.rs
@@ -140,8 +140,8 @@ mod tests {
 
     #[test]
     fn test_feature_map_filters_private() {
-        let private1 = Feature::new("_private1".into(), vec!["feature1".into()], false);
-        let feature2 = Feature::new("feature2".into(), Vec::new(), false);
+        let private1 = Feature::new("_private1".into(), vec!["feature1".into()]);
+        let feature2 = Feature::new("feature2".into(), Vec::new());
 
         let raw = vec![private1.clone(), feature2.clone()];
         let feature_map = get_feature_map(raw);
@@ -153,15 +153,14 @@ mod tests {
 
     #[test]
     fn test_default_tree_structure_with_nested_default() {
-        let default = Feature::new(DEFAULT_NAME.into(), vec!["feature1".into()], false);
-        let non_default = Feature::new("non-default".into(), Vec::new(), false);
+        let default = Feature::new(DEFAULT_NAME.into(), vec!["feature1".into()]);
+        let non_default = Feature::new("non-default".into(), Vec::new());
         let feature1 = Feature::new(
             "feature1".into(),
             vec!["feature2".into(), "feature3".into()],
-            false,
         );
-        let feature2 = Feature::new("feature2".into(), Vec::new(), false);
-        let feature3 = Feature::new("feature3".into(), Vec::new(), false);
+        let feature2 = Feature::new("feature2".into(), Vec::new());
+        let feature3 = Feature::new("feature3".into(), Vec::new());
 
         let raw = vec![
             default.clone(),
@@ -188,10 +187,9 @@ mod tests {
         let feature1 = Feature::new(
             "feature1".into(),
             vec!["feature2".into(), "feature3".into()],
-            false,
         );
-        let feature2 = Feature::new("feature2".into(), Vec::new(), false);
-        let feature3 = Feature::new("feature3".into(), Vec::new(), false);
+        let feature2 = Feature::new("feature2".into(), Vec::new());
+        let feature3 = Feature::new("feature3".into(), Vec::new());
 
         let raw = vec![feature3.clone(), feature2.clone(), feature1.clone()];
         let mut feature_map = get_feature_map(raw);
@@ -206,8 +204,8 @@ mod tests {
 
     #[test]
     fn test_default_tree_structure_single_default() {
-        let default = Feature::new(DEFAULT_NAME.into(), Vec::new(), false);
-        let non_default = Feature::new("non-default".into(), Vec::new(), false);
+        let default = Feature::new(DEFAULT_NAME.into(), Vec::new());
+        let non_default = Feature::new("non-default".into(), Vec::new());
 
         let raw = vec![default.clone(), non_default.clone()];
         let mut feature_map = get_feature_map(raw);
@@ -225,10 +223,9 @@ mod tests {
         let feature1 = Feature::new(
             "feature1".into(),
             vec!["feature10".into(), "feature11".into()],
-            false,
         );
-        let feature2 = Feature::new("feature2".into(), vec!["feature20".into()], false);
-        let feature3 = Feature::new("feature3".into(), Vec::new(), false);
+        let feature2 = Feature::new("feature2".into(), vec!["feature20".into()]);
+        let feature3 = Feature::new("feature3".into(), Vec::new());
 
         let raw = vec![feature3.clone(), feature2.clone(), feature1.clone()];
         let (features, default_len) = order_features_and_count_default_len(raw);
@@ -242,8 +239,8 @@ mod tests {
 
     #[test]
     fn test_order_features_and_get_len_single_default() {
-        let default = Feature::new(DEFAULT_NAME.into(), Vec::new(), false);
-        let non_default = Feature::new("non-default".into(), Vec::new(), false);
+        let default = Feature::new(DEFAULT_NAME.into(), Vec::new());
+        let non_default = Feature::new("non-default".into(), Vec::new());
 
         let raw = vec![default.clone(), non_default.clone()];
         let (features, default_len) = order_features_and_count_default_len(raw);


### PR DESCRIPTION
Since the `dep:` syntax was stabilized Cargo now reports optional dependencies as features for `cargo metadata`, so we don't need to manually add these ourselves, and it takes into account whether they've been hidden via `dep:` which we didn't.

We don't get told which features are from optional dependencies, which is something we have been tracking in the database. But we haven't started using this data in the UI in the 2 years it's been tracked so we may as well drop it.

The `serde` test checks that we don't regress on crates that expose their optional dependencies, the `stylish-core` test did not originally pass and checks that we now strip out optional dependencies hidden behind `dep:`.

fixes #2048 