### PR TITLE
fix path URL-encoding for redirects on crate-details pages

### DIFF
--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -681,6 +681,7 @@ mod tests {
     };
     use anyhow::Error;
     use kuchikiki::traits::TendrilSink;
+    use reqwest::StatusCode;
     use semver::Version;
     use std::collections::HashMap;
 
@@ -1666,5 +1667,22 @@ mod tests {
             ));
             Ok(())
         });
+    }
+
+    #[test]
+    fn test_crate_name_with_other_uri_chars() {
+        wrapper(|env| {
+            env.fake_release().name("dummy").version("1.0.0").create()?;
+
+            assert_eq!(
+                env.frontend()
+                    .get_no_redirect("/crate/dummy%3E")
+                    .send()?
+                    .status(),
+                StatusCode::FOUND
+            );
+
+            Ok(())
+        })
     }
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1248,4 +1248,11 @@ mod test {
         assert_eq!(req_version, ReqVersion::Semver(VersionReq::STAR));
         assert_eq!(req_version.to_string(), "*")
     }
+
+    #[test_case("/something/", "/something/")] // already valid path
+    #[test_case("/something>", "/something%3E")] // something to encode
+    #[test_case("/something%3E", "/something%3E")] // re-running doesn't change anything
+    fn test_encode_url_path(input: &str, expected: &str) {
+        assert_eq!(encode_url_path(input), expected);
+    }
 }

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -86,7 +86,7 @@ async fn try_serve_legacy_toolchain_asset(
 
 /// Handler called for `/:crate` and `/:crate/:version` URLs. Automatically redirects to the docs
 /// or crate details page based on whether the given crate version was successfully built.
-#[instrument(skip_all)]
+#[instrument(skip(storage, config, conn))]
 pub(crate) async fn rustdoc_redirector_handler(
     Path(params): Path<RustdocRedirectorParams>,
     Extension(storage): Extension<Arc<AsyncStorage>>,


### PR DESCRIPTION
Fixes [this sentry error](https://rust-lang.sentry.io/issues/5044021817/?environment=production&project=5499376&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=1) , 

where a request to http://docs.rs/crate/cargo-edit%3E would lead to a server error instead of a redirect. 

it's a regression from #2383 

I also added some more tests. 