### PR TITLE
Remove unused macro_link `extra_classes` argument

### DIFF
--- a/templates/macros.html
+++ b/templates/macros.html
@@ -20,9 +20,9 @@
     * `target` An optional target
     * `extra_classes` Optional extra css classes
 #}
-{% macro menu_link(href, text, target="", extra_classes="") %}
+{% macro menu_link(href, text, target="") %}
     <li class="pure-menu-item">
-        <a class="pure-menu-link {{ extra_classes }}" href="{{ href }}" {% if target != "" -%} target="{{ target }}" {%- endif %}>
+        <a class="pure-menu-link" href="{{ href }}" {% if target != "" -%} target="{{ target }}" {%- endif %}>
             {{ text }}
         </a>
     </li>


### PR DESCRIPTION
Another thing I noticed while going through my switch from `tera` to `askama`.