### PR TITLE
support init rustwide_builder periodically

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -181,7 +181,7 @@ impl CommandLine {
                 let build_queue = ctx.build_queue()?;
                 let config = ctx.config()?;
                 let rustwide_builder = RustwideBuilder::init(&ctx)?;
-                queue_builder(rustwide_builder, build_queue, config)?;
+                queue_builder(&ctx, rustwide_builder, build_queue, config)?;
             }
             Self::StartWebServer { socket_addr } => {
                 // Blocks indefinitely

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,6 +93,7 @@ pub struct Config {
     pub cloudfront_distribution_id_web: Option<String>,
     /// same for the `static.docs.rs` distribution
     pub cloudfront_distribution_id_static: Option<String>,
+    pub(crate) build_workspace_reinitialization_interval: Duration,
 
     // Build params
     pub(crate) build_attempts: u16,
@@ -208,6 +209,10 @@ impl Config {
             build_default_memory_limit: maybe_env("DOCSRS_BUILD_DEFAULT_MEMORY_LIMIT")?,
             include_default_targets: env("DOCSRS_INCLUDE_DEFAULT_TARGETS", true)?,
             disable_memory_limit: env("DOCSRS_DISABLE_MEMORY_LIMIT", false)?,
+            build_workspace_reinitialization_interval: Duration::from_secs(env(
+                "DOCSRS_BUILD_WORKSPACE_REINITIALIZATION_INTERVAL",
+                86400,
+            )?),
         })
     }
 }

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -138,8 +138,9 @@ pub fn start_daemon<C: Context + Send + Sync + 'static>(
     let rustwide_builder = RustwideBuilder::init(&*context)?;
     thread::Builder::new()
         .name("build queue reader".to_string())
-        .spawn(move || {
-            queue_builder(rustwide_builder, build_queue, config).unwrap();
+        .spawn({
+            let context = context.clone();
+            move || queue_builder(&*context, rustwide_builder, build_queue, config).unwrap()
         })
         .unwrap();
 

--- a/src/utils/queue_builder.rs
+++ b/src/utils/queue_builder.rs
@@ -1,5 +1,6 @@
+use crate::Context;
 use crate::{docbuilder::RustwideBuilder, utils::report_error, BuildQueue, Config};
-use anyhow::{Context, Error};
+use anyhow::{Context as _, Error};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 use std::time::Duration;
@@ -7,6 +8,7 @@ use std::{fs, io, path::Path, thread};
 use tracing::{debug, error, warn};
 
 pub fn queue_builder(
+    context: &dyn Context,
     mut builder: RustwideBuilder,
     build_queue: Arc<BuildQueue>,
     config: Arc<Config>,
@@ -37,7 +39,7 @@ pub fn queue_builder(
         // If a panic occurs while building a crate, lock the queue until an admin has a chance to look at it.
         debug!("Checking build queue");
         let res = catch_unwind(AssertUnwindSafe(|| {
-            match build_queue.build_next_queue_package(&mut builder) {
+            match build_queue.build_next_queue_package(context, &mut builder) {
                 Ok(true) => {}
                 Ok(false) => {
                     debug!("Queue is empty, going back to sleep");


### PR DESCRIPTION
This is a initial PR for:  https://github.com/rust-lang/docs.rs/issues/2199 (automatically update build docker image)

I create a `peroid_init` method for `docbuilder::rustwide_builder::RustwideBuilder`,  it will init builder again.

Please let me know if this is feasible or if there are other ways of working you prefer.