### PR TITLE
introduce new archive index format based on SQLite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,6 +788,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
+name = "bytecount"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,6 +840,37 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "camino"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1495,11 +1532,11 @@ dependencies = [
  "kuchiki",
  "log",
  "lol_html",
- "lru",
  "memmap2",
  "mime",
  "mime_guess",
  "mockito",
+ "moka",
  "num_cpus",
  "once_cell",
  "path-slash",
@@ -1510,6 +1547,7 @@ dependencies = [
  "prometheus",
  "r2d2",
  "r2d2_postgres",
+ "r2d2_sqlite",
  "rand 0.8.5",
  "rayon",
  "regex",
@@ -1623,6 +1661,15 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -2466,6 +2513,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "globset"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,15 +3171,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
-dependencies = [
- "hashbrown 0.13.2",
-]
-
-[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3285,6 +3329,28 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "similar",
+]
+
+[[package]]
+name = "moka"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6446f16d504e3d575df79cabb11bfbe9f24b17e9562d964a815db7b28ae3ec"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "num_cpus",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "rustc_version",
+ "scheduled-thread-pool",
+ "skeptic",
+ "smallvec",
+ "tagptr",
+ "thiserror",
+ "triomphe",
+ "uuid",
 ]
 
 [[package]]
@@ -3982,6 +4048,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4015,6 +4092,16 @@ checksum = "7029c56be658cb54f321e0bee597810ee16796b735fa2559d7056bf06b12230b"
 dependencies = [
  "postgres",
  "r2d2",
+]
+
+[[package]]
+name = "r2d2_sqlite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f5d0337e99cd5cacd91ffc326c6cc9d8078def459df560c4f9bf9ba4a51034"
+dependencies = [
+ "r2d2",
+ "rusqlite",
 ]
 
 [[package]]
@@ -4807,6 +4894,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
+name = "skeptic"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
+dependencies = [
+ "bytecount",
+ "cargo_metadata",
+ "error-chain",
+ "glob",
+ "pulldown-cmark",
+ "tempfile",
+ "walkdir",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5011,6 +5113,12 @@ dependencies = [
  "walkdir",
  "yaml-rust",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tar"
@@ -5465,6 +5573,12 @@ dependencies = [
  "tracing",
  "tracing-core",
 ]
+
+[[package]]
+name = "triomphe"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1ee9bd9239c339d714d657fac840c6d2a4f9c45f4f9ec7b0975113458be78db"
 
 [[package]]
 name = "try-lock"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,6 +1495,7 @@ dependencies = [
  "kuchiki",
  "log",
  "lol_html",
+ "lru",
  "memmap2",
  "mime",
  "mime_guess",
@@ -1513,6 +1514,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
+ "rusqlite",
  "rustwide",
  "schemamama",
  "schemamama_postgres",
@@ -1662,6 +1664,12 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -2553,6 +2561,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
+dependencies = [
+ "hashbrown 0.12.3",
+]
+
+[[package]]
 name = "headers"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2997,6 +3014,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libssh2-sys"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3087,6 +3115,15 @@ dependencies = [
  "safemem",
  "selectors",
  "thiserror",
+]
+
+[[package]]
+name = "lru"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
+dependencies = [
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -4210,6 +4247,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
 dependencies = [
  "xmlparser",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3342,7 +3342,7 @@ dependencies = [
  "crossbeam-utils",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "rustc_version",
  "scheduled-thread-pool",
  "skeptic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2603,6 +2603,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.6",
+]
 
 [[package]]
 name = "hashbrown"
@@ -4053,7 +4056,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "memchr",
  "unicase",
 ]
@@ -4342,7 +4345,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ semver = { version = "1.0.4", features = ["serde"] }
 slug = "0.1.1"
 r2d2 = "0.8"
 r2d2_postgres = "0.18"
+r2d2_sqlite = "0.21.0"
 url = { version = "2.1.1", features = ["serde"] }
 docsrs-metadata = { path = "crates/metadata" }
 anyhow = { version = "1.0.42", features = ["backtrace"]}
@@ -70,7 +71,7 @@ serde_cbor = "0.11.1"
 getrandom = "0.2.1"
 itertools = { version = "0.10.5", optional = true}
 rusqlite = { version = "0.28.0", features = ["bundled"] }
-lru = "0.9.0"
+moka = { version ="0.10.0", default-features = false, features = ["sync"]}
 
 # Async
 tokio = { version = "1.0", features = ["rt-multi-thread", "signal", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,8 @@ bzip2 = "0.4.4"
 serde_cbor = "0.11.1"
 getrandom = "0.2.1"
 itertools = { version = "0.10.5", optional = true}
+rusqlite = { version = "0.28.0", features = ["bundled"] }
+lru = "0.9.0"
 
 # Async
 tokio = { version = "1.0", features = ["rt-multi-thread", "signal", "macros"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,9 @@ pub struct Config {
     pub(crate) max_pool_size: u32,
     pub(crate) min_pool_idle: u32,
 
+    // local pool for sqlite connections
+    pub(crate) max_sqlite_pool_size: u64,
+
     // Storage params
     pub(crate) storage_backend: StorageKind,
 
@@ -136,6 +139,7 @@ impl Config {
 
             database_url: require_env("DOCSRS_DATABASE_URL")?,
             max_pool_size: env("DOCSRS_MAX_POOL_SIZE", 90)?,
+            max_sqlite_pool_size: env("DOCSRS_MAX_SQLITE_POOL_SIZE", 500)?,
             min_pool_idle: env("DOCSRS_MIN_POOL_IDLE", 10)?,
 
             storage_backend: env("DOCSRS_STORAGE_BACKEND", StorageKind::Database)?,

--- a/src/storage/archive_index.rs
+++ b/src/storage/archive_index.rs
@@ -107,6 +107,7 @@ pub(crate) fn create<R: io::Read + io::Seek, P: AsRef<Path>>(
 
     conn.execute("CREATE INDEX idx_files_path ON files (path);", ())?;
     conn.execute("END", ())?;
+    conn.execute("VACUUM", ())?;
 
     Ok(())
 }

--- a/src/storage/archive_index.rs
+++ b/src/storage/archive_index.rs
@@ -71,6 +71,7 @@ pub(crate) fn create<R: io::Read + io::Seek, P: AsRef<Path>>(
     let mut archive = zip::ZipArchive::new(zipfile)?;
 
     let conn = rusqlite::Connection::open(&destination)?;
+    conn.execute("PRAGMA synchronous = FULL", ())?;
     conn.execute("BEGIN", ())?;
     conn.execute(
         "

--- a/src/storage/archive_index.rs
+++ b/src/storage/archive_index.rs
@@ -222,7 +222,7 @@ fn find_in_sqlite_index(conn: &Connection, search_for: &str) -> Result<Option<Fi
 /// https://raw.githubusercontent.com/rusqlite/rusqlite/master/libsqlite3-sys/sqlite3/sqlite3.c
 /// and
 /// https://en.wikipedia.org/wiki/SQLite (-> _Magic number_)
-/// ```ignore
+/// ```text
 /// > FORMAT DETAILS
 /// > OFFSET   SIZE    DESCRIPTION
 /// >    0      16     Header string: "SQLite format 3\000"

--- a/src/storage/archive_index.rs
+++ b/src/storage/archive_index.rs
@@ -64,7 +64,7 @@ pub(crate) fn create<R: io::Read + io::Seek, P: AsRef<Path>>(
     for i in 0..archive.len() {
         let zf = archive.by_index(i)?;
 
-        let compression_bzip: i32 = CompressionAlgorithm::Bzip2.into();
+        let compression_bzip = CompressionAlgorithm::Bzip2 as i32;
 
         conn.execute(
             "INSERT INTO files (path, start, end, compression) VALUES (?, ?, ?, ?)",

--- a/src/storage/archive_index.rs
+++ b/src/storage/archive_index.rs
@@ -69,7 +69,7 @@ pub(crate) fn create<R: io::Read + io::Seek, P: AsRef<Path>>(
         conn.execute(
             "INSERT INTO files (path, start, end, compression) VALUES (?, ?, ?, ?)",
             (
-                zf.name().to_string(),
+                zf.name(),
                 zf.data_start(),
                 zf.data_start() + zf.compressed_size() - 1,
                 match zf.compression() {

--- a/src/storage/archive_index.rs
+++ b/src/storage/archive_index.rs
@@ -215,7 +215,7 @@ fn find_in_sqlite_index(conn: &Connection, search_for: &str) -> Result<Option<Fi
 /// https://raw.githubusercontent.com/rusqlite/rusqlite/master/libsqlite3-sys/sqlite3/sqlite3.c
 /// and
 /// https://en.wikipedia.org/wiki/SQLite (-> _Magic number_)
-/// ```
+/// ```ignore
 /// > FORMAT DETAILS
 /// > OFFSET   SIZE    DESCRIPTION
 /// >    0      16     Header string: "SQLite format 3\000"

--- a/src/storage/archive_index.rs
+++ b/src/storage/archive_index.rs
@@ -1,14 +1,41 @@
 use crate::error::Result;
 use crate::storage::{compression::CompressionAlgorithm, FileRange};
 use anyhow::{bail, Context as _};
+use lru::LruCache;
 use memmap2::MmapOptions;
+use rusqlite::{Connection, OpenFlags, OptionalExtension};
 use serde::de::DeserializeSeed;
 use serde::de::{IgnoredAny, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
-use std::collections::HashMap;
-use std::fmt;
-use std::path::Path;
-use std::{fs, io};
+use std::num::NonZeroUsize;
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    fmt, fs,
+    fs::File,
+    io,
+    io::Read,
+    path::{Path, PathBuf},
+};
+
+static SQLITE_FILE_HEADER: &[u8] = b"SQLite format 3\0";
+
+thread_local! {
+    // local SQLite connection cache.
+    // `rusqlite::Connection` is not `Sync`, so we need to keep this by thread.
+    // Parallel connections to the same SQLite file are handled by SQLite itself.
+    //
+    // Alternative would be to have this cache global, but to prevent using
+    // the same connection from multiple threads at once.
+    //
+    // The better solution probably depends on the request pattern: are we
+    // typically having many requests to a small group of crates?
+    // Or are the requests more spread over many crates the there wouldn't be
+    // many conflicts on the connection?
+    static SQLITE_CONNECTIONS: RefCell<LruCache<PathBuf, Connection>> = RefCell::new(
+        LruCache::new(NonZeroUsize::new(32).unwrap())
+    );
+}
 
 #[derive(Deserialize, Serialize)]
 pub(crate) struct FileInfo {
@@ -30,33 +57,60 @@ struct Index {
     files: HashMap<String, FileInfo>,
 }
 
-pub(crate) fn create<R: io::Read + io::Seek, W: io::Write>(
+/// create an archive index based on a zipfile.
+///
+/// Will delete the destination file if it already exists.
+pub(crate) fn create<R: io::Read + io::Seek, P: AsRef<Path>>(
     zipfile: &mut R,
-    writer: &mut W,
+    destination: P,
 ) -> Result<()> {
+    if destination.as_ref().exists() {
+        fs::remove_file(&destination)?;
+    }
+
     let mut archive = zip::ZipArchive::new(zipfile)?;
 
-    // get file locations
-    let mut files: HashMap<String, FileInfo> = HashMap::with_capacity(archive.len());
+    let conn = rusqlite::Connection::open(&destination)?;
+    conn.execute("BEGIN", ())?;
+    conn.execute(
+        "
+        CREATE TABLE files (
+            id INTEGER PRIMARY KEY,
+            path TEXT UNIQUE,
+            start INTEGER,
+            end INTEGER,
+            compression INTEGER
+        );
+        ",
+        (),
+    )?;
+
     for i in 0..archive.len() {
         let zf = archive.by_index(i)?;
 
-        files.insert(
-            zf.name().to_string(),
-            FileInfo {
-                range: FileRange::new(zf.data_start(), zf.data_start() + zf.compressed_size() - 1),
-                compression: match zf.compression() {
-                    zip::CompressionMethod::Bzip2 => CompressionAlgorithm::Bzip2,
+        let compression_bzip: i32 = CompressionAlgorithm::Bzip2.into();
+
+        conn.execute(
+            "INSERT INTO files (path, start, end, compression) VALUES (?, ?, ?, ?)",
+            (
+                zf.name().to_string(),
+                zf.data_start(),
+                zf.data_start() + zf.compressed_size() - 1,
+                match zf.compression() {
+                    zip::CompressionMethod::Bzip2 => compression_bzip,
                     c => bail!("unsupported compression algorithm {} in zip-file", c),
                 },
-            },
-        );
+            ),
+        )?;
     }
 
-    serde_cbor::to_writer(writer, &Index { files }).context("serialization error")
+    conn.execute("CREATE INDEX idx_files_path ON files (path);", ())?;
+    conn.execute("END", ())?;
+
+    Ok(())
 }
 
-pub(crate) fn find_in_slice(bytes: &[u8], search_for: &str) -> Result<Option<FileInfo>> {
+fn find_in_slice(bytes: &[u8], search_for: &str) -> Result<Option<FileInfo>> {
     let mut deserializer = serde_cbor::Deserializer::from_slice(bytes);
 
     /// This visitor will just find the `files` element in the top-level map.
@@ -155,18 +209,98 @@ pub(crate) fn find_in_slice(bytes: &[u8], search_for: &str) -> Result<Option<Fil
     .deserialize(&mut deserializer)?)
 }
 
+/// try to open an index file as SQLite
+/// Uses a thread-local cache of open connections to the index files.
+/// Will test the connection before returning it, and attempt to
+/// reconnect if the test fails.
+fn with_sqlite_connection<R, P: AsRef<Path>, F: Fn(&Connection) -> Result<R>>(
+    path: P,
+    f: F,
+) -> Result<R> {
+    let path = path.as_ref().to_owned();
+    SQLITE_CONNECTIONS.with(|connections| {
+        let mut connections = connections.borrow_mut();
+
+        if let Some(conn) = connections.get(&path) {
+            if conn.execute("SELECT 1", []).is_ok() {
+                return f(conn);
+            }
+        }
+
+        let conn = Connection::open_with_flags(
+            &path,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+
+        // we're using `get_or_insert` to save the second lookup receiving the
+        // reference into the cache, after having pushed the entry.
+        f(connections.get_or_insert(path, || conn))
+    })
+}
+
+fn find_in_sqlite_index(conn: &Connection, search_for: &str) -> Result<Option<FileInfo>> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT start, end, compression 
+        FROM files 
+        WHERE path = ?
+        ",
+    )?;
+
+    stmt.query_row((search_for,), |row| {
+        let compression: i32 = row.get(2)?;
+        Ok(FileInfo {
+            range: row.get(0)?..=row.get(1)?,
+            compression: compression.try_into().expect("invalid compression value"),
+        })
+    })
+    .optional()
+    .context("error fetching SQLite data")
+}
+
+/// quick check if a file is a SQLite file.
+///
+/// Helpful for the transition phase where an archive-index might be
+/// old (CBOR) or new (SQLite) format.
+///
+/// See
+/// https://raw.githubusercontent.com/rusqlite/rusqlite/master/libsqlite3-sys/sqlite3/sqlite3.c
+/// and
+/// https://en.wikipedia.org/wiki/SQLite (-> _Magic number_)
+/// ```
+/// > FORMAT DETAILS
+/// > OFFSET   SIZE    DESCRIPTION
+/// >    0      16     Header string: "SQLite format 3\000"
+/// > [...]
+fn is_sqlite_file<P: AsRef<Path>>(archive_index_path: P) -> Result<bool> {
+    let mut f = File::open(archive_index_path)?;
+
+    let mut buffer = [0; 16];
+    match f.read_exact(&mut buffer) {
+        Ok(()) => Ok(buffer == SQLITE_FILE_HEADER),
+        Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => Ok(false),
+        Err(err) => Err(err.into()),
+    }
+}
+
 pub(crate) fn find_in_file<P: AsRef<Path>>(
     archive_index_path: P,
     search_for: &str,
 ) -> Result<Option<FileInfo>> {
-    let file = fs::File::open(archive_index_path).context("could not open file")?;
-    let mmap = unsafe {
-        MmapOptions::new()
-            .map(&file)
-            .context("could not create memory map")?
-    };
+    if is_sqlite_file(&archive_index_path)? {
+        with_sqlite_connection(archive_index_path, |connection| {
+            find_in_sqlite_index(connection, search_for)
+        })
+    } else {
+        let file = fs::File::open(archive_index_path).context("could not open file")?;
+        let mmap = unsafe {
+            MmapOptions::new()
+                .map(&file)
+                .context("could not create memory map")?
+        };
 
-    find_in_slice(&mmap, search_for)
+        find_in_slice(&mmap, search_for)
+    }
 }
 
 #[cfg(test)]
@@ -175,8 +309,37 @@ mod tests {
     use std::io::Write;
     use zip::write::FileOptions;
 
-    #[test]
-    fn index_create_save_load() {
+    /// legacy archive index creation, only for testing that reading them still works
+    fn create_cbor_index<R: io::Read + io::Seek, W: io::Write>(
+        zipfile: &mut R,
+        writer: &mut W,
+    ) -> Result<()> {
+        let mut archive = zip::ZipArchive::new(zipfile)?;
+
+        // get file locations
+        let mut files: HashMap<String, FileInfo> = HashMap::with_capacity(archive.len());
+        for i in 0..archive.len() {
+            let zf = archive.by_index(i)?;
+
+            files.insert(
+                zf.name().to_string(),
+                FileInfo {
+                    range: FileRange::new(
+                        zf.data_start(),
+                        zf.data_start() + zf.compressed_size() - 1,
+                    ),
+                    compression: match zf.compression() {
+                        zip::CompressionMethod::Bzip2 => CompressionAlgorithm::Bzip2,
+                        c => bail!("unsupported compression algorithm {} in zip-file", c),
+                    },
+                },
+            );
+        }
+
+        serde_cbor::to_writer(writer, &Index { files }).context("serialization error")
+    }
+
+    fn create_test_archive() -> fs::File {
         let mut tf = tempfile::tempfile().unwrap();
 
         let objectcontent: Vec<u8> = (0..255).collect();
@@ -190,14 +353,78 @@ mod tests {
             .unwrap();
         archive.write_all(&objectcontent).unwrap();
         tf = archive.finish().unwrap();
+        tf
+    }
 
+    #[test]
+    fn index_create_save_load_cbor_direct() {
+        let mut tf = create_test_archive();
         let mut buf = Vec::new();
-        create(&mut tf, &mut buf).unwrap();
+        create_cbor_index(&mut tf, &mut buf).unwrap();
 
         let fi = find_in_slice(&buf, "testfile1").unwrap().unwrap();
         assert_eq!(fi.range, FileRange::new(39, 459));
         assert_eq!(fi.compression, CompressionAlgorithm::Bzip2);
 
         assert!(find_in_slice(&buf, "some_other_file").unwrap().is_none());
+    }
+
+    #[test]
+    fn index_create_save_load_cbor_as_fallback() {
+        let mut tf = create_test_archive();
+        let mut cbor_buf = Vec::new();
+        create_cbor_index(&mut tf, &mut cbor_buf).unwrap();
+        let mut cbor_index_file = tempfile::NamedTempFile::new().unwrap();
+        io::copy(&mut &cbor_buf[..], &mut cbor_index_file).unwrap();
+
+        assert!(!is_sqlite_file(&cbor_index_file).unwrap());
+
+        let fi = find_in_file(cbor_index_file.path(), "testfile1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(fi.range, FileRange::new(39, 459));
+        assert_eq!(fi.compression, CompressionAlgorithm::Bzip2);
+
+        assert!(find_in_file(cbor_index_file.path(), "some_other_file")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn index_create_save_load_sqlite() {
+        let mut tf = create_test_archive();
+
+        let tempfile = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        create(&mut tf, &tempfile).unwrap();
+        assert!(is_sqlite_file(&tempfile).unwrap());
+
+        let fi = find_in_file(&tempfile, "testfile1").unwrap().unwrap();
+
+        assert_eq!(fi.range, FileRange::new(39, 459));
+        assert_eq!(fi.compression, CompressionAlgorithm::Bzip2);
+
+        assert!(find_in_file(&tempfile, "some_other_file")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn is_sqlite_file_empty() {
+        let tempfile = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        assert!(!is_sqlite_file(tempfile).unwrap());
+    }
+
+    #[test]
+    fn is_sqlite_file_other_content() {
+        let mut tempfile = tempfile::NamedTempFile::new().unwrap();
+        tempfile.write_all(b"some_bytes").unwrap();
+        assert!(!is_sqlite_file(tempfile.path()).unwrap());
+    }
+
+    #[test]
+    fn is_sqlite_file_specific_headers() {
+        let mut tempfile = tempfile::NamedTempFile::new().unwrap();
+        tempfile.write_all(SQLITE_FILE_HEADER).unwrap();
+        assert!(is_sqlite_file(tempfile.path()).unwrap());
     }
 }

--- a/src/storage/sqlite_pool.rs
+++ b/src/storage/sqlite_pool.rs
@@ -1,0 +1,76 @@
+use anyhow::Result;
+use moka::sync::Cache;
+use r2d2_sqlite::SqliteConnectionManager;
+use rusqlite::{Connection, OpenFlags};
+use std::{
+    num::NonZeroU64,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+static MAX_IDLE_TIME: Duration = Duration::from_secs(10 * 60);
+static MAX_LIFE_TIME: Duration = Duration::from_secs(60 * 60);
+
+/// SQLite connection pool.
+///
+/// Typical connection pools handle many connections to a single database,
+/// while this one handles some connections to many databases.
+///
+/// The more connections we keep alive, the more open files we have,
+/// so you might need to tweak this limit based on the max open files
+/// on your system.
+///
+/// We open the databases in readonly mode.
+/// We are using an additional connection pool per database to parallel requests
+/// can be efficiently answered. Because of this the actual max connection count
+/// might be higher than the given max_connections.
+///
+/// We keep at minimum of one connection per database, for one hour.  
+/// Any additional connections will be dropped after 10 minutes of inactivity.
+#[derive(Clone)]
+pub(crate) struct SqliteConnectionPool {
+    pools: Cache<PathBuf, r2d2::Pool<SqliteConnectionManager>>,
+}
+
+impl Default for SqliteConnectionPool {
+    fn default() -> Self {
+        Self::new(NonZeroU64::new(10).unwrap())
+    }
+}
+
+impl SqliteConnectionPool {
+    pub(crate) fn new(max_connections: NonZeroU64) -> Self {
+        Self {
+            pools: Cache::builder()
+                .max_capacity(max_connections.get())
+                .time_to_idle(MAX_LIFE_TIME)
+                .build(),
+        }
+    }
+
+    pub(crate) fn with_connection<R, P: AsRef<Path>, F: Fn(&Connection) -> Result<R>>(
+        &self,
+        path: P,
+        f: F,
+    ) -> Result<R> {
+        let path = path.as_ref().to_owned();
+
+        let pool = self
+            .pools
+            .entry(path.clone())
+            .or_insert_with(|| {
+                let manager = SqliteConnectionManager::file(path)
+                    .with_flags(OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX);
+                r2d2::Pool::builder()
+                    .min_idle(Some(1))
+                    .max_lifetime(Some(MAX_LIFE_TIME))
+                    .idle_timeout(Some(MAX_IDLE_TIME))
+                    .max_size(10)
+                    .build_unchecked(manager)
+            })
+            .into_value();
+
+        let conn = pool.get()?;
+        f(&conn)
+    }
+}

--- a/src/storage/sqlite_pool.rs
+++ b/src/storage/sqlite_pool.rs
@@ -27,6 +27,9 @@ static MAX_LIFE_TIME: Duration = Duration::from_secs(60 * 60);
 ///
 /// We keep at minimum of one connection per database, for one hour.  
 /// Any additional connections will be dropped after 10 minutes of inactivity.
+///
+/// * `max_databases` is the maximum amout of databases in the pool.
+/// * for each of the databases, we manage a pool of 1-10 connections
 #[derive(Clone)]
 pub(crate) struct SqliteConnectionPool {
     pools: Cache<PathBuf, r2d2::Pool<SqliteConnectionManager>>,
@@ -39,10 +42,10 @@ impl Default for SqliteConnectionPool {
 }
 
 impl SqliteConnectionPool {
-    pub(crate) fn new(max_connections: NonZeroU64) -> Self {
+    pub(crate) fn new(max_databases: NonZeroU64) -> Self {
         Self {
             pools: Cache::builder()
-                .max_capacity(max_connections.get())
+                .max_capacity(max_databases.get())
                 .time_to_idle(MAX_LIFE_TIME)
                 .build(),
         }

--- a/src/storage/sqlite_pool.rs
+++ b/src/storage/sqlite_pool.rs
@@ -77,3 +77,26 @@ impl SqliteConnectionPool {
         f(&conn)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simple_connection() {
+        let filename = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        rusqlite::Connection::open(&filename).unwrap();
+
+        let pool = SqliteConnectionPool::new(NonZeroU64::new(1).unwrap());
+
+        pool.with_connection(&filename, |conn| {
+            conn.query_row("SELECT 1", [], |row| {
+                assert_eq!(row.get::<_, i32>(0).unwrap(), 1);
+                Ok(())
+            })
+            .unwrap();
+            Ok(())
+        })
+        .unwrap();
+    }
+}


### PR DESCRIPTION
Coming from the performance issues with the archive index I took some time to update the whole topic. 

While I started to dig into optimizing the CBOR reader I then thought about the fact that CBOR will never be scalable for bigger crates, so I started looking for alternatives  that would include some indexing. 

I did some high level tests with LMDB, sled and rocksdb, but settled for a boring, old technology: SQLite. 

( yes, I'm definitely biased towards older but perhaps more reliable things). 

In my mind, this would give us a reliable, fast, single-file format, which would also be easily extensible if we need to add more information. File-size is slightly higher, but IMO not an issue. 

This PR would only use the new format for new builds, while I would plan for a slow (lazy or active) migration of the other archive-stored releases. 


### micro-benchmarks: 
using the archive index for `stm32ral` (~1.2 million files)

```

with open               time:   [59.434 µs 59.604 µs 59.810 µs]
                        change: [-1.5928% -0.5698% +0.3278%] (p = 0.27 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe

without open            time:   [7.0644 µs 7.1273 µs 7.2172 µs]
                        change: [+2.2772% +3.9894% +5.9668%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 16 outliers among 100 measurements (16.00%)
  7 (7.00%) high mild
  9 (9.00%) high severe
```

- "with open" -> including creating a new SQLite connection opening the file 
- "without open" -> reusing an existing connection. 
- for comparison: reading an old cbor-index of that size takes ~20 seconds 


That speed doesn't fully scale with parallelism, but IMO should be good enough, especially compared to the current speed. 

## deployment / next steps 
This PR intentionally only uses the new format for new builds, so i anything goes wrong we'll be able to revert & rebuild. 

A next step could be to write an _index repack_ command that would convert old existing indexes so we can remove the old cbor code & benefit from the performance improvements. 
