### PR TITLE
remove provider specific repository icons

### DIFF
--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -131,7 +131,6 @@ pub(crate) async fn add_package_into_database(
         &metadata_pkg.name,
         &metadata_pkg.version,
         &metadata_pkg.version,
-        None,
     )
     .await
     .context("error when fetching crate-details")?

--- a/src/repositories/updater.rs
+++ b/src/repositories/updater.rs
@@ -250,16 +250,6 @@ impl RepositoryStatsUpdater {
         Ok(())
     }
 
-    pub fn get_icon_name(&self, host: &str) -> &'static str {
-        for updater in &self.updaters {
-            if updater.host() == host {
-                return updater.icon();
-            }
-        }
-        // The default icon in case it doesn't match any of the "known" ones.
-        "code-branch"
-    }
-
     async fn store_repository(
         &self,
         conn: &mut sqlx::PgConnection,
@@ -346,7 +336,6 @@ pub struct RepositoryName<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::context::Context;
 
     #[test]
     fn test_repository_name() {
@@ -422,27 +411,5 @@ mod test {
 
         // Unknown host
         assert_name("https://git.sr.ht/~ireas/merge-rs", None);
-    }
-
-    #[test]
-    fn test_icon_name() {
-        crate::test::wrapper(|env| {
-            let mut config = env.base_config();
-            config.github_accesstoken = Some("qsjdnfqdq".to_owned());
-            let updater = RepositoryStatsUpdater::new(&config, env.pool()?);
-
-            assert_eq!(updater.get_icon_name(""), "code-branch");
-            assert_eq!(updater.get_icon_name("random"), "code-branch");
-            assert_eq!(updater.get_icon_name("github"), "code-branch");
-            assert_eq!(updater.get_icon_name("github.com"), "github");
-            assert_eq!(updater.get_icon_name("gitlab"), "code-branch");
-            assert_eq!(updater.get_icon_name("gitlab.com"), "gitlab");
-            assert_eq!(updater.get_icon_name("gitlab.freedesktop.org"), "gitlab");
-            assert_eq!(
-                updater.get_icon_name("a.gitlab.freedesktop.org"),
-                "code-branch"
-            );
-            Ok(())
-        });
     }
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -273,7 +273,6 @@ fn apply_middleware(
             .layer(Extension(context.config()?))
             .layer(Extension(context.storage()?))
             .layer(Extension(async_storage))
-            .layer(Extension(context.repository_stats_updater()?))
             .layer(option_layer(template_data.map(Extension)))
             .layer(middleware::from_fn(csp::csp_middleware))
             .layer(option_layer(has_templates.then_some(middleware::from_fn(

--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -69,7 +69,7 @@
                                     {# If the repo link is for github or gitlab, show some stats #}
                                     {# TODO: add support for hosts besides github and gitlab (#35) #}
                                     {%- if details.repository_metadata -%}
-                                        {{ details.repository_metadata.icon | fab }}
+                                        {{ "code-branch" | fab }}
                                         {% if details.repository_metadata.name %}
                                             {{details.repository_metadata.name}}
                                         {% else %}


### PR DESCRIPTION
I want to slowly refactor to be able to have separate binaries for the different services we have (builder, webserver, index-watcher, while the index watcher probably includes the repo stats & cdn invalidation). 

IMO while nice, the dependency of the webserver to the repo-updaters, only for the sake of the icon in one view, is not worth it. 
