### PR TITLE
replace `.unwrap()` in `.match_version` with actual error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ axum-extra = "0.5.0"
 hyper = { version = "0.14.15", default-features = false }
 tower = "0.4.11"
 tower-service = "0.3.2"
-tower-http = { version = "0.4.0", features = ["fs", "trace", "timeout"] }
+tower-http = { version = "0.4.0", features = ["fs", "trace", "timeout", "catch-panic"] }
 mime = "0.3.16"
 percent-encoding = "2.2.0"
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -20,10 +20,11 @@ mod html;
 mod queue;
 pub(crate) mod queue_builder;
 mod rustc_version;
-use anyhow::{Context as _, Result};
+use anyhow::Result;
 use postgres::Client;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use std::panic;
 use tracing::error;
 pub(crate) mod sized_buffer;
 
@@ -107,9 +108,11 @@ where
     F: FnOnce() -> Result<R> + Send + 'static,
     R: Send + 'static,
 {
-    tokio::task::spawn_blocking(f)
-        .await
-        .context("failed to join thread")?
+    match tokio::task::spawn_blocking(f).await {
+        Ok(result) => result,
+        Err(err) if err.is_panic() => panic::resume_unwind(err.into_panic()),
+        Err(err) => Err(err.into()),
+    }
 }
 
 #[cfg(test)]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -134,7 +134,7 @@ fn match_version(
                  WHERE normalize_crate_name(name) = normalize_crate_name($1)",
                 &[&name],
             )
-            .unwrap(); // FIXME: remove this unwrap when all handlers using it are migrated to axum
+            .context("error fetching crate")?;
 
         let row = rows.get(0).ok_or(AxumNope::CrateNotFound)?;
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -49,7 +49,7 @@ use serde::Serialize;
 use std::borrow::Borrow;
 use std::{borrow::Cow, net::SocketAddr, sync::Arc};
 use tower::ServiceBuilder;
-use tower_http::{timeout::TimeoutLayer, trace::TraceLayer};
+use tower_http::{catch_panic::CatchPanicLayer, timeout::TimeoutLayer, trace::TraceLayer};
 use url::form_urlencoded;
 
 // from https://github.com/servo/rust-url/blob/master/url/src/parser.rs
@@ -275,6 +275,7 @@ pub(crate) fn build_axum_app(
             .layer(TraceLayer::new_for_http())
             .layer(sentry_tower::NewSentryLayer::new_from_top())
             .layer(sentry_tower::SentryHttpLayer::with_transaction())
+            .layer(CatchPanicLayer::new())
             .layer(option_layer(
                 config
                     .report_request_timeouts


### PR DESCRIPTION
This will give us  more context when https://rust-lang.sentry.io/issues/3924418644/ happens again / more often