### PR TITLE
add subcommand to migrate old CBOR archive indexes to SQLite

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -15,8 +15,8 @@ use docs_rs::utils::{
     remove_crate_priority, set_crate_priority, ConfigName,
 };
 use docs_rs::{
-    start_background_metrics_webserver, start_web_server, BuildQueue, Config, Context, Index,
-    InstanceMetrics, PackageKind, RustwideBuilder, ServiceMetrics, Storage,
+    migrate_old_archive_indexes, start_background_metrics_webserver, start_web_server, BuildQueue,
+    Config, Context, Index, InstanceMetrics, PackageKind, RustwideBuilder, ServiceMetrics, Storage,
 };
 use humantime::Duration;
 use once_cell::sync::OnceCell;
@@ -482,6 +482,9 @@ enum DatabaseSubcommand {
     /// Backfill GitHub/Gitlab stats for crates.
     BackfillRepositoryStats,
 
+    /// migrate the old CBOR archive index files to SQLIte
+    MigrateArchiveIndex,
+
     /// Updates info for a crate from the registry's API
     UpdateCrateRegistryFields {
         #[arg(name = "CRATE")]
@@ -531,6 +534,10 @@ impl DatabaseSubcommand {
 
             Self::UpdateRepositoryFields => {
                 ctx.repository_stats_updater()?.update_all_crates()?;
+            }
+
+            Self::MigrateArchiveIndex => {
+                migrate_old_archive_indexes(&*ctx.storage()?, &mut *ctx.conn()?)?;
             }
 
             Self::BackfillRepositoryStats => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub use self::docbuilder::PackageKind;
 pub use self::docbuilder::RustwideBuilder;
 pub use self::index::Index;
 pub use self::metrics::{InstanceMetrics, ServiceMetrics};
+pub use self::storage::migrate_old_archive_indexes;
 pub use self::storage::Storage;
 pub use self::web::{start_background_metrics_webserver, start_web_server};
 


### PR DESCRIPTION
This will give us a subcommand to migrate the existing cbor index files to SQLite, locally & on S3. 

After the migration is done, I can simplify some of the logic in `storage::archive_index` and get rid of some depdendencies (cbor, mmap)

I did a manual test with a handful of local indexes I had, but it would be awesome if @Nemo157 could run this migration on his test instance. 