### PR TITLE
retry crates.io requests when calling crate-search API

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -690,9 +690,9 @@ impl Context for BinContext {
             let config = self.config()?;
             let path = config.registry_index_path.clone();
             if let Some(registry_url) = config.registry_url.clone() {
-                Index::from_url(path, registry_url)
+                Index::from_url(path, registry_url, config.crates_io_api_call_retries)
             } else {
-                Index::new(path)
+                Index::new(path, config.crates_io_api_call_retries)
             }?
         };
         fn repository_stats_updater(self) -> RepositoryStatsUpdater = {

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,9 @@ pub struct Config {
     // Gitlab authentication
     pub(crate) gitlab_accesstoken: Option<String>,
 
+    // amount of retries for external API calls, mostly crates.io
+    pub crates_io_api_call_retries: u32,
+
     // request timeout in seconds
     pub(crate) request_timeout: Option<Duration>,
     pub(crate) report_request_timeouts: bool,
@@ -119,6 +122,8 @@ impl Config {
 
         Ok(Self {
             build_attempts: env("DOCSRS_BUILD_ATTEMPTS", 5)?,
+
+            crates_io_api_call_retries: env("DOCSRS_CRATESIO_API_CALL_RETRIES", 3)?,
 
             registry_index_path: env("REGISTRY_INDEX_PATH", prefix.join("crates.io-index"))?,
             registry_url: maybe_env("REGISTRY_URL")?,

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -372,8 +372,11 @@ impl TestEnvironment {
         self.index
             .get_or_init(|| {
                 Arc::new(
-                    Index::new(self.config().registry_index_path.clone())
-                        .expect("failed to initialize the index"),
+                    Index::new(
+                        self.config().registry_index_path.clone(),
+                        self.config().crates_io_api_call_retries,
+                    )
+                    .expect("failed to initialize the index"),
                 )
             })
             .clone()

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -27,8 +27,7 @@ use serde::Serialize;
 use tracing::error;
 pub(crate) mod sized_buffer;
 
-use std::thread;
-use std::time::Duration;
+use std::{future::Future, thread, time::Duration};
 use tracing::warn;
 
 pub(crate) const APP_USER_AGENT: &str = concat!(
@@ -135,6 +134,30 @@ pub(crate) fn retry<T>(mut f: impl FnMut() -> Result<T>, max_attempts: u32) -> R
         }
     }
     unreachable!()
+}
+
+pub(crate) async fn retry_async<T, Fut, F: FnMut() -> Fut>(mut f: F, max_attempts: u32) -> Result<T>
+where
+    Fut: Future<Output = Result<T>>,
+{
+    for attempt in 1.. {
+        match f().await {
+            Ok(result) => return Ok(result),
+            Err(err) => {
+                if attempt > max_attempts {
+                    return Err(err);
+                } else {
+                    let sleep_for = 2u32.pow(attempt);
+                    warn!(
+                        "got error on attempt {}, will try again after {}s:\n{:?}",
+                        attempt, sleep_for, err
+                    );
+                    tokio::time::sleep(Duration::from_secs(sleep_for as u64)).await;
+                }
+            }
+        }
+    }
+    unreachable!();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This works around (I think) most cases of https://rust-lang.sentry.io/issues/3972510218/ 

( the next step is probably just showing to the user that the crates.io API errored )