### PR TITLE
offload CPU intensive rendering into rayon threadpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,6 +1430,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "mockito",
+ "num_cpus",
  "once_cell",
  "path-slash",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [features]
-consistency_check = ["crates-index", "rayon", "itertools"]
+consistency_check = ["crates-index", "itertools"]
 
 [dependencies]
 sentry = "0.30.0"
@@ -31,7 +31,8 @@ tracing-log = "0.1.3"
 regex = "1"
 clap = { version = "4.0.22", features = [ "derive" ] }
 crates-index = { version = "0.18.5", optional = true }
-rayon = { version = "1", optional = true }
+rayon = "1.6.1"
+num_cpus = "1.15.0"
 crates-index-diff = { version = "16.0.1", features = [ "max-performance" ]}
 reqwest = { version = "0.11", features = ["blocking", "json"] } # TODO: Remove blocking when async is ready
 semver = { version = "1.0.4", features = ["serde"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,9 @@ pub struct Config {
     // Time between 'git gc --auto' calls in seconds
     pub(crate) registry_gc_interval: u64,
 
+    /// amout of threads for CPU intensive rendering
+    pub(crate) render_threads: usize,
+
     // random crate search generates a number of random IDs to
     // efficiently find a random crate with > 100 GH stars.
     // The amount depends on the ratio of crates with >100 stars
@@ -153,6 +156,7 @@ impl Config {
             // https://github.com/rust-lang/docs.rs/pull/930#issuecomment-667729380
             max_parse_memory: env("DOCSRS_MAX_PARSE_MEMORY", 5 * 1024 * 1024)?,
             registry_gc_interval: env("DOCSRS_REGISTRY_GC_INTERVAL", 60 * 60)?,
+            render_threads: env("DOCSRS_RENDER_THREADS", num_cpus::get())?,
 
             random_crate_search_view_size: env("DOCSRS_RANDOM_CRATE_SEARCH_VIEW_SIZE", 500)?,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ pub struct Config {
     // Time between 'git gc --auto' calls in seconds
     pub(crate) registry_gc_interval: u64,
 
-    /// amout of threads for CPU intensive rendering
+    /// amount of threads for CPU intensive rendering
     pub(crate) render_threads: usize,
 
     // random crate search generates a number of random IDs to

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -548,8 +548,13 @@ impl TestFrontend {
         }
 
         debug!("loading template data");
-        let template_data =
-            Arc::new(TemplateData::new(&mut context.pool().unwrap().get().unwrap()).unwrap());
+        let template_data = Arc::new(
+            TemplateData::new(
+                &mut context.pool().unwrap().get().unwrap(),
+                context.config().unwrap().render_threads,
+            )
+            .unwrap(),
+        );
 
         debug!("binding local TCP port for axum");
         let axum_listener =

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -548,13 +548,8 @@ impl TestFrontend {
         }
 
         debug!("loading template data");
-        let template_data = Arc::new(
-            TemplateData::new(
-                &mut context.pool().unwrap().get().unwrap(),
-                context.config().unwrap().render_threads,
-            )
-            .unwrap(),
-        );
+        let template_data =
+            Arc::new(TemplateData::new(&mut context.pool().unwrap().get().unwrap(), 1).unwrap());
 
         debug!("binding local TCP port for axum");
         let axum_listener =

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -272,7 +272,10 @@ pub(crate) fn build_axum_app(
 
 #[instrument(skip_all)]
 pub fn start_web_server(addr: Option<&str>, context: &dyn Context) -> Result<(), Error> {
-    let template_data = Arc::new(TemplateData::new(&mut *context.pool()?.get()?)?);
+    let template_data = Arc::new(TemplateData::new(
+        &mut *context.pool()?.get()?,
+        context.config()?.render_threads,
+    )?);
 
     let axum_addr: SocketAddr = addr.unwrap_or(DEFAULT_BIND).parse()?;
 

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -18,6 +18,15 @@ const TEMPLATES_DIRECTORY: &str = "templates";
 #[derive(Debug)]
 pub(crate) struct TemplateData {
     pub templates: Tera,
+    /// rendering threadpool for CPU intensive rendering.
+    /// When the app is shut down, the pool won't wait
+    /// for pending tasks in this pool.
+    /// In the case of rendering, this is what we want.
+    /// See also https://github.com/rayon-rs/rayon/issues/688.
+    ///
+    /// This is better than using `tokio::spawn_blocking` because
+    /// tokio will wait until all tasks are finished when shutting
+    /// down.
     rendering_threadpool: rayon::ThreadPool,
 }
 

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -649,33 +649,33 @@ pub(crate) async fn rustdoc_html_server_handler(
     rendering_time.step("rewrite html");
 
     // Build the page of documentation,
-    // inside `spawn_blocking` since it's CPU intensive.
-    spawn_blocking({
-        let metrics = metrics.clone();
-        move || {
-            Ok(RustdocPage {
-                latest_path,
-                permalink_path,
-                latest_version,
-                target,
-                inner_path,
-                is_latest_version,
-                is_latest_url,
-                is_prerelease,
-                metadata: krate.metadata.clone(),
-                krate: krate.clone(),
+    templates
+        .render_in_threadpool({
+            let metrics = metrics.clone();
+            move |templates| {
+                Ok(RustdocPage {
+                    latest_path,
+                    permalink_path,
+                    latest_version,
+                    target,
+                    inner_path,
+                    is_latest_version,
+                    is_latest_url,
+                    is_prerelease,
+                    metadata: krate.metadata.clone(),
+                    krate: krate.clone(),
+                }
+                .into_response(
+                    &blob.content,
+                    config.max_parse_memory,
+                    templates,
+                    &metrics,
+                    &config,
+                    &storage_path,
+                ))
             }
-            .into_response(
-                &blob.content,
-                config.max_parse_memory,
-                &templates,
-                &metrics,
-                &config,
-                &storage_path,
-            ))
-        }
-    })
-    .await?
+        })
+        .await?
 }
 
 /// Checks whether the given path exists.


### PR DESCRIPTION
for now only:
* source pages
* rustdoc pages

The currently used tokio blocking threadpool has a max count of 512 threads, assuming that these threads mostly wait for I/O. With CPU-bound work these are too many. 

This will move cpu intensive rendering work into a separate rayon threadpool, with a configurable threadcount, and a set thread-name so we can see these in `htop`. 

Worst case a too low setting on this threadpool will lead to a lower RPM for rustdoc & source pages, but we can watch this and optimize. 

Seeing the current production issues we would be able to see if the rendering leads to the CPU load, and we'll be able to tweak the threadcount, and through that, potentially limit RPM so the system stability is better. 

### alternative

One alternative could be to still use the tokio `spawn_blocking` threadpool, while limiting the rendering tasks with a `Semaphore`. Since in prod we're below the 512 thread maximum this would work too, but it wouldn't have the advantage of named rendering threads. 
