### PR TITLE
add sort by select-box for searching crate

### DIFF
--- a/static/keyboard.js
+++ b/static/keyboard.js
@@ -110,6 +110,18 @@
         }
     }
 
+    function handleSortByChange() {
+        const inputSearch = document.getElementById("nav-search");
+        const searchForm = document.getElementById("nav-search-form");
+        if (inputSearch.value && searchForm) {
+            searchForm.submit()
+        }
+    }
+    const searchSortBySel = document.getElementById("nav-sort");
+    if (searchSortBySel) {
+        searchSortBySel.addEventListener("change", handleSortByChange)
+    }
+
     document.onkeypress = handleKey;
     document.onkeydown = handleKey;
 })();

--- a/templates/header/topbar_begin.html
+++ b/templates/header/topbar_begin.html
@@ -8,6 +8,7 @@
         <div class="pure-menu pure-menu-horizontal" role="navigation" aria-label="Main navigation">
             <form action="/releases/search"
                   method="GET"
+                  id="nav-search-form"
                   class="landing-search-form-nav {%
                   if is_latest_version is defined and not is_latest_version %}not-latest{% endif
                   %} {% if metadata.yanked %}yanked{% endif %}">

--- a/templates/header/topbar_end.html
+++ b/templates/header/topbar_end.html
@@ -67,19 +67,6 @@
                     <input id="nav-search" name="query" type="text" aria-label="Find crate by search query" tabindex="-1"
                         placeholder="Find crate" {%- if search_query %} value="{{ search_query }}" {%- endif %}>
                 </div>
-                {# The sort by select-box #}
-                <div id="search-select-nav"> 
-                    <label for="nav-sort">
-                        {{ "list" | fas }}
-                    </label>
-                    <select name="sort" id="nav-sort" aria-label="Find crate by the sort by select-box"  tabindex="-1">
-                        <option value="relevance" {%- if search_sort_by and search_sort_by == "relevance" %} selected="selected" {%- endif %}>Relevance</option>
-                        <option value="downloads" {%- if search_sort_by and search_sort_by == "downloads" %} selected="selected" {%- endif %}>All-Time Downloads</option>
-                        <option value="recent-downloads" {%- if search_sort_by and search_sort_by == "recent-downloads" %} selected="selected" {%- endif %}>Recent Downloads</option>
-                        <option value="recent-updates" {%- if search_sort_by and search_sort_by == "recent-updates" %} selected="selected" {%- endif %}>Recent Updates</option>
-                        <option value="new" {%- if search_sort_by and search_sort_by == "new" %} selected="selected" {%- endif %}>Newly Added</option>
-                    </select>
-                </div>
             </form>
         </div>
     </div>

--- a/templates/header/topbar_end.html
+++ b/templates/header/topbar_end.html
@@ -67,6 +67,19 @@
                     <input id="nav-search" name="query" type="text" aria-label="Find crate by search query" tabindex="-1"
                         placeholder="Find crate" {%- if search_query %} value="{{ search_query }}" {%- endif %}>
                 </div>
+                {# The sort by select-box #}
+                <div id="search-select-nav"> 
+                    <label for="nav-sort">
+                        {{ "list" | fas }}
+                    </label>
+                    <select name="sort" id="nav-sort" aria-label="Find crate by the sort by select-box"  tabindex="-1">
+                        <option value="relevance" {%- if search_sort_by and search_sort_by == "relevance" %} selected="selected" {%- endif %}>Relevance</option>
+                        <option value="downloads" {%- if search_sort_by and search_sort_by == "downloads" %} selected="selected" {%- endif %}>All-Time Downloads</option>
+                        <option value="recent-downloads" {%- if search_sort_by and search_sort_by == "recent-downloads" %} selected="selected" {%- endif %}>Recent Downloads</option>
+                        <option value="recent-updates" {%- if search_sort_by and search_sort_by == "recent-updates" %} selected="selected" {%- endif %}>Recent Updates</option>
+                        <option value="new" {%- if search_sort_by and search_sort_by == "new" %} selected="selected" {%- endif %}>Newly Added</option>
+                    </select>
+                </div>
             </form>
         </div>
     </div>

--- a/templates/releases/releases.html
+++ b/templates/releases/releases.html
@@ -22,6 +22,7 @@ centered
 {%- block body -%}
     <div class="container">
         <div class="recent-releases-container">
+            {%- block sort_by %}{% endblock sort_by -%}
             <ul>
                 {# TODO: If there are no releases, then display a message that says so #}
                 {%- for release in releases -%}

--- a/templates/releases/search_results.html
+++ b/templates/releases/search_results.html
@@ -1,5 +1,23 @@
 {%- extends "releases/releases.html" -%}
 
+{% block sort_by %}
+<div id="search-select-nav"> 
+    <div class="item-end">
+        <span>Sort by</span>
+        <label for="nav-sort">
+            {{ "list" | fas }}
+        </label>
+        <select form="nav-search-form" name="sort" id="nav-sort" aria-label="Find crate by the sort by select-box"  tabindex="-1">
+            <option value="relevance" {%- if search_sort_by and search_sort_by == "relevance" %} selected="selected" {%- endif %}>Relevance</option>
+            <option value="downloads" {%- if search_sort_by and search_sort_by == "downloads" %} selected="selected" {%- endif %}>All-Time Downloads</option>
+            <option value="recent-downloads" {%- if search_sort_by and search_sort_by == "recent-downloads" %} selected="selected" {%- endif %}>Recent Downloads</option>
+            <option value="recent-updates" {%- if search_sort_by and search_sort_by == "recent-updates" %} selected="selected" {%- endif %}>Recent Updates</option>
+            <option value="new" {%- if search_sort_by and search_sort_by == "new" %} selected="selected" {%- endif %}>Newly Added</option>
+        </select>
+    </div>
+</div>
+{% endblock sort_by %}
+
 {% block pagination %}
     {%- if previous_page_link -%}
         <a class="pure-button pure-button-normal" href="{{ previous_page_link|safe }}">

--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -99,7 +99,7 @@ div.nav-container {
         display: flex;
         flex-direction: row;
 
-        #search-input-nav {
+        #search-input-nav, #search-select-nav {
             max-width: 150px;
             display: none;
             border-left: 1px solid var(--color-border);
@@ -120,7 +120,7 @@ div.nav-container {
                 font-size: 12.8px;
             }
 
-            input {
+            input, select {
                 border: none;
                 margin: 0 1em 0 0;
                 font-size: 12.8px;
@@ -130,7 +130,7 @@ div.nav-container {
             }
         }
 
-        input.search-input-nav:focus {
+        input.search-input-nav:focus,  select.search-select-nav:focus {
             outline: unset;
         }
 
@@ -363,7 +363,7 @@ div.nav-container {
     }
 }
 
-#nav-search {
+#nav-search, #nav-sort {
     color: var(--color-navbar-standard);
 }
 

--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -99,7 +99,7 @@ div.nav-container {
         display: flex;
         flex-direction: row;
 
-        #search-input-nav, #search-select-nav {
+        #search-input-nav {
             max-width: 150px;
             display: none;
             border-left: 1px solid var(--color-border);
@@ -130,7 +130,7 @@ div.nav-container {
             }
         }
 
-        input.search-input-nav:focus,  select.search-select-nav:focus {
+        input.search-input-nav:focus {
             outline: unset;
         }
 

--- a/templates/style/_vars.scss
+++ b/templates/style/_vars.scss
@@ -7,6 +7,7 @@ $font-family-mono: "Source Code Pro", Menlo, Monaco, Consolas, "DejaVu Sans Mono
 
 // Sizes
 $top-navbar-height: 32px; // height of the floating top navbar
+$search-result-right-left-padding: 1em; // Size of the right and left padding for the search results
 
 // Pure compatible media queries
 // usage:

--- a/templates/style/style.scss
+++ b/templates/style/style.scss
@@ -241,6 +241,15 @@ div.landing {
     }
 }
 
+#search-select-nav {
+    display: flex;
+    flex-direction: column;
+
+    .item-end {
+        align-self: flex-end
+    }
+}
+
 div.recent-releases-container {
     text-align: left;
     padding-bottom: 50px;

--- a/templates/style/style.scss
+++ b/templates/style/style.scss
@@ -244,6 +244,7 @@ div.landing {
 #search-select-nav {
     display: flex;
     flex-direction: column;
+    padding: 1em $search-result-right-left-padding;
 
     .item-end {
         align-self: flex-end
@@ -282,7 +283,7 @@ div.recent-releases-container {
     .release {
         display: block;
         border-bottom: 1px solid var(--color-border);
-        padding: 0.4em 1em;
+        padding: 0.4em $search-result-right-left-padding;
         color: var(--color-standard);
 
         a {


### PR DESCRIPTION
This PR for https://github.com/rust-lang/docs.rs/issues/2152

The main features are:

- Add a drop-down selection box to the top right of the search result to support searching by category. This prototype comes from crates-io, so the main drop-down options also come from it. 
- Another improvement is that when the dropdown option is changed, the search will be triggered if there is content in the search box

In the end, I didn't find a good way to test it, so I built some packages locally, changed the drop-down options, and saw how the results returned compared to crates-io.

the finally look is:


![image](https://github.com/rust-lang/docs.rs/assets/18266718/9e59a643-bb3b-43d8-b05f-a9144f48522f)

