### PR TITLE
Always use the `last_seen_reference` from the database 

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -202,6 +202,14 @@ enum QueueSubcommand {
         #[command(subcommand)]
         subcommand: PrioritySubcommand,
     },
+
+    /// Get the registry watcher's last seen reference
+    GetLastSeenReference,
+
+    /// Set the register watcher's last seen reference
+    SetLastSeenReference {
+        reference: crates_index_diff::gix::ObjectId,
+    },
 }
 
 impl QueueSubcommand {
@@ -217,6 +225,18 @@ impl QueueSubcommand {
                 build_priority,
                 ctx.config()?.registry_url.as_deref(),
             )?,
+
+            Self::GetLastSeenReference => {
+                if let Some(reference) = ctx.build_queue()?.last_seen_reference()? {
+                    println!("Last seen reference: {reference}");
+                } else {
+                    println!("No last seen reference available");
+                }
+            }
+
+            Self::SetLastSeenReference { reference } => {
+                ctx.build_queue()?.set_last_seen_reference(reference)?;
+            }
 
             Self::DefaultPriority { subcommand } => subcommand.handle_args(ctx)?,
         }

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -206,9 +206,16 @@ enum QueueSubcommand {
     /// Get the registry watcher's last seen reference
     GetLastSeenReference,
 
-    /// Set the register watcher's last seen reference
+    /// Set the registry watcher's last seen reference
+    #[command(arg_required_else_help(true))]
     SetLastSeenReference {
-        reference: crates_index_diff::gix::ObjectId,
+        /// The reference to set to, required unless flag used
+        #[arg(conflicts_with("head"))]
+        reference: Option<crates_index_diff::gix::ObjectId>,
+
+        /// Fetch the current HEAD of the remote index and use it
+        #[arg(long, conflicts_with("reference"))]
+        head: bool,
     },
 }
 
@@ -234,8 +241,19 @@ impl QueueSubcommand {
                 }
             }
 
-            Self::SetLastSeenReference { reference } => {
+            Self::SetLastSeenReference { reference, head } => {
+                let reference = match (reference, head) {
+                    (Some(reference), false) => reference,
+                    (None, true) => {
+                        println!("Fetching changes to set reference to HEAD");
+                        let (_, oid) = ctx.index()?.diff()?.peek_changes()?;
+                        oid
+                    }
+                    (_, _) => unreachable!(),
+                };
+
                 ctx.build_queue()?.set_last_seen_reference(reference)?;
+                println!("Set last seen reference: {reference}");
             }
 
             Self::DefaultPriority { subcommand } => subcommand.handle_args(ctx)?,

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -60,7 +60,7 @@ impl BuildQueue {
         Ok(None)
     }
 
-    fn set_last_seen_reference(&self, oid: crates_index_diff::gix::ObjectId) -> Result<()> {
+    pub fn set_last_seen_reference(&self, oid: crates_index_diff::gix::ObjectId) -> Result<()> {
         let mut conn = self.db.get()?;
         set_config(
             &mut conn,
@@ -79,7 +79,7 @@ impl BuildQueue {
         registry: Option<&str>,
     ) -> Result<()> {
         self.db.get()?.execute(
-            "INSERT INTO queue (name, version, priority, registry) 
+            "INSERT INTO queue (name, version, priority, registry)
              VALUES ($1, $2, $3, $4)
              ON CONFLICT (name, version) DO UPDATE
                 SET priority = EXCLUDED.priority,
@@ -106,10 +106,10 @@ impl BuildQueue {
 
     pub(crate) fn pending_count_by_priority(&self) -> Result<HashMap<i32, usize>> {
         let res = self.db.get()?.query(
-            "SELECT 
-                priority, 
-                COUNT(*) 
-            FROM queue 
+            "SELECT
+                priority,
+                COUNT(*)
+            FROM queue
             WHERE attempt < $1
             GROUP BY priority",
             &[&self.max_attempts],
@@ -156,9 +156,9 @@ impl BuildQueue {
             .query_opt(
                 "SELECT id
                  FROM queue
-                 WHERE 
-                    attempt < $1 AND 
-                    name = $2 AND 
+                 WHERE
+                    attempt < $1 AND
+                    name = $2 AND
                     version = $3
                  ",
                 &[&self.max_attempts, &name, &version],
@@ -185,7 +185,7 @@ impl BuildQueue {
                  FROM queue
                  WHERE attempt < $1
                  ORDER BY priority ASC, attempt ASC, id ASC
-                 LIMIT 1 
+                 LIMIT 1
                  FOR UPDATE SKIP LOCKED",
                 &[&self.max_attempts],
             )?
@@ -504,7 +504,7 @@ mod tests {
             let mut conn = env.db().conn();
             conn.execute(
                 "
-                INSERT INTO queue (name, version, priority, attempt ) 
+                INSERT INTO queue (name, version, priority, attempt )
                 VALUES ('failed_crate', '0.1.1', 0, 99)",
                 &[],
             )?;
@@ -518,7 +518,7 @@ mod tests {
             let row = conn
                 .query_opt(
                     "SELECT priority, attempt
-                     FROM queue 
+                     FROM queue
                      WHERE name = $1 AND version = $2",
                     &[&"failed_crate", &"0.1.1"],
                 )?

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -291,8 +291,24 @@ impl BuildQueue {
     pub fn get_new_crates(&self, index: &Index) -> Result<usize> {
         let mut conn = self.db.get()?;
         let diff = index.diff()?;
-        let (mut changes, oid) = diff.peek_changes_ordered()?;
+
+        let Some(last_seen_reference) = self.last_seen_reference()? else {
+            // we should always have a last seen reference in the database, other than when
+            // initialising a new deployment (e.g. dev/test/staging), in those cases we don't want
+            // to rebuild the entire world, so we get crates-index-diff to fetch the current state
+            // then use the current head as the base and will only start building new crates from
+            // now on
+            let (_, oid) = diff.peek_changes_ordered()?;
+            warn!("no last_seen_reference in database, setting to current head {oid}");
+            self.set_last_seen_reference(oid)?;
+            return Ok(0);
+        };
+        diff.set_last_seen_reference(last_seen_reference)?;
+
+        let (mut changes, new_reference) = diff.peek_changes_ordered()?;
         let mut crates_added = 0;
+
+        debug!("queueing changes from {last_seen_reference} to {new_reference}");
 
         // I believe this will fix ordering of queue if we get more than one crate from changes
         changes.reverse();
@@ -363,14 +379,10 @@ impl BuildQueue {
             }
         }
 
-        // additionally set the reference in the database
+        // set the reference in the database
         // so this survives recreating the registry watcher
         // server.
-        self.set_last_seen_reference(oid)?;
-
-        // store the last seen reference as git reference in
-        // the local crates.io index repo.
-        diff.set_last_seen_reference(oid)?;
+        self.set_last_seen_reference(new_reference)?;
 
         Ok(crates_added)
     }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -71,7 +71,7 @@ impl Index {
         })
     }
 
-    pub(crate) fn diff(&self) -> Result<crates_index_diff::Index> {
+    pub fn diff(&self) -> Result<crates_index_diff::Index> {
         let options = self
             .repository_url
             .clone()

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -12,7 +12,7 @@ use anyhow::{anyhow, Context as _, Error};
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
-use tracing::{debug, error, info};
+use tracing::{debug, info};
 
 /// Run the registry watcher
 /// NOTE: this should only be run once, otherwise crates would be added
@@ -23,22 +23,6 @@ pub fn watch_registry(
     index: Arc<Index>,
 ) -> Result<(), Error> {
     let mut last_gc = Instant::now();
-
-    // On startup we fetch the last seen index reference from
-    // the database and set it in the local index repository.
-    match build_queue.last_seen_reference() {
-        Ok(Some(oid)) => {
-            index.diff()?.set_last_seen_reference(oid)?;
-        }
-        Ok(None) => {}
-        Err(err) => {
-            error!(
-                "queue locked because of invalid last_seen_index_reference in database: {:?}",
-                err
-            );
-            build_queue.lock()?;
-        }
-    }
 
     loop {
         if build_queue.is_locked()? {


### PR DESCRIPTION
Fixes the issue that I encountered while fixing #2065, we should never be trying to queue the entire world (other than if someone is silly enough to run `cratesfyi build world`).

Also implements the change discussed in https://rust-lang.zulipchat.com/#narrow/stream/356853-t-docs-rs/topic/Limiting.20Registry.20Watcher, now when a registry watcher runs with a database without a `last_seen_reference` it will set it to the current `HEAD` and only build new crates, cc @rylev. @jyn514 it sounds like you would prefer this to be a hard error blocking queuing any builds, and require the `last_seen_reference` is manually set first? I could change it if there's consensus on what the best behavior is.

Also also has a small CLI expansion I wrote when testing the gitoxide integration to allow getting/setting the `last_seen_reference`.