### PR TITLE
upgrade gix, moka, lol_html

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,7 +1161,7 @@ checksum = "3a9ab62e768890b279e6fac79a453a9bc599a0a4758a39f72c282648fb65f312"
 dependencies = [
  "ahash 0.8.3",
  "bstr",
- "gix",
+ "gix 0.37.2",
  "hashbrown 0.13.2",
  "hex",
  "serde",
@@ -1476,7 +1476,7 @@ dependencies = [
  "font-awesome-as-a-crate",
  "futures-util",
  "getrandom 0.2.9",
- "gix",
+ "gix 0.44.1",
  "grass",
  "hostname",
  "http",
@@ -1912,39 +1912,84 @@ version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4bd774f338c0e403983e3d34bca57a798eb4142f8b96009a2b2c2daed52d4d6"
 dependencies = [
- "gix-actor",
- "gix-attributes",
- "gix-config",
- "gix-credentials",
- "gix-date",
- "gix-diff",
- "gix-discover",
- "gix-features",
- "gix-glob",
- "gix-hash",
- "gix-hashtable",
- "gix-index",
- "gix-lock",
- "gix-mailmap",
- "gix-object",
- "gix-odb",
- "gix-pack",
- "gix-path",
- "gix-prompt",
+ "gix-actor 0.17.2",
+ "gix-attributes 0.8.3",
+ "gix-config 0.16.3",
+ "gix-credentials 0.9.2",
+ "gix-date 0.4.3",
+ "gix-diff 0.26.3",
+ "gix-discover 0.13.1",
+ "gix-features 0.26.5",
+ "gix-glob 0.5.5",
+ "gix-hash 0.10.4",
+ "gix-hashtable 0.1.3",
+ "gix-index 0.12.4",
+ "gix-lock 3.0.2",
+ "gix-mailmap 0.9.3",
+ "gix-object 0.26.4",
+ "gix-odb 0.40.2",
+ "gix-pack 0.30.3",
+ "gix-path 0.7.3",
+ "gix-prompt 0.3.3",
  "gix-protocol",
- "gix-ref",
- "gix-refspec",
- "gix-revision",
- "gix-sec",
- "gix-tempfile",
+ "gix-ref 0.24.1",
+ "gix-refspec 0.7.3",
+ "gix-revision 0.10.4",
+ "gix-sec 0.6.2",
+ "gix-tempfile 3.0.2",
  "gix-transport",
- "gix-traverse",
- "gix-url",
+ "gix-traverse 0.22.2",
+ "gix-url 0.13.3",
  "gix-validate",
- "gix-worktree",
+ "gix-worktree 0.12.3",
  "log",
  "once_cell",
  "prodash",
+ "signal-hook",
+ "smallvec",
+ "thiserror",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf41b61f7df395284f7a579c0fa1a7e012c5aede655174d4e91299ef1cac643"
+dependencies = [
+ "gix-actor 0.20.0",
+ "gix-attributes 0.12.0",
+ "gix-config 0.22.0",
+ "gix-credentials 0.14.0",
+ "gix-date 0.5.0",
+ "gix-diff 0.29.0",
+ "gix-discover 0.18.1",
+ "gix-features 0.29.0",
+ "gix-fs",
+ "gix-glob 0.7.0",
+ "gix-hash 0.11.1",
+ "gix-hashtable 0.2.0",
+ "gix-ignore",
+ "gix-index 0.16.1",
+ "gix-lock 5.0.1",
+ "gix-mailmap 0.12.0",
+ "gix-object 0.29.2",
+ "gix-odb 0.45.0",
+ "gix-pack 0.35.0",
+ "gix-path 0.8.0",
+ "gix-prompt 0.5.0",
+ "gix-ref 0.29.1",
+ "gix-refspec 0.10.1",
+ "gix-revision 0.13.0",
+ "gix-sec 0.8.0",
+ "gix-tempfile 5.0.3",
+ "gix-traverse 0.25.0",
+ "gix-url 0.18.0",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree 0.17.1",
+ "log",
+ "once_cell",
  "signal-hook",
  "smallvec",
  "thiserror",
@@ -1959,10 +2004,24 @@ checksum = "381153ea93b9d8a5c6894a5c734b2e9c15d623063adfd2bda4342ecf90f9a5f8"
 dependencies = [
  "bstr",
  "btoi",
- "gix-date",
+ "gix-date 0.4.3",
  "itoa 1.0.6",
  "nom",
  "quick-error",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "848efa0f1210cea8638f95691c82a46f98a74b9e3524f01d4955ebc25a8f84f3"
+dependencies = [
+ "bstr",
+ "btoi",
+ "gix-date 0.5.0",
+ "itoa 1.0.6",
+ "nom",
+ "thiserror",
 ]
 
 [[package]]
@@ -1973,12 +2032,29 @@ checksum = "df09b20424fd4cee04c43b50df954c4b119c45b769639b60d80ee8bb6d84e0aa"
 dependencies = [
  "bstr",
  "compact_str",
- "gix-features",
- "gix-glob",
- "gix-path",
+ "gix-features 0.26.5",
+ "gix-glob 0.5.5",
+ "gix-path 0.7.3",
  "gix-quote",
  "thiserror",
- "unicode-bom",
+ "unicode-bom 1.1.4",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3015baa01ad2122fbcaab7863c857a603eb7b7ec12ac8141207c42c6439805e2"
+dependencies = [
+ "bstr",
+ "gix-glob 0.7.0",
+ "gix-path 0.8.0",
+ "gix-quote",
+ "kstring",
+ "log",
+ "smallvec",
+ "thiserror",
+ "unicode-bom 2.0.2",
 ]
 
 [[package]]
@@ -2015,18 +2091,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3f91bda4599d9d434e256fd8778fd0f368f7ae5c2015a55934899ac5b70ca99"
 dependencies = [
  "bstr",
- "gix-config-value",
- "gix-features",
- "gix-glob",
- "gix-path",
- "gix-ref",
- "gix-sec",
+ "gix-config-value 0.10.2",
+ "gix-features 0.26.5",
+ "gix-glob 0.5.5",
+ "gix-path 0.7.3",
+ "gix-ref 0.24.1",
+ "gix-sec 0.6.2",
  "memchr",
  "nom",
  "once_cell",
  "smallvec",
  "thiserror",
- "unicode-bom",
+ "unicode-bom 1.1.4",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d252a0eddb6df74600d3d8872dc9fe98835a7da43110411d705b682f49d4ac1"
+dependencies = [
+ "bstr",
+ "gix-config-value 0.12.0",
+ "gix-features 0.29.0",
+ "gix-glob 0.7.0",
+ "gix-path 0.8.0",
+ "gix-ref 0.29.1",
+ "gix-sec 0.8.0",
+ "log",
+ "memchr",
+ "nom",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+ "unicode-bom 2.0.2",
 ]
 
 [[package]]
@@ -2037,7 +2135,20 @@ checksum = "d09154c0c8677e4da0ec35e896f56ee3e338e741b9599fae06075edd83a4081c"
 dependencies = [
  "bitflags 1.3.2",
  "bstr",
- "gix-path",
+ "gix-path 0.7.3",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786861e84a5793ad5f863d846de5eb064cd23b87e61ad708c8c402608202e7be"
+dependencies = [
+ "bitflags 2.2.1",
+ "bstr",
+ "gix-path 0.8.0",
  "libc",
  "thiserror",
 ]
@@ -2050,11 +2161,27 @@ checksum = "5d1536399f70146825bd10321adc5307032e3de93f4954a3c54184281f2e6955"
 dependencies = [
  "bstr",
  "gix-command",
- "gix-config-value",
- "gix-path",
- "gix-prompt",
- "gix-sec",
- "gix-url",
+ "gix-config-value 0.10.2",
+ "gix-path 0.7.3",
+ "gix-prompt 0.3.3",
+ "gix-sec 0.6.2",
+ "gix-url 0.13.3",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-credentials"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4874a4fc11ffa844a3c2b87a66957bda30a73b577ef1acf15ac34df5745de5ff"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-config-value 0.12.0",
+ "gix-path 0.8.0",
+ "gix-prompt 0.5.0",
+ "gix-sec 0.8.0",
+ "gix-url 0.18.0",
  "thiserror",
 ]
 
@@ -2071,13 +2198,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-date"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99056f37270715f5c7584fd8b46899a2296af9cae92463bf58b8bd1f5a78e553"
+dependencies = [
+ "bstr",
+ "itoa 1.0.6",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "gix-diff"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31cdac2ae475ff7a13b9d5c80c0661245f14d9bf8d9268d4bb9c748cfe246d36"
 dependencies = [
- "gix-hash",
- "gix-object",
+ "gix-hash 0.10.4",
+ "gix-object 0.26.4",
+ "imara-diff",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644a0f2768bc42d7a69289ada80c9e15c589caefc6a315d2307202df83ed1186"
+dependencies = [
+ "gix-hash 0.11.1",
+ "gix-object 0.29.2",
  "imara-diff",
  "thiserror",
 ]
@@ -2090,10 +2241,25 @@ checksum = "38029783886cb46fbe63e61b02a70404aa04cfeacfb53ed336832c20fcb1e281"
 dependencies = [
  "bstr",
  "dunce",
- "gix-hash",
- "gix-path",
- "gix-ref",
- "gix-sec",
+ "gix-hash 0.10.4",
+ "gix-path 0.7.3",
+ "gix-ref 0.24.1",
+ "gix-sec 0.6.2",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a6b61363e63e7cdaa3e6f96acb0257ebdb3d8883e21eba5930c99f07f0a5fc0"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-hash 0.11.1",
+ "gix-path 0.8.0",
+ "gix-ref 0.29.1",
+ "gix-sec 0.8.0",
  "thiserror",
 ]
 
@@ -2108,7 +2274,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
  "flate2",
- "gix-hash",
+ "gix-hash 0.10.4",
  "jwalk",
  "libc",
  "num_cpus",
@@ -2122,6 +2288,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-features"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf69b0f5c701cc3ae22d3204b671907668f6437ca88862d355eaf9bc47a4f897"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "gix-hash 0.11.1",
+ "libc",
+ "once_cell",
+ "prodash",
+ "sha1_smol",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b37a1832f691fdc09910bd267f9a2e413737c1f9ec68c6e31f9e802616278a9"
+dependencies = [
+ "gix-features 0.29.0",
+]
+
+[[package]]
 name = "gix-glob"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,6 +2321,18 @@ checksum = "93e43efd776bc543f46f0fd0ca3d920c37af71a764a16f2aebd89765e9ff2993"
 dependencies = [
  "bitflags 1.3.2",
  "bstr",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07c98204529ac3f24b34754540a852593d2a4c7349008df389240266627a72a"
+dependencies = [
+ "bitflags 2.2.1",
+ "bstr",
+ "gix-features 0.29.0",
+ "gix-path 0.8.0",
 ]
 
 [[package]]
@@ -2142,14 +2346,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-hash"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078eec3ac2808cc03f0bddd2704cb661da5c5dc33b41a9d7947b141d499c7c42"
+dependencies = [
+ "hex",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-hashtable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e55e40dfd694884f0eb78796c5bddcf2f8b295dace47039099dd7e76534973"
 dependencies = [
- "gix-hash",
+ "gix-hash 0.10.4",
  "hashbrown 0.13.2",
  "parking_lot",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afebb85691c6a085b114e01a27f4a61364519298c5826cb87a45c304802299bc"
+dependencies = [
+ "gix-hash 0.11.1",
+ "hashbrown 0.13.2",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba205b6df563e2906768bb22834c82eb46c5fdfcd86ba2c347270bc8309a05b2"
+dependencies = [
+ "bstr",
+ "gix-glob 0.7.0",
+ "gix-path 0.8.0",
+ "unicode-bom 2.0.2",
 ]
 
 [[package]]
@@ -2163,11 +2400,33 @@ dependencies = [
  "bstr",
  "filetime",
  "gix-bitmap",
- "gix-features",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-traverse",
+ "gix-features 0.26.5",
+ "gix-hash 0.10.4",
+ "gix-lock 3.0.2",
+ "gix-object 0.26.4",
+ "gix-traverse 0.22.2",
+ "itoa 1.0.6",
+ "memmap2",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f39c1ccc8f1912cbbd5191efc28dbc5f0d0598042aa56bc09427b7c34efab3ba"
+dependencies = [
+ "bitflags 2.2.1",
+ "bstr",
+ "btoi",
+ "filetime",
+ "gix-bitmap",
+ "gix-features 0.29.0",
+ "gix-hash 0.11.1",
+ "gix-lock 5.0.1",
+ "gix-object 0.29.2",
+ "gix-traverse 0.25.0",
  "itoa 1.0.6",
  "memmap2",
  "smallvec",
@@ -2181,8 +2440,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5fe84f09afadec78a7227d80f58cb5412d216dbae4b7fa060b619c0ce62b55d"
 dependencies = [
  "fastrand",
- "gix-tempfile",
+ "gix-tempfile 3.0.2",
  "quick-error",
+]
+
+[[package]]
+name = "gix-lock"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c693d7f05730fa74a7c467150adc7cea393518410c65f0672f80226b8111555"
+dependencies = [
+ "gix-tempfile 5.0.3",
+ "gix-utils",
+ "thiserror",
 ]
 
 [[package]]
@@ -2192,8 +2462,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28214e75835ab33d34210a18981110642728bf169f5e339dbfb6f6380b94318"
 dependencies = [
  "bstr",
- "gix-actor",
+ "gix-actor 0.17.2",
  "quick-error",
+]
+
+[[package]]
+name = "gix-mailmap"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8856cec3bdc3610c06970d28b6cb20a0c6621621cf9a8ec48cbd23f2630f362"
+dependencies = [
+ "bstr",
+ "gix-actor 0.20.0",
+ "thiserror",
 ]
 
 [[package]]
@@ -2204,9 +2485,28 @@ checksum = "edce7170ebcf6fc1487304631556f8bc2b70c8bcbf997a2d73634688bcc92f4e"
 dependencies = [
  "bstr",
  "btoi",
- "gix-actor",
- "gix-features",
- "gix-hash",
+ "gix-actor 0.17.2",
+ "gix-features 0.26.5",
+ "gix-hash 0.10.4",
+ "gix-validate",
+ "hex",
+ "itoa 1.0.6",
+ "nom",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d96bd620fd08accdd37f70b2183cfa0b001b4f1c6ade8b7f6e15cb3d9e261ce"
+dependencies = [
+ "bstr",
+ "btoi",
+ "gix-actor 0.20.0",
+ "gix-features 0.29.0",
+ "gix-hash 0.11.1",
  "gix-validate",
  "hex",
  "itoa 1.0.6",
@@ -2222,11 +2522,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bd81ab7cd13c0f78bd619f967509953094f415288f8693dbb63a084e5bb39c4"
 dependencies = [
  "arc-swap",
- "gix-features",
- "gix-hash",
- "gix-object",
- "gix-pack",
- "gix-path",
+ "gix-features 0.26.5",
+ "gix-hash 0.10.4",
+ "gix-object 0.26.4",
+ "gix-pack 0.30.3",
+ "gix-path 0.7.3",
+ "gix-quote",
+ "parking_lot",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca2f324aa67672b6d0f2c0fa93f96eb6a7029d260e4c1df5dce3c015f5e5add"
+dependencies = [
+ "arc-swap",
+ "gix-features 0.29.0",
+ "gix-hash 0.11.1",
+ "gix-object 0.29.2",
+ "gix-pack 0.35.0",
+ "gix-path 0.8.0",
  "gix-quote",
  "parking_lot",
  "tempfile",
@@ -2243,19 +2561,41 @@ dependencies = [
  "clru",
  "dashmap",
  "gix-chunk",
- "gix-diff",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-path",
- "gix-tempfile",
- "gix-traverse",
+ "gix-diff 0.26.3",
+ "gix-features 0.26.5",
+ "gix-hash 0.10.4",
+ "gix-hashtable 0.1.3",
+ "gix-object 0.26.4",
+ "gix-path 0.7.3",
+ "gix-tempfile 3.0.2",
+ "gix-traverse 0.22.2",
  "memmap2",
  "parking_lot",
  "smallvec",
  "thiserror",
  "uluru",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164a515900a83257ae4aa80e741655bee7a2e39113fb535d7a5ac623b445ff20"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-diff 0.29.0",
+ "gix-features 0.29.0",
+ "gix-hash 0.11.1",
+ "gix-hashtable 0.2.0",
+ "gix-object 0.29.2",
+ "gix-path 0.8.0",
+ "gix-tempfile 5.0.3",
+ "gix-traverse 0.25.0",
+ "memmap2",
+ "parking_lot",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -2280,15 +2620,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-path"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc78f47095a0c15aea0e66103838f0748f4494bf7a9555dfe0f00425400396c"
+dependencies = [
+ "bstr",
+ "home",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-prompt"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f3034d4d935aef2c7bf719aaa54b88c520e82413118d886ae880a31d5bdee57"
 dependencies = [
  "gix-command",
- "gix-config-value",
+ "gix-config-value 0.10.2",
  "nix 0.26.2",
  "parking_lot",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-prompt"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330d11fdf88fff3366c2491efde2f3e454958efe7d5ddf60272e8fb1d944bb01"
+dependencies = [
+ "gix-command",
+ "gix-config-value 0.12.0",
+ "parking_lot",
+ "rustix 0.37.19",
  "thiserror",
 ]
 
@@ -2300,9 +2665,9 @@ checksum = "bfa35fd6d272a351ac631b28a940a937aedd50cb5c6955a5dcb8f853ac9ebeed"
 dependencies = [
  "bstr",
  "btoi",
- "gix-credentials",
- "gix-features",
- "gix-hash",
+ "gix-credentials 0.9.2",
+ "gix-features 0.26.5",
+ "gix-hash 0.10.4",
  "gix-transport",
  "maybe-async",
  "nom",
@@ -2326,13 +2691,33 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93e85abee11aa093f24da7336bf0a8ad598f15da396b28cf1270ab1091137d35"
 dependencies = [
- "gix-actor",
- "gix-features",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-path",
- "gix-tempfile",
+ "gix-actor 0.17.2",
+ "gix-features 0.26.5",
+ "gix-hash 0.10.4",
+ "gix-lock 3.0.2",
+ "gix-object 0.26.4",
+ "gix-path 0.7.3",
+ "gix-tempfile 3.0.2",
+ "gix-validate",
+ "memmap2",
+ "nom",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e03989e9d49954368e1b526578230fc7189d1634acdfbe79e9ba1de717e15d5"
+dependencies = [
+ "gix-actor 0.20.0",
+ "gix-features 0.29.0",
+ "gix-fs",
+ "gix-hash 0.11.1",
+ "gix-lock 5.0.1",
+ "gix-object 0.29.2",
+ "gix-path 0.8.0",
+ "gix-tempfile 5.0.3",
  "gix-validate",
  "memmap2",
  "nom",
@@ -2346,8 +2731,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac80b201eeeb3bc554583fd0127cb6bc9e20981cabb085149c9740329f8a2319"
 dependencies = [
  "bstr",
- "gix-hash",
- "gix-revision",
+ "gix-hash 0.10.4",
+ "gix-revision 0.10.4",
+ "gix-validate",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6ea733820df67e4cd7797deb12727905824d8f5b7c59d943c456d314475892"
+dependencies = [
+ "bstr",
+ "gix-hash 0.11.1",
+ "gix-revision 0.13.0",
  "gix-validate",
  "smallvec",
  "thiserror",
@@ -2360,10 +2759,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "107a10d92379a797bea0f1d0eceded58e08913e0a706c8d436592673c6c6503f"
 dependencies = [
  "bstr",
- "gix-date",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
+ "gix-date 0.4.3",
+ "gix-hash 0.10.4",
+ "gix-hashtable 0.1.3",
+ "gix-object 0.26.4",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810f35e9afeccca999d5d348b239f9c162353127d2e13ff3240e31b919e35476"
+dependencies = [
+ "bstr",
+ "gix-date 0.5.0",
+ "gix-hash 0.11.1",
+ "gix-hashtable 0.2.0",
+ "gix-object 0.29.2",
  "thiserror",
 ]
 
@@ -2375,9 +2788,21 @@ checksum = "e8ffa5bf0772f9b01de501c035b6b084cf9b8bb07dec41e3afc6a17336a65f47"
 dependencies = [
  "bitflags 1.3.2",
  "dirs",
- "gix-path",
+ "gix-path 0.7.3",
  "libc",
  "windows 0.43.0",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794520043d5a024dfeac335c6e520cb616f6963e30dab995892382e998c12897"
+dependencies = [
+ "bitflags 2.2.1",
+ "gix-path 0.8.0",
+ "libc",
+ "windows 0.48.0",
 ]
 
 [[package]]
@@ -2395,6 +2820,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-tempfile"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71a0d32f34e71e86586124225caefd78dabc605d0486de580d717653addf182"
+dependencies = [
+ "gix-fs",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-registry",
+ "tempfile",
+]
+
+[[package]]
 name = "gix-transport"
 version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,12 +2844,12 @@ dependencies = [
  "bstr",
  "curl",
  "gix-command",
- "gix-credentials",
- "gix-features",
+ "gix-credentials 0.9.2",
+ "gix-features 0.26.5",
  "gix-packetline",
  "gix-quote",
- "gix-sec",
- "gix-url",
+ "gix-sec 0.6.2",
+ "gix-url 0.13.3",
  "thiserror",
 ]
 
@@ -2419,9 +2859,21 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b86456d713143fac5aea6787eb3ec6efc0f6dd90ed625fb3f0badf7936ef084"
 dependencies = [
- "gix-hash",
- "gix-hashtable",
- "gix-object",
+ "gix-hash 0.10.4",
+ "gix-hashtable 0.1.3",
+ "gix-object 0.26.4",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5be1e807f288c33bb005075111886cceb43ed8a167b3182a0f62c186e2a0dd1"
+dependencies = [
+ "gix-hash 0.11.1",
+ "gix-hashtable 0.2.0",
+ "gix-object 0.29.2",
  "thiserror",
 ]
 
@@ -2432,11 +2884,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d6e3e05267f7873099b3e510ab8eebdfc28920a915ab2e3d549493abe0fd9f0"
 dependencies = [
  "bstr",
- "gix-features",
- "gix-path",
+ "gix-features 0.26.5",
+ "gix-path 0.7.3",
  "home",
  "thiserror",
  "url",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc77f89054297cc81491e31f1bab4027e554b5ef742a44bd7035db9a0f78b76"
+dependencies = [
+ "bstr",
+ "gix-features 0.29.0",
+ "gix-path 0.8.0",
+ "home",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c10b69beac219acb8df673187a1f07dde2d74092f974fb3f9eb385aeb667c909"
+dependencies = [
+ "fastrand",
 ]
 
 [[package]]
@@ -2456,13 +2931,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7ddd5b042c85cfe768d5ea97bb204cf1ed2b9413148f482146f4e831ca172e"
 dependencies = [
  "bstr",
- "gix-attributes",
- "gix-features",
- "gix-glob",
- "gix-hash",
- "gix-index",
- "gix-object",
- "gix-path",
+ "gix-attributes 0.8.3",
+ "gix-features 0.26.5",
+ "gix-glob 0.5.5",
+ "gix-hash 0.10.4",
+ "gix-index 0.12.4",
+ "gix-object 0.26.4",
+ "gix-path 0.7.3",
+ "io-close",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69eaff0ae973a9d37c40f02ae5ae50fa726c8fc2fd3ab79d0a19eb61975aafa"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-attributes 0.12.0",
+ "gix-features 0.29.0",
+ "gix-fs",
+ "gix-glob 0.7.0",
+ "gix-hash 0.11.1",
+ "gix-ignore",
+ "gix-index 0.16.1",
+ "gix-object 0.29.2",
+ "gix-path 0.8.0",
  "io-close",
  "thiserror",
 ]
@@ -2971,6 +3467,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3066350882a1cd6d950d055997f379ac37fd39f81cd4d8ed186032eb3c5747"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "kuchiki"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3100,9 +3605,9 @@ dependencies = [
 
 [[package]]
 name = "lol_html"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3334b64837c6ea62ca7d8c3ba04ca7aa921b307b664002b882e14332ee2f80f1"
+checksum = "1610d7994d67a05bb35861cd733b069b1171de8693bc8452849c59361a1bb87b"
 dependencies = [
  "bitflags 2.2.1",
  "cfg-if",
@@ -3290,9 +3795,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d3b8e76a2e4b17de765db9432e377a171c42fbe0512b8bc860ff1bfe2e273b"
+checksum = "934030d03f6191edbb4ba16835ccdb80d560788ac686570a8e2986a0fb59ded8"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -5649,6 +6154,12 @@ name = "unicode-bom"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63ec69f541d875b783ca40184d655f2927c95f0bffd486faa83cd3ac3529ec32"
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98e90c70c9f0d4d1ee6d0a7d04aa06cb9bbd53d8cfbdd62a0269a7c2eb640552"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ path-slash = "0.2.0"
 once_cell = { version = "1.4.0", features = ["parking_lot"] }
 base64 = "0.21"
 strum = { version = "0.24.0", features = ["derive"] }
-lol_html = "0.3"
+lol_html = "0.4"
 font-awesome-as-a-crate = { path = "crates/font-awesome-as-a-crate" }
 dashmap = "5.1.0"
 string_cache = "0.8.0"
@@ -71,7 +71,7 @@ serde_cbor = "0.11.1"
 getrandom = "0.2.1"
 itertools = { version = "0.10.5", optional = true}
 rusqlite = { version = "0.28.0", features = ["bundled"] }
-moka = { version ="0.10.0", default-features = false, features = ["sync"]}
+moka = { version ="0.11.0", default-features = false, features = ["sync"]}
 
 # Async
 tokio = { version = "1.0", features = ["rt-multi-thread", "signal", "macros"] }
@@ -133,7 +133,7 @@ indoc = "2.0.0"
 
 [build-dependencies]
 time = "0.3"
-gix = { version = "0.37.2", default-features = false }
+gix = { version = "0.44.1", default-features = false }
 string_cache_codegen = "0.5.1"
 walkdir = "2"
 anyhow = { version = "1.0.42", features = ["backtrace"] }


### PR DESCRIPTION
- https://github.com/cloudflare/lol-html/releases/tag/v0.4.0
- https://github.com/moka-rs/moka/blob/master/CHANGELOG.md#version-0110


gix, the ones with breaking changes (but it probably doesn't matter): 
- https://github.com/Byron/gitoxide/releases/tag/gix-v0.38.0
- https://github.com/Byron/gitoxide/releases/tag/gix-v0.40.0
- https://github.com/Byron/gitoxide/releases/tag/gix-v0.44.0