### PR TITLE
Fetch readme from source archive if available for crate details page

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -13,6 +13,7 @@ use crate::web::metrics::RenderingTimesRecorder;
 use crate::{db::Pool, Config, InstanceMetrics};
 use anyhow::{anyhow, ensure};
 use chrono::{DateTime, Utc};
+use fn_error_context::context;
 use path_slash::PathExt;
 use std::io::BufReader;
 use std::num::NonZeroU64;
@@ -199,6 +200,7 @@ impl Storage {
         })
     }
 
+    #[context("fetching {path} from {name} {version} (archive: {archive_storage})")]
     pub(crate) fn fetch_source_file(
         &self,
         name: &str,

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -619,6 +619,7 @@ mod tests {
             env.fake_release()
                 .name("fake")
                 .version("0.1.0")
+                .source_file("Cargo.toml", b"")
                 .source_file("config.json", b"{}")
                 .create()?;
 
@@ -637,7 +638,10 @@ mod tests {
             assert!(text.starts_with(r#"<!DOCTYPE html>"#));
 
             // file list doesn't show "../"
-            assert_eq!(get_file_list_links(&text), vec!["./config.json"]);
+            assert_eq!(
+                get_file_list_links(&text),
+                vec!["./Cargo.toml", "./config.json"]
+            );
 
             Ok(())
         });
@@ -649,6 +653,7 @@ mod tests {
             env.fake_release()
                 .name("fake")
                 .version("0.1.0")
+                .source_file("Cargo.toml", b"some_random_content")
                 .source_file("folder1/some_filename.rs", b"some_random_content")
                 .source_file("folder2/another_filename.rs", b"some_random_content")
                 .source_file("root_filename.rs", b"some_random_content")
@@ -665,7 +670,12 @@ mod tests {
 
             assert_eq!(
                 get_file_list_links(&response.text()?),
-                vec!["./folder1/", "./folder2/", "./root_filename.rs"]
+                vec![
+                    "./folder1/",
+                    "./folder2/",
+                    "./Cargo.toml",
+                    "./root_filename.rs"
+                ]
             );
             Ok(())
         });


### PR DESCRIPTION
Fixes #1866 and will allow to stop storing the readme in the database for new builds