### PR TITLE
add rust-toolchain.toml to make our toolchain explicit

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
coming from the discussion in #2454