### PR TITLE
add optional request timeout & reporting for it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ axum-extra = "0.5.0"
 hyper = { version = "0.14.15", default-features = false }
 tower = "0.4.11"
 tower-service = "0.3.2"
-tower-http = { version = "0.4.0", features = ["fs", "trace"] }
+tower-http = { version = "0.4.0", features = ["fs", "trace", "timeout"] }
 mime = "0.3.16"
 percent-encoding = "2.2.0"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,6 @@
 use crate::{cdn::CdnKind, storage::StorageKind};
 use anyhow::{anyhow, bail, Context, Result};
-use std::env::VarError;
-use std::error::Error;
-use std::path::PathBuf;
-use std::str::FromStr;
+use std::{env::VarError, error::Error, path::PathBuf, str::FromStr, time::Duration};
 use tracing::trace;
 
 #[derive(Debug)]
@@ -42,7 +39,7 @@ pub struct Config {
     pub(crate) gitlab_accesstoken: Option<String>,
 
     // request timeout in seconds
-    pub(crate) request_timeout: Option<u64>,
+    pub(crate) request_timeout: Option<Duration>,
     pub(crate) report_request_timeouts: bool,
 
     // Max size of the files served by the docs.rs frontend
@@ -161,7 +158,7 @@ impl Config {
             max_parse_memory: env("DOCSRS_MAX_PARSE_MEMORY", 5 * 1024 * 1024)?,
             registry_gc_interval: env("DOCSRS_REGISTRY_GC_INTERVAL", 60 * 60)?,
             render_threads: env("DOCSRS_RENDER_THREADS", num_cpus::get())?,
-            request_timeout: maybe_env("DOCSRS_REQUEST_TIMEOUT")?,
+            request_timeout: maybe_env::<u64>("DOCSRS_REQUEST_TIMEOUT")?.map(Duration::from_secs),
             report_request_timeouts: env("DOCSRS_REPORT_REQUEST_TIMEOUTS", false)?,
 
             random_crate_search_view_size: env("DOCSRS_RANDOM_CRATE_SEARCH_VIEW_SIZE", 500)?,

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,10 @@ pub struct Config {
     // Gitlab authentication
     pub(crate) gitlab_accesstoken: Option<String>,
 
+    // request timeout in seconds
+    pub(crate) request_timeout: Option<u64>,
+    pub(crate) report_request_timeouts: bool,
+
     // Max size of the files served by the docs.rs frontend
     pub(crate) max_file_size: usize,
     pub(crate) max_file_size_html: usize,
@@ -157,6 +161,8 @@ impl Config {
             max_parse_memory: env("DOCSRS_MAX_PARSE_MEMORY", 5 * 1024 * 1024)?,
             registry_gc_interval: env("DOCSRS_REGISTRY_GC_INTERVAL", 60 * 60)?,
             render_threads: env("DOCSRS_RENDER_THREADS", num_cpus::get())?,
+            request_timeout: maybe_env("DOCSRS_REQUEST_TIMEOUT")?,
+            report_request_timeouts: env("DOCSRS_REPORT_REQUEST_TIMEOUTS", false)?,
 
             random_crate_search_view_size: env("DOCSRS_RANDOM_CRATE_SEARCH_VIEW_SIZE", 500)?,
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -47,7 +47,6 @@ use postgres::Client;
 use semver::{Version, VersionReq};
 use serde::Serialize;
 use std::borrow::Borrow;
-use std::time::Duration;
 use std::{borrow::Cow, net::SocketAddr, sync::Arc};
 use tower::ServiceBuilder;
 use tower_http::{timeout::TimeoutLayer, trace::TraceLayer};
@@ -281,9 +280,7 @@ pub(crate) fn build_axum_app(
                     .report_request_timeouts
                     .then_some(middleware::from_fn(log_timeouts_to_sentry)),
             ))
-            .layer(option_layer(config.request_timeout.map(|timeout| {
-                TimeoutLayer::new(Duration::from_secs(timeout))
-            })))
+            .layer(option_layer(config.request_timeout.map(TimeoutLayer::new)))
             .layer(Extension(context.pool()?))
             .layer(Extension(context.build_queue()?))
             .layer(Extension(context.metrics()?))


### PR DESCRIPTION
This will help us: 
- improving system stability by stopping to process requests that take too long. 
- debugging the current CPU usage issues 

Typically server-side request timeouts can lead to issues in combination with data-writing requests when not using transactions, but we don't have these. 

My idea here (if I'm not missing something): 
1. set the timeout to something like 60 seconds (or 30) 
2. activate sentry reporting for these 

so even when the rendering is the issue, my guess would be that these requests would timeout too, so we would get sentry reports for them. 