### PR TITLE
Fix position of source code pages sidebar

### DIFF
--- a/gui-tests/sidebar.goml
+++ b/gui-tests/sidebar.goml
@@ -1,0 +1,43 @@
+// Checks the sidebar display.
+go-to: |DOC_PATH| + "/sysinfo"
+
+set-window-size: (1000, 1000)
+
+// First we check that the rustdoc sidebar is not overlaying the docs.rs topbar.
+store-size: (".rustdoc-page .nav-container", {"height": topbar_height})
+assert-position: (".rustdoc .sidebar", {"y": |topbar_height|, "x": 0})
+
+// We check the same in "mobile mode".
+set-window-size: (600, 1000)
+assert-position: (".rustdoc .mobile-topbar", {"y": |topbar_height|, "x": 0})
+// We check when the sidebar is shown now.
+click: ".rustdoc .mobile-topbar .sidebar-menu-toggle"
+wait-for: ".rustdoc .sidebar.shown"
+// The mobile sidebar is supposed to be under the rustdoc mobile topbar + docs.rs topbar.
+store-size: (".rustdoc .mobile-topbar", {"height": rustdoc_topbar_height})
+assert-position: (".rustdoc .sidebar.shown", {
+    "y": |topbar_height| + |rustdoc_topbar_height|,
+    "x": 0,
+})
+
+// We reset the window's size.
+set-window-size: (1000, 1000)
+
+// We now go to the source code page.
+wait-for: ".main-heading a.src"
+click: ".main-heading a.src"
+
+// We wait for the page to load...
+wait-for: ".rustdoc.src"
+// We check that the sidebar has the correct position.
+assert-position: (".rustdoc .sidebar", {"y": |topbar_height|, "x": 0})
+// We expand the sidebar.
+click: "#src-sidebar-toggle button"
+wait-for: ".src-sidebar-expanded"
+// We check the position again.
+assert-position: (".rustdoc .sidebar", {"y": |topbar_height|, "x": 0})
+
+// We check in "mobile mode".
+set-window-size: (600, 1000)
+// We check the position again.
+assert-position: (".rustdoc .sidebar", {"y": |topbar_height|, "x": 0})

--- a/templates/style/_rustdoc-common.scss
+++ b/templates/style/_rustdoc-common.scss
@@ -55,9 +55,6 @@ div.rustdoc {
         }
 
         @media (max-width: 700px) {
-            margin-left: -2 * $padding-x; // offset the additional padding added by the parent containers
-            width: calc(100% + #{4 * $padding-x});
-
             &.mobile {
                 top: $top-navbar-height;
                 margin-left: 0; // since the sidebar is now fixed position, remove the padding workaround


### PR DESCRIPTION
Fixes https://github.com/rust-lang/docs.rs/issues/2093.

I couldn't find where those rules were actually used. I tested a lot of crates but none of them used it. I suppose it was to fix a docs.rs bug we had at some point.