### PR TITLE
don't delete full crates from docs.rs when only a version was deleted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand",
+ "fastrand 1.9.0",
  "hex",
  "http",
  "hyper",
@@ -257,7 +257,7 @@ checksum = "1fcdb2f7acbc076ff5ad05e7864bdb191ca70a6fd07668dc3a1a8bcd051de5ae"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
- "fastrand",
+ "fastrand 1.9.0",
  "tokio",
  "tracing",
  "zeroize",
@@ -487,7 +487,7 @@ dependencies = [
  "aws-smithy-protocol-test",
  "aws-smithy-types",
  "bytes",
- "fastrand",
+ "fastrand 1.9.0",
  "http",
  "http-body",
  "hyper",
@@ -1111,13 +1111,13 @@ dependencies = [
 
 [[package]]
 name = "crates-index-diff"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea50e79c405e2bd3194b5b8755b9ced1bd0cb70f262bd69fed498cc0ca474b2"
+checksum = "d158febabd16b0207e1b4cd803583652904001b9313ce2f7f8407e0ee5378aa6"
 dependencies = [
  "ahash 0.8.3",
  "bstr",
- "gix",
+ "gix 0.48.0",
  "hashbrown 0.14.0",
  "hex",
  "serde",
@@ -1412,7 +1412,7 @@ dependencies = [
  "font-awesome-as-a-crate",
  "futures-util",
  "getrandom 0.2.10",
- "gix",
+ "gix 0.47.0",
  "grass",
  "hostname",
  "http",
@@ -1423,7 +1423,7 @@ dependencies = [
  "kuchiki",
  "log",
  "lol_html",
- "memmap2",
+ "memmap2 0.5.10",
  "mime",
  "mime_guess",
  "mockito",
@@ -1617,6 +1617,12 @@ checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "filetime"
@@ -1848,42 +1854,90 @@ version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f5281c55e0a7415877d91a15fae4a10ec7444615d64d78e48c07f20bcfcd9b"
 dependencies = [
- "gix-actor",
+ "gix-actor 0.22.0",
  "gix-attributes",
  "gix-commitgraph",
- "gix-config",
+ "gix-config 0.24.0",
  "gix-credentials",
- "gix-date",
- "gix-diff",
- "gix-discover",
+ "gix-date 0.6.0",
+ "gix-diff 0.31.0",
+ "gix-discover 0.20.0",
  "gix-features",
  "gix-fs",
  "gix-glob",
  "gix-hash",
  "gix-hashtable",
  "gix-ignore",
- "gix-index",
+ "gix-index 0.19.0",
  "gix-lock",
- "gix-mailmap",
- "gix-negotiate",
- "gix-object",
- "gix-odb",
- "gix-pack",
+ "gix-mailmap 0.14.0",
+ "gix-negotiate 0.3.0",
+ "gix-object 0.31.0",
+ "gix-odb 0.48.0",
+ "gix-pack 0.38.0",
+ "gix-path",
+ "gix-prompt",
+ "gix-ref 0.31.0",
+ "gix-refspec 0.12.0",
+ "gix-revision 0.16.0",
+ "gix-sec",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse 0.28.0",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree 0.20.0",
+ "log",
+ "once_cell",
+ "signal-hook",
+ "smallvec",
+ "thiserror",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e74cea676de7f53a79f3c0365812b11f6814b81e671b8ee4abae6ca09c7881"
+dependencies = [
+ "gix-actor 0.23.0",
+ "gix-attributes",
+ "gix-commitgraph",
+ "gix-config 0.25.1",
+ "gix-credentials",
+ "gix-date 0.7.0",
+ "gix-diff 0.32.0",
+ "gix-discover 0.21.1",
+ "gix-features",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index 0.20.0",
+ "gix-lock",
+ "gix-mailmap 0.15.0",
+ "gix-negotiate 0.4.0",
+ "gix-object 0.32.0",
+ "gix-odb 0.49.1",
+ "gix-pack 0.39.1",
  "gix-path",
  "gix-prompt",
  "gix-protocol",
- "gix-ref",
- "gix-refspec",
- "gix-revision",
+ "gix-ref 0.32.1",
+ "gix-refspec 0.13.0",
+ "gix-revision 0.17.0",
  "gix-sec",
  "gix-tempfile",
  "gix-trace",
  "gix-transport",
- "gix-traverse",
+ "gix-traverse 0.29.0",
  "gix-url",
  "gix-utils",
  "gix-validate",
- "gix-worktree",
+ "gix-worktree 0.21.1",
  "log",
  "once_cell",
  "signal-hook",
@@ -1900,7 +1954,21 @@ checksum = "b70d0d809ee387113df810ab4ebe585a076e35ae6ed59b5b280072146955a3ff"
 dependencies = [
  "bstr",
  "btoi",
- "gix-date",
+ "gix-date 0.6.0",
+ "itoa 1.0.6",
+ "nom",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1969b77b9ee4cc1755c841987ec6f7622aaca95e952bcafb76973ae59d1b8716"
+dependencies = [
+ "bstr",
+ "btoi",
+ "gix-date 0.7.0",
  "itoa 1.0.6",
  "nom",
  "thiserror",
@@ -1908,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d7006cc5a508514207154046e18c3c39d98ba98f865ada83b6f3f3886543bb"
+checksum = "e3772b0129dcd1fc73e985bbd08a1482d082097d2915cb1ee31ce8092b8e4434"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -1952,15 +2020,15 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e498e98d0b477d6a1c1608bee39db201e7a38873460a130a97ce88b4d95b6e1"
+checksum = "ed42baa50075d41c1a0931074ce1a97c5797c7c6fe7591d9f1f2dcd448532c26"
 dependencies = [
  "bstr",
  "gix-chunk",
  "gix-features",
  "gix-hash",
- "memmap2",
+ "memmap2 0.7.1",
  "thiserror",
 ]
 
@@ -1975,7 +2043,29 @@ dependencies = [
  "gix-features",
  "gix-glob",
  "gix-path",
- "gix-ref",
+ "gix-ref 0.31.0",
+ "gix-sec",
+ "log",
+ "memchr",
+ "nom",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "817688c7005a716d9363e267913526adea402dabd947f4ba63842d10cc5132af"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref 0.32.1",
  "gix-sec",
  "log",
  "memchr",
@@ -1988,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4783caa23062f86acfd1bc9e72c62250923d1673171ce1a524d9486f8a4556a8"
+checksum = "83960be5e99266bcf55dae5a24731bbd39f643bfb68f27e939d6b06836b5b87d"
 dependencies = [
  "bitflags 2.3.2",
  "bstr",
@@ -2001,9 +2091,9 @@ dependencies = [
 
 [[package]]
 name = "gix-credentials"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcec518a8db5b2e342ea7a2e785f46fd176b1b689ddd3f43052701bf3fa8ee3"
+checksum = "75a75565e0e6e7f80cfa4eb1b05cc448c6846ddd48dcf413a28875fbc11ee9af"
 dependencies = [
  "bstr",
  "gix-command",
@@ -2028,13 +2118,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-date"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9a04a1d2387c955ec91059d56b673000dd24f3c07cad08ed253e36381782bf"
+dependencies = [
+ "bstr",
+ "itoa 1.0.6",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "gix-diff"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5049dd5a60d5608912da0ab184f35064901f192f4adf737716789715faffa080"
 dependencies = [
  "gix-hash",
- "gix-object",
+ "gix-object 0.31.0",
+ "imara-diff",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf5d9b9b521b284ebe53ee69eee33341835ec70edc314f36b2100ea81396121"
+dependencies = [
+ "gix-hash",
+ "gix-object 0.32.0",
  "imara-diff",
  "thiserror",
 ]
@@ -2049,16 +2163,31 @@ dependencies = [
  "dunce",
  "gix-hash",
  "gix-path",
- "gix-ref",
+ "gix-ref 0.31.0",
+ "gix-sec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "272aad20dc63dedba76615373dd8885fb5aebe4795e5b5b0aa2a24e63c82085c"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-hash",
+ "gix-path",
+ "gix-ref 0.32.1",
  "gix-sec",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-features"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae82dfceec06c034728c530399ee449f97b1e542e191247c52c169ca6af1fd89"
+checksum = "06142d8cff5d17509399b04052b64d2f9b3a311d5cff0b1a32b220f62cd0d595"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -2088,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "gix-glob"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f45cd7ab22faf154db0a9f5a8011ba9cda8b298b61b7299f43a21bbaf0b3f208"
+checksum = "c18bdff83143d61e7d60da6183b87542a870d026b2a2d0b30170b8e9c0cd321a"
 dependencies = [
  "bitflags 2.3.2",
  "bstr",
@@ -2110,20 +2239,20 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cfd7f4ea905c13579565e3c264ca2c4103d192bd5fce2300c5a884cf1977d61"
+checksum = "9e133bc56d938eaec1c675af7c681a51de9662b0ada779f45607b967a10da77a"
 dependencies = [
  "gix-hash",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.0",
  "parking_lot",
 ]
 
 [[package]]
 name = "gix-ignore"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e82dec6975012b710837c6cd56353c3111d2308e016118bfc59275fcc8b5d0"
+checksum = "ca801f2d0535210f77b33e2c067d565aedecacc82f1b3dbce26da1388ebc4634"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -2145,10 +2274,32 @@ dependencies = [
  "gix-features",
  "gix-hash",
  "gix-lock",
- "gix-object",
- "gix-traverse",
+ "gix-object 0.31.0",
+ "gix-traverse 0.28.0",
  "itoa 1.0.6",
- "memmap2",
+ "memmap2 0.5.10",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68099abdf6ee50ae3c897e8b05de96871cbe54d52a37cdf559101f911b883562"
+dependencies = [
+ "bitflags 2.3.2",
+ "bstr",
+ "btoi",
+ "filetime",
+ "gix-bitmap",
+ "gix-features",
+ "gix-hash",
+ "gix-lock",
+ "gix-object 0.32.0",
+ "gix-traverse 0.29.0",
+ "itoa 1.0.6",
+ "memmap2 0.7.1",
  "smallvec",
  "thiserror",
 ]
@@ -2171,8 +2322,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0bef8d360a6a9fc5a6d872471588d8ca7db77b940e48ff20c3b4706ad5f481d"
 dependencies = [
  "bstr",
- "gix-actor",
- "gix-date",
+ "gix-actor 0.22.0",
+ "gix-date 0.6.0",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-mailmap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1787e3c37fc43b1f7c0e3be6196c6837b3ba5f869190dfeaa444b816f0a7f34b"
+dependencies = [
+ "bstr",
+ "gix-actor 0.23.0",
+ "gix-date 0.7.0",
  "thiserror",
 ]
 
@@ -2184,10 +2347,26 @@ checksum = "b626aafb9f4088058f1baa5d2029b2191820c84f6c81e43535ba70bfdc7b7d56"
 dependencies = [
  "bitflags 2.3.2",
  "gix-commitgraph",
- "gix-date",
+ "gix-date 0.6.0",
  "gix-hash",
- "gix-object",
- "gix-revwalk",
+ "gix-object 0.31.0",
+ "gix-revwalk 0.2.0",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7bce64d4452dd609f44d04b14b29da2e0ad2c45fcdf4ce1472a5f5f8ec21c2"
+dependencies = [
+ "bitflags 2.3.2",
+ "gix-commitgraph",
+ "gix-date 0.7.0",
+ "gix-hash",
+ "gix-object 0.32.0",
+ "gix-revwalk 0.3.0",
  "smallvec",
  "thiserror",
 ]
@@ -2200,8 +2379,28 @@ checksum = "255e477ae4cc8d10778238f011e6125b01cc0e7067dc8df87acd67a428a81f20"
 dependencies = [
  "bstr",
  "btoi",
- "gix-actor",
- "gix-date",
+ "gix-actor 0.22.0",
+ "gix-date 0.6.0",
+ "gix-features",
+ "gix-hash",
+ "gix-validate",
+ "hex",
+ "itoa 1.0.6",
+ "nom",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a953f3d7ffad16734aa3ab1d05807972c80e339d1bd9dde03e0198716b99e2a6"
+dependencies = [
+ "bstr",
+ "btoi",
+ "gix-actor 0.23.0",
+ "gix-date 0.7.0",
  "gix-features",
  "gix-hash",
  "gix-validate",
@@ -2219,11 +2418,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b73469f145d1e6afbcfd0ab6499a366fbbcb958c2999d41d283d6c7b94024b9"
 dependencies = [
  "arc-swap",
- "gix-date",
+ "gix-date 0.6.0",
  "gix-features",
  "gix-hash",
- "gix-object",
- "gix-pack",
+ "gix-object 0.31.0",
+ "gix-pack 0.38.0",
+ "gix-path",
+ "gix-quote",
+ "parking_lot",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.49.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6418cff00ecc2713b58c8e04bff30dda808fbba1a080e7248b299d069894a01"
+dependencies = [
+ "arc-swap",
+ "gix-date 0.7.0",
+ "gix-features",
+ "gix-hash",
+ "gix-object 0.32.0",
+ "gix-pack 0.39.1",
  "gix-path",
  "gix-quote",
  "parking_lot",
@@ -2239,15 +2457,37 @@ checksum = "a1f3bcd1aaa72aea7163b147d2bde2480a01eadefc774a479d38f29920f7f1c8"
 dependencies = [
  "clru",
  "gix-chunk",
- "gix-diff",
+ "gix-diff 0.31.0",
  "gix-features",
  "gix-hash",
  "gix-hashtable",
- "gix-object",
+ "gix-object 0.31.0",
  "gix-path",
  "gix-tempfile",
- "gix-traverse",
- "memmap2",
+ "gix-traverse 0.28.0",
+ "memmap2 0.5.10",
+ "parking_lot",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414935138d90043ea5898de7a93f02c2558e52652492719470e203ef26a8fd0a"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-diff 0.32.0",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.32.0",
+ "gix-path",
+ "gix-tempfile",
+ "gix-traverse 0.29.0",
+ "memmap2 0.7.1",
  "parking_lot",
  "smallvec",
  "thiserror",
@@ -2267,9 +2507,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea2a19d82dd55e5fad1d606b8a1ad2f7a804e10caa2efbb169cd37e0a07ede0"
+checksum = "dfca182d2575ded2ed38280f1ebf75cd5d3790b77e0872de07854cf085821fbe"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -2293,14 +2533,14 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e93c9343860c45c025e09bc26772d15cec690250d04b36822bd528dd3c44f8"
+checksum = "ed7069fac7eb23b043b4bd7890df1e244cb370c3fe8b2ff482203d36b4fd4099"
 dependencies = [
  "bstr",
  "btoi",
  "gix-credentials",
- "gix-date",
+ "gix-date 0.7.0",
  "gix-features",
  "gix-hash",
  "gix-transport",
@@ -2326,17 +2566,38 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6c74873a9d8ff5d1310f2325f09164c15a91402ab5cde4d479ae12ff55ed69"
 dependencies = [
- "gix-actor",
- "gix-date",
+ "gix-actor 0.22.0",
+ "gix-date 0.6.0",
  "gix-features",
  "gix-fs",
  "gix-hash",
  "gix-lock",
- "gix-object",
+ "gix-object 0.31.0",
  "gix-path",
  "gix-tempfile",
  "gix-validate",
- "memmap2",
+ "memmap2 0.5.10",
+ "nom",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39453f4e5f23cddc2e6e4cca2ba20adfdbec29379e3ca829714dfe98ae068ccd"
+dependencies = [
+ "gix-actor 0.23.0",
+ "gix-date 0.7.0",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object 0.32.0",
+ "gix-path",
+ "gix-tempfile",
+ "gix-validate",
+ "memmap2 0.7.1",
  "nom",
  "thiserror",
 ]
@@ -2349,7 +2610,21 @@ checksum = "ca1bc6c40bad62570683d642fcb04e977433ac8f76b674860ef7b1483c1f8990"
 dependencies = [
  "bstr",
  "gix-hash",
- "gix-revision",
+ "gix-revision 0.16.0",
+ "gix-validate",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e76ff1f82fba295a121e31ab02f69642994e532c45c0c899aa393f4b740302"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-revision 0.17.0",
  "gix-validate",
  "smallvec",
  "thiserror",
@@ -2362,11 +2637,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3751d6643d731fc5829d2f43ca049f4333c968f30908220ba0783c9dfe5010c"
 dependencies = [
  "bstr",
- "gix-date",
+ "gix-date 0.6.0",
  "gix-hash",
  "gix-hashtable",
- "gix-object",
- "gix-revwalk",
+ "gix-object 0.31.0",
+ "gix-revwalk 0.2.0",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "237428a7d3978e8572964e1e45d984027c2acc94df47e594baa6c4b0da7c9922"
+dependencies = [
+ "bstr",
+ "gix-date 0.7.0",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.32.0",
+ "gix-revwalk 0.3.0",
  "thiserror",
 ]
 
@@ -2377,19 +2667,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144995229c6e5788b1c7386f8a3f7146ace3745c9a6b56cef9123a7d83b110c5"
 dependencies = [
  "gix-commitgraph",
- "gix-date",
+ "gix-date 0.6.0",
  "gix-hash",
  "gix-hashtable",
- "gix-object",
+ "gix-object 0.31.0",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028d50fcaf8326a8f79a359490d9ca9fb4e2b51ac9ac86503560d0bcc888d2eb"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date 0.7.0",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.32.0",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-sec"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f09860e2ddc7b13119e410c46d8e9f870acc7933fb53ae65817af83a8c9f80"
+checksum = "ede298863db2a0574a14070991710551e76d1f47c9783b62d4fcbca17f56371c"
 dependencies = [
  "bitflags 2.3.2",
  "gix-path",
@@ -2414,15 +2719,15 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff8a60073500f4d6edd181432ee11394d843db7dcf05756aa137a1233b1cbf6"
+checksum = "103eac621617be3ebe0605c9065ca51a223279a23218aaf67d10daa6e452f663"
 
 [[package]]
 name = "gix-transport"
-version = "0.33.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435013c7ce6983fd2cfa9a740873c31c048c042e47d92714e43d75d861f0eedf"
+checksum = "0929bb80a07c04033edd4585091c4db9ea458cb932e883bf22efb146ebfbdc89"
 dependencies = [
  "base64 0.21.2",
  "bstr",
@@ -2444,20 +2749,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f6bba1686bfbc7e0e93d4932bc6e14d479c9c9524f7c8d65b25d2a9446a99e"
 dependencies = [
  "gix-commitgraph",
- "gix-date",
+ "gix-date 0.6.0",
  "gix-hash",
  "gix-hashtable",
- "gix-object",
- "gix-revwalk",
+ "gix-object 0.31.0",
+ "gix-revwalk 0.2.0",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3cdfd54598db4fae57d5ae6f52958422b2d13382d2745796bfe5c8015ffa86e"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date 0.7.0",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.32.0",
+ "gix-revwalk 0.3.0",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-url"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1f984816338039b151a9f5dae6100e1e51e438cf61242ea8136fedc574d825"
+checksum = "beaede6dbc83f408b19adfd95bb52f1dbf01fb8862c3faf6c6243e2e67fcdfa1"
 dependencies = [
  "bstr",
  "gix-features",
@@ -2469,11 +2790,11 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca284c260845bc0724050aec59c7a596407678342614cdf5a1d69e044f29a36"
+checksum = "7058c94f4164fcf5b8457d35f6d8f6e1007f9f7f938c9c7684a7e01d23c6ddde"
 dependencies = [
- "fastrand",
+ "fastrand 2.0.0",
 ]
 
 [[package]]
@@ -2500,8 +2821,29 @@ dependencies = [
  "gix-glob",
  "gix-hash",
  "gix-ignore",
- "gix-index",
- "gix-object",
+ "gix-index 0.19.0",
+ "gix-object 0.31.0",
+ "gix-path",
+ "io-close",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1363b9aa66b9e14412ac04e1f759827203f491729d92172535a8ce6cde02efa"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-attributes",
+ "gix-features",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index 0.20.0",
+ "gix-object 0.32.0",
  "gix-path",
  "io-close",
  "thiserror",
@@ -3261,6 +3603,15 @@ name = "memmap2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
 dependencies = [
  "libc",
 ]
@@ -5131,7 +5482,7 @@ checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
  "autocfg",
  "cfg-if",
- "fastrand",
+ "fastrand 1.9.0",
  "redox_syscall 0.3.5",
  "rustix 0.37.20",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ clap = { version = "4.0.22", features = [ "derive" ] }
 crates-index = { version = "0.19", optional = true }
 rayon = "1.6.1"
 num_cpus = "1.15.0"
-crates-index-diff = { version = "19.0.0", features = [ "max-performance" ]}
+crates-index-diff = { version = "20.0.0", features = [ "max-performance" ]}
 reqwest = { version = "0.11", features = ["blocking", "json"] } # TODO: Remove blocking when async is ready
 semver = { version = "1.0.4", features = ["serde"] }
 slug = "0.1.1"

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -554,9 +554,14 @@ impl DatabaseSubcommand {
 
             Self::Delete {
                 command: DeleteSubcommand::Version { name, version },
-            } => {
-                db::delete_version(&ctx, &name, &version).context("failed to delete the version")?
-            }
+            } => db::delete_version(
+                &mut *ctx.pool()?.get()?,
+                &*ctx.storage()?,
+                &*ctx.config()?,
+                &name,
+                &version,
+            )
+            .context("failed to delete the version")?,
             Self::Delete {
                 command: DeleteSubcommand::Crate { name },
             } => db::delete_crate(

--- a/src/utils/consistency/mod.rs
+++ b/src/utils/consistency/mod.rs
@@ -111,7 +111,9 @@ where
             }
             diff::Difference::ReleaseNotInIndex(name, version) => {
                 if !dry_run {
-                    if let Err(err) = delete::delete_version(ctx, name, version) {
+                    if let Err(err) =
+                        delete::delete_version(&mut conn, &storage, &config, name, version)
+                    {
                         warn!("{:?}", err);
                     }
                 }


### PR DESCRIPTION
related to https://rust-lang.zulipchat.com/#narrow/stream/356853-t-docs-rs/topic/glium.20gone  
where we delete all releases for a crate while only one or more releases were deleted. 

This was coming at least from a bug in the crates-index-diff docs: https://docs.rs/crates-index-diff/latest/crates_index_diff/enum.Change.html where it also emits `Deleted` for a version-delete, not only a crate-delete. 

Draft PR for a fix: https://github.com/Byron/crates-index-diff-rs/pull/38

