### PR TITLE
 parse request version in extractor, refactor match_version 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,6 +643,7 @@ checksum = "1236b4b292f6c4d6dc34604bb5120d85c3fe1d1aa596bd5cc52ca054d13e7b9e"
 dependencies = [
  "async-trait",
  "axum-core",
+ "axum-macros",
  "bytes",
  "futures-util",
  "http 1.0.0",
@@ -710,6 +711,18 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00c055ee2d014ae5981ce1016374e8213682aa14d9bf40e48ab48b5f3ef20eaa"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -1341,8 +1354,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -1360,14 +1383,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 2.0.51",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core 0.20.3",
+ "quote",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -1421,6 +1469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1438,7 +1487,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1561,6 +1610,7 @@ dependencies = [
  "sentry-tracing",
  "serde",
  "serde_json",
+ "serde_with",
  "slug",
  "sqlx",
  "string_cache",
@@ -3289,6 +3339,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -3299,6 +3350,7 @@ checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -5245,6 +5297,35 @@ dependencies = [
  "itoa 1.0.10",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.3",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
+dependencies = [
+ "darling 0.20.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.51",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,9 +84,10 @@ uuid = { version = "1.1.2", features = ["v4"]}
 # Data serialization and deserialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_with = "3.4.0"
 
 # axum dependencies
-axum = "0.7.3"
+axum = { version = "0.7.3", features = ["macros"] }
 axum-extra = { version = "0.9.1", features = ["typed-header"] }
 hyper = { version = "1.1.0", default-features = false }
 tower = "0.4.11"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-types = [
+  { path = "axum::extract::Path", reason = "use our own custom web::extractors::Path for a nicer error response" },
+]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,3 @@
-disallowed-types = [
-  { path = "axum::extract::Path", reason = "use our own custom web::extractors::Path for a nicer error response" },
-]
+[[disallowed-types]]
+path = "axum::extract::Path"
+reason = "use our own custom web::extractors::Path for a nicer error response"

--- a/src/web/build_details.rs
+++ b/src/web/build_details.rs
@@ -4,13 +4,14 @@ use crate::{
         error::{AxumNope, AxumResult},
         extractors::{DbConnection, Path},
         file::File,
-        MetaData, ReqVersion,
+        MetaData,
     },
     AsyncStorage, Config,
 };
 use anyhow::Context as _;
 use axum::{extract::Extension, response::IntoResponse};
 use chrono::{DateTime, Utc};
+use semver::Version;
 use serde::Serialize;
 use std::sync::Arc;
 
@@ -36,13 +37,12 @@ impl_axum_webpage! {
 }
 
 pub(crate) async fn build_details_handler(
-    Path((name, version, id)): Path<(String, ReqVersion, String)>,
+    Path((name, version, id)): Path<(String, Version, String)>,
     mut conn: DbConnection,
     Extension(config): Extension<Arc<Config>>,
     Extension(storage): Extension<Arc<AsyncStorage>>,
 ) -> AxumResult<impl IntoResponse> {
     let id: i32 = id.parse().map_err(|_| AxumNope::BuildNotFound)?;
-    let version = version.assume_exact()?;
 
     let row = sqlx::query!(
         "SELECT

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -51,4 +51,23 @@ impl DerefMut for DbConnection {
     }
 }
 
+/// custom axum `Path` extractor that uses our own AxumNope::BadRequest
+/// as error response instead of a plain text "bad request"
+#[allow(clippy::disallowed_types)]
+mod path_impl {
+    use super::*;
+
+    #[derive(FromRequestParts)]
+    #[from_request(via(axum::extract::Path), rejection(AxumNope))]
+    pub(crate) struct Path<T>(pub T);
+}
+
+pub(crate) use path_impl::Path;
+
+impl From<axum::extract::rejection::PathRejection> for AxumNope {
+    fn from(value: axum::extract::rejection::PathRejection) -> Self {
+        AxumNope::BadRequest(value.into())
+    }
+}
+
 // TODO: we will write tests for this when async db tests are working

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -80,14 +80,6 @@ pub(crate) enum ReqVersion {
 }
 
 impl ReqVersion {
-    fn assume_exact(self) -> Result<Version, AxumNope> {
-        if let ReqVersion::Exact(version) = self {
-            Ok(version)
-        } else {
-            Err(AxumNope::VersionNotFound)
-        }
-    }
-
     pub(crate) fn is_latest(&self) -> bool {
         matches!(self, ReqVersion::Latest)
     }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -46,10 +46,12 @@ use page::TemplateData;
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use semver::{Version, VersionReq};
 use serde::Serialize;
-use std::net::{IpAddr, Ipv4Addr};
+use serde_with::{DeserializeFromStr, SerializeDisplay};
 use std::{
     borrow::{Borrow, Cow},
-    net::SocketAddr,
+    fmt::{self, Display},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    str::FromStr,
     sync::Arc,
 };
 use tower::ServiceBuilder;
@@ -67,53 +69,166 @@ pub(crate) fn encode_url_path(path: &str) -> String {
 
 const DEFAULT_BIND: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 3000);
 
-#[derive(Debug)]
-struct MatchVersion {
-    /// Represents the crate name that was found when attempting to load a crate release.
-    ///
-    /// `match_version` will attempt to match a provided crate name against similar crate names with
-    /// dashes (`-`) replaced with underscores (`_`) and vice versa.
-    pub corrected_name: Option<String>,
-    pub version: MatchSemver,
-    pub rustdoc_status: bool,
-    pub target_name: String,
+/// Represents a version identifier in a request in the original state.
+/// Can be an exact version, a semver requirement, or the string "latest".
+#[derive(Debug, Default, Clone, PartialEq, Eq, SerializeDisplay, DeserializeFromStr)]
+pub(crate) enum ReqVersion {
+    Exact(Version),
+    Semver(VersionReq),
+    #[default]
+    Latest,
 }
 
-impl MatchVersion {
-    /// If the matched version was an exact match to the requested crate name, returns the
-    /// `MatchSemver` for the query. If the lookup required a dash/underscore conversion, returns
-    /// `CrateNotFound`.
-    fn exact_name_only(self) -> Result<MatchSemver, AxumNope> {
-        if self.corrected_name.is_none() {
-            Ok(self.version)
+impl ReqVersion {
+    fn assume_exact(self) -> Result<Version, AxumNope> {
+        if let ReqVersion::Exact(version) = self {
+            Ok(version)
         } else {
-            Err(AxumNope::CrateNotFound)
+            Err(AxumNope::VersionNotFound)
+        }
+    }
+
+    pub(crate) fn is_latest(&self) -> bool {
+        matches!(self, ReqVersion::Latest)
+    }
+}
+
+impl Display for ReqVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ReqVersion::Exact(version) => version.fmt(f),
+            ReqVersion::Semver(version_req) => version_req.fmt(f),
+            ReqVersion::Latest => write!(f, "latest"),
         }
     }
 }
 
-/// Represents the possible results of attempting to load a version requirement.
-/// The id (i32) of the release is stored to simplify successive queries.
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum MatchSemver {
-    /// `match_version` was given an exact version, which matched a saved crate version.
-    Exact((String, i32)),
-    /// `match_version` was given a semver version requirement, which matched the given saved crate
-    /// version.
-    Semver((String, i32)),
-    // `match_version` was given the string "latest", which matches the given saved crate version.
-    Latest((String, i32)),
+impl FromStr for ReqVersion {
+    type Err = semver::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "latest" {
+            Ok(ReqVersion::Latest)
+        } else if let Ok(version) = Version::parse(s) {
+            Ok(ReqVersion::Exact(version))
+        } else if s.is_empty() || s == "newest" {
+            Ok(ReqVersion::Semver(VersionReq::STAR))
+        } else {
+            VersionReq::parse(s).map(ReqVersion::Semver)
+        }
+    }
 }
 
-impl MatchSemver {
-    /// Discard information about whether the loaded version was an exact match, and return the
-    /// matched version string and id.
-    pub fn into_parts(self) -> (String, i32) {
-        match self {
-            MatchSemver::Exact((v, i))
-            | MatchSemver::Semver((v, i))
-            | MatchSemver::Latest((v, i)) => (v, i),
+#[derive(Debug)]
+struct MatchedRelease {
+    /// crate name
+    pub name: String,
+
+    /// The crate name that was found when attempting to load a crate release.
+    /// `match_version` will attempt to match a provided crate name against similar crate names with
+    /// dashes (`-`) replaced with underscores (`_`) and vice versa.
+    pub corrected_name: Option<String>,
+
+    /// what kind of version did we get in the request? ("latest", semver, exact)
+    pub req_version: ReqVersion,
+
+    /// the matched release
+    pub release: crate_details::Release,
+}
+
+impl MatchedRelease {
+    fn assume_exact_name(self) -> Result<Self, AxumNope> {
+        if self.corrected_name.is_none() {
+            Ok(self)
+        } else {
+            Err(AxumNope::CrateNotFound)
         }
+    }
+
+    fn into_exactly_named(self) -> Self {
+        if let Some(corrected_name) = self.corrected_name {
+            Self {
+                name: corrected_name.to_owned(),
+                corrected_name: None,
+                ..self
+            }
+        } else {
+            self
+        }
+    }
+
+    fn into_exactly_named_or_else<F>(self, f: F) -> Result<Self, AxumNope>
+    where
+        F: FnOnce(&str, &ReqVersion) -> AxumNope,
+    {
+        if let Some(corrected_name) = self.corrected_name {
+            Err(f(&corrected_name, &self.req_version))
+        } else {
+            Ok(self)
+        }
+    }
+
+    /// Canonicalize the the version from the request
+    ///
+    /// Mainly:
+    /// * "newest"/"*" or empty -> "latest" in the URL
+    /// * any other semver requirement -> specific version in the URL
+    fn into_canonical_req_version(self) -> Self {
+        match self.req_version {
+            ReqVersion::Exact(_) | ReqVersion::Latest => self,
+            ReqVersion::Semver(version_req) => {
+                if version_req == VersionReq::STAR {
+                    Self {
+                        req_version: ReqVersion::Latest,
+                        ..self
+                    }
+                } else {
+                    Self {
+                        req_version: ReqVersion::Exact(self.release.version.clone()),
+                        ..self
+                    }
+                }
+            }
+        }
+    }
+
+    /// translate this MatchRelease into a specific semver::Version while canonicalizing the
+    /// version specification.
+    fn into_canonical_req_version_or_else<F>(self, f: F) -> Result<Self, AxumNope>
+    where
+        F: FnOnce(&ReqVersion) -> AxumNope,
+    {
+        let original_req_version = self.req_version.clone();
+        let canonicalized = self.into_canonical_req_version();
+
+        if canonicalized.req_version == original_req_version {
+            Ok(canonicalized)
+        } else {
+            Err(f(&canonicalized.req_version))
+        }
+    }
+
+    fn into_version(self) -> Version {
+        self.release.version
+    }
+
+    fn id(&self) -> i32 {
+        self.release.id
+    }
+
+    fn version(&self) -> &Version {
+        &self.release.version
+    }
+
+    fn rustdoc_status(&self) -> bool {
+        self.release.rustdoc_status
+    }
+
+    fn target_name(&self) -> &str {
+        &self.release.target_name
+    }
+
+    fn is_latest_url(&self) -> bool {
+        matches!(self.req_version, ReqVersion::Latest)
     }
 }
 
@@ -128,8 +243,8 @@ impl MatchSemver {
 async fn match_version(
     conn: &mut sqlx::PgConnection,
     name: &str,
-    input_version: Option<&str>,
-) -> Result<MatchVersion, AxumNope> {
+    input_version: &ReqVersion,
+) -> Result<MatchedRelease, AxumNope> {
     let (crate_id, corrected_name) = {
         let row = sqlx::query!(
             "SELECT id, name
@@ -150,9 +265,8 @@ async fn match_version(
     };
 
     // first load and parse all versions of this crate,
-    // skipping and reporting versions that are not semver valid.
     // `releases_for_crate` is already sorted, newest version first.
-    let releases = crate_details::releases_for_crate(conn, crate_id)
+    let mut releases = crate_details::releases_for_crate(conn, crate_id)
         .await
         .context("error fetching releases for crate")?;
 
@@ -160,55 +274,45 @@ async fn match_version(
         return Err(AxumNope::CrateNotFound);
     }
 
-    // version is an Option<&str> from router::Router::get, need to decode first.
-    // Any encoding errors we treat as _any version_.
-    let req_version = input_version.unwrap_or("*");
+    let req_semver: VersionReq = match input_version {
+        ReqVersion::Exact(parsed_req_version) => {
+            if let Some(release) = releases
+                .iter()
+                .find(|release| &release.version == parsed_req_version)
+            {
+                return Ok(MatchedRelease {
+                    name: name.to_owned(),
+                    corrected_name,
+                    req_version: input_version.clone(),
+                    release: release.clone(),
+                });
+            }
 
-    // first check for exact match, we can't expect users to use semver in query
-    if let Ok(parsed_req_version) = Version::parse(req_version) {
-        if let Some(release) = releases
-            .iter()
-            .find(|release| release.version == parsed_req_version)
-        {
-            return Ok(MatchVersion {
-                corrected_name,
-                version: MatchSemver::Exact((release.version.to_string(), release.id)),
-                rustdoc_status: release.rustdoc_status,
-                target_name: release.target_name.clone(),
-            });
+            if let Ok(version_req) = VersionReq::parse(&parsed_req_version.to_string()) {
+                // when we don't find a release with exact version,
+                // we try to interpret it as a semver requirement.
+                // A normal semver version ("1.2.3") is equivalent to a caret semver requirement.
+                version_req
+            } else {
+                return Err(AxumNope::VersionNotFound);
+            }
         }
-    }
-
-    // Now try to match with semver, treat `newest` and `latest` as `*`
-    let req_semver = if req_version == "newest" || req_version == "latest" {
-        VersionReq::STAR
-    } else {
-        VersionReq::parse(req_version).map_err(|err| {
-            info!(
-                "could not parse version requirement \"{}\": {:?}",
-                req_version, err
-            );
-            AxumNope::VersionNotFound
-        })?
+        ReqVersion::Latest => VersionReq::STAR,
+        ReqVersion::Semver(version_req) => version_req.clone(),
     };
 
-    // starting here, we only look at non-yanked releases
-    let releases: Vec<_> = releases.iter().filter(|r| !r.yanked).collect();
+    // when matching semver requirements, we only want to look at non-yanked releases.
+    releases.retain(|r| !r.yanked);
 
-    // try to match the version in all un-yanked releases.
     if let Some(release) = releases
         .iter()
         .find(|release| req_semver.matches(&release.version))
     {
-        return Ok(MatchVersion {
+        return Ok(MatchedRelease {
+            name: name.to_owned(),
             corrected_name,
-            version: if input_version == Some("latest") {
-                MatchSemver::Latest((release.version.to_string(), release.id))
-            } else {
-                MatchSemver::Semver((release.version.to_string(), release.id))
-            },
-            rustdoc_status: release.rustdoc_status,
-            target_name: release.target_name.clone(),
+            req_version: input_version.clone(),
+            release: release.clone(),
         });
     }
 
@@ -218,11 +322,11 @@ async fn match_version(
     if req_semver == VersionReq::STAR {
         return releases
             .first()
-            .map(|release| MatchVersion {
+            .map(|release| MatchedRelease {
+                name: name.to_owned(),
                 corrected_name: corrected_name.clone(),
-                version: MatchSemver::Semver((release.version.to_string(), release.id)),
-                rustdoc_status: release.rustdoc_status,
-                target_name: release.target_name.clone(),
+                req_version: input_version.clone(),
+                release: release.clone(),
             })
             .ok_or(AxumNope::VersionNotFound);
     }
@@ -485,11 +589,13 @@ where
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct MetaData {
     pub(crate) name: String,
-    // If we're on a page with /latest/ in the URL, the string "latest".
-    // Otherwise, the version as a string.
-    pub(crate) version_or_latest: String,
-    // The exact version of the crate being shown. Never contains "latest".
-    pub(crate) version: String,
+    /// The exact version of the release being shown.
+    pub(crate) version: Version,
+    /// The version identifier in the request that was used to request this page.
+    /// This might be any of the variants of `ReqVersion`, but
+    /// due to a canonicalization step, it is either an Exact version, or `/latest/`
+    /// most of the time.
+    pub(crate) req_version: ReqVersion,
     pub(crate) description: Option<String>,
     pub(crate) target_name: Option<String>,
     pub(crate) rustdoc_status: bool,
@@ -505,8 +611,8 @@ impl MetaData {
     async fn from_crate(
         conn: &mut sqlx::PgConnection,
         name: &str,
-        version: &str,
-        version_or_latest: &str,
+        version: &Version,
+        req_version: Option<ReqVersion>,
     ) -> Result<MetaData> {
         sqlx::query!(
             "SELECT
@@ -523,15 +629,15 @@ impl MetaData {
             INNER JOIN crates ON crates.id = releases.crate_id
             WHERE crates.name = $1 AND releases.version = $2",
             name,
-            version
+            version.to_string(),
         )
         .fetch_optional(&mut *conn)
         .await
         .context("error fetching crate metadata")?
         .map(|row| MetaData {
             name: row.name,
-            version: row.version,
-            version_or_latest: version_or_latest.to_string(),
+            version: version.clone(),
+            req_version: req_version.unwrap_or_else(|| ReqVersion::Exact(version.clone())),
             description: row.description,
             target_name: Some(row.target_name),
             rustdoc_status: row.rustdoc_status,
@@ -592,26 +698,29 @@ mod test {
             .unwrap()
     }
 
-    async fn version(v: Option<&str>, db: &TestDatabase) -> Option<String> {
+    async fn version(v: Option<&str>, db: &TestDatabase) -> Option<Version> {
         let mut conn = db.async_conn().await;
-        let version = match_version(&mut conn, "foo", v)
-            .await
-            .ok()?
-            .exact_name_only()
-            .ok()?
-            .into_parts()
-            .0;
+        let version = match_version(
+            &mut conn,
+            "foo",
+            &ReqVersion::from_str(v.unwrap_or_default()).unwrap(),
+        )
+        .await
+        .ok()?
+        .assume_exact_name()
+        .ok()?
+        .into_version();
         Some(version)
     }
 
     #[allow(clippy::unnecessary_wraps)]
-    fn semver(version: &'static str) -> Option<String> {
-        Some(version.into())
+    fn semver(version: &'static str) -> Option<Version> {
+        version.parse().ok()
     }
 
     #[allow(clippy::unnecessary_wraps)]
-    fn exact(version: &'static str) -> Option<String> {
-        Some(version.into())
+    fn exact(version: &'static str) -> Option<Version> {
+        version.parse().ok()
     }
 
     fn clipboard_is_present_for_path(path: &str, web: &TestFrontend) -> bool {
@@ -746,7 +855,7 @@ mod test {
     }
 
     #[test]
-    fn double_slash_does_redirect_and_remove_slash() {
+    fn double_slash_does_redirect_to_latest_version() {
         wrapper(|env| {
             env.fake_release()
                 .name("bat")
@@ -754,8 +863,7 @@ mod test {
                 .create()
                 .unwrap();
             let web = env.frontend();
-            let response = web.get("/bat//").send()?;
-            assert_eq!(response.status().as_u16(), StatusCode::NOT_FOUND.as_u16());
+            assert_redirect("/bat//", "/bat/latest/bat/", web)?;
             Ok(())
         })
     }
@@ -933,8 +1041,8 @@ mod test {
     fn serialize_metadata() {
         let mut metadata = MetaData {
             name: "serde".to_string(),
-            version: "1.0.0".to_string(),
-            version_or_latest: "1.0.0".to_string(),
+            version: "1.0.0".parse().unwrap(),
+            req_version: ReqVersion::Latest,
             description: Some("serde does stuff".to_string()),
             target_name: None,
             rustdoc_status: true,
@@ -950,7 +1058,7 @@ mod test {
         let correct_json = json!({
             "name": "serde",
             "version": "1.0.0",
-            "version_or_latest": "1.0.0",
+            "req_version": "latest",
             "description": "serde does stuff",
             "target_name": null,
             "rustdoc_status": true,
@@ -969,7 +1077,7 @@ mod test {
         let correct_json = json!({
             "name": "serde",
             "version": "1.0.0",
-            "version_or_latest": "1.0.0",
+            "req_version": "latest",
             "description": "serde does stuff",
             "target_name": "serde_lib_name",
             "rustdoc_status": true,
@@ -988,7 +1096,7 @@ mod test {
         let correct_json = json!({
             "name": "serde",
             "version": "1.0.0",
-            "version_or_latest": "1.0.0",
+            "req_version": "latest",
             "description": null,
             "target_name": "serde_lib_name",
             "rustdoc_status": true,
@@ -1009,13 +1117,19 @@ mod test {
         async_wrapper(|env| async move {
             release("0.1.0", &env).await;
             let mut conn = env.async_db().await.async_conn().await;
-            let metadata = MetaData::from_crate(&mut conn, "foo", "0.1.0", "latest").await;
+            let metadata = MetaData::from_crate(
+                &mut conn,
+                "foo",
+                &"0.1.0".parse().unwrap(),
+                Some(ReqVersion::Latest),
+            )
+            .await;
             assert_eq!(
                 metadata.unwrap(),
                 MetaData {
                     name: "foo".to_string(),
-                    version_or_latest: "latest".to_string(),
-                    version: "0.1.0".to_string(),
+                    version: "0.1.0".parse().unwrap(),
+                    req_version: ReqVersion::Latest,
                     description: Some("Fake package".to_string()),
                     target_name: Some("foo".to_string()),
                     rustdoc_status: true,
@@ -1081,5 +1195,41 @@ mod test {
     fn test_axum_redirect_failure(path: &str) {
         assert!(axum_redirect(path).is_err());
         assert!(axum_cached_redirect(path, cache::CachePolicy::NoCaching).is_err());
+    }
+
+    #[test]
+    fn test_parse_req_version_latest() {
+        let req_version: ReqVersion = "latest".parse().unwrap();
+        assert_eq!(req_version, ReqVersion::Latest);
+        assert_eq!(req_version.to_string(), "latest");
+    }
+
+    #[test_case("1.2.3")]
+    fn test_parse_req_version_exact(input: &str) {
+        let req_version: ReqVersion = input.parse().unwrap();
+        assert_eq!(
+            req_version,
+            ReqVersion::Exact(Version::parse(input).unwrap())
+        );
+        assert_eq!(req_version.to_string(), input);
+    }
+
+    #[test_case("^1.2.3")]
+    #[test_case("*")]
+    fn test_parse_req_version_semver(input: &str) {
+        let req_version: ReqVersion = input.parse().unwrap();
+        assert_eq!(
+            req_version,
+            ReqVersion::Semver(VersionReq::parse(input).unwrap())
+        );
+        assert_eq!(req_version.to_string(), input);
+    }
+
+    #[test_case("")]
+    #[test_case("newest")]
+    fn test_parse_req_version_semver_latest(input: &str) {
+        let req_version: ReqVersion = input.parse().unwrap();
+        assert_eq!(req_version, ReqVersion::Semver(VersionReq::STAR));
+        assert_eq!(req_version.to_string(), "*")
     }
 }

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -5,16 +5,12 @@ use crate::{
     utils::{get_config, spawn_blocking, ConfigName},
     web::{
         error::{AxumNope, AxumResult},
-        extractors::DbConnection,
+        extractors::{DbConnection, Path},
         AxumErrorPage,
     },
     Config,
 };
-use axum::{
-    extract::{Extension, Path},
-    http::StatusCode,
-    response::IntoResponse,
-};
+use axum::{extract::Extension, http::StatusCode, response::IntoResponse};
 use chrono::{TimeZone, Utc};
 use futures_util::stream::TryStreamExt;
 use serde::Serialize;

--- a/templates/crate/features.html
+++ b/templates/crate/features.html
@@ -56,9 +56,9 @@
                 <div class="info">
                     There is very little structured metadata to build this page
                     from currently. You should check the
-                    <a href="/{{ metadata.name }}/{{ metadata.version_or_latest }}/{{ metadata.target_name }}/">main library docs</a>,
-                    <a href="/crate/{{ metadata.name }}/{{ metadata.version_or_latest }}/">readme</a>, or
-                    <a href="/crate/{{ metadata.name }}/{{ metadata.version_or_latest }}/source/Cargo.toml.orig">Cargo.toml</a>
+                    <a href="/{{ metadata.name }}/{{ metadata.req_version }}/{{ metadata.target_name }}/">main library docs</a>,
+                    <a href="/crate/{{ metadata.name }}/{{ metadata.req_version }}/">readme</a>, or
+                    <a href="/crate/{{ metadata.name }}/{{ metadata.req_version }}/source/Cargo.toml.orig">Cargo.toml</a>
                     in case the author documented the features in them.
                 </div>
                 {%- if features -%}

--- a/templates/header/package_navigation.html
+++ b/templates/header/package_navigation.html
@@ -17,7 +17,7 @@
         <div class="container">
             <div class="description-container">
                 {# The partial path of the crate, `:name/:release` #}
-                {%- set crate_path = metadata.name ~ "/" ~ metadata.version_or_latest -%}
+                {%- set crate_path = metadata.name ~ "/" ~ metadata.req_version -%}
 
                 {# If docs are built, show a button for them #}
 

--- a/templates/rustdoc/platforms.html
+++ b/templates/rustdoc/platforms.html
@@ -5,10 +5,10 @@
         because the documentation root page is guaranteed to exist for all targets.
     #}
     {%- if use_direct_platform_links -%}
-        {%- set target_url = "/" ~ metadata.name ~ "/" ~ metadata.version_or_latest ~ "/" ~ target ~ "/" ~ inner_path -%}
+        {%- set target_url = "/" ~ metadata.name ~ "/" ~ metadata.req_version ~ "/" ~ target ~ "/" ~ inner_path -%}
         {%- set target_no_follow = "" -%}
     {%- else -%}
-        {%- set target_url = "/crate/" ~ metadata.name ~ "/" ~ metadata.version_or_latest ~ "/target-redirect/" ~ target ~ "/" ~ inner_path -%}
+        {%- set target_url = "/crate/" ~ metadata.name ~ "/" ~ metadata.req_version ~ "/target-redirect/" ~ target ~ "/" ~ inner_path -%}
         {%- set target_no_follow = "nofollow" -%}
     {%- endif -%}
     {%- if current_target is defined and current_target == target -%}

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -1,7 +1,7 @@
 {%- import "macros.html" as macros -%}
 
 {# The url of the current release, `/crate/:name/:version` #}
-{%- set crate_url = "/crate/" ~ metadata.name ~ "/" ~ metadata.version_or_latest -%}
+{%- set crate_url = "/crate/" ~ metadata.name ~ "/" ~ metadata.req_version -%}
 
 {%- include "header/topbar_begin.html" -%}{#
 extra whitespace unremovable, need to use html tags unaffacted by whitespace T_T
@@ -22,7 +22,7 @@ extra whitespace unremovable, need to use html tags unaffacted by whitespace T_T
                         <span id="clipboard" class="fa-svg fa-svg-fw" title="Copy crate name and version information">{%- include "clipboard.svg" -%}</span>
                     </li>
 
-                    {%- if metadata.version_or_latest == "latest" -%}
+                    {%- if metadata.req_version == "latest" -%}
                     <li class="pure-menu-item">
                         <a href="{{permalink_path | safe}}" class="pure-menu-link description" id="permalink" title="Get a link to this specific version">
                             {{ "link" | fas }} Permalink


### PR DESCRIPTION
So, this is a somewhat mid-sized refactor in how we handle & match version requirements in requests. 

The general idea is: 
- we are using a new axum extractor to parse the version requirement (`web::ReqVersion`). It can parse static names like `/latest/`, but also specific `semver::Version` and `semver::VersionReq`. **This changes the status code for an invalid version identifier.**. Previously we returned a 404, now it will be a 400. I added a custom `Path` extractor so we have a nice error page on 400 too, so for users it should be fine. 
- All places where we _use_ the extracted version identifier we can now use a `semver::Version` 
- `match_version` and its response types are refactored to use the new `ReqVersion`. 
- in our handlers there was much repetition around how we handle different `ReqVersion` and redirect in some cases. This is replaced by introducing `AxumNope::Redirect` and `into_canonical_req_version_or_else` for the `match_version` result. This unifies the version identifier canonicalization in more places. 
- In there I also added a redirect from `newest` or semver `*` to `/latest/`, which IMO makes more sense. 

I think there will also be more edge cases where the exact redirects for version identifiers are not slightly different than before, but IMO this is fine for a (mostly) web interface. 