### PR TITLE
upgrade tracing-log, zstd, gix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33bc10579ea08741ae173928194b6c42c90b295d51ddd0d18238eaf15502ac87"
 dependencies = [
- "gix",
+ "gix 0.54.1",
  "hex",
  "home",
  "memchr",
@@ -1151,7 +1151,7 @@ checksum = "47853e52d7d4ed77e354fca702c7af2ef62b4f54924cd0c3d3aa65d7b5c29fcc"
 dependencies = [
  "ahash 0.8.6",
  "bstr",
- "gix",
+ "gix 0.54.1",
  "hashbrown 0.14.2",
  "hex",
  "serde",
@@ -1547,7 +1547,7 @@ dependencies = [
  "font-awesome-as-a-crate",
  "futures-util",
  "getrandom 0.2.10",
- "gix",
+ "gix 0.55.2",
  "grass",
  "hostname",
  "http",
@@ -2063,46 +2063,87 @@ version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad6d32e74454459690d57d18ea4ebec1629936e6b130b51d12cb4a81630ac953"
 dependencies = [
- "gix-actor",
+ "gix-actor 0.27.0",
  "gix-attributes",
- "gix-commitgraph",
- "gix-config",
+ "gix-commitgraph 0.21.0",
+ "gix-config 0.30.0",
  "gix-credentials",
  "gix-date",
- "gix-diff",
- "gix-discover",
- "gix-features",
+ "gix-diff 0.36.0",
+ "gix-discover 0.25.0",
+ "gix-features 0.35.0",
  "gix-filter",
- "gix-fs",
- "gix-glob",
+ "gix-fs 0.7.0",
+ "gix-glob 0.13.0",
  "gix-hash",
  "gix-hashtable",
  "gix-ignore",
  "gix-index",
- "gix-lock",
+ "gix-lock 10.0.0",
  "gix-macros",
  "gix-negotiate",
- "gix-object",
- "gix-odb",
- "gix-pack",
+ "gix-object 0.37.0",
+ "gix-odb 0.53.0",
+ "gix-pack 0.43.0",
  "gix-path",
  "gix-pathspec",
  "gix-prompt",
  "gix-protocol",
- "gix-ref",
- "gix-refspec",
- "gix-revision",
- "gix-revwalk",
+ "gix-ref 0.37.0",
+ "gix-refspec 0.18.0",
+ "gix-revision 0.22.0",
+ "gix-revwalk 0.8.0",
  "gix-sec",
  "gix-submodule",
- "gix-tempfile",
+ "gix-tempfile 10.0.0",
  "gix-trace",
  "gix-transport",
- "gix-traverse",
- "gix-url",
+ "gix-traverse 0.33.0",
+ "gix-url 0.24.0",
  "gix-utils",
  "gix-validate",
  "gix-worktree",
+ "once_cell",
+ "parking_lot",
+ "smallvec",
+ "thiserror",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "002667cd1ebb789313d0d0afe3d23b2821cf3b0e91605095f0e6d8751f0ceeea"
+dependencies = [
+ "gix-actor 0.28.0",
+ "gix-commitgraph 0.22.0",
+ "gix-config 0.31.0",
+ "gix-date",
+ "gix-diff 0.37.0",
+ "gix-discover 0.26.0",
+ "gix-features 0.36.0",
+ "gix-fs 0.8.0",
+ "gix-glob 0.14.0",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-lock 11.0.0",
+ "gix-macros",
+ "gix-object 0.38.0",
+ "gix-odb 0.54.0",
+ "gix-pack 0.44.0",
+ "gix-path",
+ "gix-ref 0.38.0",
+ "gix-refspec 0.19.0",
+ "gix-revision 0.23.0",
+ "gix-revwalk 0.9.0",
+ "gix-sec",
+ "gix-tempfile 11.0.0",
+ "gix-trace",
+ "gix-traverse 0.34.0",
+ "gix-url 0.25.1",
+ "gix-utils",
+ "gix-validate",
  "once_cell",
  "parking_lot",
  "smallvec",
@@ -2125,6 +2166,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-actor"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "948a5f9e43559d16faf583694f1c742eb401ce24ce8e6f2238caedea7486433c"
+dependencies = [
+ "bstr",
+ "btoi",
+ "gix-date",
+ "itoa 1.0.9",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
 name = "gix-attributes"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2132,7 +2187,7 @@ checksum = "2451665e70709ba4753b623ef97511ee98c4a73816b2c5b5df25678d607ed820"
 dependencies = [
  "bstr",
  "byteyarn",
- "gix-glob",
+ "gix-glob 0.13.0",
  "gix-path",
  "gix-quote",
  "gix-trace",
@@ -2176,7 +2231,21 @@ checksum = "e75a975ee22cf0a002bfe9b5d5cb3d2a88e263a8a178cd7509133cff10f4df8a"
 dependencies = [
  "bstr",
  "gix-chunk",
- "gix-features",
+ "gix-features 0.35.0",
+ "gix-hash",
+ "memmap2",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8bc78b1a6328fa6d8b3a53b6c73997af37fd6bfc1d6c49f149e63bda5cbb36"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-features 0.36.0",
  "gix-hash",
  "memmap2",
  "thiserror",
@@ -2190,10 +2259,31 @@ checksum = "c171514b40487d3f677ae37efc0f45ac980e3169f23c27eb30a70b47fdf88ab5"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features",
- "gix-glob",
+ "gix-features 0.35.0",
+ "gix-glob 0.13.0",
  "gix-path",
- "gix-ref",
+ "gix-ref 0.37.0",
+ "gix-sec",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+ "winnow",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cae98c6b4c66c09379bc35274b172587d6b0ac369a416c39128ad8c6454f9bb"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features 0.36.0",
+ "gix-glob 0.14.0",
+ "gix-path",
+ "gix-ref 0.38.0",
  "gix-sec",
  "memchr",
  "once_cell",
@@ -2228,7 +2318,7 @@ dependencies = [
  "gix-path",
  "gix-prompt",
  "gix-sec",
- "gix-url",
+ "gix-url 0.24.0",
  "thiserror",
 ]
 
@@ -2251,8 +2341,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "788ddb152c388206e81f36bcbb574e7ed7827c27d8fa62227b34edc333d8928c"
 dependencies = [
  "gix-hash",
- "gix-object",
+ "gix-object 0.37.0",
  "imara-diff",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931394f69fb8c9ed6afc0aae3487bd869e936339bcc13ed8884472af072e0554"
+dependencies = [
+ "gix-hash",
+ "gix-object 0.38.0",
  "thiserror",
 ]
 
@@ -2266,7 +2367,22 @@ dependencies = [
  "dunce",
  "gix-hash",
  "gix-path",
- "gix-ref",
+ "gix-ref 0.37.0",
+ "gix-sec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45d5cf0321178883e38705ab2b098f625d609a7d4c391b33ac952eff2c490f2"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-hash",
+ "gix-path",
+ "gix-ref 0.38.0",
  "gix-sec",
  "thiserror",
 ]
@@ -2295,6 +2411,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-features"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f4365ba17c4f218d7fd9ec102b8d2d3cb0ca200a835e81151ace7778aec827"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "gix-hash",
+ "gix-trace",
+ "libc",
+ "once_cell",
+ "prodash",
+ "sha1_smol",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
 name = "gix-filter"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,7 +2439,7 @@ dependencies = [
  "gix-attributes",
  "gix-command",
  "gix-hash",
- "gix-object",
+ "gix-object 0.37.0",
  "gix-packetline-blocking",
  "gix-path",
  "gix-quote",
@@ -2320,7 +2454,16 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09815faba62fe9b32d918b75a554686c98e43f7d48c43a80df58eb718e5c6635"
 dependencies = [
- "gix-features",
+ "gix-features 0.35.0",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd171c0cae97cd0dc57e7b4601cb1ebf596450e263ef3c02be9107272c877bd"
+dependencies = [
+ "gix-features 0.36.0",
 ]
 
 [[package]]
@@ -2331,7 +2474,19 @@ checksum = "a9d76e85f11251dcf751d2c5e918a14f562db5be6f727fd24775245653e9b19d"
 dependencies = [
  "bitflags 2.4.1",
  "bstr",
- "gix-features",
+ "gix-features 0.35.0",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fac08925dbc14d414bd02eb45ffb4cecd912d1fce3883f867bd0103c192d3e4"
+dependencies = [
+ "bitflags 2.4.1",
+ "bstr",
+ "gix-features 0.36.0",
  "gix-path",
 ]
 
@@ -2363,7 +2518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048f443a1f6b02da4205c34d2e287e3fd45d75e8e2f06cfb216630ea9bff5e3"
 dependencies = [
  "bstr",
- "gix-glob",
+ "gix-glob 0.13.0",
  "gix-path",
  "unicode-bom",
 ]
@@ -2379,12 +2534,12 @@ dependencies = [
  "btoi",
  "filetime",
  "gix-bitmap",
- "gix-features",
- "gix-fs",
+ "gix-features 0.35.0",
+ "gix-fs 0.7.0",
  "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-traverse",
+ "gix-lock 10.0.0",
+ "gix-object 0.37.0",
+ "gix-traverse 0.33.0",
  "itoa 1.0.9",
  "memmap2",
  "smallvec",
@@ -2397,7 +2552,18 @@ version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47fc96fa8b6b6d33555021907c81eb3b27635daecf6e630630bdad44f8feaa95"
 dependencies = [
- "gix-tempfile",
+ "gix-tempfile 10.0.0",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-lock"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4feb1dcd304fe384ddc22edba9dd56a42b0800032de6537728cea2f033a4f37"
+dependencies = [
+ "gix-tempfile 11.0.0",
  "gix-utils",
  "thiserror",
 ]
@@ -2420,11 +2586,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f1697bf9911c6d1b8d709b9e6ef718cb5ea5821a1b7991520125a8134448004"
 dependencies = [
  "bitflags 2.4.1",
- "gix-commitgraph",
+ "gix-commitgraph 0.21.0",
  "gix-date",
  "gix-hash",
- "gix-object",
- "gix-revwalk",
+ "gix-object 0.37.0",
+ "gix-revwalk 0.8.0",
  "smallvec",
  "thiserror",
 ]
@@ -2437,9 +2603,28 @@ checksum = "1e7e19616c67967374137bae83e950e9b518a9ea8a605069bd6716ada357fd6f"
 dependencies = [
  "bstr",
  "btoi",
- "gix-actor",
+ "gix-actor 0.27.0",
  "gix-date",
- "gix-features",
+ "gix-features 0.35.0",
+ "gix-hash",
+ "gix-validate",
+ "itoa 1.0.9",
+ "smallvec",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740f2a44267f58770a1cb3a3d01d14e67b089c7136c48d4bddbb3cfd2bf86a51"
+dependencies = [
+ "bstr",
+ "btoi",
+ "gix-actor 0.28.0",
+ "gix-date",
+ "gix-features 0.36.0",
  "gix-hash",
  "gix-validate",
  "itoa 1.0.9",
@@ -2456,10 +2641,29 @@ checksum = "8d6a392c6ba3a2f133cdc63120e9bc7aec81eef763db372c817de31febfe64bf"
 dependencies = [
  "arc-swap",
  "gix-date",
- "gix-features",
+ "gix-features 0.35.0",
  "gix-hash",
- "gix-object",
- "gix-pack",
+ "gix-object 0.37.0",
+ "gix-pack 0.43.0",
+ "gix-path",
+ "gix-quote",
+ "parking_lot",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8630b56cb80d8fa684d383dad006a66401ee8314e12fbf0e566ddad8c115143b"
+dependencies = [
+ "arc-swap",
+ "gix-date",
+ "gix-features 0.36.0",
+ "gix-hash",
+ "gix-object 0.38.0",
+ "gix-pack 0.44.0",
  "gix-path",
  "gix-quote",
  "parking_lot",
@@ -2475,17 +2679,37 @@ checksum = "7536203a45b31e1bc5694bbf90ba8da1b736c77040dd6a520db369f371eb1ab3"
 dependencies = [
  "clru",
  "gix-chunk",
- "gix-features",
+ "gix-features 0.35.0",
  "gix-hash",
  "gix-hashtable",
- "gix-object",
+ "gix-object 0.37.0",
  "gix-path",
- "gix-tempfile",
+ "gix-tempfile 10.0.0",
  "memmap2",
  "parking_lot",
  "smallvec",
  "thiserror",
  "uluru",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1431ba2e30deff1405920693d54ab231c88d7c240dd6ccc936ee223d8f8697c3"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-features 0.36.0",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.38.0",
+ "gix-path",
+ "gix-tempfile 11.0.0",
+ "memmap2",
+ "parking_lot",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -2533,7 +2757,7 @@ dependencies = [
  "bstr",
  "gix-attributes",
  "gix-config-value",
- "gix-glob",
+ "gix-glob 0.13.0",
  "gix-path",
  "thiserror",
 ]
@@ -2561,7 +2785,7 @@ dependencies = [
  "btoi",
  "gix-credentials",
  "gix-date",
- "gix-features",
+ "gix-features 0.35.0",
  "gix-hash",
  "gix-transport",
  "maybe-async",
@@ -2586,15 +2810,36 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22e6b749660b613641769edc1954132eb8071a13c32224891686091bef078de4"
 dependencies = [
- "gix-actor",
+ "gix-actor 0.27.0",
  "gix-date",
- "gix-features",
- "gix-fs",
+ "gix-features 0.35.0",
+ "gix-fs 0.7.0",
  "gix-hash",
- "gix-lock",
- "gix-object",
+ "gix-lock 10.0.0",
+ "gix-object 0.37.0",
  "gix-path",
- "gix-tempfile",
+ "gix-tempfile 10.0.0",
+ "gix-validate",
+ "memmap2",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec2f6d07ac88d2fb8007ee3fa3e801856fb9d82e7366ec0ca332eb2c9d74a52"
+dependencies = [
+ "gix-actor 0.28.0",
+ "gix-date",
+ "gix-features 0.36.0",
+ "gix-fs 0.8.0",
+ "gix-hash",
+ "gix-lock 11.0.0",
+ "gix-object 0.38.0",
+ "gix-path",
+ "gix-tempfile 11.0.0",
  "gix-validate",
  "memmap2",
  "thiserror",
@@ -2609,7 +2854,21 @@ checksum = "0895cb7b1e70f3c3bd4550c329e9f5caf2975f97fcd4238e05754e72208ef61e"
 dependencies = [
  "bstr",
  "gix-hash",
- "gix-revision",
+ "gix-revision 0.22.0",
+ "gix-validate",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccb0974cc41dbdb43a180c7f67aa481e1c1e160fcfa8f4a55291fd1126c1a6e7"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-revision 0.23.0",
  "gix-validate",
  "smallvec",
  "thiserror",
@@ -2625,8 +2884,24 @@ dependencies = [
  "gix-date",
  "gix-hash",
  "gix-hashtable",
- "gix-object",
- "gix-revwalk",
+ "gix-object 0.37.0",
+ "gix-revwalk 0.8.0",
+ "gix-trace",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ca97ac73459a7f3766aa4a5638a6e37d56d4c7962bc1986fbaf4883d0772588"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.38.0",
+ "gix-revwalk 0.9.0",
  "gix-trace",
  "thiserror",
 ]
@@ -2637,11 +2912,26 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9870c6b1032f2084567710c3b2106ac603377f8d25766b8a6b7c33e6e3ca279"
 dependencies = [
- "gix-commitgraph",
+ "gix-commitgraph 0.21.0",
  "gix-date",
  "gix-hash",
  "gix-hashtable",
- "gix-object",
+ "gix-object 0.37.0",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a16d8c892e4cd676d86f0265bf9d40cefd73d8d94f86b213b8b77d50e77efae0"
+dependencies = [
+ "gix-commitgraph 0.22.0",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.38.0",
  "smallvec",
  "thiserror",
 ]
@@ -2665,11 +2955,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0150e82e9282d3f2ab2dd57a22f9f6c3447b9d9856e5321ac92d38e3e0e2b7"
 dependencies = [
  "bstr",
- "gix-config",
+ "gix-config 0.30.0",
  "gix-path",
  "gix-pathspec",
- "gix-refspec",
- "gix-url",
+ "gix-refspec 0.18.0",
+ "gix-url 0.24.0",
  "thiserror",
 ]
 
@@ -2679,7 +2969,20 @@ version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ae0978f3e11dc57290ee75ac2477c815bca1ce2fa7ed5dc5f16db067410ac4d"
 dependencies = [
- "gix-fs",
+ "gix-fs 0.7.0",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05cc2205cf10d99f70b96e04e16c55d4c7cf33efc151df1f793e29fd12a931f8"
+dependencies = [
+ "gix-fs 0.8.0",
  "libc",
  "once_cell",
  "parking_lot",
@@ -2703,11 +3006,11 @@ dependencies = [
  "curl",
  "gix-command",
  "gix-credentials",
- "gix-features",
+ "gix-features 0.35.0",
  "gix-packetline",
  "gix-quote",
  "gix-sec",
- "gix-url",
+ "gix-url 0.24.0",
  "thiserror",
 ]
 
@@ -2717,12 +3020,28 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ef04ab3643acba289b5cedd25d6f53c0430770b1d689d1d654511e6fb81ba0"
 dependencies = [
- "gix-commitgraph",
+ "gix-commitgraph 0.21.0",
  "gix-date",
  "gix-hash",
  "gix-hashtable",
- "gix-object",
- "gix-revwalk",
+ "gix-object 0.37.0",
+ "gix-revwalk 0.8.0",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14d050ec7d4e1bb76abf0636cf4104fb915b70e54e3ced9a4427c999100ff38a"
+dependencies = [
+ "gix-commitgraph 0.22.0",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object 0.38.0",
+ "gix-revwalk 0.9.0",
  "smallvec",
  "thiserror",
 ]
@@ -2734,7 +3053,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6125ecf46e8c68bf7202da6cad239831daebf0247ffbab30210d72f3856e420f"
 dependencies = [
  "bstr",
- "gix-features",
+ "gix-features 0.35.0",
+ "gix-path",
+ "home",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1b9ac8ed32ad45f9fc6c5f8c0be2ed911e544a5a19afd62d95d524ebaa95671"
+dependencies = [
+ "bstr",
+ "gix-features 0.36.0",
  "gix-path",
  "home",
  "thiserror",
@@ -2768,13 +3101,13 @@ checksum = "9f5e32972801bd82d56609e6fc84efc358fa1f11f25c5e83b7807ee2280f14fe"
 dependencies = [
  "bstr",
  "gix-attributes",
- "gix-features",
- "gix-fs",
- "gix-glob",
+ "gix-features 0.35.0",
+ "gix-fs 0.7.0",
+ "gix-glob 0.13.0",
  "gix-hash",
  "gix-ignore",
  "gix-index",
- "gix-object",
+ "gix-object 0.37.0",
  "gix-path",
 ]
 
@@ -6145,9 +6478,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
@@ -6847,20 +7180,19 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
+checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "6.0.6"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
+checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
 dependencies = [
- "libc",
  "zstd-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ sentry-anyhow = { version = "0.31.0", features = ["backtrace"] }
 log = "0.4"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", default-features = false, features = ["ansi", "fmt", "env-filter"] }
-tracing-log = "0.1.3"
+tracing-log = "0.2.0"
 regex = "1"
 clap = { version = "4.0.22", features = [ "derive" ] }
 crates-index = { version = "2.2.0", default-features = false, features = ["git", "git-performance", "parallel"], optional = true }
@@ -55,7 +55,7 @@ schemamama_postgres = "0.3"
 prometheus = { version = "0.13.0", default-features = false }
 rustwide = { version = "0.16.0", features = ["unstable-toolchain-ci", "unstable"] }
 mime_guess = "2"
-zstd = "0.12.0"
+zstd = "0.13.0"
 hostname = "0.3.1"
 path-slash = "0.2.0"
 once_cell = { version = "1.4.0", features = ["parking_lot"] }
@@ -131,7 +131,7 @@ indoc = "2.0.0"
 
 [build-dependencies]
 time = "0.3"
-gix = { version = "0.54.1", default-features = false }
+gix = { version = "0.55.2", default-features = false }
 string_cache_codegen = "0.5.1"
 walkdir = "2"
 anyhow = { version = "1.0.42", features = ["backtrace"] }


### PR DESCRIPTION
- https://github.com/tokio-rs/tracing/releases/tag/tracing-log-0.2.0 
- https://github.com/gyscos/zstd-rs/releases/tag/v0.13.0
- https://github.com/Byron/gitoxide/releases/tag/gix-v0.55.0