### PR TITLE
Separate registry-api from the index, use the configured base url

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,13 +2,14 @@ use crate::{cdn::CdnKind, storage::StorageKind};
 use anyhow::{anyhow, bail, Context, Result};
 use std::{env::VarError, error::Error, path::PathBuf, str::FromStr, time::Duration};
 use tracing::trace;
+use url::Url;
 
 #[derive(Debug)]
 pub struct Config {
     pub prefix: PathBuf,
     pub registry_index_path: PathBuf,
     pub registry_url: Option<String>,
-    pub registry_api_host: String,
+    pub registry_api_host: Url,
 
     // Database connection params
     pub(crate) database_url: String,
@@ -140,7 +141,10 @@ impl Config {
 
             registry_index_path: env("REGISTRY_INDEX_PATH", prefix.join("crates.io-index"))?,
             registry_url: maybe_env("REGISTRY_URL")?,
-            registry_api_host: env("DOCSRS_REGISTRY_API_HOST", "https://crates.io".into())?,
+            registry_api_host: env(
+                "DOCSRS_REGISTRY_API_HOST",
+                "https://crates.io".parse().unwrap(),
+            )?,
             prefix: prefix.clone(),
 
             database_url: require_env("DOCSRS_DATABASE_URL")?,

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,7 +2,9 @@ use crate::cdn::CdnBackend;
 use crate::db::Pool;
 use crate::error::Result;
 use crate::repositories::RepositoryStatsUpdater;
-use crate::{AsyncStorage, BuildQueue, Config, Index, InstanceMetrics, ServiceMetrics, Storage};
+use crate::{
+    AsyncStorage, BuildQueue, Config, Index, InstanceMetrics, RegistryApi, ServiceMetrics, Storage,
+};
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 
@@ -16,6 +18,7 @@ pub trait Context {
     fn service_metrics(&self) -> Result<Arc<ServiceMetrics>>;
     fn instance_metrics(&self) -> Result<Arc<InstanceMetrics>>;
     fn index(&self) -> Result<Arc<Index>>;
+    fn registry_api(&self) -> Result<Arc<RegistryApi>>;
     fn repository_stats_updater(&self) -> Result<Arc<RepositoryStatsUpdater>>;
     fn runtime(&self) -> Result<Arc<Runtime>>;
 }

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -2,7 +2,7 @@ use crate::{
     db::types::Feature,
     docbuilder::{BuildResult, DocCoverage},
     error::Result,
-    index::api::{CrateData, CrateOwner, ReleaseData},
+    registry_api::{CrateData, CrateOwner, ReleaseData},
     storage::CompressionAlgorithm,
     utils::MetadataPackage,
     web::crate_details::CrateDetails,

--- a/src/db/delete.rs
+++ b/src/db/delete.rs
@@ -194,7 +194,7 @@ fn delete_crate_from_database(conn: &mut Client, name: &str, crate_id: i32) -> R
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::index::api::CrateOwner;
+    use crate::registry_api::CrateOwner;
     use crate::test::{assert_success, wrapper};
     use postgres::Client;
     use test_case::test_case;

--- a/src/index.rs
+++ b/src/index.rs
@@ -3,72 +3,40 @@ use std::{path::PathBuf, process::Command};
 
 use anyhow::Context;
 use crates_index_diff::gix;
-use url::Url;
 
-use self::api::Api;
 use crate::error::Result;
 use crate::utils::report_error;
 
-pub(crate) mod api;
-
 pub struct Index {
     path: PathBuf,
-    api: Api,
     repository_url: Option<String>,
 }
 
-#[derive(Debug, serde::Deserialize, Clone)]
-#[serde(rename_all = "kebab-case")]
-struct IndexConfig {
-    #[serde(default)]
-    api: Option<Url>,
-}
-
-/// Inspects the given repository to find the config as specified in [RFC 2141][], assumes that the
-/// repository has a remote called `origin` and that the branch `master` exists on it.
-///
-/// [RFC 2141]: https://rust-lang.github.io/rfcs/2141-alternative-registries.html
-fn load_config(repo: &gix::Repository) -> Result<IndexConfig> {
-    let file = repo
-        .rev_parse_single("refs/remotes/origin/master:config.json")
-        .with_context(|| anyhow::anyhow!("registry index missing ./config.json in root"))?
-        .object()?;
-
-    let config = serde_json::from_slice(&file.data)?;
-    Ok(config)
-}
-
 impl Index {
-    pub fn from_url(path: PathBuf, url: String, max_api_call_retries: u32) -> Result<Self> {
-        let diff = crates_index_diff::Index::from_path_or_cloned_with_options(
+    pub fn from_url(path: PathBuf, url: String) -> Result<Self> {
+        crates_index_diff::Index::from_path_or_cloned_with_options(
             &path,
             gix::progress::Discard,
             &AtomicBool::default(),
             crates_index_diff::index::CloneOptions { url: url.clone() },
         )
+        .map(|_| ())
         .context("initialising registry index repository")?;
 
-        let config = load_config(diff.repository()).context("loading registry config")?;
-        let api = Api::new(config.api, max_api_call_retries)
-            .context("initialising registry api client")?;
         Ok(Self {
             path,
-            api,
             repository_url: Some(url),
         })
     }
 
-    pub fn new(path: PathBuf, max_api_call_retries: u32) -> Result<Self> {
+    pub fn new(path: PathBuf) -> Result<Self> {
         // This initializes the repository, then closes it afterwards to avoid leaking file descriptors.
         // See https://github.com/rust-lang/docs.rs/pull/847
-        let diff = crates_index_diff::Index::from_path_or_cloned(&path)
+        crates_index_diff::Index::from_path_or_cloned(&path)
+            .map(|_| ())
             .context("initialising registry index repository")?;
-        let config = load_config(diff.repository()).context("loading registry config")?;
-        let api = Api::new(config.api, max_api_call_retries)
-            .context("initialising registry api client")?;
         Ok(Self {
             path,
-            api,
             repository_url: None,
         })
     }
@@ -100,10 +68,6 @@ impl Index {
         let mut index = crates_index::GitIndex::with_path(&self.path, repo_url)?;
         index.update()?;
         Ok(index)
-    }
-
-    pub fn api(&self) -> &Api {
-        &self.api
     }
 
     pub fn run_git_gc(&self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub use self::docbuilder::PackageKind;
 pub use self::docbuilder::RustwideBuilder;
 pub use self::index::Index;
 pub use self::metrics::{InstanceMetrics, ServiceMetrics};
+pub use self::registry_api::RegistryApi;
 pub use self::storage::{AsyncStorage, Storage};
 pub use self::web::{start_background_metrics_webserver, start_web_server};
 
@@ -21,6 +22,7 @@ mod docbuilder;
 mod error;
 pub mod index;
 pub mod metrics;
+mod registry_api;
 pub mod repositories;
 pub mod storage;
 #[cfg(test)]

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -2,7 +2,7 @@ use super::TestDatabase;
 
 use crate::docbuilder::{BuildResult, DocCoverage};
 use crate::error::Result;
-use crate::index::api::{CrateData, CrateOwner, ReleaseData};
+use crate::registry_api::{CrateData, CrateOwner, ReleaseData};
 use crate::storage::{rustdoc_archive_path, source_archive_path, Storage};
 use crate::utils::{Dependency, MetadataPackage, Target};
 use anyhow::Context;

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -666,7 +666,7 @@ pub(crate) async fn get_all_platforms(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::index::api::CrateOwner;
+    use crate::registry_api::CrateOwner;
     use crate::test::{
         assert_cache_control, assert_redirect, assert_redirect_cached, wrapper, TestDatabase,
         TestEnvironment,

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -163,10 +163,9 @@ async fn get_search_results(
             .unwrap()
     });
 
-    let url = url::Url::parse(&format!(
-        "{}/api/v1/crates{query_params}",
-        config.registry_api_host
-    ))?;
+    let url = config
+        .registry_api_host
+        .join(&format!("/api/v1/crates{query_params}"))?;
     debug!("fetching search results from {}", url);
 
     // extract the query from the query args.
@@ -747,7 +746,7 @@ pub(crate) async fn build_queue_handler(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::index::api::CrateOwner;
+    use crate::registry_api::CrateOwner;
     use crate::test::{
         assert_redirect, assert_redirect_unchecked, assert_success, wrapper, TestFrontend,
     };
@@ -899,7 +898,7 @@ mod tests {
         wrapper(|env| {
             let mut crates_io = mockito::Server::new();
             env.override_config(|config| {
-                config.registry_api_host = crates_io.url();
+                config.registry_api_host = crates_io.url().parse().unwrap();
             });
 
             let web = env.frontend();
@@ -985,7 +984,7 @@ mod tests {
             let mut crates_io = mockito::Server::new();
             env.override_config(|config| {
                 config.crates_io_api_call_retries = 0;
-                config.registry_api_host = crates_io.url();
+                config.registry_api_host = crates_io.url().parse().unwrap();
             });
 
             let _m = crates_io
@@ -1013,7 +1012,7 @@ mod tests {
         wrapper(|env| {
             let mut crates_io = mockito::Server::new();
             env.override_config(|config| {
-                config.registry_api_host = crates_io.url();
+                config.registry_api_host = crates_io.url().parse().unwrap();
             });
 
             let web = env.frontend();
@@ -1060,7 +1059,7 @@ mod tests {
         wrapper(|env| {
             let mut crates_io = mockito::Server::new();
             env.override_config(|config| {
-                config.registry_api_host = crates_io.url();
+                config.registry_api_host = crates_io.url().parse().unwrap();
             });
 
             let web = env.frontend();
@@ -1107,7 +1106,7 @@ mod tests {
         wrapper(|env| {
             let mut crates_io = mockito::Server::new();
             env.override_config(|config| {
-                config.registry_api_host = crates_io.url();
+                config.registry_api_host = crates_io.url().parse().unwrap();
             });
 
             let web = env.frontend();


### PR DESCRIPTION
As mentioned in #2269, we don't want to have a crates.io-index on the build server just to lookup the index base url. We're already passing it in as config for accessing the search API, so just use that when we want to access the api to update release metadata too.