### PR TITLE
add RSA rustsec warning to ignores, we don't use that dependency

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -5,6 +5,8 @@ ignore = [
 
     "RUSTSEC-2023-0018", # rustwide -> remove_dir_all,TOCTOU / Race Condition 
     # https://github.com/rust-lang/docs.rs/issues/2074
+
+    "RUSTSEC-2023-0071", # potential key recovery through timing sidechannels
 ]
 informational_warnings = ["unmaintained"] # warn for categories of informational advisories
 severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "critical")


### PR DESCRIPTION
fixes #2346 ~~Interestingly there is no issue created.~~  

Also I don't seem to find the reason why `cargo audit` warns here, 

```
Crate:     rsa
Version:   0.9.4
Title:     Marvin Attack: potential key recovery through timing sidechannels
Date:      2023-11-22
ID:        RUSTSEC-2023-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2023-0071
Severity:  7.4 (high)
Solution:  No fixed upgrade is available!
Dependency tree:
rsa 0.9.4
└── sqlx-mysql 0.7.2
    ├── sqlx-macros-core 0.7.2
    │   └── sqlx-macros 0.7.2
    │       └── sqlx 0.7.2
    │           └── docs-rs 0.6.0
    └── sqlx 0.7.2
```

( while th mysql feature is not active from our side)