### PR TITLE
Add subcommands for getting and listing all default priorities

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -201,7 +201,8 @@ enum QueueSubcommand {
             name = "BUILD_PRIORITY",
             short = 'p',
             long = "priority",
-            default_value = "5"
+            default_value = "5",
+            allow_negative_numbers = true
         )]
         build_priority: i32,
     },
@@ -249,6 +250,7 @@ enum PrioritySubcommand {
         #[arg(name = "PATTERN")]
         pattern: String,
         /// The priority to give crates matching the given `PATTERN`
+        #[arg(allow_negative_numbers = true)]
         priority: i32,
     },
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,7 +4,10 @@ pub(crate) use self::cargo_metadata::{CargoMetadata, Package as MetadataPackage}
 pub(crate) use self::copy::copy_dir_all;
 pub use self::daemon::{start_daemon, watch_registry};
 pub(crate) use self::html::rewrite_lol;
-pub use self::queue::{get_crate_priority, remove_crate_priority, set_crate_priority};
+pub use self::queue::{
+    get_crate_pattern_and_priority, get_crate_priority, list_crate_priorities,
+    remove_crate_priority, set_crate_priority,
+};
 pub use self::queue_builder::queue_builder;
 pub(crate) use self::rustc_version::{get_correct_docsrs_style_file, parse_rustc_version};
 
@@ -62,7 +65,7 @@ pub fn set_config(
 ) -> anyhow::Result<()> {
     let name: &'static str = name.into();
     conn.execute(
-        "INSERT INTO config (name, value) 
+        "INSERT INTO config (name, value)
         VALUES ($1, $2)
         ON CONFLICT (name) DO UPDATE SET value = $2;",
         &[&name, &serde_json::to_value(value)?],


### PR DESCRIPTION
Also added the option to `clap` to allow `--priority -10` instead of having to write `--priority=-10` to boost crates above the default level.