### PR TITLE
Add `optional` suffix to dependency

### DIFF
--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -220,8 +220,8 @@ async fn initialize_package_in_database(
     }
 }
 
-/// Convert dependencies into Vec<(String, String, String)>
-fn convert_dependencies(pkg: &MetadataPackage) -> Vec<(String, String, String)> {
+/// Convert dependencies into Vec<(String, String, String, bool)>
+fn convert_dependencies(pkg: &MetadataPackage) -> Vec<(String, String, String, bool)> {
     pkg.dependencies
         .iter()
         .map(|dependency| {
@@ -231,8 +231,7 @@ fn convert_dependencies(pkg: &MetadataPackage) -> Vec<(String, String, String)> 
                 .kind
                 .clone()
                 .unwrap_or_else(|| "normal".to_string());
-
-            (name, version, kind)
+            (name, version, kind, dependency.optional)
         })
         .collect()
 }

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -115,6 +115,11 @@ impl<'a> FakeRelease<'a> {
         self
     }
 
+    pub(crate) fn add_dependency(mut self, dependency: Dependency) -> Self {
+        self.package.dependencies.push(dependency);
+        self
+    }
+
     pub(crate) fn release_time(mut self, new: DateTime<Utc>) -> Self {
         self.registry_release_data.release_time = new;
         self

--- a/src/utils/cargo_metadata.rs
+++ b/src/utils/cargo_metadata.rs
@@ -130,6 +130,25 @@ pub(crate) struct Dependency {
     pub(crate) optional: bool,
 }
 
+impl Dependency {
+    #[cfg(test)]
+    pub fn new(name: String, req: String) -> Dependency {
+        Dependency {
+            name,
+            req,
+            kind: None,
+            rename: None,
+            optional: false,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn set_optional(mut self, optional: bool) -> Self {
+        self.optional = optional;
+        self
+    }
+}
+
 #[derive(Deserialize, Serialize)]
 struct DeserializedMetadata {
     packages: Vec<Package>,

--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -106,6 +106,9 @@
                                             <a href="/crate/{{ dep[0] }}/{{ dep[1] }}" class="pure-menu-link">
                                                 {{ dep[0] }} {{ dep[1] }}
                                                 <i class="dependencies {{ dep[2] | default(value='') }}">{{ dep[2] | default(value="") }}</i>
+                                                {%- if dep[3] -%}
+                                                <i> optional </i>
+                                                {%- endif -%}
                                             </a>
                                         </li>
                                     {%- endfor -%}

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -120,6 +120,9 @@ extra whitespace unremovable, need to use html tags unaffacted by whitespace T_T
                                                 <a href="/{{ dep[0] }}/{{ dep[1] }}" class="pure-menu-link">
                                                     {{ dep[0] }} {{ dep[1] }}
                                                     <i class="dependencies {{ dep[2] | default(value='') }}">{{ dep[2] | default(value="") }}</i>
+                                                    {%- if dep[3] -%}
+                                                    <i> optional </i>
+                                                    {%- endif -%}
                                                 </a>
                                             </li>
                                         {%- endfor -%}


### PR DESCRIPTION
Addressed https://github.com/rust-lang/docs.rs/issues/2397

Add `optional` suffix to dependency.  