### PR TITLE
implement custom Drop for AsyncPoolClient so we can drop it in sync context

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -882,7 +882,7 @@ impl Context for BinContext {
             .get_or_try_init::<_, Error>(|| {
                 Ok(Pool::new(
                     &*self.config()?,
-                    &*self.runtime()?,
+                    self.runtime()?,
                     self.instance_metrics()?,
                 )?)
             })?

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -590,7 +590,7 @@ impl TestDatabase {
         // test to create a fresh instance of the database to run within.
         let schema = format!("docs_rs_test_schema_{}", rand::random::<u64>());
 
-        let pool = Pool::new_with_schema(config, &runtime, metrics, &schema)?;
+        let pool = Pool::new_with_schema(config, runtime.clone(), metrics, &schema)?;
 
         runtime.block_on({
             let schema = schema.clone();


### PR DESCRIPTION
I just thought about another approach to #2476, which would be more generic so we can more easily use the async connection when we continue the sqlx migration. 