### PR TITLE
Add new endpoint giving simple rustdoc status for a version

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -149,16 +149,20 @@ fn assert_redirect_common(
 }
 
 /// Makes sure that a URL redirects to a specific page, but doesn't check that the target exists
+///
+/// Returns the redirect response
 #[context("expected redirect from {path} to {expected_target}")]
 pub(crate) fn assert_redirect_unchecked(
     path: &str,
     expected_target: &str,
     web: &TestFrontend,
-) -> Result<()> {
-    assert_redirect_common(path, expected_target, web).map(|_| ())
+) -> Result<Response> {
+    assert_redirect_common(path, expected_target, web)
 }
 
 /// Makes sure that a URL redirects to a specific page, but doesn't check that the target exists
+///
+/// Returns the redirect response
 #[context("expected redirect from {path} to {expected_target}")]
 pub(crate) fn assert_redirect_cached_unchecked(
     path: &str,
@@ -166,16 +170,22 @@ pub(crate) fn assert_redirect_cached_unchecked(
     cache_policy: cache::CachePolicy,
     web: &TestFrontend,
     config: &Config,
-) -> Result<()> {
+) -> Result<Response> {
     let redirect_response = assert_redirect_common(path, expected_target, web)?;
     assert_cache_control(&redirect_response, cache_policy, config);
-    Ok(())
+    Ok(redirect_response)
 }
 
 /// Make sure that a URL redirects to a specific page, and that the target exists and is not another redirect
+///
+/// Returns the redirect response
 #[context("expected redirect from {path} to {expected_target}")]
-pub(crate) fn assert_redirect(path: &str, expected_target: &str, web: &TestFrontend) -> Result<()> {
-    assert_redirect_common(path, expected_target, web)?;
+pub(crate) fn assert_redirect(
+    path: &str,
+    expected_target: &str,
+    web: &TestFrontend,
+) -> Result<Response> {
+    let redirect_response = assert_redirect_common(path, expected_target, web)?;
 
     let response = web.get_no_redirect(expected_target).send()?;
     let status = response.status();
@@ -183,11 +193,13 @@ pub(crate) fn assert_redirect(path: &str, expected_target: &str, web: &TestFront
         anyhow::bail!("failed to GET {expected_target}: {status}");
     }
 
-    Ok(())
+    Ok(redirect_response)
 }
 
 /// Make sure that a URL redirects to a specific page, and that the target exists and is not another redirect.
 /// Also verifies that the redirect's cache-control header matches the provided cache policy.
+///
+/// Returns the redirect response
 #[context("expected redirect from {path} to {expected_target}")]
 pub(crate) fn assert_redirect_cached(
     path: &str,
@@ -195,7 +207,7 @@ pub(crate) fn assert_redirect_cached(
     cache_policy: cache::CachePolicy,
     web: &TestFrontend,
     config: &Config,
-) -> Result<()> {
+) -> Result<Response> {
     let redirect_response = assert_redirect_common(path, expected_target, web)?;
     assert_cache_control(&redirect_response, cache_policy, config);
 
@@ -205,7 +217,7 @@ pub(crate) fn assert_redirect_cached(
         anyhow::bail!("failed to GET {expected_target}: {status}");
     }
 
-    Ok(())
+    Ok(redirect_response)
 }
 
 pub(crate) struct TestEnvironment {

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -43,7 +43,7 @@ pub(crate) async fn build_list_handler(
 ) -> AxumResult<impl IntoResponse> {
     let (version, version_or_latest) = match match_version_axum(&pool, &name, Some(&req_version))
         .await?
-        .assume_exact()?
+        .exact_name_only()?
     {
         MatchSemver::Exact((version, _)) => (version.clone(), version),
         MatchSemver::Latest((version, _)) => (version, "latest".to_string()),
@@ -85,7 +85,7 @@ pub(crate) async fn build_list_json_handler(
 ) -> AxumResult<impl IntoResponse> {
     let version = match match_version_axum(&pool, &name, Some(&req_version))
         .await?
-        .assume_exact()?
+        .exact_name_only()?
     {
         MatchSemver::Exact((version, _)) | MatchSemver::Latest((version, _)) => version,
         MatchSemver::Semver((version, _)) => {

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -332,7 +332,7 @@ pub(crate) async fn crate_details_handler(
             let mut conn = pool.get()?;
             Ok(
                 match_version(&mut conn, &params.name, params.version.as_deref())
-                    .and_then(|m| m.assume_exact())?,
+                    .and_then(|m| m.exact_name_only())?,
             )
         }
     })

--- a/src/web/features.rs
+++ b/src/web/features.rs
@@ -42,7 +42,7 @@ pub(crate) async fn build_features_handler(
     let (version, version_or_latest, is_latest_url) =
         match match_version_axum(&pool, &name, Some(&req_version))
             .await?
-            .assume_exact()?
+            .exact_name_only()?
         {
             MatchSemver::Exact((version, _)) => (version.clone(), version, false),
             MatchSemver::Latest((version, _)) => (version, "latest".to_string(), true),

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -177,6 +177,10 @@ mod tests {
                 "/crate/rcc/0.0.0/builds.json",
                 "/crate/:name/:version/builds.json",
             ),
+            (
+                "/crate/rcc/0.0.0/status.json",
+                "/crate/:name/:version/status.json",
+            ),
             ("/-/static/index.js", "static resource"),
             ("/-/static/menu.js", "static resource"),
             ("/-/static/keyboard.js", "static resource"),

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -173,13 +173,17 @@ mod tests {
             ("/", "/"),
             ("/crate/hexponent/0.2.0", "/crate/:name/:version"),
             ("/crate/rcc/0.0.0", "/crate/:name/:version"),
+            (
+                "/crate/rcc/0.0.0/builds.json",
+                "/crate/:name/:version/builds.json",
+            ),
             ("/-/static/index.js", "static resource"),
             ("/-/static/menu.js", "static resource"),
             ("/-/static/keyboard.js", "static resource"),
             ("/-/static/source.js", "static resource"),
             ("/-/static/opensearch.xml", "static resource"),
             ("/releases", "/releases"),
-            ("/releases/feed", "static resource"),
+            ("/releases/feed", "/releases/feed"),
             ("/releases/queue", "/releases/queue"),
             ("/releases/recent-failures", "/releases/recent-failures"),
             (

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -84,7 +84,7 @@ impl MatchVersion {
     /// If the matched version was an exact match to the requested crate name, returns the
     /// `MatchSemver` for the query. If the lookup required a dash/underscore conversion, returns
     /// `CrateNotFound`.
-    fn assume_exact(self) -> Result<MatchSemver, AxumNope> {
+    fn exact_name_only(self) -> Result<MatchSemver, AxumNope> {
         if self.corrected_name.is_none() {
             Ok(self.version)
         } else {
@@ -120,7 +120,7 @@ impl MatchSemver {
     /// If the matched version was an exact match to a semver version, returns the
     /// version string and id for the query. If the lookup required a semver match, returns
     /// `VersionNotFound`.
-    fn assume_exact(self) -> Result<(String, i32), AxumNope> {
+    fn exact_version_only(self) -> Result<(String, i32), AxumNope> {
         let MatchSemver::Exact(details) = self else { return Err(AxumNope::VersionNotFound) };
         Ok(details)
     }
@@ -605,7 +605,7 @@ mod test {
     fn version(v: Option<&str>, db: &TestDatabase) -> Option<String> {
         let version = match_version(&mut db.conn(), "foo", v)
             .ok()?
-            .assume_exact()
+            .exact_name_only()
             .ok()?
             .into_parts()
             .0;

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -27,6 +27,7 @@ mod rustdoc;
 mod sitemap;
 mod source;
 mod statics;
+mod status;
 
 use crate::{db::Pool, impl_axum_webpage, Context};
 use anyhow::Error;
@@ -114,6 +115,14 @@ impl MatchSemver {
             | MatchSemver::Semver((v, i))
             | MatchSemver::Latest((v, i)) => (v, i),
         }
+    }
+
+    /// If the matched version was an exact match to a semver version, returns the
+    /// version string and id for the query. If the lookup required a semver match, returns
+    /// `VersionNotFound`.
+    fn assume_exact(self) -> Result<(String, i32), AxumNope> {
+        let MatchSemver::Exact(details) = self else { return Err(AxumNope::VersionNotFound) };
+        Ok(details)
     }
 }
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -116,14 +116,6 @@ impl MatchSemver {
             | MatchSemver::Latest((v, i)) => (v, i),
         }
     }
-
-    /// If the matched version was an exact match to a semver version, returns the
-    /// version string and id for the query. If the lookup required a semver match, returns
-    /// `VersionNotFound`.
-    fn exact_version_only(self) -> Result<(String, i32), AxumNope> {
-        let MatchSemver::Exact(details) = self else { return Err(AxumNope::VersionNotFound) };
-        Ok(details)
-    }
 }
 
 /// Checks the database for crate releases that match the given name and version.

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -190,7 +190,7 @@ pub(super) fn build_axum_routes() -> AxumRouter {
         )
         .route_with_tsr(
             "/releases/feed",
-            get_static(super::releases::releases_feed_handler),
+            get_internal(super::releases::releases_feed_handler),
         )
         .route_with_tsr(
             "/releases/:owner",
@@ -218,7 +218,7 @@ pub(super) fn build_axum_routes() -> AxumRouter {
         )
         .route(
             "/crate/:name/:version/builds.json",
-            get_static(super::builds::build_list_json_handler),
+            get_internal(super::builds::build_list_json_handler),
         )
         .route_with_tsr(
             "/crate/:name/:version/builds/:id",

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -220,6 +220,10 @@ pub(super) fn build_axum_routes() -> AxumRouter {
             "/crate/:name/:version/builds.json",
             get_internal(super::builds::build_list_json_handler),
         )
+        .route(
+            "/crate/:name/:version/status.json",
+            get_internal(super::status::status_handler),
+        )
         .route_with_tsr(
             "/crate/:name/:version/builds/:id",
             get_internal(super::build_details::build_details_handler),

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -874,7 +874,7 @@ pub(crate) async fn download_handler(
 ) -> AxumResult<impl IntoResponse> {
     let (version, _) = match_version_axum(&pool, &name, Some(&req_version))
         .await?
-        .assume_exact()?
+        .exact_name_only()?
         .into_parts();
 
     let archive_path = rustdoc_archive_path(&name, &version);

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -2149,11 +2149,14 @@ mod test {
                 .archive_storage(archive_storage)
                 .rustdoc_file("tokio/time/index.html")
                 .create()?;
+
             assert_redirect(
                 "/tokio/0.2.21/tokio/time",
                 "/tokio/0.2.21/tokio/time/index.html",
                 env.frontend(),
-            )
+            )?;
+
+            Ok(())
         })
     }
 

--- a/src/web/status.rs
+++ b/src/web/status.rs
@@ -17,8 +17,8 @@ pub(crate) async fn status_handler(
 ) -> AxumResult<impl IntoResponse> {
     let (_, id) = match_version_axum(&pool, &name, Some(&req_version))
         .await?
-        .assume_exact()?
-        .assume_exact()?;
+        .exact_name_only()?
+        .exact_version_only()?;
 
     let rustdoc_status: bool = spawn_blocking({
         move || {

--- a/src/web/status.rs
+++ b/src/web/status.rs
@@ -1,0 +1,143 @@
+use super::cache::CachePolicy;
+use crate::{
+    db::Pool,
+    utils::spawn_blocking,
+    web::{error::AxumResult, match_version_axum},
+};
+use axum::{
+    extract::{Extension, Path},
+    http::header::ACCESS_CONTROL_ALLOW_ORIGIN,
+    response::IntoResponse,
+    Json,
+};
+
+pub(crate) async fn status_handler(
+    Path((name, req_version)): Path<(String, String)>,
+    Extension(pool): Extension<Pool>,
+) -> AxumResult<impl IntoResponse> {
+    let (_, id) = match_version_axum(&pool, &name, Some(&req_version))
+        .await?
+        .assume_exact()?
+        .assume_exact()?;
+
+    let rustdoc_status: bool = spawn_blocking({
+        move || {
+            Ok(pool
+                .get()?
+                .query_one(
+                    "SELECT releases.rustdoc_status
+                     FROM releases
+                     WHERE releases.id = $1
+                    ",
+                    &[&id],
+                )?
+                .get("rustdoc_status"))
+        }
+    })
+    .await?;
+
+    Ok((
+        Extension(CachePolicy::NoStoreMustRevalidate),
+        [(ACCESS_CONTROL_ALLOW_ORIGIN, "*")],
+        Json(serde_json::json!({ "doc_status": rustdoc_status })),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        test::{assert_cache_control, wrapper},
+        web::cache::CachePolicy,
+    };
+    use reqwest::StatusCode;
+
+    #[test]
+    fn success() {
+        wrapper(|env| {
+            env.fake_release().name("foo").version("0.1.0").create()?;
+
+            let response = env.frontend().get("/crate/foo/0.1.0/status.json").send()?;
+            assert_cache_control(&response, CachePolicy::NoStoreMustRevalidate, &env.config());
+            assert_eq!(response.headers()["access-control-allow-origin"], "*");
+            let value: serde_json::Value = serde_json::from_str(&response.text()?)?;
+
+            assert_eq!(value, serde_json::json!({"doc_status": true}));
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn failure() {
+        wrapper(|env| {
+            env.fake_release()
+                .name("foo")
+                .version("0.1.0")
+                .build_result_failed()
+                .create()?;
+
+            let response = env.frontend().get("/crate/foo/0.1.0/status.json").send()?;
+            assert_cache_control(&response, CachePolicy::NoStoreMustRevalidate, &env.config());
+            assert_eq!(response.headers()["access-control-allow-origin"], "*");
+            let value: serde_json::Value = serde_json::from_str(&response.text()?)?;
+
+            assert_eq!(value, serde_json::json!({"doc_status": false}));
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn crate_version_not_found() {
+        wrapper(|env| {
+            env.fake_release().name("foo").version("0.1.0").create()?;
+
+            let response = env.frontend().get("/crate/foo/0.2.0/status.json").send()?;
+            assert!(response
+                .url()
+                .as_str()
+                .ends_with("/crate/foo/0.2.0/status.json"));
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn invalid_semver() {
+        wrapper(|env| {
+            env.fake_release().name("foo").version("0.1.0").create()?;
+
+            let response = env.frontend().get("/crate/foo/0,1,0/status.json").send()?;
+            assert!(response
+                .url()
+                .as_str()
+                .ends_with("/crate/foo/0,1,0/status.json"));
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+            Ok(())
+        });
+    }
+
+    /// We only support asking for the status of exact versions
+    #[test]
+    fn no_semver() {
+        wrapper(|env| {
+            env.fake_release().name("foo").version("0.1.0").create()?;
+
+            let response = env.frontend().get("/crate/foo/latest/status.json").send()?;
+            assert!(response
+                .url()
+                .as_str()
+                .ends_with("/crate/foo/latest/status.json"));
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+            let response = env.frontend().get("/crate/foo/0.1/status.json").send()?;
+            assert!(response
+                .url()
+                .as_str()
+                .ends_with("/crate/foo/0.1/status.json"));
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+            Ok(())
+        });
+    }
+}


### PR DESCRIPTION
As discussed in #2144, this adds a new endpoint for simply requesting whether docs are available for a specific version, without exposing other details about our builds.

I've also fixed the metrics recording `/builds.json` requests as being "static resource" stopping us from being able to see how many requests we get, that will let us verify whether there's any other clients hitting that endpoint once shields.io/crates.io/lib.rs have migrated over.