### PR TITLE
ignore security alert for libgit2

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,6 +7,9 @@ ignore = [
     # https://github.com/rust-lang/docs.rs/issues/2074
 
     "RUSTSEC-2023-0071", # potential key recovery through timing sidechannels
+
+    "RUSTSEC-2024-0013", # Memory corruption, denial of service, and arbitrary code execution in libgit2
+    # https://github.com/rust-lang/docs.rs/issues/2414
 ]
 informational_warnings = ["unmaintained"] # warn for categories of informational advisories
 severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "critical")


### PR DESCRIPTION
Fixes #2414 : 

`libgit2` is used by `rustwide`: 
```
$ cargo tree -i libgit2-sys                                                   
libgit2-sys v0.15.2+1.6.4
└── git2 v0.17.2
    └── rustwide v0.16.0
        └── docs-rs v0.6.0 (/Users/syphar/src/rust-lang/docs.rs)
```

and from what I see, the affected methods are not used. 