### PR TITLE
Don't generate unneeded redirections on platforms links on docs.rs crates pages

### DIFF
--- a/src/web/build_details.rs
+++ b/src/web/build_details.rs
@@ -31,6 +31,7 @@ pub(crate) struct BuildDetails {
 struct BuildDetailsPage {
     metadata: MetaData,
     build_details: BuildDetails,
+    use_direct_platform_links: bool,
 }
 
 impl_axum_webpage! {
@@ -91,6 +92,7 @@ pub(crate) async fn build_details_handler(
             build_time: row.get("build_time"),
             output,
         },
+        use_direct_platform_links: true,
     }
     .into_response())
 }

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -33,6 +33,7 @@ struct BuildsPage {
     builds: Vec<Build>,
     limits: Limits,
     canonical_url: CanonicalUrl,
+    use_direct_platform_links: bool,
 }
 
 impl_axum_webpage! {
@@ -78,6 +79,7 @@ pub(crate) async fn build_list_handler(
         builds,
         limits,
         canonical_url: CanonicalUrl::from_path(format!("/crate/{name}/latest/builds")),
+        use_direct_platform_links: true,
     }
     .into_response())
 }

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -1305,30 +1305,12 @@ mod tests {
             platform_links
         }
 
-        fn run_check_links(
-            env: &TestEnvironment,
-            url_start: &str,
-            url_end: &str,
-            extra: &str,
-            should_contain_redirect: bool,
-        ) {
-            run_check_links_redir(
-                env,
-                url_start,
-                url_end,
-                extra,
-                should_contain_redirect,
-                should_contain_redirect,
-            )
-        }
-
         fn run_check_links_redir(
             env: &TestEnvironment,
             url_start: &str,
             url_end: &str,
             extra: &str,
             should_contain_redirect: bool,
-            ajax_should_contain_redirect: bool,
         ) {
             let response = env
                 .frontend()
@@ -1351,18 +1333,8 @@ mod tests {
                 .send()
                 .unwrap();
             assert!(response.status().is_success());
-            let list2 = check_links(response.text().unwrap(), true, ajax_should_contain_redirect);
-            if should_contain_redirect == ajax_should_contain_redirect {
-                assert_eq!(list1, list2);
-            } else {
-                // If redirects differ, we only check platform names.
-                assert!(
-                    list1.iter().zip(&list2).all(|(a, b)| a.0 == b.0),
-                    "{:?} != {:?}",
-                    list1,
-                    list2,
-                );
-            }
+            let list2 = check_links(response.text().unwrap(), true, should_contain_redirect);
+            assert_eq!(list1, list2);
         }
 
         wrapper(|env| {
@@ -1379,28 +1351,21 @@ mod tests {
 
             // FIXME: For some reason, there are target-redirects on non-AJAX lists on docs.rs
             // crate pages other than the "default" one.
-            run_check_links_redir(env, "/crate/dummy/0.4.0", "/features", "", true, false);
-            run_check_links_redir(env, "/crate/dummy/0.4.0", "/builds", "", true, false);
-            run_check_links_redir(env, "/crate/dummy/0.4.0", "/source/", "", true, false);
-            run_check_links_redir(
-                env,
-                "/crate/dummy/0.4.0",
-                "/source/README.md",
-                "",
-                true,
-                false,
-            );
+            run_check_links_redir(env, "/crate/dummy/0.4.0", "/features", "", false);
+            run_check_links_redir(env, "/crate/dummy/0.4.0", "/builds", "", false);
+            run_check_links_redir(env, "/crate/dummy/0.4.0", "/source/", "", false);
+            run_check_links_redir(env, "/crate/dummy/0.4.0", "/source/README.md", "", false);
 
-            run_check_links(env, "/crate/dummy/0.4.0", "", "/", false);
-            run_check_links(env, "/dummy/latest", "/dummy", "/", true);
-            run_check_links(
+            run_check_links_redir(env, "/crate/dummy/0.4.0", "", "/", false);
+            run_check_links_redir(env, "/dummy/latest", "/dummy", "/", true);
+            run_check_links_redir(
                 env,
                 "/dummy/0.4.0",
                 "/x86_64-pc-windows-msvc/dummy",
                 "/",
                 true,
             );
-            run_check_links(
+            run_check_links_redir(
                 env,
                 "/dummy/0.4.0",
                 "/x86_64-pc-windows-msvc/dummy/struct.A.html",

--- a/src/web/features.rs
+++ b/src/web/features.rs
@@ -24,6 +24,7 @@ struct FeaturesPage {
     default_len: usize,
     canonical_url: CanonicalUrl,
     is_latest_url: bool,
+    use_direct_platform_links: bool,
 }
 
 impl_axum_webpage! {
@@ -89,6 +90,7 @@ pub(crate) async fn build_features_handler(
         default_len,
         is_latest_url,
         canonical_url: CanonicalUrl::from_path(format!("/crate/{}/latest/features", &name)),
+        use_direct_platform_links: true,
     }
     .into_response())
 }

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -171,6 +171,7 @@ struct SourcePage {
     file_content: Option<String>,
     canonical_url: CanonicalUrl,
     is_latest_url: bool,
+    use_direct_platform_links: bool,
 }
 
 impl_axum_webpage! {
@@ -312,6 +313,7 @@ pub(crate) async fn source_browser_handler(
         file_content,
         canonical_url,
         is_latest_url,
+        use_direct_platform_links: true,
     }
     .into_response())
 }


### PR DESCRIPTION
It fixes the bug I discovered while working on https://github.com/rust-lang/docs.rs/pull/2181: we are generating redirects on pages like `/crate/sysinfo/0.29.7/source/.cirrus.yml` whereas we shouldn't.