### PR TITLE
Show a badge on fully yanked crates in search results

### DIFF
--- a/dockerfiles/run-gui-tests.sh
+++ b/dockerfiles/run-gui-tests.sh
@@ -18,6 +18,7 @@ cargo run -- database migrate
 cargo run -- build update-toolchain
 cargo run -- build crate sysinfo 0.23.4
 cargo run -- build crate sysinfo 0.23.5
+cargo run -- build crate libtest 0.0.1
 cargo run -- build add-essential-files
 
 if [ -f .tmp.env ]; then

--- a/gui-tests/yanked.goml
+++ b/gui-tests/yanked.goml
@@ -1,0 +1,3 @@
+go-to: |DOC_PATH| + "/releases/search?query=libtest"
+
+assert-text: ("//*[contains(@class, 'release')]//*[contains(@class, 'name')][contains(text(), 'libtest-0.0.1')]", "Yanked", CONTAINS)

--- a/templates/releases/releases.html
+++ b/templates/releases/releases.html
@@ -41,6 +41,12 @@ centered
                             <div class="pure-g">
                                 <div class="pure-u-1 pure-u-sm-6-24 pure-u-md-5-24 name">
                                     {{ release.name }}-{{ release.version }}
+                                    {% if not has_unyanked_releases %}
+                                        <span class="yanked" title="all releases of {{ release.name }} have been yanked">
+                                            {{ "trash" | fas }}
+                                            Yanked
+                                        </span>
+                                    {% endif %}
                                 </div>
 
                                 <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description">

--- a/templates/style/style.scss
+++ b/templates/style/style.scss
@@ -380,6 +380,13 @@ div.recent-releases-container {
     h4 {
         border-bottom-color: var(--color-border) !important;
     }
+
+    .yanked {
+      color: var(--color-warn-msg);
+      background-color: var(--color-warn-background);
+      padding: .2em .8em .2em .5em;
+      border-radius: 1em;
+    }
 }
 
 div.package-container {


### PR DESCRIPTION
Inspired by the [recent zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/356853-t-docs-rs/topic/crate.20removal.3F) I thought we should at least make it obvious in search results which have been yanked.

![image](https://github.com/rust-lang/docs.rs/assets/81079/2d22a867-f191-4028-8caf-5ab0c45b58f7)

The badge is reminiscent of the one crates.io shows on the version pages (it has no indication on search results):

![image](https://github.com/rust-lang/docs.rs/assets/81079/7b2c9998-16ca-4e59-8fb9-57167be2d0f1)
