### PR TITLE
upgrade grass, gix, crates-index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "crates-index"
-version = "0.19.13"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3cab38e209d6ba8bd5b0d41c784ec63a5a9ea3adf866b820d377588960f1ded"
+checksum = "385938adbefae319f3e8dbcfd7a5bc06dda20733de549c05468a53470a6c7d61"
 dependencies = [
  "git2",
  "hex",
@@ -1380,7 +1380,7 @@ dependencies = [
  "font-awesome-as-a-crate",
  "futures-util",
  "getrandom 0.2.10",
- "gix 0.47.0",
+ "gix 0.50.1",
  "grass",
  "hostname",
  "http",
@@ -1851,72 +1851,24 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f5281c55e0a7415877d91a15fae4a10ec7444615d64d78e48c07f20bcfcd9b"
-dependencies = [
- "gix-actor 0.22.0",
- "gix-attributes",
- "gix-commitgraph",
- "gix-config 0.24.0",
- "gix-credentials",
- "gix-date 0.6.0",
- "gix-diff 0.31.0",
- "gix-discover 0.20.0",
- "gix-features 0.31.1",
- "gix-fs 0.3.0",
- "gix-glob",
- "gix-hash",
- "gix-hashtable",
- "gix-ignore",
- "gix-index 0.19.0",
- "gix-lock",
- "gix-mailmap 0.14.0",
- "gix-negotiate 0.3.0",
- "gix-object 0.31.0",
- "gix-odb 0.48.0",
- "gix-pack 0.38.0",
- "gix-path",
- "gix-prompt",
- "gix-ref 0.31.0",
- "gix-refspec 0.12.0",
- "gix-revision 0.16.0",
- "gix-sec",
- "gix-tempfile",
- "gix-trace",
- "gix-traverse 0.28.0",
- "gix-url",
- "gix-utils",
- "gix-validate",
- "gix-worktree 0.20.0",
- "log",
- "once_cell",
- "signal-hook",
- "smallvec",
- "thiserror",
- "unicode-normalization",
-]
-
-[[package]]
-name = "gix"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e74cea676de7f53a79f3c0365812b11f6814b81e671b8ee4abae6ca09c7881"
 dependencies = [
  "gix-actor 0.23.0",
- "gix-attributes",
- "gix-commitgraph",
+ "gix-attributes 0.14.1",
+ "gix-commitgraph 0.17.1",
  "gix-config 0.25.1",
- "gix-credentials",
- "gix-date 0.7.1",
+ "gix-credentials 0.16.1",
+ "gix-date",
  "gix-diff 0.32.0",
  "gix-discover 0.21.1",
  "gix-features 0.31.1",
  "gix-fs 0.3.0",
- "gix-glob",
+ "gix-glob 0.9.1",
  "gix-hash",
  "gix-hashtable",
- "gix-ignore",
+ "gix-ignore 0.4.1",
  "gix-index 0.20.0",
  "gix-lock",
  "gix-mailmap 0.15.0",
@@ -1935,7 +1887,7 @@ dependencies = [
  "gix-trace",
  "gix-transport",
  "gix-traverse 0.29.0",
- "gix-url",
+ "gix-url 0.20.1",
  "gix-utils",
  "gix-validate",
  "gix-worktree 0.21.1",
@@ -1948,17 +1900,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-actor"
-version = "0.22.0"
+name = "gix"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b70d0d809ee387113df810ab4ebe585a076e35ae6ed59b5b280072146955a3ff"
+checksum = "275b1bfa0d6f6ed31a2e2e878a4539f4994eac8840546283ab3aebbd8fcaa42d"
 dependencies = [
- "bstr",
- "btoi",
- "gix-date 0.6.0",
- "itoa 1.0.9",
- "nom",
+ "gix-actor 0.24.1",
+ "gix-attributes 0.16.0",
+ "gix-commitgraph 0.18.1",
+ "gix-config 0.26.1",
+ "gix-credentials 0.17.1",
+ "gix-date",
+ "gix-diff 0.33.1",
+ "gix-discover 0.22.1",
+ "gix-features 0.32.1",
+ "gix-filter",
+ "gix-fs 0.4.1",
+ "gix-glob 0.10.1",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore 0.5.1",
+ "gix-index 0.21.1",
+ "gix-lock",
+ "gix-mailmap 0.16.1",
+ "gix-negotiate 0.5.1",
+ "gix-object 0.33.1",
+ "gix-odb 0.50.1",
+ "gix-pack 0.40.2",
+ "gix-path",
+ "gix-prompt",
+ "gix-ref 0.33.2",
+ "gix-refspec 0.14.1",
+ "gix-revision 0.18.1",
+ "gix-sec",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse 0.30.1",
+ "gix-url 0.21.1",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree 0.23.0",
+ "log",
+ "once_cell",
+ "signal-hook",
+ "smallvec",
  "thiserror",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1969,7 +1956,21 @@ checksum = "1969b77b9ee4cc1755c841987ec6f7622aaca95e952bcafb76973ae59d1b8716"
 dependencies = [
  "bstr",
  "btoi",
- "gix-date 0.7.1",
+ "gix-date",
+ "itoa 1.0.9",
+ "nom",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7606482631d56cc6bfba3394ae42fc64927635024298befbb7923b6144774e8"
+dependencies = [
+ "bstr",
+ "btoi",
+ "gix-date",
  "itoa 1.0.9",
  "nom",
  "thiserror",
@@ -1982,7 +1983,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3772b0129dcd1fc73e985bbd08a1482d082097d2915cb1ee31ce8092b8e4434"
 dependencies = [
  "bstr",
- "gix-glob",
+ "gix-glob 0.9.1",
+ "gix-path",
+ "gix-quote",
+ "kstring",
+ "log",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a134a674e39e238bd273326a9815296cc71f867ad5466518da71392cff98ce"
+dependencies = [
+ "bstr",
+ "gix-glob 0.10.1",
  "gix-path",
  "gix-quote",
  "kstring",
@@ -2034,17 +2052,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-config"
-version = "0.24.0"
+name = "gix-commitgraph"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b32541232a2c626849df7843e05b50cb43ac38a4f675abbe2f661874fc1e9d"
+checksum = "c4c2d5ce99eba59fe9477a9e3037b0e1d0266d53925cc4b322bc06c566589b99"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-features 0.32.1",
+ "gix-hash",
+ "memmap2 0.7.1",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "817688c7005a716d9363e267913526adea402dabd947f4ba63842d10cc5132af"
 dependencies = [
  "bstr",
  "gix-config-value",
  "gix-features 0.31.1",
- "gix-glob",
+ "gix-glob 0.9.1",
  "gix-path",
- "gix-ref 0.31.0",
+ "gix-ref 0.32.1",
  "gix-sec",
  "log",
  "memchr",
@@ -2057,16 +2089,16 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.25.1"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817688c7005a716d9363e267913526adea402dabd947f4ba63842d10cc5132af"
+checksum = "b51e83bd9d08118e0ff06ea14be953c418b4c056e57d93c8103e777584e48b0a"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.31.1",
- "gix-glob",
+ "gix-features 0.32.1",
+ "gix-glob 0.10.1",
  "gix-path",
- "gix-ref 0.32.1",
+ "gix-ref 0.33.2",
  "gix-sec",
  "log",
  "memchr",
@@ -2102,20 +2134,24 @@ dependencies = [
  "gix-path",
  "gix-prompt",
  "gix-sec",
- "gix-url",
+ "gix-url 0.20.1",
  "thiserror",
 ]
 
 [[package]]
-name = "gix-date"
-version = "0.6.0"
+name = "gix-credentials"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0213f923d63c2c7d10799c1977f42df38ec586ebbf1d14fd00dfa363ac994c2b"
+checksum = "307d91ec5f7c8e9bfaa217fe30c2e0099101cbe83dbed27a222dbb6def38725f"
 dependencies = [
  "bstr",
- "itoa 1.0.9",
+ "gix-command",
+ "gix-config-value",
+ "gix-path",
+ "gix-prompt",
+ "gix-sec",
+ "gix-url 0.21.1",
  "thiserror",
- "time",
 ]
 
 [[package]]
@@ -2132,18 +2168,6 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5049dd5a60d5608912da0ab184f35064901f192f4adf737716789715faffa080"
-dependencies = [
- "gix-hash",
- "gix-object 0.31.0",
- "imara-diff",
- "thiserror",
-]
-
-[[package]]
-name = "gix-diff"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf5d9b9b521b284ebe53ee69eee33341835ec70edc314f36b2100ea81396121"
@@ -2155,17 +2179,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-discover"
-version = "0.20.0"
+name = "gix-diff"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c14865cb9c6eb817d6a8d53595f1051239d2d31feae7a5e5b2f00910c94a8eb4"
+checksum = "9a49d7a9a9ed5ec3428c3061da45d0fc5f50b3c07b91ea4e7ec4959668f25f6c"
 dependencies = [
- "bstr",
- "dunce",
  "gix-hash",
- "gix-path",
- "gix-ref 0.31.0",
- "gix-sec",
+ "gix-object 0.33.1",
+ "imara-diff",
  "thiserror",
 ]
 
@@ -2180,6 +2201,21 @@ dependencies = [
  "gix-hash",
  "gix-path",
  "gix-ref 0.32.1",
+ "gix-sec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "041480eb03d8aa0894d9b73d25d182d51bc4d0ea8925a6ee0c971262bbc7715e"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-hash",
+ "gix-path",
+ "gix-ref 0.33.2",
  "gix-sec",
  "thiserror",
 ]
@@ -2213,9 +2249,36 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "882695cccf38da4c3cc7ee687bdb412cf25e37932d7f8f2c306112ea712449f1"
 dependencies = [
+ "crc32fast",
+ "flate2",
  "gix-hash",
  "gix-trace",
  "libc",
+ "once_cell",
+ "prodash",
+ "sha1_smol",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4d4d61f2ab07de4612f8e078d7f1a443c7ab5c40f382784c8eacdf0fd172b9"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes 0.16.0",
+ "gix-command",
+ "gix-hash",
+ "gix-object 0.33.1",
+ "gix-packetline-blocking",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -2249,6 +2312,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-glob"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c79b881a18d89a75876ba277476d5a2bad5b19f03759c7a07e0808dfe08212"
+dependencies = [
+ "bitflags 2.3.3",
+ "bstr",
+ "gix-features 0.32.1",
+ "gix-path",
+]
+
+[[package]]
 name = "gix-hash"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,31 +2351,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca801f2d0535210f77b33e2c067d565aedecacc82f1b3dbce26da1388ebc4634"
 dependencies = [
  "bstr",
- "gix-glob",
+ "gix-glob 0.9.1",
  "gix-path",
  "unicode-bom",
 ]
 
 [[package]]
-name = "gix-index"
-version = "0.19.0"
+name = "gix-ignore"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef2fa392d351e62ac3a6309146f61880abfbe0c07474e075d3b2ac78a6834a5"
+checksum = "a88b95ceb3bc45abcab6eb55ef4e0053e58b4df0712d3f9aec7d0ca990952603"
 dependencies = [
- "bitflags 2.3.3",
  "bstr",
- "btoi",
- "filetime",
- "gix-bitmap",
- "gix-features 0.31.1",
- "gix-hash",
- "gix-lock",
- "gix-object 0.31.0",
- "gix-traverse 0.28.0",
- "itoa 1.0.9",
- "memmap2 0.5.10",
- "smallvec",
- "thiserror",
+ "gix-glob 0.10.1",
+ "gix-path",
+ "unicode-bom",
 ]
 
 [[package]]
@@ -2326,6 +2391,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-index"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732f61ec71576bd443a3c24f4716dc7eac180d8929e7bb8603c7310161507106"
+dependencies = [
+ "bitflags 2.3.3",
+ "bstr",
+ "btoi",
+ "filetime",
+ "gix-bitmap",
+ "gix-features 0.32.1",
+ "gix-fs 0.4.1",
+ "gix-hash",
+ "gix-lock",
+ "gix-object 0.33.1",
+ "gix-traverse 0.30.1",
+ "itoa 1.0.9",
+ "memmap2 0.7.1",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-lock"
 version = "7.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2338,41 +2426,25 @@ dependencies = [
 
 [[package]]
 name = "gix-mailmap"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0bef8d360a6a9fc5a6d872471588d8ca7db77b940e48ff20c3b4706ad5f481d"
-dependencies = [
- "bstr",
- "gix-actor 0.22.0",
- "gix-date 0.6.0",
- "thiserror",
-]
-
-[[package]]
-name = "gix-mailmap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1787e3c37fc43b1f7c0e3be6196c6837b3ba5f869190dfeaa444b816f0a7f34b"
 dependencies = [
  "bstr",
  "gix-actor 0.23.0",
- "gix-date 0.7.1",
+ "gix-date",
  "thiserror",
 ]
 
 [[package]]
-name = "gix-negotiate"
-version = "0.3.0"
+name = "gix-mailmap"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b626aafb9f4088058f1baa5d2029b2191820c84f6c81e43535ba70bfdc7b7d56"
+checksum = "7fc0dbbf35d29639770af68d7ff55924d83786c8924b0e6a1766af1a98b7d58b"
 dependencies = [
- "bitflags 2.3.3",
- "gix-commitgraph",
- "gix-date 0.6.0",
- "gix-hash",
- "gix-object 0.31.0",
- "gix-revwalk 0.2.0",
- "smallvec",
+ "bstr",
+ "gix-actor 0.24.1",
+ "gix-date",
  "thiserror",
 ]
 
@@ -2383,8 +2455,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7bce64d4452dd609f44d04b14b29da2e0ad2c45fcdf4ce1472a5f5f8ec21c2"
 dependencies = [
  "bitflags 2.3.3",
- "gix-commitgraph",
- "gix-date 0.7.1",
+ "gix-commitgraph 0.17.1",
+ "gix-date",
  "gix-hash",
  "gix-object 0.32.0",
  "gix-revwalk 0.3.0",
@@ -2393,21 +2465,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-object"
-version = "0.31.0"
+name = "gix-negotiate"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255e477ae4cc8d10778238f011e6125b01cc0e7067dc8df87acd67a428a81f20"
+checksum = "ce0061b7ae867e830c77b1ecfc5875f0d042aebb3d7e6014d04fd86ca6c71d59"
 dependencies = [
- "bstr",
- "btoi",
- "gix-actor 0.22.0",
- "gix-date 0.6.0",
- "gix-features 0.31.1",
+ "bitflags 2.3.3",
+ "gix-commitgraph 0.18.1",
+ "gix-date",
  "gix-hash",
- "gix-validate",
- "hex",
- "itoa 1.0.9",
- "nom",
+ "gix-object 0.33.1",
+ "gix-revwalk 0.4.1",
  "smallvec",
  "thiserror",
 ]
@@ -2421,7 +2489,7 @@ dependencies = [
  "bstr",
  "btoi",
  "gix-actor 0.23.0",
- "gix-date 0.7.1",
+ "gix-date",
  "gix-features 0.31.1",
  "gix-hash",
  "gix-validate",
@@ -2433,21 +2501,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-odb"
-version = "0.48.0"
+name = "gix-object"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b73469f145d1e6afbcfd0ab6499a366fbbcb958c2999d41d283d6c7b94024b9"
+checksum = "70f18b688854af4440695b943e705877f94171325b8bcacaee2d898ecf2766d2"
 dependencies = [
- "arc-swap",
- "gix-date 0.6.0",
- "gix-features 0.31.1",
+ "bstr",
+ "btoi",
+ "gix-actor 0.24.1",
+ "gix-date",
+ "gix-features 0.32.1",
  "gix-hash",
- "gix-object 0.31.0",
- "gix-pack 0.38.0",
- "gix-path",
- "gix-quote",
- "parking_lot",
- "tempfile",
+ "gix-validate",
+ "hex",
+ "itoa 1.0.9",
+ "nom",
+ "smallvec",
  "thiserror",
 ]
 
@@ -2458,7 +2527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6418cff00ecc2713b58c8e04bff30dda808fbba1a080e7248b299d069894a01"
 dependencies = [
  "arc-swap",
- "gix-date 0.7.1",
+ "gix-date",
  "gix-features 0.31.1",
  "gix-hash",
  "gix-object 0.32.0",
@@ -2471,24 +2540,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-pack"
-version = "0.38.0"
+name = "gix-odb"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f3bcd1aaa72aea7163b147d2bde2480a01eadefc774a479d38f29920f7f1c8"
+checksum = "7dc2129d25313b594adfb5a71f2a617aaa2c3c4cfd3b2943823692db12fbc1db"
 dependencies = [
- "clru",
- "gix-chunk",
- "gix-diff 0.31.0",
- "gix-features 0.31.1",
+ "arc-swap",
+ "gix-date",
+ "gix-features 0.32.1",
  "gix-hash",
- "gix-hashtable",
- "gix-object 0.31.0",
+ "gix-object 0.33.1",
+ "gix-pack 0.40.2",
  "gix-path",
- "gix-tempfile",
- "gix-traverse 0.28.0",
- "memmap2 0.5.10",
+ "gix-quote",
  "parking_lot",
- "smallvec",
+ "tempfile",
  "thiserror",
 ]
 
@@ -2516,10 +2582,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-pack"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46f029a4dce9ac91da35c968c3abdcae573b3e52c123be86cbab3011599de533"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-diff 0.33.1",
+ "gix-features 0.32.1",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.33.1",
+ "gix-path",
+ "gix-tempfile",
+ "gix-traverse 0.30.1",
+ "memmap2 0.7.1",
+ "parking_lot",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-packetline"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb532b34627186a9a2705a360f64f6a8feb34c42344b127f9f230687d85358bd"
+dependencies = [
+ "bstr",
+ "hex",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-packetline-blocking"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20276373def40fc3be7a86d09e1bb607d33dd6bf83e3504e83cd594e51438667"
 dependencies = [
  "bstr",
  "hex",
@@ -2560,8 +2659,8 @@ checksum = "ed7069fac7eb23b043b4bd7890df1e244cb370c3fe8b2ff482203d36b4fd4099"
 dependencies = [
  "bstr",
  "btoi",
- "gix-credentials",
- "gix-date 0.7.1",
+ "gix-credentials 0.16.1",
+ "gix-date",
  "gix-features 0.31.1",
  "gix-hash",
  "gix-transport",
@@ -2583,33 +2682,12 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6c74873a9d8ff5d1310f2325f09164c15a91402ab5cde4d479ae12ff55ed69"
-dependencies = [
- "gix-actor 0.22.0",
- "gix-date 0.6.0",
- "gix-features 0.31.1",
- "gix-fs 0.3.0",
- "gix-hash",
- "gix-lock",
- "gix-object 0.31.0",
- "gix-path",
- "gix-tempfile",
- "gix-validate",
- "memmap2 0.5.10",
- "nom",
- "thiserror",
-]
-
-[[package]]
-name = "gix-ref"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39453f4e5f23cddc2e6e4cca2ba20adfdbec29379e3ca829714dfe98ae068ccd"
 dependencies = [
  "gix-actor 0.23.0",
- "gix-date 0.7.1",
+ "gix-date",
  "gix-features 0.31.1",
  "gix-fs 0.3.0",
  "gix-hash",
@@ -2624,16 +2702,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-refspec"
-version = "0.12.0"
+name = "gix-ref"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca1bc6c40bad62570683d642fcb04e977433ac8f76b674860ef7b1483c1f8990"
+checksum = "c16776eab78f4a918464064fa9c0f640014e8f1c3f9d1d366e929251c7193b2c"
 dependencies = [
- "bstr",
+ "gix-actor 0.24.1",
+ "gix-date",
+ "gix-features 0.32.1",
+ "gix-fs 0.4.1",
  "gix-hash",
- "gix-revision 0.16.0",
+ "gix-lock",
+ "gix-object 0.33.1",
+ "gix-path",
+ "gix-tempfile",
  "gix-validate",
- "smallvec",
+ "memmap2 0.7.1",
+ "nom",
  "thiserror",
 ]
 
@@ -2652,17 +2737,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-revision"
-version = "0.16.0"
+name = "gix-refspec"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3751d6643d731fc5829d2f43ca049f4333c968f30908220ba0783c9dfe5010c"
+checksum = "d19a02bf740b326d6c082a7d6f754ebe56eef900986c5e91be7cf000df9ea18d"
 dependencies = [
  "bstr",
- "gix-date 0.6.0",
  "gix-hash",
- "gix-hashtable",
- "gix-object 0.31.0",
- "gix-revwalk 0.2.0",
+ "gix-revision 0.18.1",
+ "gix-validate",
+ "smallvec",
  "thiserror",
 ]
 
@@ -2673,7 +2757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "237428a7d3978e8572964e1e45d984027c2acc94df47e594baa6c4b0da7c9922"
 dependencies = [
  "bstr",
- "gix-date 0.7.1",
+ "gix-date",
  "gix-hash",
  "gix-hashtable",
  "gix-object 0.32.0",
@@ -2682,17 +2766,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-revwalk"
-version = "0.2.0"
+name = "gix-revision"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144995229c6e5788b1c7386f8a3f7146ace3745c9a6b56cef9123a7d83b110c5"
+checksum = "38a13500890435e3b9e7746bceda248646bfc69e259210884c98e29bb7a1aa6f"
 dependencies = [
- "gix-commitgraph",
- "gix-date 0.6.0",
+ "bstr",
+ "gix-date",
  "gix-hash",
  "gix-hashtable",
- "gix-object 0.31.0",
- "smallvec",
+ "gix-object 0.33.1",
+ "gix-revwalk 0.4.1",
  "thiserror",
 ]
 
@@ -2702,11 +2786,26 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028d50fcaf8326a8f79a359490d9ca9fb4e2b51ac9ac86503560d0bcc888d2eb"
 dependencies = [
- "gix-commitgraph",
- "gix-date 0.7.1",
+ "gix-commitgraph 0.17.1",
+ "gix-date",
  "gix-hash",
  "gix-hashtable",
  "gix-object 0.32.0",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d4cbaf3cfbfde2b81b5ee8b469aff42c34693ce0fe17fc3c244d5085307f2c"
+dependencies = [
+ "gix-commitgraph 0.18.1",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.33.1",
  "smallvec",
  "thiserror",
 ]
@@ -2754,28 +2853,12 @@ dependencies = [
  "bstr",
  "curl",
  "gix-command",
- "gix-credentials",
+ "gix-credentials 0.16.1",
  "gix-features 0.31.1",
  "gix-packetline",
  "gix-quote",
  "gix-sec",
- "gix-url",
- "thiserror",
-]
-
-[[package]]
-name = "gix-traverse"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f6bba1686bfbc7e0e93d4932bc6e14d479c9c9524f7c8d65b25d2a9446a99e"
-dependencies = [
- "gix-commitgraph",
- "gix-date 0.6.0",
- "gix-hash",
- "gix-hashtable",
- "gix-object 0.31.0",
- "gix-revwalk 0.2.0",
- "smallvec",
+ "gix-url 0.20.1",
  "thiserror",
 ]
 
@@ -2785,12 +2868,28 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3cdfd54598db4fae57d5ae6f52958422b2d13382d2745796bfe5c8015ffa86e"
 dependencies = [
- "gix-commitgraph",
- "gix-date 0.7.1",
+ "gix-commitgraph 0.17.1",
+ "gix-date",
  "gix-hash",
  "gix-hashtable",
  "gix-object 0.32.0",
  "gix-revwalk 0.3.0",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12e0fe428394226c37dd686ad64b09a04b569fe157d638b125b4a4c1e7e2df0"
+dependencies = [
+ "gix-commitgraph 0.18.1",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.33.1",
+ "gix-revwalk 0.4.1",
  "smallvec",
  "thiserror",
 ]
@@ -2803,6 +2902,20 @@ checksum = "beaede6dbc83f408b19adfd95bb52f1dbf01fb8862c3faf6c6243e2e67fcdfa1"
 dependencies = [
  "bstr",
  "gix-features 0.31.1",
+ "gix-path",
+ "home",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4411bdbd1d46b35ae50e84c191660d437f89974e4236627785024be0b577170a"
+dependencies = [
+ "bstr",
+ "gix-features 0.32.1",
  "gix-path",
  "home",
  "thiserror",
@@ -2830,20 +2943,20 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee22549d6723189366235e1c6959ccdac73b58197cdbb437684eaa2169edcb9"
+checksum = "c1363b9aa66b9e14412ac04e1f759827203f491729d92172535a8ce6cde02efa"
 dependencies = [
  "bstr",
  "filetime",
- "gix-attributes",
+ "gix-attributes 0.14.1",
  "gix-features 0.31.1",
  "gix-fs 0.3.0",
- "gix-glob",
+ "gix-glob 0.9.1",
  "gix-hash",
- "gix-ignore",
- "gix-index 0.19.0",
- "gix-object 0.31.0",
+ "gix-ignore 0.4.1",
+ "gix-index 0.20.0",
+ "gix-object 0.32.0",
  "gix-path",
  "io-close",
  "thiserror",
@@ -2851,20 +2964,21 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.21.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1363b9aa66b9e14412ac04e1f759827203f491729d92172535a8ce6cde02efa"
+checksum = "8fd60b32d15287aef77e4fb1955627e0db1f13e40bf9a3481100223a51791f5f"
 dependencies = [
  "bstr",
  "filetime",
- "gix-attributes",
- "gix-features 0.31.1",
- "gix-fs 0.3.0",
- "gix-glob",
+ "gix-attributes 0.16.0",
+ "gix-features 0.32.1",
+ "gix-filter",
+ "gix-fs 0.4.1",
+ "gix-glob 0.10.1",
  "gix-hash",
- "gix-ignore",
- "gix-index 0.20.0",
- "gix-object 0.32.0",
+ "gix-ignore 0.5.1",
+ "gix-index 0.21.1",
+ "gix-object 0.33.1",
  "gix-path",
  "io-close",
  "thiserror",
@@ -2902,18 +3016,18 @@ dependencies = [
 
 [[package]]
 name = "grass"
-version = "0.12.4"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cc4b64880a2264a41f9eab431780e72a68a6c88b9bddef361ba638812d572e"
+checksum = "7746cd9bf09f9bb7d98638774a70642000356f543898d9a352cd043f82744528"
 dependencies = [
  "grass_compiler",
 ]
 
 [[package]]
 name = "grass_compiler"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e4feeef87d958eebd4d55431040768b93a5b088202198e0b203adc3c1d468c6"
+checksum = "187adfc0b34289c7f8f3819453ce9da3177c3d73f40ac74bb17faba578813d45"
 dependencies = [
  "codemap",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tracing-subscriber = { version = "0.3.16", default-features = false, features = 
 tracing-log = "0.1.3"
 regex = "1"
 clap = { version = "4.0.22", features = [ "derive" ] }
-crates-index = { version = "0.19", optional = true }
+crates-index = { version = "1.0.0", optional = true }
 rayon = "1.6.1"
 num_cpus = "1.15.0"
 crates-index-diff = { version = "20.0.0", features = [ "max-performance" ]}
@@ -134,11 +134,11 @@ indoc = "2.0.0"
 
 [build-dependencies]
 time = "0.3"
-gix = { version = "0.47.0", default-features = false }
+gix = { version = "0.50.1", default-features = false }
 string_cache_codegen = "0.5.1"
 walkdir = "2"
 anyhow = { version = "1.0.42", features = ["backtrace"] }
-grass = { version = "0.12.3", default-features = false }
+grass = { version = "0.13.1", default-features = false }
 once_cell = { version = "1.4.0", features = ["parking_lot"] }
 syntect = { version = "5.0.0", default-features = false, features = ["parsing", "dump-create", "yaml-load", "regex-onig"] }
 


### PR DESCRIPTION
- https://github.com/frewsxcv/rust-crates-index#migration-from-019-to-100
- https://github.com/Byron/gitoxide/releases/tag/gix-v0.48.0
- https://github.com/Byron/gitoxide/releases/tag/gix-v0.49.0
- https://github.com/Byron/gitoxide/releases/tag/gix-v0.50.0