### PR TITLE
fix initial migration that should not include old `database_versions` table

### DIFF
--- a/migrations/20231021111635_initial.down.sql
+++ b/migrations/20231021111635_initial.down.sql
@@ -5,7 +5,6 @@ DROP TABLE compression_rels CASCADE;
 DROP TABLE config CASCADE;
 DROP TABLE crate_priorities CASCADE;
 DROP TABLE crates CASCADE;
-DROP TABLE database_versions CASCADE;
 DROP TABLE doc_coverage CASCADE;
 DROP TABLE files CASCADE;
 DROP TABLE keyword_rels CASCADE;

--- a/migrations/20231021111635_initial.up.sql
+++ b/migrations/20231021111635_initial.up.sql
@@ -130,11 +130,6 @@ ALTER SEQUENCE crates_id_seq OWNED BY crates.id;
 
 
 
-CREATE TABLE database_versions (
-    version bigint NOT NULL
-);
-
-
 
 CREATE TABLE doc_coverage (
     release_id integer NOT NULL,
@@ -385,11 +380,6 @@ ALTER TABLE ONLY crates
 
 ALTER TABLE ONLY crates
     ADD CONSTRAINT crates_pkey PRIMARY KEY (id);
-
-
-
-ALTER TABLE ONLY database_versions
-    ADD CONSTRAINT database_versions_pkey PRIMARY KEY (version);
 
 
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -39,12 +39,16 @@ pub async fn migrate(conn: &mut sqlx::PgConnection, target: Option<i64>) -> Resu
     .await?
     .is_some()
     {
-        let max_version: i64 = sqlx::query_scalar("SELECT max(version) FROM database_versions")
-            .fetch_one(&mut *conn)
-            .await?;
+        let max_version: Option<i64> =
+            sqlx::query_scalar("SELECT max(version) FROM database_versions")
+                .fetch_one(&mut *conn)
+                .await?;
 
-        if max_version != 39 {
-            anyhow::bail!("database_versions table has unexpected version");
+        if max_version != Some(39) {
+            anyhow::bail!(
+                "database_versions table has unexpected version: {:?}",
+                max_version
+            );
         }
 
         sqlx::query(


### PR DESCRIPTION
This is coming from [this discussion on zulip](https://rust-lang.zulipchat.com/#narrow/stream/356853-t-docs-rs/topic/Setup.20a.20dev.20environment.3A.20stuck.20with.20database.20migration.20error). 

When creating the new initial database migration in #2327 I mistakenly left the `database_versions` table in there. 
This lead to a confusing error message when a developer ran `cargo run -- database migrate` the _second_ time. 

Since we drop the `database_versions` table in our migration-flow from the old schemamama migrations to the new sqlx migrations, I think the correct solution is to fix the initial migration instead of adding another one. 

IMO the developers having this error locally should not be many, they could drop the table manually, or recreate their local database. 