### PR TITLE
Update `toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,7 +1492,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "thiserror",
- "toml 0.5.11",
+ "toml 0.7.3",
 ]
 
 [[package]]

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -14,5 +14,5 @@ path = "lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-toml = { version = "0.5", default-features = false }
+toml = { version = "0.7", default-features = false }
 thiserror = "1"


### PR DESCRIPTION
Combined with https://github.com/rust-lang/rustwide/pull/77/, this will remove a duplicate version of toml.