### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.{rs,html,js}]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
I keep having to fix indentation because my default html/js indent is set to 2, it might be nice to actually auto-format these files at some point, but for now at least it'd be good to tell editors what the expected setup is.