### PR TITLE
fix rendering time recording to include storage-fetch again

### DIFF
--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -187,6 +187,8 @@ pub(crate) async fn rustdoc_redirector_handler(
             .await?
             .ok_or(AxumNope::ResourceNotFound)?;
 
+            rendering_time.step("fetch from storage");
+
             match spawn_blocking({
                 let version = version.clone();
                 let storage = storage.clone();
@@ -491,6 +493,10 @@ pub(crate) async fn rustdoc_html_server_handler(
     }
 
     trace!(?storage_path, ?req_path, "try fetching from storage");
+
+    // record the data-fetch step
+    // until we re-add it below inside `fetch_rustdoc_file`
+    rendering_time.step("fetch from storage");
 
     // Attempt to load the file from the database
     let blob = match spawn_blocking({


### PR DESCRIPTION
In 11777494b0b48fe58c525a0fa954745f2965d688 I had to remove a part of detailed rendering time recording. 

IMO this lead to the storage-fetch being recorded as `crate details` fetching. 

( this would not give us back the detail-level of separating betweenthe archive index lookup & doing the range request)