### PR TITLE
fix clippy warnings, small refactor in storage::compression

### DIFF
--- a/src/utils/consistency/db.rs
+++ b/src/utils/consistency/db.rs
@@ -41,7 +41,6 @@ pub(super) fn load(conn: &mut postgres::Client, config: &Config) -> Result<Crate
         // we can use Itertools.group_by on it.
         .iterator()
         .map(|row| row.expect("error fetching rows"))
-        .into_iter()
         .group_by(|row| row.get("name"))
     {
         let releases: Releases = release_rows


### PR DESCRIPTION
This fixes two new clippy warnings. 

Since one of then would have needed adaption to the `enum_id` macro I felt like the better approach is to replace the whole thing with `strum`. 