### PR TITLE
Don't record badge requests as 'rustdoc page'

### DIFF
--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -306,7 +306,7 @@ pub(super) fn build_axum_routes() -> AxumRouter {
         )
         .route(
             "/:name/badge.svg",
-            get_rustdoc(super::rustdoc::badge_handler),
+            get_internal(super::rustdoc::badge_handler),
         )
         .route(
             "/:name",


### PR DESCRIPTION
I just happened to be trying to look at our badge request volume, and realised we don't record it :pensive:.