### PR TITLE
Delete obsolete `--disable-per-crate-search` flag

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -776,7 +776,6 @@ impl RustwideBuilder {
         const UNCONDITIONAL_ARGS: &[&str] = &[
             "--static-root-path", "/-/rustdoc.static/",
             "--cap-lints", "warn",
-            "--disable-per-crate-search",
             "--extern-html-root-takes-precedence",
         ];
 


### PR DESCRIPTION
This flag is unused by rustdoc since https://github.com/rust-lang/rust/pull/92526/commits/ef96d573bff12330080d22f12cad96b818ea5da7.