### PR TITLE
ci: set prefix for rust-cache to purge it once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: restore build & cargo cache
         uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "rust-cache-20231109"
 
       - name: Build
         run: cargo build --workspace --locked
@@ -72,6 +74,8 @@ jobs:
 
       - name: restore build & cargo cache
         uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "rust-cache-20231109"
 
       - name: Build
         run: cargo build --workspace --locked


### PR DESCRIPTION
As a first help for #2307. 

Then we will see how it evolves in the future, perhaps adding `cargo sweep` later. 