### PR TITLE
allow unmaintained yaml-rust

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -10,6 +10,9 @@ ignore = [
 
     "RUSTSEC-2024-0013", # Memory corruption, denial of service, and arbitrary code execution in libgit2
     # https://github.com/rust-lang/docs.rs/issues/2414
+
+    "RUSTSEC-2024-0320", # yaml-rust is unmaintained. 
+    # https://github.com/rust-lang/docs.rs/issues/2469
 ]
 informational_warnings = ["unmaintained"] # warn for categories of informational advisories
 severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "critical")


### PR DESCRIPTION
Ref #2469 

It seems like the `syntect` maintainers don't want to use the active fork: https://github.com/trishume/syntect/pull/526 