### PR TITLE
Don't cache the detected rustc-version, it's cheap enough to requery

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -1329,4 +1329,25 @@ mod tests {
             Ok(())
         })
     }
+
+    #[test]
+    #[ignore]
+    fn test_new_builder_detects_existing_rustc() {
+        wrapper(|env: &TestEnvironment| {
+            let mut builder = RustwideBuilder::init(env)?;
+            builder.update_toolchain()?;
+            drop(builder);
+
+            // new builder should detect the existing rustc version from the previous builder
+            // (simulating running `update-toolchain` and `build crate` in separate invocations)
+            let mut builder = RustwideBuilder::init(env)?;
+            assert!(builder.build_package(
+                DUMMY_CRATE_NAME,
+                DUMMY_CRATE_VERSION,
+                PackageKind::CratesIo
+            )?);
+
+            Ok(())
+        })
+    }
 }


### PR DESCRIPTION
Fixes the issue from https://github.com/rust-lang/docs.rs/pull/2296#issuecomment-1794893757, running local builds still fails after updating the toolchain in a separate invocation because it does not attempt to detect the version.