### PR TITLE
Read build-status and rustc-version directly from builds instead of release

### DIFF
--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -136,7 +136,7 @@ impl CrateDetails {
                 releases.license,
                 releases.documentation_url,
                 releases.default_target,
-                releases.doc_rustc_version,
+                builds.rustc_version,
                 doc_coverage.total_items,
                 doc_coverage.documented_items,
                 doc_coverage.total_items_needing_examples,
@@ -188,7 +188,10 @@ impl CrateDetails {
             default_target: krate.get("default_target"),
             doc_targets: MetaData::parse_doc_targets(krate.get("doc_targets")),
             yanked: krate.get("yanked"),
-            rustdoc_css_file: get_correct_docsrs_style_file(krate.get("doc_rustc_version"))?,
+            rustdoc_css_file: krate
+                .get::<_, Option<&str>>("rustc_version")
+                .map(get_correct_docsrs_style_file)
+                .transpose()?,
         };
 
         let mut crate_details = CrateDetails {

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -90,7 +90,7 @@ pub(crate) fn get_releases(
         INNER JOIN builds ON releases.id = builds.rid
         LEFT JOIN repositories ON releases.repository_id = repositories.id
         WHERE
-            ((NOT $3) OR (releases.build_status = FALSE AND releases.is_library = TRUE))
+            ((NOT $3) OR (builds.build_status = FALSE AND releases.is_library = TRUE))
             AND {0} IS NOT NULL
 
         ORDER BY {0} DESC
@@ -658,7 +658,7 @@ pub(crate) async fn activity_handler(
                 SELECT
                     release_time::date AS date_,
                     COUNT(*) AS counts,
-                    SUM(CAST((is_library = TRUE AND build_status = FALSE) AS INT)) AS failures
+                    SUM(CAST((is_library = TRUE AND (SELECT builds.build_status FROM builds WHERE builds.rid = releases.id ORDER BY builds.build_time DESC LIMIT 1) = FALSE) AS INT)) AS failures
                 FROM
                     releases
                 WHERE

--- a/templates/rustdoc/head.html
+++ b/templates/rustdoc/head.html
@@ -1,5 +1,7 @@
 {%- import "macros.html" as macros -%}
+        {% if metadata.rustdoc_css_file %}
         <link rel="stylesheet" href="/-/static/{{metadata.rustdoc_css_file}}?{{ docsrs_version() | slugify }}" media="all" />
+        {% endif %}
 
         <link rel="search" href="/-/static/opensearch.xml" type="application/opensearchdescription+xml" title="Docs.rs" />
 


### PR DESCRIPTION
This is a first step on preparing the database for having a release without any builds. I have a separate branch that deletes the columns that become unused here, but think that this should be deployed first so that it can be easily reverted if necessary.