### PR TITLE
use axum extractor to retrieve database connection from the pool

### DIFF
--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -1,13 +1,14 @@
-use std::borrow::Cow;
-
 use crate::{
+    db::PoolError,
     storage::PathNotFoundError,
     web::{releases::Search, AxumErrorPage},
 };
+use anyhow::anyhow;
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response as AxumResponse},
 };
+use std::borrow::Cow;
 
 #[derive(Debug, thiserror::Error)]
 #[allow(dead_code)] // FIXME: remove after iron is gone
@@ -128,6 +129,12 @@ impl From<anyhow::Error> for AxumNope {
                 Err(err) => AxumNope::InternalError(err),
             },
         }
+    }
+}
+
+impl From<PoolError> for AxumNope {
+    fn from(err: PoolError) -> Self {
+        AxumNope::InternalError(anyhow!(err))
     }
 }
 

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -1,0 +1,54 @@
+use crate::db::{AsyncPoolClient, Pool};
+use anyhow::Context as _;
+use axum::{
+    async_trait,
+    extract::{Extension, FromRequestParts},
+    http::request::Parts,
+    RequestPartsExt,
+};
+use std::ops::{Deref, DerefMut};
+
+use super::error::AxumNope;
+
+/// Extractor for a async sqlx database connection.
+/// Can be used in normal axum handlers, middleware, or other extractors.
+///
+/// For now, we will retrieve a new connection each time the extractor is used.
+///
+/// This could be optimized in the future by caching the connection as a request
+/// extension, so one request only uses on connection.
+#[derive(Debug)]
+pub(crate) struct DbConnection(AsyncPoolClient);
+
+#[async_trait]
+impl<S> FromRequestParts<S> for DbConnection
+where
+    S: Send + Sync,
+{
+    type Rejection = AxumNope;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let Extension(pool) = parts
+            .extract::<Extension<Pool>>()
+            .await
+            .context("could not extract pool extension")?;
+
+        Ok(Self(pool.get_async().await?))
+    }
+}
+
+impl Deref for DbConnection {
+    type Target = sqlx::PgConnection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for DbConnection {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+// TODO: we will write tests for this when async db tests are working

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod cache;
 pub(crate) mod crate_details;
 mod csp;
 pub(crate) mod error;
+mod extractors;
 mod features;
 mod file;
 mod headers;


### PR DESCRIPTION
This is an early morning idea that I had, which IMO reduces repetition in our handlers. 

I also thought about making `AsyncPoolClient` an extractor itself, though right now it feels better to have the separation between the extractor and the connection. 