### PR TITLE
Make "About" link point to current website and not open in a new tab

### DIFF
--- a/templates/header/topbar_end.html
+++ b/templates/header/topbar_end.html
@@ -11,9 +11,8 @@
                         <a href="#" class="pure-menu-link" aria-label="Rust">Rust</a>
                         <ul class="pure-menu-children">
                             {{ macros::menu_link(
-                                href="https://docs.rs/about",
-                                text="About docs.rs",
-                                target="_blank"
+                                href="/about",
+                                text="About docs.rs"
                             ) }}
                             {{ macros::menu_link(
                                 href="https://foundation.rust-lang.org/policies/privacy-policy/#docs.rs",


### PR DESCRIPTION
When I was working on https://github.com/rust-lang/docs.rs/pull/2218, I realized (after some time...) that it was actually redirecting me to `docs.rs` every time and not simply use my local instance.

So this PR changes two things:
 1. Use a relative URL instead of pointing to `docs.rs`.
 2. Since it's the same website, not open this link into a new tab.