### PR TITLE
Add limits on what code will be highlighted

### DIFF
--- a/src/web/highlight.rs
+++ b/src/web/highlight.rs
@@ -73,14 +73,16 @@ pub fn with_lang(lang: Option<&str>, code: &str) -> String {
             } else {
                 log::error!("failed while highlighting code: {err:?}");
             }
-            code.to_owned()
+            tera::escape_html(code)
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{select_syntax, try_with_lang, LimitsExceeded, CODE_SIZE_LIMIT, LINE_SIZE_LIMIT};
+    use super::{
+        select_syntax, try_with_lang, with_lang, LimitsExceeded, CODE_SIZE_LIMIT, LINE_SIZE_LIMIT,
+    };
 
     #[test]
     fn custom_filetypes() {
@@ -106,5 +108,12 @@ mod tests {
         };
         assert!(is_limited("a\n".repeat(CODE_SIZE_LIMIT)));
         assert!(is_limited("aa".repeat(LINE_SIZE_LIMIT)));
+    }
+
+    #[test]
+    fn limited_escaped() {
+        let text = "<p>\n".to_string() + "aa".repeat(LINE_SIZE_LIMIT).as_str();
+        let highlighted = with_lang(Some("toml"), &text);
+        assert!(highlighted.starts_with("&lt;p&gt;\n"));
     }
 }


### PR DESCRIPTION
The numbers are pretty arbitrary, I didn't actually time it but opening a 3MB `.rs` file felt like it was just about on the threshold of too long, and my machine is faster than production.

I did consider having the numbers configurable, but threading the config through was looking quite complex and I don't think it's that useful.

This also exposed another bug, if highlighting failed we weren't escaping any html in the source files, so fixed that now that failure will be much more common.