### PR TITLE
Sort platforms list

### DIFF
--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -550,7 +550,7 @@ impl MetaData {
     }
 
     fn parse_doc_targets(targets: Value) -> Vec<String> {
-        targets
+        let mut targets = targets
             .as_array()
             .map(|array| {
                 array
@@ -558,7 +558,9 @@ impl MetaData {
                     .filter_map(|item| item.as_str().map(|s| s.to_owned()))
                     .collect()
             })
-            .unwrap_or_else(Vec::new)
+            .unwrap_or_else(Vec::new);
+        targets.sort_unstable();
+        targets
     }
 }
 


### PR DESCRIPTION
As you can see:

![image](https://github.com/rust-lang/docs.rs/assets/3050060/fa263988-f618-4e4a-8ad2-b804e448825f)

it's currently complicated to find the correct one from the list. However, I'm not sure if it's the best approach to sort the list every time or if we should insert it correctly instead. But in the second case, that would mean updating all the entries in the DB. Not sure which solution you prefer?