### PR TITLE
add option to disable the full page cache

### DIFF
--- a/src/cdn.rs
+++ b/src/cdn.rs
@@ -401,6 +401,11 @@ pub(crate) fn queue_crate_invalidation(
     config: &Config,
     name: &str,
 ) -> Result<()> {
+    if !config.full_page_cache {
+        info!("full page cache disabled, skipping queueing invalidation");
+        return Ok(());
+    }
+
     let mut add = |distribution_id: &str, path_patterns: &[&str]| -> Result<()> {
         for pattern in path_patterns {
             debug!(distribution_id, pattern, "enqueueing web CDN invalidation");

--- a/src/cdn.rs
+++ b/src/cdn.rs
@@ -401,7 +401,7 @@ pub(crate) fn queue_crate_invalidation(
     config: &Config,
     name: &str,
 ) -> Result<()> {
-    if !config.full_page_cache {
+    if !config.cache_invalidatable_responses {
         info!("full page cache disabled, skipping queueing invalidation");
         return Ok(());
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,7 +80,7 @@ pub struct Config {
     // Activate full page caching.
     // When disabled, we still cache static assets.
     // This only affects pages that depend on invalidations to work.
-    pub(crate) full_page_cache: bool,
+    pub(crate) cache_invalidatable_responses: bool,
 
     pub(crate) cdn_backend: CdnKind,
 
@@ -179,7 +179,7 @@ impl Config {
                 "CACHE_CONTROL_STALE_WHILE_REVALIDATE",
             )?,
 
-            full_page_cache: env("DOCSRS_FULL_PAGE_CACHE", true)?,
+            cache_invalidatable_responses: env("DOCSRS_CACHE_INVALIDATEABLE_RESPONSES", true)?,
 
             cdn_backend: env("DOCSRS_CDN_BACKEND", CdnKind::Dummy)?,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,6 +77,11 @@ pub struct Config {
     // generate just that directive. Values are in seconds.
     pub(crate) cache_control_stale_while_revalidate: Option<u32>,
 
+    // Activate full page caching.
+    // When disabled, we still cache static assets.
+    // This only affects pages that depend on invalidations to work.
+    pub(crate) full_page_cache: bool,
+
     pub(crate) cdn_backend: CdnKind,
 
     // CloudFront distribution ID for the web server.
@@ -173,6 +178,8 @@ impl Config {
             cache_control_stale_while_revalidate: maybe_env(
                 "CACHE_CONTROL_STALE_WHILE_REVALIDATE",
             )?,
+
+            full_page_cache: env("DOCSRS_FULL_PAGE_CACHE", true)?,
 
             cdn_backend: env("DOCSRS_CDN_BACKEND", CdnKind::Dummy)?,
 

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -109,6 +109,11 @@ pub fn start_background_cdn_invalidator(context: &dyn Context) -> Result<(), Err
         return Ok(());
     }
 
+    if !config.full_page_cache {
+        info!("full page cache disabled, skipping background cdn invalidation");
+        return Ok(());
+    }
+
     cron("cdn invalidator", Duration::from_secs(60), move || {
         let mut conn = pool.get()?;
         if let Some(distribution_id) = config.cloudfront_distribution_id_web.as_ref() {

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -109,7 +109,7 @@ pub fn start_background_cdn_invalidator(context: &dyn Context) -> Result<(), Err
         return Ok(());
     }
 
-    if !config.full_page_cache {
+    if !config.cache_invalidatable_responses {
         info!("full page cache disabled, skipping background cdn invalidation");
         return Ok(());
     }

--- a/src/web/cache.rs
+++ b/src/web/cache.rs
@@ -48,7 +48,7 @@ impl CachePolicy {
             CachePolicy::NoStoreMustRevalidate => Some(NO_STORE_MUST_REVALIDATE.clone()),
             CachePolicy::ForeverInCdnAndBrowser => Some(FOREVER_IN_CDN_AND_BROWSER.clone()),
             CachePolicy::ForeverInCdn => {
-                if config.full_page_cache {
+                if config.cache_invalidatable_responses {
                     // A missing `max-age` or `s-maxage` in the Cache-Control header will lead to
                     // CloudFront using the default TTL, while the browser not seeing any caching header.
                     // This means we can have the CDN caching the documentation while just
@@ -60,7 +60,7 @@ impl CachePolicy {
                 }
             }
             CachePolicy::ForeverInCdnAndStaleInBrowser => {
-                if config.full_page_cache {
+                if config.cache_invalidatable_responses {
                     config
                         .cache_control_stale_while_revalidate
                         .map(|seconds| format!("stale-while-revalidate={seconds}").parse().unwrap())
@@ -161,7 +161,7 @@ mod tests {
     fn render_forever_in_cdn_disabled() {
         wrapper(|env| {
             env.override_config(|config| {
-                config.full_page_cache = false;
+                config.cache_invalidatable_responses = false;
             });
 
             assert_eq!(
@@ -176,7 +176,7 @@ mod tests {
     fn render_forever_in_cdn_or_stale_disabled() {
         wrapper(|env| {
             env.override_config(|config| {
-                config.full_page_cache = false;
+                config.cache_invalidatable_responses = false;
             });
 
             assert_eq!(


### PR DESCRIPTION
As long as the current invalidation process is broken, we can disable the cache with this new option. 

