### PR TITLE
upgrade toml to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1470,7 +1470,7 @@ dependencies = [
  "thread_local",
  "time",
  "tokio",
- "toml 0.7.8",
+ "toml 0.8.0",
  "tower",
  "tower-http",
  "tower-service",
@@ -1490,7 +1490,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "thiserror",
- "toml 0.7.8",
+ "toml 0.8.0",
 ]
 
 [[package]]
@@ -5450,18 +5450,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c226a7bba6d859b63c92c4b4fe69c5b6b72d0cb897dbc8e6012298e6154cb56e"
@@ -5469,7 +5457,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.20.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5479,19 +5467,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.0.0",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ failure = "0.1.8"
 thiserror = "1.0.26"
 comrak = { version = "0.18.0", default-features = false }
 syntect = { version = "5.0.0", default-features = false, features = ["parsing", "html", "dump-load", "regex-onig"] }
-toml = "0.7.2"
+toml = "0.8.0"
 schemamama = "0.3"
 schemamama_postgres = "0.3"
 prometheus = { version = "0.13.0", default-features = false }

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -14,5 +14,5 @@ path = "lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-toml = { version = "0.7", default-features = false }
+toml = "0.8"
 thiserror = "1"


### PR DESCRIPTION
[One important breaking change is in the changelog](https://github.com/toml-rs/toml/blob/main/crates/toml/CHANGELOG.md#compatibility): 
> Serialization and deserialization of tuple variants has changed from being an array to being a table with the key being the variant name and the value being the array

https://github.com/toml-rs/toml/compare/toml-v0.7.8...toml-v0.8.0


I _think_ that our usage of `toml` in `web::crate_details` should be fine with the change, I'm not 100% sure about our usage in the `metadata` crate. 

I would love to have a second pair of eyes on the change. 

