### PR TITLE
Improve formatting of `rustwide` log messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ sentry-tower = { version = "0.31.0", features = ["http"] }
 sentry-anyhow = { version = "0.31.0", features = ["backtrace"] }
 log = "0.4"
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", default-features = false, features = ["ansi", "fmt", "env-filter"] }
+tracing-subscriber = { version = "0.3.16", default-features = false, features = ["ansi", "fmt", "env-filter", "tracing-log"] }
 tracing-log = "0.2.0"
 regex = "1"
 clap = { version = "4.0.22", features = [ "derive" ] }

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -41,15 +41,16 @@ fn main() {
         );
 
     let _sentry_guard = if let Ok(sentry_dsn) = env::var("SENTRY_DSN") {
-        tracing_registry
-            .with(sentry_tracing::layer().event_filter(|md| {
+        tracing::subscriber::set_global_default(tracing_registry.with(
+            sentry_tracing::layer().event_filter(|md| {
                 if md.fields().field("reported_to_sentry").is_some() {
                     sentry_tracing::EventFilter::Ignore
                 } else {
                     sentry_tracing::default_event_filter(md)
                 }
-            }))
-            .init();
+            }),
+        ))
+        .unwrap();
 
         Some(sentry::init((
             sentry_dsn,
@@ -65,7 +66,7 @@ fn main() {
             .add_integration(sentry_panic::PanicIntegration::default()),
         )))
     } else {
-        tracing_registry.init();
+        tracing::subscriber::set_global_default(tracing_registry).unwrap();
         None
     };
 


### PR DESCRIPTION
Enables `tracing-subscriber/tracing-log` feature to get its support for formatting based on these messages custom attributes. Requires manually registering the registry to avoid `tracing-subscriber` attempting to register its own `tracing-log` instance as we've already registered one through `rustwide`.

fixes #2336 