### PR TITLE
Indicate current documentation target

### DIFF
--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -668,6 +668,7 @@ pub(crate) async fn rustdoc_html_server_handler(
         .render_in_threadpool({
             let metrics = metrics.clone();
             move |templates| {
+                let metadata = krate.metadata.clone();
                 Ok(RustdocPage {
                     latest_path,
                     permalink_path,
@@ -677,8 +678,8 @@ pub(crate) async fn rustdoc_html_server_handler(
                     is_latest_version,
                     is_latest_url,
                     is_prerelease,
-                    metadata: krate.metadata.clone(),
-                    krate: krate.clone(),
+                    metadata,
+                    krate,
                 }
                 .into_response(
                     &blob.content,

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -301,6 +301,7 @@ struct RustdocPage {
     is_prerelease: bool,
     krate: CrateDetails,
     metadata: MetaData,
+    current_target: String,
 }
 
 impl RustdocPage {
@@ -624,10 +625,13 @@ pub(crate) async fn rustdoc_html_server_handler(
     };
 
     // Find the path of the latest version for the `Go to latest` and `Permalink` links
+    let mut current_target = String::new();
     let target_redirect = if latest_release.build_status {
         let target = if target.is_empty() {
+            current_target = krate.metadata.default_target.clone();
             &krate.metadata.default_target
         } else {
+            current_target = target.to_owned();
             target
         };
         format!("/target-redirect/{target}/{inner_path}")
@@ -680,6 +684,7 @@ pub(crate) async fn rustdoc_html_server_handler(
                     is_prerelease,
                     metadata,
                     krate,
+                    current_target,
                 }
                 .into_response(
                     &blob.content,

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -222,9 +222,14 @@ extra whitespace unremovable, need to use html tags unaffacted by whitespace T_T
                     {%- set target_url = "/crate/" ~ metadata.name ~ "/" ~ metadata.version_or_latest ~ "/target-redirect/" ~ target ~ "/" ~ inner_path -%}
                     {%- set target_no_follow = "nofollow" -%}
                 {%- endif -%}
+                {%- if current_target is defined and current_target == target -%}
+                    {%- set current = " current" -%}
+                {%- else -%}
+                    {%- set current = "" -%}
+                {%- endif -%}
 
                 <li class="pure-menu-item">
-                    <a href="{{ target_url | safe }}" class="pure-menu-link" data-fragment="retain" rel="{{ target_no_follow }}">
+                    <a href="{{ target_url | safe }}" class="pure-menu-link{{ current | safe }}" data-fragment="retain" rel="{{ target_no_follow }}">
                         {{- target -}}
                     </a>
                 </li>

--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -349,6 +349,16 @@ div.nav-container {
         li a {
             overflow-x: hidden;
             text-overflow: ellipsis;
+
+            &.current {
+                font-weight: bold;
+
+                &::before {
+                    content: "•";
+                    position: absolute;
+                    margin-left: -10px;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
As mentioned in https://github.com/rust-lang/docs.rs/pull/2170. It allows to know what is the platform being checked currently. It looks like this:

![Screenshot from 2023-07-30 14-51-12](https://github.com/rust-lang/docs.rs/assets/3050060/641950db-24f2-476b-b6d6-cde6a11601f8)
