### PR TITLE
Remove builds.json API endpoint

### DIFF
--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -9,9 +9,7 @@ use crate::{
 use anyhow::Result;
 use axum::{
     extract::{Extension, Path},
-    http::header::ACCESS_CONTROL_ALLOW_ORIGIN,
     response::IntoResponse,
-    Json,
 };
 use chrono::{DateTime, Utc};
 use serde::Serialize;
@@ -79,40 +77,6 @@ pub(crate) async fn build_list_handler(
     .into_response())
 }
 
-pub(crate) async fn build_list_json_handler(
-    Path((name, req_version)): Path<(String, String)>,
-    Extension(pool): Extension<Pool>,
-) -> AxumResult<impl IntoResponse> {
-    let version = match match_version_axum(&pool, &name, Some(&req_version))
-        .await?
-        .exact_name_only()?
-    {
-        MatchSemver::Exact((version, _)) | MatchSemver::Latest((version, _)) => version,
-        MatchSemver::Semver((version, _)) => {
-            return Ok(super::axum_cached_redirect(
-                &format!("/crate/{name}/{version}/builds.json"),
-                CachePolicy::ForeverInCdn,
-            )?
-            .into_response());
-        }
-    };
-
-    let builds = spawn_blocking({
-        move || {
-            let mut conn = pool.get()?;
-            get_builds(&mut conn, &name, &version)
-        }
-    })
-    .await?;
-
-    Ok((
-        Extension(CachePolicy::NoStoreMustRevalidate),
-        [(ACCESS_CONTROL_ALLOW_ORIGIN, "*")],
-        Json(builds),
-    )
-        .into_response())
-}
-
 fn get_builds(conn: &mut postgres::Client, name: &str, version: &str) -> Result<Vec<Build>> {
     Ok(conn
         .query(
@@ -150,7 +114,7 @@ mod tests {
         test::{assert_cache_control, wrapper, FakeBuild},
         web::cache::CachePolicy,
     };
-    use chrono::{DateTime, Duration, Utc};
+    use chrono::Duration;
     use kuchikiki::traits::TendrilSink;
     use reqwest::StatusCode;
 
@@ -190,88 +154,6 @@ mod tests {
             assert!(rows[1].contains("docs.rs 2.0.0"));
             assert!(rows[2].contains("rustc (blabla 2019-01-01)"));
             assert!(rows[2].contains("docs.rs 1.0.0"));
-
-            Ok(())
-        });
-    }
-
-    #[test]
-    fn build_list_json() {
-        wrapper(|env| {
-            env.fake_release()
-                .name("foo")
-                .version("0.1.0")
-                .builds(vec![
-                    FakeBuild::default()
-                        .rustc_version("rustc (blabla 2019-01-01)")
-                        .docsrs_version("docs.rs 1.0.0"),
-                    FakeBuild::default()
-                        .successful(false)
-                        .rustc_version("rustc (blabla 2020-01-01)")
-                        .docsrs_version("docs.rs 2.0.0"),
-                    FakeBuild::default()
-                        .rustc_version("rustc (blabla 2021-01-01)")
-                        .docsrs_version("docs.rs 3.0.0"),
-                ])
-                .create()?;
-
-            let response = env.frontend().get("/crate/foo/0.1.0/builds.json").send()?;
-            assert_cache_control(&response, CachePolicy::NoStoreMustRevalidate, &env.config());
-            let value: serde_json::Value = serde_json::from_str(&response.text()?)?;
-
-            assert_eq!(value.pointer("/0/build_status"), Some(&true.into()));
-            assert_eq!(
-                value.pointer("/0/docsrs_version"),
-                Some(&"docs.rs 3.0.0".into())
-            );
-            assert_eq!(
-                value.pointer("/0/rustc_version"),
-                Some(&"rustc (blabla 2021-01-01)".into())
-            );
-            assert!(value.pointer("/0/id").unwrap().is_i64());
-            assert!(serde_json::from_value::<DateTime<Utc>>(
-                value.pointer("/0/build_time").unwrap().clone()
-            )
-            .is_ok());
-
-            assert_eq!(value.pointer("/1/build_status"), Some(&false.into()));
-            assert_eq!(
-                value.pointer("/1/docsrs_version"),
-                Some(&"docs.rs 2.0.0".into())
-            );
-            assert_eq!(
-                value.pointer("/1/rustc_version"),
-                Some(&"rustc (blabla 2020-01-01)".into())
-            );
-            assert!(value.pointer("/1/id").unwrap().is_i64());
-            assert!(serde_json::from_value::<DateTime<Utc>>(
-                value.pointer("/1/build_time").unwrap().clone()
-            )
-            .is_ok());
-
-            assert_eq!(value.pointer("/2/build_status"), Some(&true.into()));
-            assert_eq!(
-                value.pointer("/2/docsrs_version"),
-                Some(&"docs.rs 1.0.0".into())
-            );
-            assert_eq!(
-                value.pointer("/2/rustc_version"),
-                Some(&"rustc (blabla 2019-01-01)".into())
-            );
-            assert!(value.pointer("/2/id").unwrap().is_i64());
-            assert!(serde_json::from_value::<DateTime<Utc>>(
-                value.pointer("/2/build_time").unwrap().clone()
-            )
-            .is_ok());
-
-            assert!(
-                value.pointer("/1/build_time").unwrap().as_str().unwrap()
-                    < value.pointer("/0/build_time").unwrap().as_str().unwrap()
-            );
-            assert!(
-                value.pointer("/2/build_time").unwrap().as_str().unwrap()
-                    < value.pointer("/1/build_time").unwrap().as_str().unwrap()
-            );
 
             Ok(())
         });
@@ -354,15 +236,6 @@ mod tests {
             assert!(body.contains("<a href=\"/crate/aquarelle/latest/builds\""));
             assert!(body.contains("<a href=\"/crate/aquarelle/latest/source/\""));
             assert!(body.contains("<a href=\"/crate/aquarelle/latest\""));
-
-            let resp_json = env
-                .frontend()
-                .get("/crate/aquarelle/latest/builds.json")
-                .send()?;
-            assert!(resp_json
-                .url()
-                .as_str()
-                .ends_with("/crate/aquarelle/latest/builds.json"));
 
             Ok(())
         });

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -174,10 +174,6 @@ mod tests {
             ("/crate/hexponent/0.2.0", "/crate/:name/:version"),
             ("/crate/rcc/0.0.0", "/crate/:name/:version"),
             (
-                "/crate/rcc/0.0.0/builds.json",
-                "/crate/:name/:version/builds.json",
-            ),
-            (
                 "/crate/rcc/0.0.0/status.json",
                 "/crate/:name/:version/status.json",
             ),

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -217,10 +217,6 @@ pub(super) fn build_axum_routes() -> AxumRouter {
             get_internal(super::builds::build_list_handler),
         )
         .route(
-            "/crate/:name/:version/builds.json",
-            get_internal(super::builds::build_list_json_handler),
-        )
-        .route(
             "/crate/:name/:version/status.json",
             get_internal(super::status::status_handler),
         )


### PR DESCRIPTION
I would have exact stats, but grafana is currently down 🙃. IIRC we went from ~100 req/min to somewhere around 1 req/hour. The major consumers crates.io and shields.io have definitely migrated, lib.rs is the other known consumer and @kornelski 👍'd [my comment about migrating](https://github.com/rust-lang/docs.rs/pull/2147#issuecomment-1657097067) so I hope it has updated by now.