### PR TITLE
Build id for archive index

### DIFF
--- a/src/db/delete.rs
+++ b/src/db/delete.rs
@@ -174,8 +174,8 @@ fn delete_crate_from_database(conn: &mut Client, name: &str, crate_id: i32) -> R
     transaction.execute("DELETE FROM owner_rels WHERE cid = $1;", &[&crate_id])?;
     let has_library = transaction
         .query_one(
-            "SELECT 
-                BOOL_OR(releases.is_library) AS has_library 
+            "SELECT
+                BOOL_OR(releases.is_library) AS has_library
             FROM releases
             WHERE releases.crate_id = $1
             ",
@@ -249,6 +249,7 @@ mod tests {
                 assert!(env.storage().rustdoc_file_exists(
                     pkg,
                     version,
+                    0,
                     &format!("{pkg}/index.html"),
                     archive_storage
                 )?);
@@ -266,6 +267,7 @@ mod tests {
             assert!(env.storage().rustdoc_file_exists(
                 "package-2",
                 "1.0.0",
+                0,
                 "package-2/index.html",
                 archive_storage
             )?);
@@ -282,12 +284,14 @@ mod tests {
                 assert!(!env.storage().rustdoc_file_exists(
                     "package-1",
                     "1.0.0",
+                    0,
                     "package-1/index.html",
                     archive_storage
                 )?);
                 assert!(!env.storage().rustdoc_file_exists(
                     "package-1",
                     "2.0.0",
+                    0,
                     "package-1/index.html",
                     archive_storage
                 )?);
@@ -329,6 +333,7 @@ mod tests {
             assert!(env.storage().rustdoc_file_exists(
                 "a",
                 "1.0.0",
+                0,
                 "a/index.html",
                 archive_storage
             )?);
@@ -358,6 +363,7 @@ mod tests {
             assert!(env.storage().rustdoc_file_exists(
                 "a",
                 "2.0.0",
+                0,
                 "a/index.html",
                 archive_storage
             )?);
@@ -386,6 +392,7 @@ mod tests {
                 assert!(!env.storage().rustdoc_file_exists(
                     "a",
                     "1.0.0",
+                    0,
                     "a/index.html",
                     archive_storage
                 )?);
@@ -394,6 +401,7 @@ mod tests {
             assert!(env.storage().rustdoc_file_exists(
                 "a",
                 "2.0.0",
+                0,
                 "a/index.html",
                 archive_storage
             )?);

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -994,15 +994,20 @@ mod tests {
             assert!(storage.exists(&source_archive)?, "{}", source_archive);
 
             // default target was built and is accessible
-            assert!(storage.exists_in_archive(&doc_archive, &format!("{crate_path}/index.html"))?);
+            assert!(storage.exists_in_archive(
+                &doc_archive,
+                0,
+                &format!("{crate_path}/index.html"),
+            )?);
             assert_success(&format!("/{crate_}/{version}/{crate_path}"), web)?;
 
             // source is also packaged
-            assert!(storage.exists_in_archive(&source_archive, "src/lib.rs")?);
+            assert!(storage.exists_in_archive(&source_archive, 0, "src/lib.rs",)?);
             assert_success(&format!("/crate/{crate_}/{version}/source/src/lib.rs"), web)?;
 
             assert!(!storage.exists_in_archive(
                 &doc_archive,
+                0,
                 &format!("{default_target}/{crate_path}/index.html"),
             )?);
 
@@ -1036,6 +1041,7 @@ mod tests {
                     }
                     let target_docs_present = storage.exists_in_archive(
                         &doc_archive,
+                        0,
                         &format!("{target}/{crate_path}/index.html"),
                     )?;
 
@@ -1153,8 +1159,11 @@ mod tests {
 
             let target = "x86_64-unknown-linux-gnu";
             let crate_path = crate_.replace('-', "_");
-            let target_docs_present = storage
-                .exists_in_archive(&doc_archive, &format!("{target}/{crate_path}/index.html"))?;
+            let target_docs_present = storage.exists_in_archive(
+                &doc_archive,
+                0,
+                &format!("{target}/{crate_path}/index.html"),
+            )?;
 
             let web = env.frontend();
             let target_url = format!("/{crate_}/{version}/{target}/{crate_path}/index.html");

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -191,6 +191,7 @@ pub(crate) async fn rustdoc_redirector_handler(
                 .fetch_rustdoc_file(
                     &crate_name,
                     &version,
+                    krate.latest_build_id.unwrap_or(0),
                     target,
                     krate.archive_storage,
                     Some(&mut rendering_time),
@@ -504,6 +505,7 @@ pub(crate) async fn rustdoc_html_server_handler(
         .fetch_rustdoc_file(
             &params.name,
             &version,
+            krate.latest_build_id.unwrap_or(0),
             &storage_path,
             krate.archive_storage,
             Some(&mut rendering_time),
@@ -522,7 +524,13 @@ pub(crate) async fn rustdoc_html_server_handler(
             req_path.push("index.html");
 
             return if storage
-                .rustdoc_file_exists(&params.name, &version, &storage_path, krate.archive_storage)
+                .rustdoc_file_exists(
+                    &params.name,
+                    &version,
+                    krate.latest_build_id.unwrap_or(0),
+                    &storage_path,
+                    krate.archive_storage,
+                )
                 .await?
             {
                 redirect(
@@ -809,6 +817,7 @@ pub(crate) async fn target_redirect_handler(
         .rustdoc_file_exists(
             &name,
             &version,
+            crate_details.latest_build_id.unwrap_or(0),
             &storage_location_for_path,
             crate_details.archive_storage,
         )


### PR DESCRIPTION
This PR is based on / includes the changes from #2274. 

The basic idea is to include an additional identifier (the latest build ID) into the filename for local archive indexes. 

Through this we will invalidate the local files when there is a new build available. 

This will solve #2273 and through that solve rebuilds with the new infrastructure. 