### PR TITLE
handle S3 "KeyTooLongError" as PathNotFoundError in storage

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -964,6 +964,19 @@ mod backend_tests {
         Ok(())
     }
 
+    fn test_too_long_filename(storage: &Storage) -> Result<()> {
+        // minio returns ErrKeyTooLongError when the key is over 1024 bytes long.
+        // When testing, minio just gave me `XMinioInvalidObjectName`, so I'll check that too.
+        let long_filename = "ATCG".repeat(512);
+
+        assert!(storage
+            .get(&long_filename, 42)
+            .unwrap_err()
+            .is::<PathNotFoundError>());
+
+        Ok(())
+    }
+
     fn test_get_too_big(storage: &Storage) -> Result<()> {
         const MAX_SIZE: usize = 1024;
 
@@ -1307,6 +1320,7 @@ mod backend_tests {
             test_get_object,
             test_get_range,
             test_get_too_big,
+            test_too_long_filename,
             test_delete_prefix,
             test_delete_prefix_without_matches,
             test_delete_percent,

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -25,12 +25,12 @@ fn err_is_not_found<E>(err: &SdkError<E>) -> bool
 where
     E: ProvideErrorMetadata,
 {
-    match err {
-        SdkError::ServiceError(err) => {
-            err.raw().status().as_u16() == http::StatusCode::NOT_FOUND.as_u16()
-        }
-        e if e.code() == Some("KeyTooLongError") => true,
-        _ => false,
+    if err.code() == Some("KeyTooLongError") || err.code() == Some("XMinioInvalidObjectName") {
+        true
+    } else if let SdkError::ServiceError(err) = err {
+        err.raw().status().as_u16() == http::StatusCode::NOT_FOUND.as_u16()
+    } else {
+        false
     }
 }
 


### PR DESCRIPTION
in [sentry we are seeing a new error from S3](https://rust-lang.sentry.io/issues/4864185388/events/57b8fec679f44b68b15feae0a6d5f766/?environment=production&project=5499376&query=is%3Aunresolved&referrer=next-event&statsPeriod=90d&stream_index=2): 

> ### Unhandled
> unhandled error (KeyTooLongError)
> ### ErrorMetadata
> Error { code: "KeyTooLongError", message: "Your key is too long", s3_extended_request_id: "8hzp1Kv7cGOsjW3EUaqBxaI8krQbNJYFX1UZdb5DzKsKpHG7B1K9rvRATlrT/MHw3kPtIbLIn9fEdGUrm85/Uw==", aws_request_id: "16PF5FB54MZZ081Q" }


it happens when the path in the requested URL is too long, and IMO should be seen as the same as a 404 from S3. 