### PR TITLE
Add missing centered CSS class

### DIFF
--- a/templates/crate/build_details.html
+++ b/templates/crate/build_details.html
@@ -5,6 +5,10 @@
     {{ macros::doc_title(name=metadata.name, version=metadata.version) }}
 {%- endblock title -%}
 
+{%- block body_classes -%}
+centered
+{%- endblock body_classes -%}
+
 {%- block topbar -%}
   {%- set latest_version = "" -%}
   {%- set latest_path = "" -%}

--- a/templates/crate/builds.html
+++ b/templates/crate/builds.html
@@ -9,6 +9,10 @@
 <link rel="canonical" href="{{ canonical_url | safe }}" />
 {%- endblock -%}
 
+{%- block body_classes -%}
+centered
+{%- endblock body_classes -%}
+
 {%- block topbar -%}
   {%- set latest_version = "" -%}
   {%- set latest_path = "" -%}

--- a/templates/releases/releases.html
+++ b/templates/releases/releases.html
@@ -15,6 +15,10 @@
     }}
 {%- endblock header -%}
 
+{%- block body_classes -%}
+centered
+{%- endblock body_classes -%}
+
 {%- block body -%}
     <div class="container">
         <div class="recent-releases-container">


### PR DESCRIPTION
Fixes cases like this (content is completely on the left, leaving big "empty space" on the right):

![Screenshot from 2023-02-26 21-37-52](https://user-images.githubusercontent.com/3050060/221435838-8b93e4ee-3f9b-43fe-bf5f-72b3ad73c37d.png)

As a reminder, https://github.com/rust-lang/docs.rs/pull/1698 is still waiting for feedback to prevent regressions like this to happen. ;)