### PR TITLE
adapt style_css test to support reqwest stripping BOM from response

### DIFF
--- a/src/web/statics.rs
+++ b/src/web/statics.rs
@@ -102,7 +102,7 @@ mod tests {
                 Some(&"text/css".parse().unwrap()),
             );
             assert_eq!(resp.content_length().unwrap(), STYLE_CSS.len() as u64);
-            assert_eq!(resp.text()?, STYLE_CSS);
+            assert_eq!(resp.bytes()?, STYLE_CSS.as_bytes());
 
             Ok(())
         });


### PR DESCRIPTION
This is related to the reqwest update, still failing in this PR: #2212 

IMO this is the cleaner solution, since we don't change response, only the test assertion. 

Related comment: https://github.com/rust-lang/docs.rs/pull/2194#issuecomment-1690010467