### PR TITLE
Update setup documentation to update the toolchain before the first build

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ docker-compose up -d db s3
 mcli policy set download docsrs/rust-docs-rs
 # Setup the database you just created
 cargo run -- database migrate
-# Build a sample crate to make sure it works
+# Update the currently used toolchain to the latest nightly
 # This also sets up the docs.rs build environment.
 # This will take a while the first time but will be cached afterwards.
+cargo run -- build update-toolchain
+# Build a sample crate to make sure it works
 cargo run -- build crate regex 1.3.1
-# Generate important files for the web navigation
-cargo run -- build add-essential-files
 # This starts the web server but does not build any crates.
 # It does not automatically run the migrations, so you need to do that manually (see above).
 cargo run -- start-web-server


### PR DESCRIPTION
The `update-toolchain` command also integrates the `add-essential-files` step so that no longer needs to be run separately.