### PR TITLE
Faster docker development

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*.{rs,html,js,json}]
+[*.{rs,html,js,json,scss}]
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   RUST_BACKTRACE: 1
-  RUST_CACHE_KEY: rust-cache-20240320
+  RUST_CACHE_KEY: rust-cache-20240327
   DOCSRS_PREFIX: ignored/cratesfyi-prefix
   DOCSRS_DATABASE_URL: postgresql://cratesfyi:password@localhost:15432
   DOCSRS_LOG: docs_rs=debug,rustwide=info

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,8 +132,9 @@ aws-smithy-runtime = {version = "1.0.1", features = ["client", "test-util"]}
 aws-smithy-http = "0.60.0"
 indoc = "2.0.0"
 
-[profile.dev.package.sqlx-macros]
+[profile.dev.package."*"]
 opt-level = 2
+debug = "line-tables-only"
 
 [build-dependencies]
 time = "0.3"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
         build:
             context: .
             dockerfile: ./dockerfiles/Dockerfile
+            args:
+              PROFILE: dev
+              PROFILE_DIR: debug
         platform: "linux/amd64"
         depends_on:
             - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
             - "/var/run/docker.sock:/var/run/docker.sock"
             - ".rustwide-docker:/opt/docsrs/rustwide"
             - "cratesio-index:/opt/docsrs/prefix/crates.io-index"
+            - "./static:/opt/docsrs/static:ro"
         environment:
             DOCSRS_RUSTWIDE_WORKSPACE: /opt/docsrs/rustwide
             DOCSRS_DATABASE_URL: postgresql://cratesfyi:password@db

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -36,7 +36,9 @@ RUN mkdir -p src/bin && \
     echo "fn main() {}" > build.rs
 
 RUN cargo fetch
-RUN cargo build --release
+
+ARG PROFILE=release
+RUN cargo build --profile=$PROFILE
 
 # Dependencies are now cached, copy the actual source code and do another full
 # build. The touch on all the .rs files is needed, otherwise cargo assumes the
@@ -54,7 +56,7 @@ COPY assets assets/
 COPY .sqlx .sqlx/
 COPY migrations migrations/
 
-RUN cargo build --release
+RUN cargo build --profile=$PROFILE
 
 ######################
 #  Web server stage  #
@@ -69,7 +71,8 @@ RUN apt-get update \
         tini \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build /build/target/release/cratesfyi /usr/local/bin
+ARG PROFILE_DIR=release
+COPY --from=build /build/target/$PROFILE_DIR/cratesfyi /usr/local/bin
 COPY static /srv/docsrs/static
 COPY templates /srv/docsrs/templates
 COPY vendor /srv/docsrs/vendor
@@ -96,7 +99,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 
 RUN mkdir -p /opt/docsrs/prefix
 
-COPY --from=build /build/target/release/cratesfyi /usr/local/bin
+ARG PROFILE_DIR=release
+COPY --from=build /build/target/$PROFILE_DIR/cratesfyi /usr/local/bin
 COPY static /opt/docsrs/static
 COPY templates /opt/docsrs/templates
 COPY dockerfiles/entrypoint.sh /opt/docsrs/

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -14,13 +14,18 @@ FROM ubuntu:22.04 AS build
 # Install packaged dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential git curl cmake gcc g++ pkg-config libmagic-dev \
-    libssl-dev zlib1g-dev ca-certificates
+    libssl-dev zlib1g-dev ca-certificates mold clang
 
 # Install the stable toolchain with rustup
 RUN curl https://sh.rustup.rs >/tmp/rustup-init && \
     chmod +x /tmp/rustup-init && \
     /tmp/rustup-init -y --no-modify-path --default-toolchain stable --profile minimal
 ENV PATH=/root/.cargo/bin:$PATH
+
+# Configure linking to use mold instead for speed (need to use clang because gcc
+# is too old on this image)
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS=-Clink-arg=-fuse-ld=mold
 
 # Build the dependencies in a separate step to avoid rebuilding all of them
 # every time the source code changes. This takes advantage of Docker's layer


### PR DESCRIPTION
This is a set of various changes I did to make working on the UI faster while using a docker-compose instance. Overall it about halved the time between changing a `templates/style` file and being able to view the result for me after `docker compose up -d --build web`. (And allows changing the JS on the fly and just reloading the page).