### PR TITLE
add delay between build attempts

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -97,6 +97,7 @@ pub struct Config {
 
     // Build params
     pub(crate) build_attempts: u16,
+    pub(crate) delay_between_build_attempts: Duration,
     pub(crate) rustwide_workspace: PathBuf,
     pub(crate) temp_dir: PathBuf,
     pub(crate) inside_docker: bool,
@@ -133,6 +134,10 @@ impl Config {
 
         Ok(Self {
             build_attempts: env("DOCSRS_BUILD_ATTEMPTS", 5)?,
+            delay_between_build_attempts: Duration::from_secs(env::<u64>(
+                "DOCSRS_DELAY_BETWEEN_BUILD_ATTEMPTS",
+                60,
+            )?),
 
             crates_io_api_call_retries: env("DOCSRS_CRATESIO_API_CALL_RETRIES", 3)?,
 

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -896,6 +896,15 @@ pub fn migrate(version: Option<Version>, conn: &mut Client) -> crate::error::Res
             "ALTER TYPE feature DROP ATTRIBUTE optional_dependency;",
             "ALTER TYPE feature ADD ATTRIBUTE optional_dependency BOOL;"
         ),
+        sql_migration!(
+            context,
+            39,
+            "Added last_attempt column to build queue",
+            // upgrade query
+            "ALTER TABLE queue ADD COLUMN last_attempt TIMESTAMP WITH TIME ZONE;",
+            // downgrade query
+            "ALTER TABLE queue DROP COLUMN last_attempt;"
+        ),
     ];
 
     for migration in migrations {


### PR DESCRIPTION
this is the next try to resolve #2262 by adding a delay between build attempts, as a follow-up to #2264 which I didn't think through. 

I'm not yet 100% certain about the other `BuildQueue` methods, right now it makes sense to me, but I would love feedback on this (specifically: should we add the delay-filtering in more places? )