### PR TITLE
drop rendering times recording in favor of sentry performance tracing

### DIFF
--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -87,10 +87,6 @@ metrics! {
         pub(crate) routes_visited: IntCounterVec["route"],
         /// The response times of various docs.rs routes
         pub(crate) response_time: HistogramVec["route"],
-        /// The time it takes to render a rustdoc page
-        pub(crate) rustdoc_rendering_times: HistogramVec["step"],
-        /// The time it takes to render a rustdoc redirect page
-        pub(crate) rustdoc_redirect_rendering_times: HistogramVec["step"],
 
         /// Count of recently accessed crates
         pub(crate) recent_crates: IntGaugeVec["duration"],

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -6,10 +6,7 @@ mod s3;
 pub use self::compression::{compress, decompress, CompressionAlgorithm, CompressionAlgorithms};
 use self::database::DatabaseBackend;
 use self::s3::S3Backend;
-use crate::{
-    db::Pool, error::Result, utils::spawn_blocking, web::metrics::RenderingTimesRecorder, Config,
-    InstanceMetrics,
-};
+use crate::{db::Pool, error::Result, utils::spawn_blocking, Config, InstanceMetrics};
 use anyhow::{anyhow, ensure};
 use chrono::{DateTime, Utc};
 use fn_error_context::context;
@@ -175,8 +172,7 @@ impl AsyncStorage {
     /// * `path` - the wanted path inside the documentation.
     /// * `archive_storage` - if `true`, we will assume we have a remove ZIP archive and an index
     ///    where we can fetch the requested path from inside the ZIP file.
-    /// * `fetch_time` - used to collect metrics when using the storage inside web server handlers.
-    #[instrument(skip(fetch_time))]
+    #[instrument]
     pub(crate) async fn fetch_rustdoc_file(
         &self,
         name: &str,
@@ -184,7 +180,6 @@ impl AsyncStorage {
         latest_build_id: i32,
         path: &str,
         archive_storage: bool,
-        fetch_time: Option<&mut RenderingTimesRecorder<'_>>,
     ) -> Result<Blob> {
         trace!("fetch rustdoc file");
         Ok(if archive_storage {
@@ -193,13 +188,9 @@ impl AsyncStorage {
                 latest_build_id,
                 path,
                 self.max_file_size_for(path),
-                fetch_time,
             )
             .await?
         } else {
-            if let Some(fetch_time) = fetch_time {
-                fetch_time.step("fetch from storage");
-            }
             // Add rustdoc prefix, name and version to the path for accessing the file stored in the database
             let remote_path = format!("rustdoc/{name}/{version}/{path}");
             self.get(&remote_path, self.max_file_size_for(path)).await?
@@ -221,7 +212,6 @@ impl AsyncStorage {
                 latest_build_id,
                 path,
                 self.max_file_size_for(path),
-                None,
             )
             .await?
         } else {
@@ -347,18 +337,14 @@ impl AsyncStorage {
         Ok(local_index_path)
     }
 
-    #[instrument(skip(fetch_time))]
+    #[instrument]
     pub(crate) async fn get_from_archive(
         &self,
         archive_path: &str,
         latest_build_id: i32,
         path: &str,
         max_size: usize,
-        mut fetch_time: Option<&mut RenderingTimesRecorder<'_>>,
     ) -> Result<Blob> {
-        if let Some(ref mut t) = fetch_time {
-            t.step("find path in index");
-        }
         let index_filename = self
             .download_archive_index(archive_path, latest_build_id)
             .instrument(info_span!("download archive index"))
@@ -372,9 +358,6 @@ impl AsyncStorage {
         }?
         .ok_or(PathNotFoundError)?;
 
-        if let Some(t) = fetch_time {
-            t.step("range request");
-        }
         let blob = self
             .get_range(
                 archive_path,
@@ -641,7 +624,6 @@ impl Storage {
         latest_build_id: i32,
         path: &str,
         archive_storage: bool,
-        fetch_time: Option<&mut RenderingTimesRecorder<'_>>,
     ) -> Result<Blob> {
         self.runtime.block_on(self.inner.fetch_rustdoc_file(
             name,
@@ -649,7 +631,6 @@ impl Storage {
             latest_build_id,
             path,
             archive_storage,
-            fetch_time,
         ))
     }
 
@@ -731,14 +712,12 @@ impl Storage {
         latest_build_id: i32,
         path: &str,
         max_size: usize,
-        fetch_time: Option<&mut RenderingTimesRecorder<'_>>,
     ) -> Result<Blob> {
         self.runtime.block_on(self.inner.get_from_archive(
             archive_path,
             latest_build_id,
             path,
             max_size,
-            fetch_time,
         ))
     }
 
@@ -1173,14 +1152,13 @@ mod backend_tests {
         assert!(local_index_location.exists());
         assert!(storage.exists_in_archive("folder/test.zip", 0, "src/main.rs",)?);
 
-        let file =
-            storage.get_from_archive("folder/test.zip", 0, "Cargo.toml", std::usize::MAX, None)?;
+        let file = storage.get_from_archive("folder/test.zip", 0, "Cargo.toml", std::usize::MAX)?;
         assert_eq!(file.content, b"data");
         assert_eq!(file.mime, "text/toml");
         assert_eq!(file.path, "folder/test.zip/Cargo.toml");
 
         let file =
-            storage.get_from_archive("folder/test.zip", 0, "src/main.rs", std::usize::MAX, None)?;
+            storage.get_from_archive("folder/test.zip", 0, "src/main.rs", std::usize::MAX)?;
         assert_eq!(file.content, b"data");
         assert_eq!(file.mime, "text/rust");
         assert_eq!(file.path, "folder/test.zip/src/main.rs");


### PR DESCRIPTION
After looking at some traces I believe we're far better of with using sentry performance tracing (based on tracing spans) for this. 

Example for a single trace: 
<img width="1293" alt="grafik" src="https://github.com/rust-lang/docs.rs/assets/540890/4e91b902-7296-4bba-b899-126042e2d122">

On the transaction we can also see longer spans specifically: 
<img width="1301" alt="grafik" src="https://github.com/rust-lang/docs.rs/assets/540890/1690a7f5-7882-4db3-a069-45282d750bc3">

Generally we currently create transactions for 1% of the requests, while we could also totally add more specific config like [crates.io does](https://github.com/syphar/crates.io/blob/dcf9045a3368e5bb039f8cce0d524407c081d566/src/sentry/mod.rs#L22-L53), where they define on a transaction name level if a certain transaction should be logged. 