### PR TITLE
store & show build logs for non-default targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: run slow tests
         env:
-          DOCSRS_INCLUDE_DEFAULT_TARGETS: false
+          DOCSRS_INCLUDE_DEFAULT_TARGETS: true
         run: |
           cargo test --locked -- --ignored --test-threads=1
 

--- a/.sqlx/query-3d98a27dab09b6f74a097b8cea8077063f77fb1758c9c4a075d2dfa4e4a80822.json
+++ b/.sqlx/query-3d98a27dab09b6f74a097b8cea8077063f77fb1758c9c4a075d2dfa4e4a80822.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT path\n             FROM files\n             WHERE path LIKE $1\n             ORDER BY path;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "path",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "3d98a27dab09b6f74a097b8cea8077063f77fb1758c9c4a075d2dfa4e4a80822"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.51",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,6 +1567,7 @@ name = "docs-rs"
 version = "0.6.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "aws-config",
  "aws-sdk-cloudfront",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ hex = "0.4.3"
 # Async
 tokio = { version = "1.0", features = ["rt-multi-thread", "signal", "macros"] }
 futures-util = "0.3.5"
+async-stream = "0.3.5"
 aws-config = "1.0.0"
 aws-sdk-s3 = "1.3.0"
 aws-sdk-cloudfront = "1.3.0"

--- a/src/web/build_details.rs
+++ b/src/web/build_details.rs
@@ -89,7 +89,7 @@ pub(crate) async fn build_details_handler(
         (
             String::from_utf8(file.0.content).context("non utf8")?,
             storage
-                .list_prefix(&prefix)
+                .list_prefix(&prefix) // the result from S3 is ordered by key
                 .await
                 .map_ok(|path| {
                     path.strip_prefix(&prefix)

--- a/src/web/build_details.rs
+++ b/src/web/build_details.rs
@@ -11,8 +11,9 @@ use crate::{
 use anyhow::Context as _;
 use axum::{extract::Extension, response::IntoResponse};
 use chrono::{DateTime, Utc};
+use futures_util::TryStreamExt;
 use semver::Version;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -30,19 +31,29 @@ struct BuildDetailsPage {
     metadata: MetaData,
     build_details: BuildDetails,
     use_direct_platform_links: bool,
+    all_log_filenames: Vec<String>,
+    current_filename: Option<String>,
 }
 
 impl_axum_webpage! {
     BuildDetailsPage = "crate/build_details.html",
 }
 
+#[derive(Clone, Deserialize, Debug)]
+pub(crate) struct BuildDetailsParams {
+    pub(crate) name: String,
+    pub(crate) version: Version,
+    pub(crate) id: String,
+    pub(crate) filename: Option<String>,
+}
+
 pub(crate) async fn build_details_handler(
-    Path((name, version, id)): Path<(String, Version, String)>,
+    Path(params): Path<BuildDetailsParams>,
     mut conn: DbConnection,
     Extension(config): Extension<Arc<Config>>,
     Extension(storage): Extension<Arc<AsyncStorage>>,
 ) -> AxumResult<impl IntoResponse> {
-    let id: i32 = id.parse().map_err(|_| AxumNope::BuildNotFound)?;
+    let id: i32 = params.id.parse().map_err(|_| AxumNope::BuildNotFound)?;
 
     let row = sqlx::query!(
         "SELECT
@@ -57,23 +68,42 @@ pub(crate) async fn build_details_handler(
          INNER JOIN crates ON releases.crate_id = crates.id
          WHERE builds.id = $1 AND crates.name = $2 AND releases.version = $3",
         id,
-        name,
-        version.to_string(),
+        params.name,
+        params.version.to_string(),
     )
     .fetch_optional(&mut *conn)
     .await?
     .ok_or(AxumNope::BuildNotFound)?;
 
-    let output = if let Some(output) = row.output {
-        output
+    let (output, all_log_filenames, current_filename) = if let Some(output) = row.output {
+        (output, Vec::new(), None)
     } else {
-        let path = format!("build-logs/{id}/{}.txt", row.default_target);
+        let prefix = format!("build-logs/{}/", id);
+
+        let current_filename = params
+            .filename
+            .unwrap_or_else(|| format!("{}.txt", row.default_target));
+
+        let path = format!("{prefix}{current_filename}");
         let file = File::from_path(&storage, &path, &config).await?;
-        String::from_utf8(file.0.content).context("non utf8")?
+        (
+            String::from_utf8(file.0.content).context("non utf8")?,
+            storage
+                .list_prefix(&prefix)
+                .await
+                .map_ok(|path| {
+                    path.strip_prefix(&prefix)
+                        .expect("since we query for the prefix, it has to be always there")
+                        .to_owned()
+                })
+                .try_collect()
+                .await?,
+            Some(current_filename),
+        )
     };
 
     Ok(BuildDetailsPage {
-        metadata: MetaData::from_crate(&mut conn, &name, &version, None).await?,
+        metadata: MetaData::from_crate(&mut conn, &params.name, &params.version, None).await?,
         build_details: BuildDetails {
             id,
             rustc_version: row.rustc_version,
@@ -83,6 +113,8 @@ pub(crate) async fn build_details_handler(
             output,
         },
         use_direct_platform_links: true,
+        all_log_filenames,
+        current_filename,
     }
     .into_response())
 }
@@ -92,6 +124,19 @@ mod tests {
     use crate::test::{wrapper, FakeBuild};
     use kuchikiki::traits::TendrilSink;
     use test_case::test_case;
+
+    fn get_all_log_links(page: &kuchikiki::NodeRef) -> Vec<(String, String)> {
+        page.select("ul > li a.release")
+            .unwrap()
+            .map(|el| {
+                let attributes = el.attributes.borrow();
+                (
+                    el.text_contents().trim().to_owned(),
+                    attributes.get("href").unwrap().to_string(),
+                )
+            })
+            .collect()
+    }
 
     #[test]
     fn db_build_logs() {
@@ -116,6 +161,7 @@ mod tests {
             let url = attrs.get("href").unwrap();
 
             let page = kuchikiki::parse_html().one(env.frontend().get(url).send()?.text()?);
+            assert!(get_all_log_links(&page).is_empty());
 
             let log = page.select("pre").unwrap().next().unwrap().text_contents();
 
@@ -143,14 +189,98 @@ mod tests {
 
             let node = page.select("ul > li a.release").unwrap().next().unwrap();
             let attrs = node.attributes.borrow();
-            let url = attrs.get("href").unwrap();
+            let build_url = attrs.get("href").unwrap();
 
-            let page = kuchikiki::parse_html()
-                .one(env.frontend().get(url).send()?.error_for_status()?.text()?);
+            let page = kuchikiki::parse_html().one(env.frontend().get(build_url).send()?.text()?);
 
             let log = page.select("pre").unwrap().next().unwrap().text_contents();
 
             assert!(log.contains("A build log"));
+
+            let all_log_links = get_all_log_links(&page);
+            assert_eq!(
+                all_log_links,
+                vec![(
+                    "x86_64-unknown-linux-gnu.txt".into(),
+                    format!("{build_url}/x86_64-unknown-linux-gnu.txt")
+                )]
+            );
+
+            // now get the log with the specific filename in the URL
+            let log = kuchikiki::parse_html()
+                .one(env.frontend().get(&all_log_links[0].1).send()?.text()?)
+                .select("pre")
+                .unwrap()
+                .next()
+                .unwrap()
+                .text_contents();
+
+            assert!(log.contains("A build log"));
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn s3_build_logs_multiple_targets() {
+        wrapper(|env| {
+            env.fake_release()
+                .name("foo")
+                .version("0.1.0")
+                .builds(vec![FakeBuild::default()
+                    .s3_build_log("A build log")
+                    .build_log_for_other_target(
+                        "other_target",
+                        "other target build log",
+                    )])
+                .create()?;
+
+            let page = kuchikiki::parse_html().one(
+                env.frontend()
+                    .get("/crate/foo/0.1.0/builds")
+                    .send()?
+                    .text()?,
+            );
+
+            let node = page.select("ul > li a.release").unwrap().next().unwrap();
+            let attrs = node.attributes.borrow();
+            let build_url = attrs.get("href").unwrap();
+
+            let page = kuchikiki::parse_html().one(env.frontend().get(build_url).send()?.text()?);
+
+            let log = page.select("pre").unwrap().next().unwrap().text_contents();
+
+            assert!(log.contains("A build log"));
+
+            let all_log_links = get_all_log_links(&page);
+            assert_eq!(
+                all_log_links,
+                vec![
+                    (
+                        "other_target.txt".into(),
+                        format!("{build_url}/other_target.txt")
+                    ),
+                    (
+                        "x86_64-unknown-linux-gnu.txt".into(),
+                        format!("{build_url}/x86_64-unknown-linux-gnu.txt"),
+                    )
+                ]
+            );
+
+            for (url, expected_content) in &[
+                (&all_log_links[0].1, "other target build log"),
+                (&all_log_links[1].1, "A build log"),
+            ] {
+                let other_log = kuchikiki::parse_html()
+                    .one(env.frontend().get(url).send()?.text()?)
+                    .select("pre")
+                    .unwrap()
+                    .next()
+                    .unwrap()
+                    .text_contents();
+
+                assert!(other_log.contains(expected_content));
+            }
 
             Ok(())
         });

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -221,6 +221,10 @@ pub(super) fn build_axum_routes() -> AxumRouter {
             get_internal(super::build_details::build_details_handler),
         )
         .route_with_tsr(
+            "/crate/:name/:version/builds/:id/:filename",
+            get_internal(super::build_details::build_details_handler),
+        )
+        .route_with_tsr(
             "/crate/:name/:version/features",
             get_internal(super::features::build_features_handler),
         )

--- a/templates/crate/build_details.html
+++ b/templates/crate/build_details.html
@@ -30,6 +30,25 @@ centered
                 <strong>Build #{{ build_details.id }} {{ build_details.build_time | date(format="%+") }}</strong>
             </div>
 
+            <ul>
+                {%- for filename in all_log_filenames -%}
+                    <li>
+                        <a href="/crate/{{ metadata.name }}/{{ metadata.version }}/builds/{{ build_details.id }}/{{ filename }}" class="release">
+                            <div class="pure-g">
+                                <div class="pure-u-1 pure-u-sm-1-24 build">{{ "file-lines" | fas }}</div>
+                                <div class="pure-u-1 pure-u-sm-10-24">
+                                    {% if current_filename and current_filename == filename %}
+                                        <b>{{ filename }}</b>
+                                    {% else %}
+                                        {{ filename }}
+                                    {% endif %}
+                                </div>
+                            </div>
+                        </a>
+                    </li>
+                {%- endfor -%}
+            </ul>
+
             {%- filter dedent -%}
                 <pre>
                     # rustc version


### PR DESCRIPTION
fixes #787. 

Generally the idea is: 
- we store additional logs next to the default-target logs 
- the build-details view just shows all files in that folder

Due to lack of web frontend skills I just added a barely functional way to switch through the logs, I would appreciate help here, though I would also be fine with merging the interface as-is. 