### PR TITLE
Pin eslint back to v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,5 +186,5 @@ jobs:
       - uses: actions/setup-node@v4
       - name: install `just`
         run: sudo snap install --edge --classic just
-      - run: npm install -g eslint
+      - run: npm install -g eslint@8
       - run: just lint-js


### PR DESCRIPTION
v9 has a breaking change around config file formats: https://eslint.org/docs/latest/use/migrate-to-9.0.0#flat-config