### PR TITLE
migrate limits & overrides to sqlx / async, introduce async test wrapper

### DIFF
--- a/.sqlx/query-4f81678f0d680c4be7215ef0667729e8518063e0ee4ecad5aa7e559e88b8e1cb.json
+++ b/.sqlx/query-4f81678f0d680c4be7215ef0667729e8518063e0ee4ecad5aa7e559e88b8e1cb.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM crates WHERE crates.name = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "4f81678f0d680c4be7215ef0667729e8518063e0ee4ecad5aa7e559e88b8e1cb"
+}

--- a/.sqlx/query-73ff86cdb5b9d0ab312493690d4108803ce04531d497d6dd8d67ad05a844eab3.json
+++ b/.sqlx/query-73ff86cdb5b9d0ab312493690d4108803ce04531d497d6dd8d67ad05a844eab3.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO sandbox_overrides (\n                crate_name, max_memory_bytes, max_targets, timeout_seconds\n            )\n            VALUES ($1, $2, $3, $4)\n            ON CONFLICT (crate_name) DO UPDATE\n                SET\n                    max_memory_bytes = $2,\n                    max_targets = $3,\n                    timeout_seconds = $4\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Int8",
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "73ff86cdb5b9d0ab312493690d4108803ce04531d497d6dd8d67ad05a844eab3"
+}

--- a/.sqlx/query-de4ba149a561c4bb467bcea081bdedff233398cddf4996734a64536b6a8c6579.json
+++ b/.sqlx/query-de4ba149a561c4bb467bcea081bdedff233398cddf4996734a64536b6a8c6579.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM sandbox_overrides WHERE crate_name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "de4ba149a561c4bb467bcea081bdedff233398cddf4996734a64536b6a8c6579"
+}

--- a/src/db/overrides.rs
+++ b/src/db/overrides.rs
@@ -1,5 +1,6 @@
 use crate::error::Result;
-use postgres::Client;
+use futures_util::stream::TryStreamExt;
+use sqlx::{postgres::PgRow, FromRow, Row};
 use std::time::Duration;
 
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
@@ -9,75 +10,83 @@ pub struct Overrides {
     pub timeout: Option<Duration>,
 }
 
-impl Overrides {
-    pub fn all(conn: &mut Client) -> Result<Vec<(String, Self)>> {
-        Ok(conn
-            .query("SELECT * FROM sandbox_overrides", &[])?
-            .into_iter()
-            .map(|row| (row.get("crate_name"), Self::from_row(row)))
-            .collect())
-    }
-
-    pub fn for_crate(conn: &mut Client, krate: &str) -> Result<Option<Self>> {
-        Ok(conn
-            .query_opt(
-                "SELECT * FROM sandbox_overrides WHERE crate_name = $1",
-                &[&krate],
-            )?
-            .map(Self::from_row))
-    }
-
-    fn from_row(row: postgres::Row) -> Self {
-        Self {
+impl FromRow<'_, PgRow> for Overrides {
+    fn from_row(row: &PgRow) -> sqlx::Result<Self> {
+        Ok(Self {
             memory: row
-                .get::<_, Option<i64>>("max_memory_bytes")
+                .get::<Option<i64>, _>("max_memory_bytes")
                 .map(|i| i as usize),
-            targets: row.get::<_, Option<i32>>("max_targets").map(|i| i as usize),
+            targets: row.get::<Option<i32>, _>("max_targets").map(|i| i as usize),
             timeout: row
-                .get::<_, Option<i32>>("timeout_seconds")
+                .get::<Option<i32>, _>("timeout_seconds")
                 .map(|i| Duration::from_secs(i as u64)),
-        }
+        })
+    }
+}
+
+impl Overrides {
+    pub async fn all(conn: &mut sqlx::PgConnection) -> Result<Vec<(String, Self)>> {
+        Ok(sqlx::query("SELECT * FROM sandbox_overrides")
+            .fetch(conn)
+            .map_ok(|row| {
+                (
+                    row.get("crate_name"),
+                    Overrides::from_row(&row)
+                        .expect("this is fine because we never return Err(_) in from_row"),
+                )
+            })
+            .try_collect()
+            .await?)
     }
 
-    pub fn save(conn: &mut Client, krate: &str, overrides: Self) -> Result<()> {
+    pub async fn for_crate(conn: &mut sqlx::PgConnection, krate: &str) -> Result<Option<Self>> {
+        Ok(
+            sqlx::query_as("SELECT * FROM sandbox_overrides WHERE crate_name = $1")
+                .bind(krate)
+                .fetch_optional(conn)
+                .await?,
+        )
+    }
+
+    pub async fn save(conn: &mut sqlx::PgConnection, krate: &str, overrides: Self) -> Result<()> {
         if overrides.timeout.is_some() && overrides.targets.is_none() {
             tracing::warn!("setting `Overrides::timeout` implies a default `Overrides::targets = 1`, prefer setting this explicitly");
         }
 
-        if conn
-            .query_opt("SELECT id FROM crates WHERE crates.name = $1", &[&krate])?
+        if sqlx::query_scalar!("SELECT id FROM crates WHERE crates.name = $1", krate)
+            .fetch_optional(&mut *conn)
+            .await?
             .is_none()
         {
             tracing::warn!("setting overrides for unknown crate `{krate}`");
         }
 
-        conn.execute(
+        sqlx::query!(
             "
-                INSERT INTO sandbox_overrides (
-                    crate_name, max_memory_bytes, max_targets, timeout_seconds
-                )
-                VALUES ($1, $2, $3, $4)
-                ON CONFLICT (crate_name) DO UPDATE
-                    SET
-                        max_memory_bytes = $2,
-                        max_targets = $3,
-                        timeout_seconds = $4
-                ",
-            &[
-                &krate,
-                &overrides.memory.map(|i| i as i64),
-                &overrides.targets.map(|i| i as i32),
-                &overrides.timeout.map(|d| d.as_secs() as i32),
-            ],
-        )?;
+            INSERT INTO sandbox_overrides (
+                crate_name, max_memory_bytes, max_targets, timeout_seconds
+            )
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (crate_name) DO UPDATE
+                SET
+                    max_memory_bytes = $2,
+                    max_targets = $3,
+                    timeout_seconds = $4
+            ",
+            krate,
+            overrides.memory.map(|i| i as i64),
+            overrides.targets.map(|i| i as i32),
+            overrides.timeout.map(|d| d.as_secs() as i32),
+        )
+        .execute(&mut *conn)
+        .await?;
         Ok(())
     }
 
-    pub fn remove(conn: &mut Client, krate: &str) -> Result<()> {
-        conn.execute(
-            "DELETE FROM sandbox_overrides WHERE crate_name = $1",
-            &[&krate],
-        )?;
+    pub async fn remove(conn: &mut sqlx::PgConnection, krate: &str) -> Result<()> {
+        sqlx::query!("DELETE FROM sandbox_overrides WHERE crate_name = $1", krate)
+            .execute(conn)
+            .await?;
         Ok(())
     }
 }
@@ -87,15 +96,16 @@ mod test {
     use crate::{db::Overrides, test::*};
     use std::time::Duration;
 
-    #[test]
-    fn retrieve_overrides() {
-        wrapper(|env| {
-            let db = env.db();
+    #[tokio::test]
+    async fn retrieve_overrides() {
+        async_wrapper(|env| async move {
+            let db = env.async_db().await;
+            let mut conn = db.async_conn().await;
 
             let krate = "hexponent";
 
             // no overrides
-            let actual = Overrides::for_crate(&mut db.conn(), krate)?;
+            let actual = Overrides::for_crate(&mut conn, krate).await?;
             assert_eq!(actual, None);
 
             // add partial overrides
@@ -103,8 +113,8 @@ mod test {
                 targets: Some(1),
                 ..Overrides::default()
             };
-            Overrides::save(&mut db.conn(), krate, expected)?;
-            let actual = Overrides::for_crate(&mut db.conn(), krate)?;
+            Overrides::save(&mut conn, krate, expected).await?;
+            let actual = Overrides::for_crate(&mut conn, krate).await?;
             assert_eq!(actual, Some(expected));
 
             // overwrite with full overrides
@@ -113,8 +123,8 @@ mod test {
                 targets: Some(1),
                 timeout: Some(Duration::from_secs(300)),
             };
-            Overrides::save(&mut db.conn(), krate, expected)?;
-            let actual = Overrides::for_crate(&mut db.conn(), krate)?;
+            Overrides::save(&mut conn, krate, expected).await?;
+            let actual = Overrides::for_crate(&mut conn, krate).await?;
             assert_eq!(actual, Some(expected));
 
             // overwrite with partial overrides
@@ -122,16 +132,17 @@ mod test {
                 memory: Some(1),
                 ..Overrides::default()
             };
-            Overrides::save(&mut db.conn(), krate, expected)?;
-            let actual = Overrides::for_crate(&mut db.conn(), krate)?;
+            Overrides::save(&mut conn, krate, expected).await?;
+            let actual = Overrides::for_crate(&mut conn, krate).await?;
             assert_eq!(actual, Some(expected));
 
             // remove overrides
-            Overrides::remove(&mut db.conn(), krate)?;
-            let actual = Overrides::for_crate(&mut db.conn(), krate)?;
+            Overrides::remove(&mut conn, krate).await?;
+            let actual = Overrides::for_crate(&mut conn, krate).await?;
             assert_eq!(actual, None);
 
             Ok(())
-        });
+        })
+        .await;
     }
 }

--- a/src/db/overrides.rs
+++ b/src/db/overrides.rs
@@ -96,8 +96,8 @@ mod test {
     use crate::{db::Overrides, test::*};
     use std::time::Duration;
 
-    #[tokio::test]
-    async fn retrieve_overrides() {
+    #[test]
+    fn retrieve_overrides() {
         async_wrapper(|env| async move {
             let db = env.async_db().await;
             let mut conn = db.async_conn().await;
@@ -143,6 +143,5 @@ mod test {
 
             Ok(())
         })
-        .await;
     }
 }

--- a/src/docbuilder/limits.rs
+++ b/src/docbuilder/limits.rs
@@ -73,8 +73,8 @@ mod test {
     use super::*;
     use crate::test::*;
 
-    #[tokio::test]
-    async fn retrieve_limits() {
+    #[test]
+    fn retrieve_limits() {
         async_wrapper(|env| async move {
             let db = env.async_db().await;
             let mut conn = db.async_conn().await;
@@ -129,11 +129,10 @@ mod test {
             );
             Ok(())
         })
-        .await;
     }
 
-    #[tokio::test]
-    async fn targets_default_to_one_with_timeout() {
+    #[test]
+    fn targets_default_to_one_with_timeout() {
         async_wrapper(|env| async move {
             let db = env.async_db().await;
             let mut conn = db.async_conn().await;
@@ -152,11 +151,10 @@ mod test {
 
             Ok(())
         })
-        .await;
     }
 
-    #[tokio::test]
-    async fn config_default_memory_limit() {
+    #[test]
+    fn config_default_memory_limit() {
         async_wrapper(|env| async move {
             env.override_config(|config| {
                 config.build_default_memory_limit = Some(6 * GB);
@@ -170,11 +168,10 @@ mod test {
 
             Ok(())
         })
-        .await;
     }
 
-    #[tokio::test]
-    async fn overrides_dont_lower_memory_limit() {
+    #[test]
+    fn overrides_dont_lower_memory_limit() {
         async_wrapper(|env| async move {
             let db = env.async_db().await;
             let mut conn = db.async_conn().await;
@@ -196,6 +193,5 @@ mod test {
 
             Ok(())
         })
-        .await;
     }
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1008,7 +1008,7 @@ mod test {
         wrapper(|env| {
             release("0.1.0", env);
             let metadata = env.runtime().block_on(async move {
-                let mut conn = env.db().async_conn().await;
+                let mut conn = env.async_db().await.async_conn().await;
                 MetaData::from_crate(&mut conn, "foo", "0.1.0", "latest").await
             });
             assert_eq!(


### PR DESCRIPTION
This migrates limits & overrides to sqlx / async. 
Also this is a first idea of an `async_wrapper` for tests. 

I have some other ideas how to improve the test setup further, but since test database creation / cleanup is still sync, it's harder in this PR, and I would move the task to a later point. 