### PR TITLE
Remove unused `rustc_resource_suffix` tera function and `TemplateContext` type

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -586,8 +586,7 @@ impl TestFrontend {
         }
 
         debug!("loading template data");
-        let template_data =
-            Arc::new(TemplateData::new(&mut context.pool().unwrap().get().unwrap(), 1).unwrap());
+        let template_data = Arc::new(TemplateData::new(1).unwrap());
 
         debug!("binding local TCP port for axum");
         let axum_listener =

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -343,10 +343,7 @@ pub fn start_background_metrics_webserver(
 
 #[instrument(skip_all)]
 pub fn start_web_server(addr: Option<SocketAddr>, context: &dyn Context) -> Result<(), Error> {
-    let template_data = Arc::new(TemplateData::new(
-        &mut *context.pool()?.get()?,
-        context.config()?.render_threads,
-    )?);
+    let template_data = Arc::new(TemplateData::new(context.config()?.render_threads)?);
 
     let axum_addr = addr.unwrap_or(DEFAULT_BIND);
 

--- a/src/web/page/web_page.rs
+++ b/src/web/page/web_page.rs
@@ -9,7 +9,6 @@ use axum::{
 };
 use futures_util::future::{BoxFuture, FutureExt};
 use http::header::CONTENT_LENGTH;
-use serde::Serialize;
 use std::sync::Arc;
 use tera::Context;
 
@@ -109,13 +108,6 @@ macro_rules! impl_axum_webpage {
             }
         }
     };
-}
-
-#[derive(Serialize)]
-struct TemplateContext<'a, T> {
-    csp_nonce: &'a str,
-    #[serde(flatten)]
-    page: &'a T,
 }
 
 /// adding this to the axum response extensions will lead


### PR DESCRIPTION
Working slowly towards replacing `tera` with `askama` and I realized that some things were not actually used so I removed them.