### PR TITLE
migrate web::releases to sqlx, set up sqlx db pool for production

### DIFF
--- a/.sqlx/query-340670c2844a0e5df3b5384a8c3a92c3ad35bd1484a6ef9fa02d508f65c7c3ec.json
+++ b/.sqlx/query-340670c2844a0e5df3b5384a8c3a92c3ad35bd1484a6ef9fa02d508f65c7c3ec.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH dates AS (\n               -- we need this series so that days in the statistic that don't have any releases are included\n               SELECT generate_series(\n                       CURRENT_DATE - INTERVAL '30 days',\n                       CURRENT_DATE - INTERVAL '1 day',\n                       '1 day'::interval\n                   )::date AS date_\n           ),\n           release_stats AS (\n               SELECT\n                   release_time::date AS date_,\n                   COUNT(*) AS counts,\n                   SUM(CAST((is_library = TRUE AND build_status = FALSE) AS INT)) AS failures\n               FROM\n                   releases\n               WHERE\n                   release_time >= CURRENT_DATE - INTERVAL '30 days' AND\n                   release_time < CURRENT_DATE\n               GROUP BY\n                   release_time::date\n           )\n           SELECT\n               dates.date_ AS \"date!\",\n               COALESCE(rs.counts, 0) AS \"counts!\",\n               COALESCE(rs.failures, 0) AS \"failures!\"\n           FROM\n               dates\n               LEFT OUTER JOIN Release_stats AS rs ON dates.date_ = rs.date_\n\n               ORDER BY\n                   dates.date_\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "date!",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 1,
+        "name": "counts!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "failures!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "340670c2844a0e5df3b5384a8c3a92c3ad35bd1484a6ef9fa02d508f65c7c3ec"
+}

--- a/.sqlx/query-545ccf8362ae92d921df5da730c10e24ddda6f411a0f5c9461f8ee5f6231c5b4.json
+++ b/.sqlx/query-545ccf8362ae92d921df5da730c10e24ddda6f411a0f5c9461f8ee5f6231c5b4.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n               crates.name,\n               releases.version,\n               releases.description,\n               builds.build_time,\n               releases.target_name,\n               releases.rustdoc_status,\n               repositories.stars as \"stars?\"\n\n           FROM crates\n           INNER JOIN releases ON crates.latest_version_id = releases.id\n           INNER JOIN builds ON releases.id = builds.rid\n           LEFT JOIN repositories ON releases.repository_id = repositories.id\n\n           WHERE crates.name = ANY($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "build_time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "target_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "rustdoc_status",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "stars?",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "545ccf8362ae92d921df5da730c10e24ddda6f411a0f5c9461f8ee5f6231c5b4"
+}

--- a/.sqlx/query-bdddad099e891bb45ba3703d7144160056d6cb620c55be459ead0f95c3523035.json
+++ b/.sqlx/query-bdddad099e891bb45ba3703d7144160056d6cb620c55be459ead0f95c3523035.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH params AS (\n            -- get maximum possible id-value in crates-table\n            SELECT last_value AS max_id FROM crates_id_seq\n        )\n        SELECT\n            crates.name,\n            releases.version,\n            releases.target_name\n        FROM (\n            -- generate random numbers in the ID-range.\n            SELECT DISTINCT 1 + trunc(random() * params.max_id)::INTEGER AS id\n            FROM params, generate_series(1, $1)\n        ) AS r\n        INNER JOIN crates ON r.id = crates.id\n        INNER JOIN releases ON crates.latest_version_id = releases.id\n        INNER JOIN repositories ON releases.repository_id = repositories.id\n        WHERE\n            releases.rustdoc_status = TRUE AND\n            repositories.stars >= 100\n        LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "target_name",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "bdddad099e891bb45ba3703d7144160056d6cb620c55be459ead0f95c3523035"
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ pub struct Config {
 
     // Database connection params
     pub(crate) database_url: String,
+    pub(crate) max_legacy_pool_size: u32,
     pub(crate) max_pool_size: u32,
     pub(crate) min_pool_idle: u32,
 
@@ -148,7 +149,8 @@ impl Config {
             prefix: prefix.clone(),
 
             database_url: require_env("DOCSRS_DATABASE_URL")?,
-            max_pool_size: env("DOCSRS_MAX_POOL_SIZE", 90)?,
+            max_legacy_pool_size: env("DOCSRS_MAX_LEGACY_POOL_SIZE", 45)?,
+            max_pool_size: env("DOCSRS_MAX_POOL_SIZE", 45)?,
             min_pool_idle: env("DOCSRS_MIN_POOL_IDLE", 10)?,
 
             storage_backend: env("DOCSRS_STORAGE_BACKEND", StorageKind::Database)?,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -9,7 +9,7 @@ pub use self::{
     file::{add_path_into_database, add_path_into_remote_archive},
     migrate::migrate,
     overrides::Overrides,
-    pool::{Pool, PoolClient, PoolError},
+    pool::{AsyncPoolClient, Pool, PoolClient, PoolError},
 };
 
 mod add_package;


### PR DESCRIPTION
This migrates the first batch of handlers to sqlx / async database. 
I introduced a second setting for the async pool size so be able to update the sizes depending on the errors or usage. 

Generally I don't like having `block_on` in the test-case, I would prefer using `tokio::test` (or `sqlx::test`) for that, but that needs more refactoring. 