### PR TITLE
Fix incorrect `end_macro` statement

### DIFF
--- a/templates/macros.html
+++ b/templates/macros.html
@@ -26,7 +26,7 @@
             {{ text }}
         </a>
     </li>
-{% endmacro active_link %}
+{% endmacro menu_link %}
 
 {#
     Creates a formatted table showing the resource limits of a crate


### PR DESCRIPTION
The `active_link` macro is above this one, the `end_macro` is completely wrong here.