### PR TITLE
Don't report errors getting readme when manifest is missing

### DIFF
--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -34,6 +34,7 @@ pub(crate) struct FakeRelease<'a> {
     readme: Option<&'a str>,
     github_stats: Option<FakeGithubStats>,
     doc_coverage: Option<DocCoverage>,
+    no_cargo_toml: bool,
 }
 
 pub(crate) struct FakeBuild {
@@ -96,6 +97,7 @@ impl<'a> FakeRelease<'a> {
             github_stats: None,
             doc_coverage: None,
             archive_storage: false,
+            no_cargo_toml: false,
         }
     }
 
@@ -170,6 +172,11 @@ impl<'a> FakeRelease<'a> {
 
     pub(crate) fn source_file(mut self, path: &'a str, data: &'a [u8]) -> Self {
         self.source_files.push((path, data));
+        self
+    }
+
+    pub(crate) fn no_cargo_toml(mut self) -> Self {
+        self.no_cargo_toml = true;
         self
     }
 
@@ -354,10 +361,11 @@ impl<'a> FakeRelease<'a> {
         let source_tmp = create_temp_dir();
         store_files_into(&self.source_files, source_tmp.path())?;
 
-        if !self
-            .source_files
-            .iter()
-            .any(|&(path, _)| path == "Cargo.toml")
+        if !self.no_cargo_toml
+            && !self
+                .source_files
+                .iter()
+                .any(|&(path, _)| path == "Cargo.toml")
         {
             let MetadataPackage { name, version, .. } = &package;
             let content = format!(

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -1196,6 +1196,14 @@ mod tests {
                 .source_file("Cargo.toml", br#"package.readme = "MEREAD""#)
                 .create()?;
 
+            env.fake_release()
+                .name("dummy")
+                .version("0.5.0")
+                .readme_only_database("database readme")
+                .source_file("README.md", b"storage readme")
+                .no_cargo_toml()
+                .create()?;
+
             let check_readme = |path, content| {
                 let resp = env.frontend().get(path).send().unwrap();
                 let body = String::from_utf8(resp.bytes().unwrap().to_vec()).unwrap();
@@ -1207,6 +1215,10 @@ mod tests {
             check_readme("/crate/dummy/0.3.0", "storage readme");
             check_readme("/crate/dummy/0.4.0", "storage meread");
 
+            let details = CrateDetails::new(&mut *env.db().conn(), "dummy", "0.5.0", "0.5.0", None)
+                .unwrap()
+                .unwrap();
+            assert!(matches!(details.fetch_readme(&env.storage()), Ok(None)));
             Ok(())
         });
     }


### PR DESCRIPTION
Stops reporting of https://rust-lang.sentry.io/share/issue/4c65524a03f84ac19d295eda11d442c3/

It seems like at some point we had some crates get added without their corresponding source files being stored.