### PR TITLE
Allow focusing query search field via accesskey

### DIFF
--- a/templates/header/topbar_end.html
+++ b/templates/header/topbar_end.html
@@ -64,7 +64,7 @@
 
                     {# If there is a search query, put it in the search bar #}
                     {# The tabindex="-1" is used to prevent it to be the first input focused on the page when using the browser shortcut #}
-                    <input id="nav-search" name="query" type="text" aria-label="Find crate by search query" tabindex="-1"
+                    <input id="nav-search" accesskey="q" name="query" type="text" aria-label="Find crate by search query" tabindex="-1"
                         placeholder="Find crate" {%- if search_query %} value="{{ search_query }}" {%- endif %}>
                 </div>
             </form>


### PR DESCRIPTION
Conveniently focus the search field via alt+shift+q (e.g. in FF); the particular key is opinionated of course, but i remember "q" (for "query") being fairly standard some years ago.