### PR TITLE
Replace version with "latest" in the URL.

### DIFF
--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -1050,7 +1050,7 @@ mod tests {
             )?;
 
             assert_eq!(links.len(), 1);
-            assert_eq!(links[0], "/some_random_crate/1.0.0/some_random_crate/",);
+            assert_eq!(links[0], "/some_random_crate/latest/some_random_crate/",);
             Ok(())
         })
     }
@@ -1097,7 +1097,7 @@ mod tests {
             )?;
 
             assert_eq!(links.len(), 1);
-            assert_eq!(links[0], "/some_random_crate/1.0.0/some_random_crate/");
+            assert_eq!(links[0], "/some_random_crate/latest/some_random_crate/");
             Ok(())
         })
     }
@@ -1157,8 +1157,8 @@ mod tests {
             //   might not have it yet, or the doc-build might be in progress.
             // * ranking/order from crates.io result is preserved
             // * version used is the highest semver following our own "latest version" logic
-            assert_eq!(links[0], "/some_random_crate/2.0.0/some_random_crate/");
-            assert_eq!(links[1], "/and_another_one/0.0.1/and_another_one/");
+            assert_eq!(links[0], "/some_random_crate/latest/some_random_crate/");
+            assert_eq!(links[1], "/and_another_one/latest/and_another_one/");
             Ok(())
         })
     }

--- a/templates/releases/releases.html
+++ b/templates/releases/releases.html
@@ -25,12 +25,15 @@ centered
             <ul>
                 {# TODO: If there are no releases, then display a message that says so #}
                 {%- for release in releases -%}
-                    {%- if release.rustdoc_status -%}
-                        {% set link = "/" ~ release.name ~ "/" ~ release.version ~ "/" ~ release.target_name ~ "/" -%}
-                    {%- else -%}
-                        {% set link = "/crate/" ~ release.name ~ "/" ~ release.version -%}
+                    {%- set release_version = release.version -%}
+                    {%- if release_type == "search" -%} 
+                        {%- set release_version = "latest" -%}
                     {%- endif -%}
-
+                    {%- if release.rustdoc_status -%}
+                        {% set link = "/" ~ release.name ~ "/" ~ release_version ~ "/" ~ release.target_name ~ "/" -%}
+                    {%- else -%}
+                        {% set link = "/crate/" ~ release.name ~ "/" ~ release_version -%}
+                    {%- endif -%}
                     <li>
                         <a href="{{ link | safe }}" class="release">
                             <div class="pure-g">


### PR DESCRIPTION
This is an enhancement from: https://github.com/rust-lang/docs.rs/issues/1691

it will replace the latest version with "latest" in the URL, like 
-  /serde/latest/serde
-  /crate/regex/latest