### PR TITLE
start migration more web endpoints to sqlx

### DIFF
--- a/.sqlx/query-5d8e187d604de870d347be77abae3a272114732644975e9dbf396f5ffe689f6b.json
+++ b/.sqlx/query-5d8e187d604de870d347be77abae3a272114732644975e9dbf396f5ffe689f6b.json
@@ -1,0 +1,71 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n                crates.name,\n                releases.version,\n                releases.description,\n                releases.target_name,\n                releases.rustdoc_status,\n                releases.default_target,\n                releases.doc_targets,\n                releases.yanked,\n                releases.doc_rustc_version\n            FROM releases\n            INNER JOIN crates ON crates.id = releases.crate_id\n            WHERE crates.name = $1 AND releases.version = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "target_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "rustdoc_status",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "default_target",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "doc_targets",
+        "type_info": "Json"
+      },
+      {
+        "ordinal": 7,
+        "name": "yanked",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "doc_rustc_version",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5d8e187d604de870d347be77abae3a272114732644975e9dbf396f5ffe689f6b"
+}

--- a/.sqlx/query-65b0ead56880b369931c3a5ec324910dde51096de4ee2ad868cc5025161ab466.json
+++ b/.sqlx/query-65b0ead56880b369931c3a5ec324910dde51096de4ee2ad868cc5025161ab466.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT crates.name,\n                releases.target_name,\n                MAX(releases.release_time) as \"release_time!\"\n         FROM crates\n         INNER JOIN releases ON releases.crate_id = crates.id\n         WHERE\n            rustdoc_status = true AND\n            crates.name ILIKE $1\n         GROUP BY crates.name, releases.target_name\n         ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "target_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "release_time!",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "65b0ead56880b369931c3a5ec324910dde51096de4ee2ad868cc5025161ab466"
+}

--- a/.sqlx/query-908827d37c731be4a6611eacd2e53aa03ae0b38047e0e58c034a3d34f8e29631.json
+++ b/.sqlx/query-908827d37c731be4a6611eacd2e53aa03ae0b38047e0e58c034a3d34f8e29631.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT releases.rustdoc_status\n                 FROM releases\n                 WHERE releases.id = $1\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "rustdoc_status",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "908827d37c731be4a6611eacd2e53aa03ae0b38047e0e58c034a3d34f8e29631"
+}

--- a/.sqlx/query-96817014a0af7e5946ecd00000ff08b5deaa12d85e1e0bb7bd845beafb0f2702.json
+++ b/.sqlx/query-96817014a0af7e5946ecd00000ff08b5deaa12d85e1e0bb7bd845beafb0f2702.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n            builds.id,\n            builds.rustc_version,\n            builds.docsrs_version,\n            builds.build_status,\n            builds.build_time\n         FROM builds\n         INNER JOIN releases ON releases.id = builds.rid\n         INNER JOIN crates ON releases.crate_id = crates.id\n         WHERE crates.name = $1 AND releases.version = $2\n         ORDER BY id DESC",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "rustc_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "docsrs_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "build_status",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "build_time",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "96817014a0af7e5946ecd00000ff08b5deaa12d85e1e0bb7bd845beafb0f2702"
+}

--- a/.sqlx/query-a7cbfecb1e270232061de05fa4a53f926d9e289dcb4b03cba3e3eeebce74dfe0.json
+++ b/.sqlx/query-a7cbfecb1e270232061de05fa4a53f926d9e289dcb4b03cba3e3eeebce74dfe0.json
@@ -1,0 +1,54 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n             builds.rustc_version,\n             builds.docsrs_version,\n             builds.build_status,\n             builds.build_time,\n             builds.output,\n             releases.default_target\n         FROM builds\n         INNER JOIN releases ON releases.id = builds.rid\n         INNER JOIN crates ON releases.crate_id = crates.id\n         WHERE builds.id = $1 AND crates.name = $2 AND releases.version = $3",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "rustc_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "docsrs_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "build_status",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 3,
+        "name": "build_time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "output",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "default_target",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "a7cbfecb1e270232061de05fa4a53f926d9e289dcb4b03cba3e3eeebce74dfe0"
+}

--- a/src/db/types.rs
+++ b/src/db/types.rs
@@ -1,7 +1,7 @@
 use postgres_types::{FromSql, ToSql};
 use serde::Serialize;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, FromSql, ToSql)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, FromSql, ToSql, sqlx::Type)]
 #[postgres(name = "feature")]
 pub struct Feature {
     pub(crate) name: String,
@@ -15,5 +15,11 @@ impl Feature {
 
     pub fn is_private(&self) -> bool {
         self.name.starts_with('_')
+    }
+}
+
+impl sqlx::postgres::PgHasArrayType for Feature {
+    fn array_type_info() -> sqlx::postgres::PgTypeInfo {
+        sqlx::postgres::PgTypeInfo::with_name("_feature")
     }
 }

--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -132,6 +132,12 @@ impl From<anyhow::Error> for AxumNope {
     }
 }
 
+impl From<sqlx::Error> for AxumNope {
+    fn from(err: sqlx::Error) -> Self {
+        AxumNope::InternalError(anyhow!(err))
+    }
+}
+
 impl From<PoolError> for AxumNope {
     fn from(err: PoolError) -> Self {
         AxumNope::InternalError(anyhow!(err))

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -618,14 +618,7 @@ impl_axum_webpage! {
     ReleaseActivity = "releases/activity.html",
 }
 
-pub(crate) async fn activity_handler(
-    Extension(pool): Extension<Pool>,
-) -> AxumResult<impl IntoResponse> {
-    let mut conn = pool
-        .get_async()
-        .await
-        .context("can't get pool connection")?;
-
+pub(crate) async fn activity_handler(mut conn: DbConnection) -> AxumResult<impl IntoResponse> {
     let rows: Vec<_> = sqlx::query!(
         r#"WITH dates AS (
                -- we need this series so that days in the statistic that don't have any releases are included


### PR DESCRIPTION
refs #874 

This migrates more web endpoints to sqlx. 

Notable omissions around `Limits` and `CrateDetails`, which should be async too, but I wanted to leave them for another PR. 

Also I want to find a better way to use async in tests, bestrefs #874 

This migrates more web endpoints to sqlx. 

Notable omissions around `Limits` and `CrateDetails`, which should be async too, but I wanted to leave them for another PR. 

Also I want to find a better way to use async in tests, best case even using `tokio::test` or even `sqlx::test`, at the least some `async_wrapper` that enables you to write `.await` in tests. Also for a separate PR.  case even using `tokio::test` or even `sqlx::test`, at the least some `async_wrapper` that enables you to write `.await` in tests. Also for a separate PR. 

Last think I also didn't do is parallelization of independent queries in a single handler, which could be investigated separately. 