### PR TITLE
Load release list only when needed

### DIFF
--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -167,6 +167,10 @@ pub(super) fn build_axum_routes() -> AxumRouter {
             "/crate/:name",
             get_internal(super::crate_details::crate_details_handler),
         )
+        .route(
+            "/:name/releases",
+            get_internal(super::crate_details::get_all_releases),
+        )
         .route_with_tsr(
             "/crate/:name/:version",
             get_internal(super::crate_details::crate_details_handler),

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -2240,12 +2240,8 @@ mod test {
                 .create()?;
 
             // test rustdoc pages stay on the documentation
-            let page = kuchiki::parse_html().one(
-                env.frontend()
-                    .get("/hexponent/0.3.0/hexponent/")
-                    .send()?
-                    .text()?,
-            );
+            let page = kuchiki::parse_html()
+                .one(env.frontend().get("/hexponent/releases").send()?.text()?);
             let selector =
                 r#"ul > li a[href="/crate/hexponent/0.3.1/target-redirect/hexponent/index.html"]"#
                     .to_string();

--- a/static/menu.js
+++ b/static/menu.js
@@ -5,6 +5,34 @@ const updateMenuPositionForSubMenu = (currentMenuSupplier) => {
     subMenu?.style.setProperty('--menu-x', `${currentMenu.getBoundingClientRect().x}px`);
 }
 
+function generateReleaseList(data, crateName) {
+}
+
+let loadReleases = function() {
+    const releaseListElem = document.getElementById('releases-list');
+    // To prevent reloading the list unnecessarily.
+    loadReleases = function() {};
+    if (!releaseListElem) {
+        // We're not in a documentation page, so no need to do anything.
+        return;
+    }
+    const crateName = window.location.pathname.split('/')[1];
+    const xhttp = new XMLHttpRequest();
+    xhttp.onreadystatechange = function() {
+        if (xhttp.readyState !== XMLHttpRequest.DONE) {
+          return;
+        }
+        if (xhttp.status === 200) {
+            releaseListElem.innerHTML = xhttp.responseText;
+        } else {
+            console.error(`Failed to load release list: [${xhttp.status}] ${xhttp.responseText}`);
+            document.getElementById('releases-list').innerHTML = "Failed to load release list";
+        }
+    };
+    xhttp.open("GET", `/${crateName}/releases`, true);
+    xhttp.send();
+};
+
 // Allow menus to be open and used by keyboard.
 (function() {
     var currentMenu;
@@ -53,6 +81,7 @@ const updateMenuPositionForSubMenu = (currentMenuSupplier) => {
         currentMenu = newMenu;
         newMenu.className += " pure-menu-active";
         backdrop.style.display = "block";
+        loadReleases();
     }
     function menuOnClick(e) {
         if (this.getAttribute("href") != "#") {

--- a/templates/rustdoc/releases.html
+++ b/templates/rustdoc/releases.html
@@ -1,0 +1,6 @@
+{% import "macros.html" as macros %}
+{% set target = "" %}
+{% set inner_path = releases[0].target_name ~ "/index.html" %}
+<ul class="pure-menu-list">
+{{ macros::releases_list(name=crate_name, releases=releases, target=target, inner_path=inner_path) }}
+</ul>

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -134,11 +134,8 @@ extra whitespace unremovable, need to use html tags unaffacted by whitespace T_T
                             <li class="pure-menu-heading">Versions</li>
 
                             <li class="pure-menu-item">
-                                <div class="pure-menu pure-menu-scrollable sub-menu" tabindex="-1">
-                                    <ul class="pure-menu-list">
-                                        {# Display all releases of this crate #}
-                                        {{ macros::releases_list(name=krate.name, releases=krate.releases, target=target, inner_path=inner_path) }}
-                                    </ul>
+                                <div class="pure-menu pure-menu-scrollable sub-menu" id="releases-list" tabindex="-1">
+                                    <span class="rotate">{{ "spinner" | fas }}</span>
                                 </div>
                             </li>
                         </ul>

--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -15,6 +15,15 @@ body {
     padding: 0;
 }
 
+@keyframes rotating_text {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
 div.nav-container {
     // Nothing is supposed to be over or hovering the top navbar. Maybe add a few others '('? :)
     z-index: 999;
@@ -322,6 +331,14 @@ div.nav-container {
             li.pure-menu-item:last-child {
                 border-bottom: none;
             }
+        }
+    }
+
+    #releases-list {
+        .rotate {
+            display: inline-block;
+            font-size: 30px;
+            animation: rotating_text 2s linear infinite;
         }
     }
 }


### PR DESCRIPTION
It was something we discussed some time ago. Instead of loading the release list all the time, with this PR it's only loaded when the menu is opened. It should greatly reduce the page size on crates with a lot of releases.

Original issue: https://github.com/rust-lang/docs.rs/issues/1999

cc @Nemo157 @jsha 