### PR TITLE
cache the homepage for a minute

### DIFF
--- a/src/web/cache.rs
+++ b/src/web/cache.rs
@@ -6,6 +6,7 @@ use http::{header::CACHE_CONTROL, HeaderValue};
 use std::sync::Arc;
 
 pub static NO_CACHING: HeaderValue = HeaderValue::from_static("max-age=0");
+pub static SHORT: HeaderValue = HeaderValue::from_static("max-age=60");
 
 pub static NO_STORE_MUST_REVALIDATE: HeaderValue =
     HeaderValue::from_static("no-cache, no-store, must-revalidate, max-age=0");
@@ -24,7 +25,12 @@ pub enum CachePolicy {
     /// * enforce revalidation
     /// * never store
     NoStoreMustRevalidate,
-    /// cache forever in browser & CDN.  
+    /// cache for a short time in the browser & CDN.
+    /// right now: one minute.
+    /// Can be used when the content can be a _little_ outdated,
+    /// while protecting agains spikes in traffic.
+    ShortInCdnAndBrowser,
+    /// cache forever in browser & CDN.
     /// Valid when you have hashed / versioned filenames and every rebuild would
     /// change the filename.
     ForeverInCdnAndBrowser,
@@ -46,6 +52,7 @@ impl CachePolicy {
         match *self {
             CachePolicy::NoCaching => Some(NO_CACHING.clone()),
             CachePolicy::NoStoreMustRevalidate => Some(NO_STORE_MUST_REVALIDATE.clone()),
+            CachePolicy::ShortInCdnAndBrowser => Some(SHORT.clone()),
             CachePolicy::ForeverInCdnAndBrowser => Some(FOREVER_IN_CDN_AND_BROWSER.clone()),
             CachePolicy::ForeverInCdn => {
                 if config.cache_invalidatable_responses {

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -1013,7 +1013,7 @@ mod test {
                 .build_result_failed()
                 .create()?;
             let web = env.frontend();
-            assert_success_cached("/", web, CachePolicy::NoCaching, &env.config())?;
+            assert_success_cached("/", web, CachePolicy::ShortInCdnAndBrowser, &env.config())?;
             assert_success_cached(
                 "/crate/buggy/0.1.0/",
                 web,


### PR DESCRIPTION
Coming from this traffic spike today: 
<img width="721" alt="grafik" src="https://github.com/rust-lang/docs.rs/assets/540890/d1f6313c-7cfb-4f19-b887-30b00a6175fb">

I just implemented a thing I had on my mind for some time already. 

When the content can be outdated for a short time, caching with a short TTL can really help with these kind of spikes. 

We might also add this to more pages. 

