### PR TITLE
add metric for queued builds

### DIFF
--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -335,6 +335,7 @@ impl BuildQueue {
                             "{}-{} added into build queue",
                             release.name, release.version
                         );
+                        self.metrics.queued_builds.inc();
                         crates_added += 1;
                     }
                     Err(err) => report_error(&err),

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -83,6 +83,8 @@ metrics! {
         /// Count of recently accessed platforms of versions of crates
         pub(crate) recent_platforms: IntGaugeVec["duration"],
 
+        /// number of queued builds
+        pub(crate) queued_builds: IntCounter,
         /// Number of crates built
         pub(crate) total_builds: IntCounter,
         /// Number of builds that successfully generated docs


### PR DESCRIPTION
This adds a metric for _queued builds_, so we can get alerted in situations like #2065 ( [users had to report stuck builds](https://rust-lang.zulipchat.com/#narrow/stream/356853-t-docs-rs/topic/Stuck.20Builds.20.3F) ) . 

