### PR TITLE
upgrade gix to 0.52.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,7 +1387,7 @@ dependencies = [
  "font-awesome-as-a-crate",
  "futures-util",
  "getrandom 0.2.10",
- "gix 0.50.1",
+ "gix 0.52.0",
  "grass",
  "hostname",
  "http",
@@ -1589,6 +1589,15 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "faster-hex"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9042d281a5eec0f2387f8c3ea6c4514e2cf2732c90a85aaf383b761ee3b290d"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "fastrand"
@@ -1873,30 +1882,30 @@ dependencies = [
  "gix-features 0.31.1",
  "gix-fs 0.3.0",
  "gix-glob 0.9.1",
- "gix-hash",
- "gix-hashtable",
+ "gix-hash 0.11.4",
+ "gix-hashtable 0.2.4",
  "gix-ignore 0.4.1",
  "gix-index 0.20.0",
- "gix-lock",
+ "gix-lock 7.0.2",
  "gix-mailmap 0.15.0",
  "gix-negotiate 0.4.0",
  "gix-object 0.32.0",
  "gix-odb 0.49.1",
  "gix-pack 0.39.1",
- "gix-path",
- "gix-prompt",
+ "gix-path 0.8.4",
+ "gix-prompt 0.5.5",
  "gix-protocol 0.35.0",
  "gix-ref 0.32.1",
  "gix-refspec 0.13.0",
  "gix-revision 0.17.0",
- "gix-sec",
- "gix-tempfile",
+ "gix-sec 0.8.4",
+ "gix-tempfile 7.0.2",
  "gix-trace",
  "gix-transport 0.33.1",
  "gix-traverse 0.29.0",
  "gix-url 0.20.1",
  "gix-utils",
- "gix-validate",
+ "gix-validate 0.7.7",
  "gix-worktree 0.21.1",
  "log",
  "once_cell",
@@ -1921,35 +1930,88 @@ dependencies = [
  "gix-diff 0.33.1",
  "gix-discover 0.22.1",
  "gix-features 0.32.1",
- "gix-filter",
+ "gix-filter 0.2.0",
  "gix-fs 0.4.1",
  "gix-glob 0.10.2",
- "gix-hash",
- "gix-hashtable",
+ "gix-hash 0.11.4",
+ "gix-hashtable 0.2.4",
  "gix-ignore 0.5.1",
  "gix-index 0.21.1",
- "gix-lock",
+ "gix-lock 7.0.2",
  "gix-mailmap 0.16.1",
  "gix-negotiate 0.5.1",
  "gix-object 0.33.2",
  "gix-odb 0.50.2",
  "gix-pack 0.40.2",
- "gix-path",
- "gix-prompt",
+ "gix-path 0.8.4",
+ "gix-prompt 0.5.5",
  "gix-protocol 0.36.1",
  "gix-ref 0.33.3",
  "gix-refspec 0.14.1",
  "gix-revision 0.18.1",
- "gix-sec",
- "gix-tempfile",
+ "gix-sec 0.8.4",
+ "gix-tempfile 7.0.2",
  "gix-trace",
  "gix-traverse 0.30.1",
  "gix-url 0.21.1",
  "gix-utils",
- "gix-validate",
+ "gix-validate 0.7.7",
  "gix-worktree 0.23.1",
  "log",
  "once_cell",
+ "signal-hook",
+ "smallvec",
+ "thiserror",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35ed1401a11506b45361746507a7c94c546574ddd7dfc2717f8941e30070254"
+dependencies = [
+ "gix-actor 0.25.0",
+ "gix-attributes 0.17.0",
+ "gix-commitgraph 0.19.0",
+ "gix-config 0.28.0",
+ "gix-credentials 0.18.0",
+ "gix-date",
+ "gix-diff 0.34.0",
+ "gix-discover 0.23.0",
+ "gix-features 0.33.0",
+ "gix-filter 0.3.0",
+ "gix-fs 0.5.0",
+ "gix-glob 0.11.0",
+ "gix-hash 0.12.0",
+ "gix-hashtable 0.3.0",
+ "gix-ignore 0.6.0",
+ "gix-index 0.22.0",
+ "gix-lock 8.0.0",
+ "gix-mailmap 0.17.0",
+ "gix-negotiate 0.6.0",
+ "gix-object 0.35.0",
+ "gix-odb 0.51.0",
+ "gix-pack 0.41.0",
+ "gix-path 0.9.0",
+ "gix-pathspec",
+ "gix-prompt 0.6.0",
+ "gix-ref 0.35.0",
+ "gix-refspec 0.16.0",
+ "gix-revision 0.20.0",
+ "gix-sec 0.9.0",
+ "gix-submodule",
+ "gix-tempfile 8.0.0",
+ "gix-trace",
+ "gix-traverse 0.31.0",
+ "gix-url 0.22.0",
+ "gix-utils",
+ "gix-validate 0.8.0",
+ "gix-worktree 0.24.0",
+ "gix-worktree-state",
+ "log",
+ "once_cell",
+ "parking_lot",
  "signal-hook",
  "smallvec",
  "thiserror",
@@ -1985,6 +2047,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-actor"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f8a773b5385e9d2f88bd879fb763ec1212585f6d630ebe13adb7bac93bce975"
+dependencies = [
+ "bstr",
+ "btoi",
+ "gix-date",
+ "itoa 1.0.9",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
 name = "gix-attributes"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,7 +2068,7 @@ checksum = "e3772b0129dcd1fc73e985bbd08a1482d082097d2915cb1ee31ce8092b8e4434"
 dependencies = [
  "bstr",
  "gix-glob 0.9.1",
- "gix-path",
+ "gix-path 0.8.4",
  "gix-quote",
  "kstring",
  "log",
@@ -2009,7 +2085,24 @@ checksum = "63a134a674e39e238bd273326a9815296cc71f867ad5466518da71392cff98ce"
 dependencies = [
  "bstr",
  "gix-glob 0.10.2",
- "gix-path",
+ "gix-path 0.8.4",
+ "gix-quote",
+ "kstring",
+ "log",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1ecae08f2625d8abcd27570fa2f9c2fcf01a1cd968a8d90858e63f8e08211a3"
+dependencies = [
+ "bstr",
+ "gix-glob 0.11.0",
+ "gix-path 0.9.0",
  "gix-quote",
  "kstring",
  "log",
@@ -2020,9 +2113,9 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa8bbde7551a9e3e783a2871f53bbb0f50aac7a77db5680c8709f69e8ce724f"
+checksum = "0ccab4bc576844ddb51b78d81b4a42d73e6229660fa614dfc3d3999c874d1959"
 dependencies = [
  "thiserror",
 ]
@@ -2038,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "gix-command"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2783ad148fb16bf9cfd46423706ba552a62a4d4a18fda5dd07648eb0228862dd"
+checksum = "0f28f654184b5f725c5737c7e4f466cbd8f0102ac352d5257eeab19647ee4256"
 dependencies = [
  "bstr",
 ]
@@ -2054,7 +2147,7 @@ dependencies = [
  "bstr",
  "gix-chunk",
  "gix-features 0.31.1",
- "gix-hash",
+ "gix-hash 0.11.4",
  "memmap2 0.7.1",
  "thiserror",
 ]
@@ -2068,7 +2161,21 @@ dependencies = [
  "bstr",
  "gix-chunk",
  "gix-features 0.32.1",
- "gix-hash",
+ "gix-hash 0.11.4",
+ "memmap2 0.7.1",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3845b3c8722a0e97d9d593c05d384bb1275a5865f1cd967523a3780ffc93168e"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-features 0.33.0",
+ "gix-hash 0.12.0",
  "memmap2 0.7.1",
  "thiserror",
 ]
@@ -2080,12 +2187,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "817688c7005a716d9363e267913526adea402dabd947f4ba63842d10cc5132af"
 dependencies = [
  "bstr",
- "gix-config-value",
+ "gix-config-value 0.12.5",
  "gix-features 0.31.1",
  "gix-glob 0.9.1",
- "gix-path",
+ "gix-path 0.8.4",
  "gix-ref 0.32.1",
- "gix-sec",
+ "gix-sec 0.8.4",
  "log",
  "memchr",
  "nom",
@@ -2102,12 +2209,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2135b921a699a4c36167148193bea23c653a16ef0686f6a280e383469709a773"
 dependencies = [
  "bstr",
- "gix-config-value",
+ "gix-config-value 0.12.5",
  "gix-features 0.32.1",
  "gix-glob 0.10.2",
- "gix-path",
+ "gix-path 0.8.4",
  "gix-ref 0.33.3",
- "gix-sec",
+ "gix-sec 0.8.4",
+ "log",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+ "winnow",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a312d120231dc8d5a2e34928a9a2098c1d3dbad76f0660ee38d0b1a87de5271"
+dependencies = [
+ "bstr",
+ "gix-config-value 0.13.0",
+ "gix-features 0.33.0",
+ "gix-glob 0.11.0",
+ "gix-path 0.9.0",
+ "gix-ref 0.35.0",
+ "gix-sec 0.9.0",
  "log",
  "memchr",
  "once_cell",
@@ -2125,7 +2254,20 @@ checksum = "6e874f41437441c02991dcea76990b9058fadfc54b02ab4dd06ab2218af43897"
 dependencies = [
  "bitflags 2.4.0",
  "bstr",
- "gix-path",
+ "gix-path 0.8.4",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "901e184f3d4f99bf015ca13b5ccacb09e26b400f198fe2066651089e2c490680"
+dependencies = [
+ "bitflags 2.4.0",
+ "bstr",
+ "gix-path 0.9.0",
  "libc",
  "thiserror",
 ]
@@ -2138,10 +2280,10 @@ checksum = "75a75565e0e6e7f80cfa4eb1b05cc448c6846ddd48dcf413a28875fbc11ee9af"
 dependencies = [
  "bstr",
  "gix-command",
- "gix-config-value",
- "gix-path",
- "gix-prompt",
- "gix-sec",
+ "gix-config-value 0.12.5",
+ "gix-path 0.8.4",
+ "gix-prompt 0.5.5",
+ "gix-sec 0.8.4",
  "gix-url 0.20.1",
  "thiserror",
 ]
@@ -2154,19 +2296,35 @@ checksum = "307d91ec5f7c8e9bfaa217fe30c2e0099101cbe83dbed27a222dbb6def38725f"
 dependencies = [
  "bstr",
  "gix-command",
- "gix-config-value",
- "gix-path",
- "gix-prompt",
- "gix-sec",
+ "gix-config-value 0.12.5",
+ "gix-path 0.8.4",
+ "gix-prompt 0.5.5",
+ "gix-sec 0.8.4",
  "gix-url 0.21.1",
  "thiserror",
 ]
 
 [[package]]
-name = "gix-date"
-version = "0.7.2"
+name = "gix-credentials"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f7c76578a69b736c3f0770f14757e9027354011d24c56d79207add9d7d1be6"
+checksum = "2988e917f7ee4a99072354d5885ca14c9e7039de8246e96e300ab3e5060cad19"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-config-value 0.13.0",
+ "gix-path 0.9.0",
+ "gix-prompt 0.6.0",
+ "gix-sec 0.9.0",
+ "gix-url 0.22.0",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e476b4e156f6044d35bf1ce2079d97b7207515cfb5a2bb6fcd489bb697d700"
 dependencies = [
  "bstr",
  "itoa 1.0.9",
@@ -2180,7 +2338,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf5d9b9b521b284ebe53ee69eee33341835ec70edc314f36b2100ea81396121"
 dependencies = [
- "gix-hash",
+ "gix-hash 0.11.4",
  "gix-object 0.32.0",
  "imara-diff",
  "thiserror",
@@ -2192,8 +2350,20 @@ version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a49d7a9a9ed5ec3428c3061da45d0fc5f50b3c07b91ea4e7ec4959668f25f6c"
 dependencies = [
- "gix-hash",
+ "gix-hash 0.11.4",
  "gix-object 0.33.2",
+ "imara-diff",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016be5f0789da595b61d15a862476be0cbae8fd29e2c91d66770fdd8df145773"
+dependencies = [
+ "gix-hash 0.12.0",
+ "gix-object 0.35.0",
  "imara-diff",
  "thiserror",
 ]
@@ -2206,10 +2376,10 @@ checksum = "272aad20dc63dedba76615373dd8885fb5aebe4795e5b5b0aa2a24e63c82085c"
 dependencies = [
  "bstr",
  "dunce",
- "gix-hash",
- "gix-path",
+ "gix-hash 0.11.4",
+ "gix-path 0.8.4",
  "gix-ref 0.32.1",
- "gix-sec",
+ "gix-sec 0.8.4",
  "thiserror",
 ]
 
@@ -2221,10 +2391,25 @@ checksum = "041480eb03d8aa0894d9b73d25d182d51bc4d0ea8925a6ee0c971262bbc7715e"
 dependencies = [
  "bstr",
  "dunce",
- "gix-hash",
- "gix-path",
+ "gix-hash 0.11.4",
+ "gix-path 0.8.4",
  "gix-ref 0.33.3",
- "gix-sec",
+ "gix-sec 0.8.4",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b74760d912716b287357dae5654ad84be12a2a75a721f00b58ecdd65496e024"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-hash 0.12.0",
+ "gix-path 0.9.0",
+ "gix-ref 0.35.0",
+ "gix-sec 0.9.0",
  "thiserror",
 ]
 
@@ -2238,7 +2423,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "flate2",
- "gix-hash",
+ "gix-hash 0.11.4",
  "gix-trace",
  "jwalk",
  "libc",
@@ -2260,7 +2445,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "flate2",
- "gix-hash",
+ "gix-hash 0.11.4",
  "gix-trace",
  "jwalk",
  "libc",
@@ -2268,6 +2453,24 @@ dependencies = [
  "parking_lot",
  "prodash",
  "sha1",
+ "sha1_smol",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f77decb545f63a52852578ef5f66ecd71017ffc1983d551d5fa2328d6d9817f"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "gix-hash 0.12.0",
+ "gix-trace",
+ "libc",
+ "once_cell",
+ "prodash",
  "sha1_smol",
  "thiserror",
  "walkdir",
@@ -2283,10 +2486,30 @@ dependencies = [
  "encoding_rs",
  "gix-attributes 0.16.0",
  "gix-command",
- "gix-hash",
+ "gix-hash 0.11.4",
  "gix-object 0.33.2",
  "gix-packetline-blocking",
- "gix-path",
+ "gix-path 0.8.4",
+ "gix-quote",
+ "gix-trace",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f5495cdd54f4c3bb05b35a525cd39df1643362d917a7e03f112564c2825feb4"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes 0.17.0",
+ "gix-command",
+ "gix-hash 0.12.0",
+ "gix-object 0.35.0",
+ "gix-packetline-blocking",
+ "gix-path 0.9.0",
  "gix-quote",
  "gix-trace",
  "smallvec",
@@ -2312,6 +2535,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-fs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d5089f3338647776733a75a800a664ab046f56f21c515fa4722e395f877ef8"
+dependencies = [
+ "gix-features 0.33.0",
+]
+
+[[package]]
 name = "gix-glob"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,7 +2552,7 @@ dependencies = [
  "bitflags 2.4.0",
  "bstr",
  "gix-features 0.31.1",
- "gix-path",
+ "gix-path 0.8.4",
 ]
 
 [[package]]
@@ -2332,7 +2564,19 @@ dependencies = [
  "bitflags 2.4.0",
  "bstr",
  "gix-features 0.32.1",
- "gix-path",
+ "gix-path 0.8.4",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c753299d14a29ca06d7adc8464c16f1786eb97bc9a44a796ad0a37f57235a494"
+dependencies = [
+ "bitflags 2.4.0",
+ "bstr",
+ "gix-features 0.33.0",
+ "gix-path 0.9.0",
 ]
 
 [[package]]
@@ -2346,12 +2590,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-hash"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d4796bac3aaf0c2f8bea152ca924ae3bdc5f135caefe6431116bcd67e98eab9"
+dependencies = [
+ "faster-hex",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-hashtable"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "385f4ce6ecf3692d313ca3aa9bd3b3d8490de53368d6d94bedff3af8b6d9c58d"
 dependencies = [
- "gix-hash",
+ "gix-hash 0.11.4",
+ "hashbrown 0.14.0",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ad1b70efd1e77c32729d5a522f0c855e9827242feb10318e1acaf2259222c0"
+dependencies = [
+ "gix-hash 0.12.0",
  "hashbrown 0.14.0",
  "parking_lot",
 ]
@@ -2364,7 +2629,7 @@ checksum = "ca801f2d0535210f77b33e2c067d565aedecacc82f1b3dbce26da1388ebc4634"
 dependencies = [
  "bstr",
  "gix-glob 0.9.1",
- "gix-path",
+ "gix-path 0.8.4",
  "unicode-bom",
 ]
 
@@ -2376,7 +2641,19 @@ checksum = "a88b95ceb3bc45abcab6eb55ef4e0053e58b4df0712d3f9aec7d0ca990952603"
 dependencies = [
  "bstr",
  "gix-glob 0.10.2",
- "gix-path",
+ "gix-path 0.8.4",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b355098421f5cc91a0e5f1ef3600ae250c13b7c3c472b18c361897c6081bfbb1"
+dependencies = [
+ "bstr",
+ "gix-glob 0.11.0",
+ "gix-path 0.9.0",
  "unicode-bom",
 ]
 
@@ -2392,8 +2669,8 @@ dependencies = [
  "filetime",
  "gix-bitmap",
  "gix-features 0.31.1",
- "gix-hash",
- "gix-lock",
+ "gix-hash 0.11.4",
+ "gix-lock 7.0.2",
  "gix-object 0.32.0",
  "gix-traverse 0.29.0",
  "itoa 1.0.9",
@@ -2415,10 +2692,33 @@ dependencies = [
  "gix-bitmap",
  "gix-features 0.32.1",
  "gix-fs 0.4.1",
- "gix-hash",
- "gix-lock",
+ "gix-hash 0.11.4",
+ "gix-lock 7.0.2",
  "gix-object 0.33.2",
  "gix-traverse 0.30.1",
+ "itoa 1.0.9",
+ "memmap2 0.7.1",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9738fc58ca30e232c7b1be8e8ab52b072979acb9bf3fa97662b5b23c0c6fbca"
+dependencies = [
+ "bitflags 2.4.0",
+ "bstr",
+ "btoi",
+ "filetime",
+ "gix-bitmap",
+ "gix-features 0.33.0",
+ "gix-fs 0.5.0",
+ "gix-hash 0.12.0",
+ "gix-lock 8.0.0",
+ "gix-object 0.35.0",
+ "gix-traverse 0.31.0",
  "itoa 1.0.9",
  "memmap2 0.7.1",
  "smallvec",
@@ -2431,7 +2731,18 @@ version = "7.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e82ec23c8a281f91044bf3ed126063b91b59f9c9340bf0ae746f385cc85a6fa"
 dependencies = [
- "gix-tempfile",
+ "gix-tempfile 7.0.2",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-lock"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de4363023577b31906b476b34eefbf76931363ec574f88b5c7b6027789f1e3ce"
+dependencies = [
+ "gix-tempfile 8.0.0",
  "gix-utils",
  "thiserror",
 ]
@@ -2461,6 +2772,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-mailmap"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244a4a6f08e8104110675de649ccd20fe1d1116783063920e19aa7da197a4ad0"
+dependencies = [
+ "bstr",
+ "gix-actor 0.25.0",
+ "gix-date",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-negotiate"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2469,7 +2792,7 @@ dependencies = [
  "bitflags 2.4.0",
  "gix-commitgraph 0.17.1",
  "gix-date",
- "gix-hash",
+ "gix-hash 0.11.4",
  "gix-object 0.32.0",
  "gix-revwalk 0.3.0",
  "smallvec",
@@ -2485,9 +2808,25 @@ dependencies = [
  "bitflags 2.4.0",
  "gix-commitgraph 0.18.2",
  "gix-date",
- "gix-hash",
+ "gix-hash 0.11.4",
  "gix-object 0.33.2",
  "gix-revwalk 0.4.1",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b0ea711559f843b8286cdf71ea421560c072120fae35a949bcf6b068b73745"
+dependencies = [
+ "bitflags 2.4.0",
+ "gix-commitgraph 0.19.0",
+ "gix-date",
+ "gix-hash 0.12.0",
+ "gix-object 0.35.0",
+ "gix-revwalk 0.6.0",
  "smallvec",
  "thiserror",
 ]
@@ -2503,8 +2842,8 @@ dependencies = [
  "gix-actor 0.23.0",
  "gix-date",
  "gix-features 0.31.1",
- "gix-hash",
- "gix-validate",
+ "gix-hash 0.11.4",
+ "gix-validate 0.7.7",
  "hex",
  "itoa 1.0.9",
  "nom",
@@ -2523,13 +2862,32 @@ dependencies = [
  "gix-actor 0.24.2",
  "gix-date",
  "gix-features 0.32.1",
- "gix-hash",
- "gix-validate",
+ "gix-hash 0.11.4",
+ "gix-validate 0.7.7",
  "hex",
  "itoa 1.0.9",
  "nom",
  "smallvec",
  "thiserror",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4283b7b5e9438afe2e3183e9acd1c77e750800937bb56c06b750822d2ff6d95"
+dependencies = [
+ "bstr",
+ "btoi",
+ "gix-actor 0.25.0",
+ "gix-date",
+ "gix-features 0.33.0",
+ "gix-hash 0.12.0",
+ "gix-validate 0.8.0",
+ "itoa 1.0.9",
+ "smallvec",
+ "thiserror",
+ "winnow",
 ]
 
 [[package]]
@@ -2541,10 +2899,10 @@ dependencies = [
  "arc-swap",
  "gix-date",
  "gix-features 0.31.1",
- "gix-hash",
+ "gix-hash 0.11.4",
  "gix-object 0.32.0",
  "gix-pack 0.39.1",
- "gix-path",
+ "gix-path 0.8.4",
  "gix-quote",
  "parking_lot",
  "tempfile",
@@ -2560,10 +2918,29 @@ dependencies = [
  "arc-swap",
  "gix-date",
  "gix-features 0.32.1",
- "gix-hash",
+ "gix-hash 0.11.4",
  "gix-object 0.33.2",
  "gix-pack 0.40.2",
- "gix-path",
+ "gix-path 0.8.4",
+ "gix-quote",
+ "parking_lot",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dd295ca055d8270de23b6037176b03782de753f75c84dabb7713f7d7e229fd"
+dependencies = [
+ "arc-swap",
+ "gix-date",
+ "gix-features 0.33.0",
+ "gix-hash 0.12.0",
+ "gix-object 0.35.0",
+ "gix-pack 0.41.0",
+ "gix-path 0.9.0",
  "gix-quote",
  "parking_lot",
  "tempfile",
@@ -2580,11 +2957,11 @@ dependencies = [
  "gix-chunk",
  "gix-diff 0.32.0",
  "gix-features 0.31.1",
- "gix-hash",
- "gix-hashtable",
+ "gix-hash 0.11.4",
+ "gix-hashtable 0.2.4",
  "gix-object 0.32.0",
- "gix-path",
- "gix-tempfile",
+ "gix-path 0.8.4",
+ "gix-tempfile 7.0.2",
  "gix-traverse 0.29.0",
  "memmap2 0.7.1",
  "parking_lot",
@@ -2603,17 +2980,39 @@ dependencies = [
  "gix-chunk",
  "gix-diff 0.33.1",
  "gix-features 0.32.1",
- "gix-hash",
- "gix-hashtable",
+ "gix-hash 0.11.4",
+ "gix-hashtable 0.2.4",
  "gix-object 0.33.2",
- "gix-path",
- "gix-tempfile",
+ "gix-path 0.8.4",
+ "gix-tempfile 7.0.2",
  "gix-traverse 0.30.1",
  "memmap2 0.7.1",
  "parking_lot",
  "smallvec",
  "thiserror",
  "uluru",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e645c38138216b9de2f6279bfb1b8567de6f4539f8fa2761eea961d991f448"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-diff 0.34.0",
+ "gix-features 0.33.0",
+ "gix-hash 0.12.0",
+ "gix-hashtable 0.3.0",
+ "gix-object 0.35.0",
+ "gix-path 0.9.0",
+ "gix-tempfile 8.0.0",
+ "gix-traverse 0.31.0",
+ "memmap2 0.7.1",
+ "parking_lot",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -2629,12 +3028,12 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline-blocking"
-version = "0.16.4"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20276373def40fc3be7a86d09e1bb607d33dd6bf83e3504e83cd594e51438667"
+checksum = "e39142400d3faa7057680ed3947c3b70e46b6a0b16a7c242ec8f0249e37518ba"
 dependencies = [
  "bstr",
- "hex",
+ "faster-hex",
  "thiserror",
 ]
 
@@ -2652,13 +3051,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-path"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764b31ac54472e796f08be376eaeea3e30800949650566620809659d39969dbd"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "home",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ba6662a29a6332926494542f6144ee87a59df3c70a4c680ebd235b646d7866"
+dependencies = [
+ "bitflags 2.4.0",
+ "bstr",
+ "gix-attributes 0.17.0",
+ "gix-config-value 0.13.0",
+ "gix-glob 0.11.0",
+ "gix-path 0.9.0",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-prompt"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c22decaf4a063ccae2b2108820c8630c01bd6756656df3fe464b32b8958a5ea"
 dependencies = [
  "gix-command",
- "gix-config-value",
+ "gix-config-value 0.12.5",
+ "parking_lot",
+ "rustix 0.38.8",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-prompt"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ebf6f126413908bfbdc27bf69f6f8b94b674457546fab8ba613be22b917d33"
+dependencies = [
+ "gix-command",
+ "gix-config-value 0.13.0",
  "parking_lot",
  "rustix 0.38.8",
  "thiserror",
@@ -2675,7 +3115,7 @@ dependencies = [
  "gix-credentials 0.16.1",
  "gix-date",
  "gix-features 0.31.1",
- "gix-hash",
+ "gix-hash 0.11.4",
  "gix-transport 0.33.1",
  "maybe-async",
  "nom",
@@ -2693,7 +3133,7 @@ dependencies = [
  "gix-credentials 0.17.1",
  "gix-date",
  "gix-features 0.32.1",
- "gix-hash",
+ "gix-hash 0.11.4",
  "gix-transport 0.34.2",
  "maybe-async",
  "nom",
@@ -2702,9 +3142,9 @@ dependencies = [
 
 [[package]]
 name = "gix-quote"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfd80d3d0c733508df9449b1d3795da36083807e31d851d7d61d29af13bd4b0a"
+checksum = "475c86a97dd0127ba4465fbb239abac9ea10e68301470c9791a6dd5351cdc905"
 dependencies = [
  "bstr",
  "btoi",
@@ -2721,12 +3161,12 @@ dependencies = [
  "gix-date",
  "gix-features 0.31.1",
  "gix-fs 0.3.0",
- "gix-hash",
- "gix-lock",
+ "gix-hash 0.11.4",
+ "gix-lock 7.0.2",
  "gix-object 0.32.0",
- "gix-path",
- "gix-tempfile",
- "gix-validate",
+ "gix-path 0.8.4",
+ "gix-tempfile 7.0.2",
+ "gix-validate 0.7.7",
  "memmap2 0.7.1",
  "nom",
  "thiserror",
@@ -2742,15 +3182,36 @@ dependencies = [
  "gix-date",
  "gix-features 0.32.1",
  "gix-fs 0.4.1",
- "gix-hash",
- "gix-lock",
+ "gix-hash 0.11.4",
+ "gix-lock 7.0.2",
  "gix-object 0.33.2",
- "gix-path",
- "gix-tempfile",
- "gix-validate",
+ "gix-path 0.8.4",
+ "gix-tempfile 7.0.2",
+ "gix-validate 0.7.7",
  "memmap2 0.7.1",
  "nom",
  "thiserror",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993ce5c448a94038b8da1a8969c0facd6c1fbac509fa013344c580458f41527d"
+dependencies = [
+ "gix-actor 0.25.0",
+ "gix-date",
+ "gix-features 0.33.0",
+ "gix-fs 0.5.0",
+ "gix-hash 0.12.0",
+ "gix-lock 8.0.0",
+ "gix-object 0.35.0",
+ "gix-path 0.9.0",
+ "gix-tempfile 8.0.0",
+ "gix-validate 0.8.0",
+ "memmap2 0.7.1",
+ "thiserror",
+ "winnow",
 ]
 
 [[package]]
@@ -2760,9 +3221,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e76ff1f82fba295a121e31ab02f69642994e532c45c0c899aa393f4b740302"
 dependencies = [
  "bstr",
- "gix-hash",
+ "gix-hash 0.11.4",
  "gix-revision 0.17.0",
- "gix-validate",
+ "gix-validate 0.7.7",
  "smallvec",
  "thiserror",
 ]
@@ -2774,9 +3235,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19a02bf740b326d6c082a7d6f754ebe56eef900986c5e91be7cf000df9ea18d"
 dependencies = [
  "bstr",
- "gix-hash",
+ "gix-hash 0.11.4",
  "gix-revision 0.18.1",
- "gix-validate",
+ "gix-validate 0.7.7",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3171923a0f9075feae790bb81d824c0c1f91a899df51508705d4957bacd006e"
+dependencies = [
+ "bstr",
+ "gix-hash 0.12.0",
+ "gix-revision 0.20.0",
+ "gix-validate 0.8.0",
  "smallvec",
  "thiserror",
 ]
@@ -2789,8 +3264,8 @@ checksum = "237428a7d3978e8572964e1e45d984027c2acc94df47e594baa6c4b0da7c9922"
 dependencies = [
  "bstr",
  "gix-date",
- "gix-hash",
- "gix-hashtable",
+ "gix-hash 0.11.4",
+ "gix-hashtable 0.2.4",
  "gix-object 0.32.0",
  "gix-revwalk 0.3.0",
  "thiserror",
@@ -2804,10 +3279,26 @@ checksum = "38a13500890435e3b9e7746bceda248646bfc69e259210884c98e29bb7a1aa6f"
 dependencies = [
  "bstr",
  "gix-date",
- "gix-hash",
- "gix-hashtable",
+ "gix-hash 0.11.4",
+ "gix-hashtable 0.2.4",
  "gix-object 0.33.2",
  "gix-revwalk 0.4.1",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2443886b7c55e73a813f203fe8603b94ac5deb3dfad8812d25e731b81f569f27"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-hash 0.12.0",
+ "gix-hashtable 0.3.0",
+ "gix-object 0.35.0",
+ "gix-revwalk 0.6.0",
+ "gix-trace",
  "thiserror",
 ]
 
@@ -2819,8 +3310,8 @@ checksum = "028d50fcaf8326a8f79a359490d9ca9fb4e2b51ac9ac86503560d0bcc888d2eb"
 dependencies = [
  "gix-commitgraph 0.17.1",
  "gix-date",
- "gix-hash",
- "gix-hashtable",
+ "gix-hash 0.11.4",
+ "gix-hashtable 0.2.4",
  "gix-object 0.32.0",
  "smallvec",
  "thiserror",
@@ -2834,9 +3325,24 @@ checksum = "71d4cbaf3cfbfde2b81b5ee8b469aff42c34693ce0fe17fc3c244d5085307f2c"
 dependencies = [
  "gix-commitgraph 0.18.2",
  "gix-date",
- "gix-hash",
- "gix-hashtable",
+ "gix-hash 0.11.4",
+ "gix-hashtable 0.2.4",
  "gix-object 0.33.2",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362f71e173364f67d02899388c4b3d2f6bac7c16c0f3a9bbc04683f984f59daa"
+dependencies = [
+ "gix-commitgraph 0.19.0",
+ "gix-date",
+ "gix-hash 0.12.0",
+ "gix-hashtable 0.3.0",
+ "gix-object 0.35.0",
  "smallvec",
  "thiserror",
 ]
@@ -2848,9 +3354,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9615cbd6b456898aeb942cd75e5810c382fbfc48dbbff2fa23ebd2d33dcbe9c7"
 dependencies = [
  "bitflags 2.4.0",
- "gix-path",
+ "gix-path 0.8.4",
  "libc",
  "windows",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0debc2e70613a077c257c2bb45ab4f652a550ae1d00bdca356633ea9de88a230"
+dependencies = [
+ "bitflags 2.4.0",
+ "gix-path 0.9.0",
+ "libc",
+ "windows",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71cc3ecd5e2387102aa275fc88fcf36e0f0b9df23a1335bf6255327abbb9bb3f"
+dependencies = [
+ "bstr",
+ "gix-config 0.28.0",
+ "gix-path 0.9.0",
+ "gix-pathspec",
+ "gix-refspec 0.16.0",
+ "gix-url 0.22.0",
+ "thiserror",
 ]
 
 [[package]]
@@ -2860,6 +3393,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa28d567848cec8fdd77d36ad4f5f78ecfaba7d78f647d4f63c8ae1a2cec7243"
 dependencies = [
  "gix-fs 0.4.1",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-registry",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea558d3daf3b1d0001052b12218c66c8f84788852791333b633d7eeb6999db1"
+dependencies = [
+ "gix-fs 0.5.0",
  "libc",
  "once_cell",
  "parking_lot",
@@ -2888,7 +3436,7 @@ dependencies = [
  "gix-features 0.31.1",
  "gix-packetline",
  "gix-quote",
- "gix-sec",
+ "gix-sec 0.8.4",
  "gix-url 0.20.1",
  "thiserror",
 ]
@@ -2904,7 +3452,7 @@ dependencies = [
  "gix-features 0.32.1",
  "gix-packetline",
  "gix-quote",
- "gix-sec",
+ "gix-sec 0.8.4",
  "gix-url 0.21.1",
  "thiserror",
 ]
@@ -2917,8 +3465,8 @@ checksum = "e3cdfd54598db4fae57d5ae6f52958422b2d13382d2745796bfe5c8015ffa86e"
 dependencies = [
  "gix-commitgraph 0.17.1",
  "gix-date",
- "gix-hash",
- "gix-hashtable",
+ "gix-hash 0.11.4",
+ "gix-hashtable 0.2.4",
  "gix-object 0.32.0",
  "gix-revwalk 0.3.0",
  "smallvec",
@@ -2933,10 +3481,26 @@ checksum = "e12e0fe428394226c37dd686ad64b09a04b569fe157d638b125b4a4c1e7e2df0"
 dependencies = [
  "gix-commitgraph 0.18.2",
  "gix-date",
- "gix-hash",
- "gix-hashtable",
+ "gix-hash 0.11.4",
+ "gix-hashtable 0.2.4",
  "gix-object 0.33.2",
  "gix-revwalk 0.4.1",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beecf2e4d8924cbe0cace0bd396f9b037fdf7db9799d5695fe70dcad959ed067"
+dependencies = [
+ "gix-commitgraph 0.19.0",
+ "gix-date",
+ "gix-hash 0.12.0",
+ "gix-hashtable 0.3.0",
+ "gix-object 0.35.0",
+ "gix-revwalk 0.6.0",
  "smallvec",
  "thiserror",
 ]
@@ -2949,7 +3513,7 @@ checksum = "beaede6dbc83f408b19adfd95bb52f1dbf01fb8862c3faf6c6243e2e67fcdfa1"
 dependencies = [
  "bstr",
  "gix-features 0.31.1",
- "gix-path",
+ "gix-path 0.8.4",
  "home",
  "thiserror",
  "url",
@@ -2963,7 +3527,21 @@ checksum = "4411bdbd1d46b35ae50e84c191660d437f89974e4236627785024be0b577170a"
 dependencies = [
  "bstr",
  "gix-features 0.32.1",
- "gix-path",
+ "gix-path 0.8.4",
+ "home",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6059e15828df32027a7db9097e5a9baf320d2dcc10a4e1598ffe05be8dfd1fa6"
+dependencies = [
+ "bstr",
+ "gix-features 0.33.0",
+ "gix-path 0.9.0",
  "home",
  "thiserror",
  "url",
@@ -2989,6 +3567,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-validate"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05cab2b03a45b866156e052aa38619f4ece4adcb2f79978bfc249bc3b21b8c5"
+dependencies = [
+ "bstr",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-worktree"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3000,11 +3588,11 @@ dependencies = [
  "gix-features 0.31.1",
  "gix-fs 0.3.0",
  "gix-glob 0.9.1",
- "gix-hash",
+ "gix-hash 0.11.4",
  "gix-ignore 0.4.1",
  "gix-index 0.20.0",
  "gix-object 0.32.0",
- "gix-path",
+ "gix-path 0.8.4",
  "io-close",
  "thiserror",
 ]
@@ -3019,14 +3607,52 @@ dependencies = [
  "filetime",
  "gix-attributes 0.16.0",
  "gix-features 0.32.1",
- "gix-filter",
+ "gix-filter 0.2.0",
  "gix-fs 0.4.1",
  "gix-glob 0.10.2",
- "gix-hash",
+ "gix-hash 0.11.4",
  "gix-ignore 0.5.1",
  "gix-index 0.21.1",
  "gix-object 0.33.2",
- "gix-path",
+ "gix-path 0.8.4",
+ "io-close",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38eab0fdd752ecfa50130c127c9f42bd329bf7f4e52872f4ac24c12bbc02baf"
+dependencies = [
+ "bstr",
+ "gix-attributes 0.17.0",
+ "gix-features 0.33.0",
+ "gix-fs 0.5.0",
+ "gix-glob 0.11.0",
+ "gix-hash 0.12.0",
+ "gix-ignore 0.6.0",
+ "gix-index 0.22.0",
+ "gix-object 0.35.0",
+ "gix-path 0.9.0",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44629a04d238493f0da657a0eee4d60086f0172c364ca4a71398b1898fda32a6"
+dependencies = [
+ "bstr",
+ "gix-features 0.33.0",
+ "gix-filter 0.3.0",
+ "gix-fs 0.5.0",
+ "gix-glob 0.11.0",
+ "gix-hash 0.12.0",
+ "gix-index 0.22.0",
+ "gix-object 0.35.0",
+ "gix-path 0.9.0",
+ "gix-worktree 0.24.0",
  "io-close",
  "thiserror",
 ]
@@ -6649,9 +7275,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.5.10"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5504cc7644f4b593cbc05c4a55bf9bd4e94b867c3c0bd440934174d50482427d"
+checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ indoc = "2.0.0"
 
 [build-dependencies]
 time = "0.3"
-gix = { version = "0.50.1", default-features = false }
+gix = { version = "0.52.0", default-features = false }
 string_cache_codegen = "0.5.1"
 walkdir = "2"
 anyhow = { version = "1.0.42", features = ["backtrace"] }


### PR DESCRIPTION
- https://github.com/Byron/gitoxide/releases/tag/gix-v0.51.0
- https://github.com/Byron/gitoxide/releases/tag/gix-v0.52.0
