### PR TITLE
Specify color-scheme for each theme

### DIFF
--- a/templates/style/_themes.scss
+++ b/templates/style/_themes.scss
@@ -1,5 +1,6 @@
 // Standard white theme
 html {
+  color-scheme: light;
   --color-background-code: #f5f5f5;
   --color-background: #fff;
   --input-color: #000;
@@ -35,6 +36,7 @@ html {
 // block below and change the colors
 
 html[data-theme="dark"] {
+  color-scheme: dark;
   --color-background-code: #2a2a2a;
   --color-background: #353535;
   --input-color: #111;
@@ -67,6 +69,7 @@ html[data-theme="dark"] {
 }
 
 html[data-theme="ayu"] {
+  color-scheme: dark;
   --color-background-code: #191f26;
   --color-background: #0f1419;
   --input-color: #c5c5c5;


### PR DESCRIPTION
This PR adds a CSS property color-scheme to `_schemes.scss`. 
It allows the browser to apply the appropriate default user-agent styles for the current theme. For example, to use dark scrollbar on Windows in chromium-based browsers. 

Learn more about this property: https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme

Here's an example of improvement in scrollbar style for dark themes on Windows in MS Edge:

| Before | After |
|--------|--------|
| ![image](https://github.com/rust-lang/docs.rs/assets/18244287/6fa45793-066b-4d5f-b11f-169eca69e10b) | ![image](https://github.com/rust-lang/docs.rs/assets/18244287/3887ec46-c178-4fe7-b863-3f98f550fd34) | 