### PR TITLE
Remove imports that are redundant with a glob import

### DIFF
--- a/src/cdn.rs
+++ b/src/cdn.rs
@@ -553,10 +553,7 @@ mod tests {
     use super::*;
     use crate::test::wrapper;
 
-    use aws_sdk_cloudfront::{
-        config::{Credentials, Region},
-        Client, Config,
-    };
+    use aws_sdk_cloudfront::{config::Credentials, Config};
     use aws_smithy_runtime::client::http::test_util::{ReplayEvent, StaticReplayClient};
     use aws_smithy_types::body::SdkBody;
 

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -526,7 +526,7 @@ where
 mod test {
     use super::*;
     use crate::test::*;
-    use crate::utils::{CargoMetadata, MetadataPackage};
+    use crate::utils::CargoMetadata;
     use test_case::test_case;
 
     #[test]

--- a/src/db/delete.rs
+++ b/src/db/delete.rs
@@ -198,7 +198,6 @@ mod tests {
     use super::*;
     use crate::registry_api::CrateOwner;
     use crate::test::{assert_success, wrapper};
-    use postgres::Client;
     use test_case::test_case;
 
     fn crate_exists(conn: &mut Client, name: &str) -> Result<bool> {

--- a/src/storage/database.rs
+++ b/src/storage/database.rs
@@ -3,7 +3,7 @@ use crate::{db::Pool, error::Result, InstanceMetrics};
 use chrono::{DateTime, Utc};
 use futures_util::stream::{Stream, TryStreamExt};
 use sqlx::Acquire;
-use std::{convert::TryFrom, sync::Arc};
+use std::sync::Arc;
 
 pub(crate) struct DatabaseBackend {
     pool: Pool,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -878,7 +878,6 @@ mod test {
 #[cfg(test)]
 mod backend_tests {
     use super::*;
-    use std::fs;
 
     fn test_exists(storage: &Storage) -> Result<()> {
         assert!(!storage.exists("path/to/file.txt").unwrap());

--- a/src/utils/consistency/db.rs
+++ b/src/utils/consistency/db.rs
@@ -62,7 +62,6 @@ pub(super) fn load(conn: &mut postgres::Client, config: &Config) -> Result<Crate
 #[cfg(test)]
 mod tests {
     use super::*;
-    use super::{Crate, Release};
     use crate::test::wrapper;
 
     #[test]

--- a/src/utils/copy.rs
+++ b/src/utils/copy.rs
@@ -21,7 +21,6 @@ pub(crate) fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::fs;
 
     #[test]
     fn test_copy_doc_dir() {

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -695,14 +695,10 @@ mod tests {
         assert_cache_control, assert_redirect, assert_redirect_cached, async_wrapper, wrapper,
         FakeBuild, TestDatabase, TestEnvironment,
     };
-    use crate::{
-        db::{types::BuildStatus, update_build_status},
-        registry_api::CrateOwner,
-    };
+    use crate::{db::update_build_status, registry_api::CrateOwner};
     use anyhow::Error;
     use kuchikiki::traits::TendrilSink;
     use reqwest::StatusCode;
-    use semver::Version;
     use std::collections::HashMap;
 
     async fn release_build_status(

--- a/src/web/features.rs
+++ b/src/web/features.rs
@@ -126,10 +126,8 @@ fn get_feature_map(raw: Vec<Feature>) -> HashMap<String, Feature> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::types::Feature;
     use crate::test::{assert_cache_control, assert_redirect_cached, wrapper};
     use reqwest::StatusCode;
-    use std::collections::HashMap;
 
     #[test]
     fn test_feature_map_filters_private() {

--- a/src/web/file.rs
+++ b/src/web/file.rs
@@ -64,7 +64,7 @@ impl IntoResponse for File {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test::wrapper, web::cache::CachePolicy};
+    use crate::test::wrapper;
     use chrono::Utc;
     use http::header::CACHE_CONTROL;
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -714,8 +714,7 @@ impl_axum_webpage! {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{docbuilder::DocCoverage, test::*, web::match_version};
-    use axum::http::StatusCode;
+    use crate::{docbuilder::DocCoverage, test::*};
     use kuchikiki::traits::TendrilSink;
     use serde_json::json;
     use test_case::test_case;

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -789,7 +789,6 @@ mod tests {
     use mockito::Matcher;
     use reqwest::StatusCode;
     use serde_json::json;
-    use std::collections::HashSet;
     use test_case::test_case;
 
     #[test]


### PR DESCRIPTION
Rust 1.78+ reports the following warnings:

<details>
<summary><code>cargo check --all-features --tests</code></summary>

```console
warning: the item `TryFrom` is imported redundantly
   --> src/storage/database.rs:6:11
    |
6   | use std::{convert::TryFrom, sync::Arc};
    |           ^^^^^^^^^^^^^^^^
    |
   ::: ~/.rustup/toolchains/beta-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/prelude/mod.rs:129:13
    |
129 |     pub use core::prelude::rust_2021::*;
    |             ------------------------ the item `TryFrom` is already defined here
    |
    = note: `#[warn(unused_imports)]` on by default

warning: the item `Region` is imported redundantly
   --> src/cdn.rs:557:31
    |
553 |     use super::*;
    |         -------- the item `Region` is already imported here
...
557 |         config::{Credentials, Region},
    |                               ^^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default

warning: the item `Client` is imported redundantly
   --> src/cdn.rs:558:9
    |
553 |     use super::*;
    |         -------- the item `Client` is already imported here
...
558 |         Client, Config,
    |         ^^^^^^

warning: the item `MetadataPackage` is imported redundantly
   --> src/db/add_package.rs:529:39
    |
527 |     use super::*;
    |         -------- the item `MetadataPackage` is already imported here
528 |     use crate::test::*;
529 |     use crate::utils::{CargoMetadata, MetadataPackage};
    |                                       ^^^^^^^^^^^^^^^

warning: the item `Client` is imported redundantly
   --> src/db/delete.rs:201:9
    |
198 |     use super::*;
    |         -------- the item `Client` is already imported here
...
201 |     use postgres::Client;
    |         ^^^^^^^^^^^^^^^^

warning: the item `fs` is imported redundantly
   --> src/storage/mod.rs:881:9
    |
880 |     use super::*;
    |         -------- the item `fs` is already imported here
881 |     use std::fs;
    |         ^^^^^^^

warning: the item `fs` is imported redundantly
  --> src/utils/copy.rs:24:9
   |
23 |     use super::*;
   |         -------- the item `fs` is already imported here
24 |     use std::fs;
   |         ^^^^^^^

warning: the item `BuildStatus` is imported redundantly
   --> src/web/crate_details.rs:699:14
    |
693 |     use super::*;
    |         -------- the item `BuildStatus` is already imported here
...
699 |         db::{types::BuildStatus, update_build_status},
    |              ^^^^^^^^^^^^^^^^^^

warning: the item `Version` is imported redundantly
   --> src/web/crate_details.rs:705:9
    |
693 |     use super::*;
    |         -------- the item `Version` is already imported here
...
705 |     use semver::Version;
    |         ^^^^^^^^^^^^^^^

warning: the item `Feature` is imported redundantly
   --> src/web/features.rs:129:9
    |
128 |     use super::*;
    |         -------- the item `Feature` is already imported here
129 |     use crate::db::types::Feature;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^

warning: the item `HashMap` is imported redundantly
   --> src/web/features.rs:132:9
    |
128 |     use super::*;
    |         -------- the item `HashMap` is already imported here
...
132 |     use std::collections::HashMap;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^

warning: the item `CachePolicy` is imported redundantly
  --> src/web/file.rs:67:32
   |
66 |     use super::*;
   |         -------- the item `CachePolicy` is already imported here
67 |     use crate::{test::wrapper, web::cache::CachePolicy};
   |                                ^^^^^^^^^^^^^^^^^^^^^^^

warning: the item `HashSet` is imported redundantly
   --> src/web/releases.rs:792:9
    |
780 |     use super::*;
    |         -------- the item `HashSet` is already imported here
...
792 |     use std::collections::HashSet;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^

warning: the item `match_version` is imported redundantly
   --> src/web/mod.rs:717:51
    |
716 |     use super::*;
    |         -------- the item `match_version` is already imported here
717 |     use crate::{docbuilder::DocCoverage, test::*, web::match_version};
    |                                                   ^^^^^^^^^^^^^^^^^^

warning: the item `StatusCode` is imported redundantly
   --> src/web/mod.rs:718:9
    |
716 |     use super::*;
    |         -------- the item `StatusCode` is already imported here
717 |     use crate::{docbuilder::DocCoverage, test::*, web::match_version};
718 |     use axum::http::StatusCode;
    |         ^^^^^^^^^^^^^^^^^^^^^^
```
</details>