### PR TITLE
fix new clippy errors & formatting errors

### DIFF
--- a/crates/font-awesome-as-a-crate/build.rs
+++ b/crates/font-awesome-as-a-crate/build.rs
@@ -34,7 +34,7 @@ fn write_fontawesome_sprite() {
             dest_file
                 .write_all(
                     format!(
-                        r####"(b"{dirname}",b"{filename}")=>r###"{data}"###,"####,
+                        r####"(b"{dirname}",b"{filename}")=>r#"{data}"#,"####,
                         data = data,
                         dirname = dirname,
                         filename = filename.replace(".svg", ""),

--- a/src/cdn.rs
+++ b/src/cdn.rs
@@ -136,7 +136,11 @@ impl CdnBackend {
         invalidation_id: &str,
         path_patterns: &[&str],
     ) {
-        let CdnBackend::Dummy { ref invalidation_requests, .. } = self else {
+        let CdnBackend::Dummy {
+            ref invalidation_requests,
+            ..
+        } = self
+        else {
             panic!("invalid CDN backend");
         };
 
@@ -559,7 +563,11 @@ mod tests {
     use aws_smithy_http::body::SdkBody;
 
     fn active_invalidations(cdn: &CdnBackend, distribution_id: &str) -> Vec<CdnInvalidation> {
-        let CdnBackend::Dummy {ref invalidation_requests, .. } = cdn  else {
+        let CdnBackend::Dummy {
+            ref invalidation_requests,
+            ..
+        } = cdn
+        else {
             panic!("invalid CDN backend");
         };
 

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -47,6 +47,7 @@ macro_rules! migration {
                     self.description()
                 );
 
+                #[allow(clippy::redundant_closure_call)]
                 $up_func(transaction)
             }
             fn down(&self, transaction: &mut Transaction) -> Result<(), PostgresError> {
@@ -56,6 +57,7 @@ macro_rules! migration {
                     self.version(),
                     self.description()
                 );
+                #[allow(clippy::redundant_closure_call)]
                 $down_func(transaction)
             }
         }

--- a/src/utils/consistency/diff.rs
+++ b/src/utils/consistency/diff.rs
@@ -120,7 +120,7 @@ mod tests {
         }];
 
         assert_eq!(
-            calculate_diff(db_releases.iter(), vec![].iter()),
+            calculate_diff(db_releases.iter(), [].iter()),
             vec![Difference::CrateNotInIndex("krate".into())]
         );
     }
@@ -142,7 +142,7 @@ mod tests {
         }];
 
         assert_eq!(
-            calculate_diff(vec![].iter(), index_releases.iter()),
+            calculate_diff([].iter(), index_releases.iter()),
             vec![Difference::CrateNotInDb(
                 "krate".into(),
                 vec!["0.0.2".into(), "0.0.3".into()]


### PR DESCRIPTION
I didn't dig deeper into `redundant_closure_call` from our migration macros