### PR TITLE
Fix display of platforms list if there are too many

### DIFF
--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -208,7 +208,7 @@ extra whitespace unremovable, need to use html tags unaffacted by whitespace T_T
         </a>
 
         {# Build the dropdown list showing available targets #}
-        <ul class="pure-menu-children">
+        <ul class="pure-menu-children" id="platforms">
             {%- for target in metadata.doc_targets -%}
                 {#
                     The crate-detail page is the only page where we want to allow google to follow

--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -341,6 +341,16 @@ div.nav-container {
             animation: rotating_text 2s linear infinite;
         }
     }
+
+    #platforms {
+        max-height: 75vh;
+        overflow-y: auto;
+
+        li a {
+            overflow-x: hidden;
+            text-overflow: ellipsis;
+        }
+    }
 }
 
 #nav-search {


### PR DESCRIPTION
It limits the height of the platform list and allow to scroll it:

![image](https://github.com/rust-lang/docs.rs/assets/3050060/b38c215e-85ad-4a50-99da-b73b8f284155)
