### PR TITLE
Mark sqlx files as generated for github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 *.sh eol=lf
-/.sqlx/* binary
+/.sqlx/* binary linguist-generated=true


### PR DESCRIPTION
Based on https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github it appears github doesn't use the normal `binary` annotation but needs its own.