### PR TITLE
migrate CDN & build_queue to SQLx

### DIFF
--- a/.sqlx/query-014a054d852f0937191e1a54f742d4b4c454361689fb3841cc12fd7dd1094948.json
+++ b/.sqlx/query-014a054d852f0937191e1a54f742d4b4c454361689fb3841cc12fd7dd1094948.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM releases WHERE crate_id = $1 AND version = $2 RETURNING is_library",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "is_library",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "014a054d852f0937191e1a54f742d4b4c454361689fb3841cc12fd7dd1094948"
+}

--- a/.sqlx/query-064932c2e513213d930bc8f3518e0ad41b509316ce9a21b80034bcea76fd1136.json
+++ b/.sqlx/query-064932c2e513213d930bc8f3518e0ad41b509316ce9a21b80034bcea76fd1136.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, path_pattern, queued\n         FROM cdn_invalidation_queue\n         WHERE cdn_distribution_id = $1 AND created_in_cdn IS NULL\n         ORDER BY queued, id\n         LIMIT $2\n         FOR UPDATE",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "path_pattern",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "queued",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "064932c2e513213d930bc8f3518e0ad41b509316ce9a21b80034bcea76fd1136"
+}

--- a/.sqlx/query-12c203c76454f3b597186769c28550affce7342fc6a79de7c3b3da048232e3ec.json
+++ b/.sqlx/query-12c203c76454f3b597186769c28550affce7342fc6a79de7c3b3da048232e3ec.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO crate_priorities (pattern, priority) VALUES ($1, $2)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "12c203c76454f3b597186769c28550affce7342fc6a79de7c3b3da048232e3ec"
+}

--- a/.sqlx/query-25d29a471a449e741843246190149a6028edf072940cd5a1a2a6cc4d2978aeb5.json
+++ b/.sqlx/query-25d29a471a449e741843246190149a6028edf072940cd5a1a2a6cc4d2978aeb5.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n            BOOL_OR(releases.is_library) AS has_library\n        FROM releases\n        WHERE releases.crate_id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "has_library",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "25d29a471a449e741843246190149a6028edf072940cd5a1a2a6cc4d2978aeb5"
+}

--- a/.sqlx/query-3c31ccb7cf53d13519c6fa0b01002dc4b30d57e94f827633d59ffdd3b98585cb.json
+++ b/.sqlx/query-3c31ccb7cf53d13519c6fa0b01002dc4b30d57e94f827633d59ffdd3b98585cb.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM cdn_invalidation_queue\n         WHERE\n             cdn_distribution_id = $1 AND\n             created_in_cdn IS NOT NULL AND\n             NOT (cdn_reference = ANY($2))\n         RETURNING created_in_cdn\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "created_in_cdn",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "3c31ccb7cf53d13519c6fa0b01002dc4b30d57e94f827633d59ffdd3b98585cb"
+}

--- a/.sqlx/query-43d0bb3b88356af3abdae506b7699ec762a6f1debbbda49a3479fddaa8917e17.json
+++ b/.sqlx/query-43d0bb3b88356af3abdae506b7699ec762a6f1debbbda49a3479fddaa8917e17.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, name, version, priority, registry\n                 FROM queue\n                 WHERE\n                    attempt < $1 AND\n                    (last_attempt IS NULL OR last_attempt < NOW() - make_interval(secs => $2))\n                 ORDER BY priority ASC, attempt ASC, id ASC\n                 LIMIT 1\n                 FOR UPDATE SKIP LOCKED",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "registry",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Float8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "43d0bb3b88356af3abdae506b7699ec762a6f1debbbda49a3479fddaa8917e17"
+}

--- a/.sqlx/query-4504bbfe4e4b21c82c4f56562d42e904426f9899fbf95f177e61b1f6be226ae4.json
+++ b/.sqlx/query-4504bbfe4e4b21c82c4f56562d42e904426f9899fbf95f177e61b1f6be226ae4.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                INSERT INTO queue (name, version, priority, attempt, last_attempt )\n                VALUES ('failed_crate', '0.1.1', 0, 99, NOW())",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "4504bbfe4e4b21c82c4f56562d42e904426f9899fbf95f177e61b1f6be226ae4"
+}

--- a/.sqlx/query-4a6887c2d436121cb2ba6a9c5069455b8f222d929672dc1ff810fa49c2940e2c.json
+++ b/.sqlx/query-4a6887c2d436121cb2ba6a9c5069455b8f222d929672dc1ff810fa49c2940e2c.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO config (name, value)\n         VALUES ($1, $2)\n         ON CONFLICT (name) DO UPDATE SET value = $2;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Json"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4a6887c2d436121cb2ba6a9c5069455b8f222d929672dc1ff810fa49c2940e2c"
+}

--- a/.sqlx/query-4ec79e1fa4249f4e1b085d1bbdffa537d1e3160d642e4a3325f4aea6c21974eb.json
+++ b/.sqlx/query-4ec79e1fa4249f4e1b085d1bbdffa537d1e3160d642e4a3325f4aea6c21974eb.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM config",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "4ec79e1fa4249f4e1b085d1bbdffa537d1e3160d642e4a3325f4aea6c21974eb"
+}

--- a/.sqlx/query-5999ff17eaffa304654fb25e0d6d530cfcb83011441716e7e44b7698b146c9c8.json
+++ b/.sqlx/query-5999ff17eaffa304654fb25e0d6d530cfcb83011441716e7e44b7698b146c9c8.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT crate_id FROM releases WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "crate_id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "5999ff17eaffa304654fb25e0d6d530cfcb83011441716e7e44b7698b146c9c8"
+}

--- a/.sqlx/query-5ad9cd6cd9d444d258f7486fda178d4dd071cf43cb0ea950574af8e2f37b4a21.json
+++ b/.sqlx/query-5ad9cd6cd9d444d258f7486fda178d4dd071cf43cb0ea950574af8e2f37b4a21.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT value FROM config WHERE name = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "value",
+        "type_info": "Json"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "5ad9cd6cd9d444d258f7486fda178d4dd071cf43cb0ea950574af8e2f37b4a21"
+}

--- a/.sqlx/query-6dfb41e931f7d9c5b7e53c2a23f7c3626a7a3f7c5eddd66a323f0e39cc1e3113.json
+++ b/.sqlx/query-6dfb41e931f7d9c5b7e53c2a23f7c3626a7a3f7c5eddd66a323f0e39cc1e3113.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE cdn_invalidation_queue\n                 SET\n                     created_in_cdn = CURRENT_TIMESTAMP,\n                     cdn_reference = $1\n                 WHERE\n                     id = ANY($2)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Int8Array"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6dfb41e931f7d9c5b7e53c2a23f7c3626a7a3f7c5eddd66a323f0e39cc1e3113"
+}

--- a/.sqlx/query-7d82c098700685f05565765b87dd1768a61b48caaf8a1cfbba9a8c075760de60.json
+++ b/.sqlx/query-7d82c098700685f05565765b87dd1768a61b48caaf8a1cfbba9a8c075760de60.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n             DISTINCT cdn_reference as \"cdn_reference!\"\n         FROM cdn_invalidation_queue\n         WHERE\n             cdn_reference IS NOT NULL AND\n             cdn_distribution_id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "cdn_reference!",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "7d82c098700685f05565765b87dd1768a61b48caaf8a1cfbba9a8c075760de60"
+}

--- a/.sqlx/query-7d9e8bfad4f2ab459f4669218f372a5591925228175bd12579ed3ee9360d8685.json
+++ b/.sqlx/query-7d9e8bfad4f2ab459f4669218f372a5591925228175bd12579ed3ee9360d8685.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n             SELECT\n                cdn_distribution_id,\n                count(*) as \"count!\"\n             FROM cdn_invalidation_queue\n             GROUP BY cdn_distribution_id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "cdn_distribution_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "7d9e8bfad4f2ab459f4669218f372a5591925228175bd12579ed3ee9360d8685"
+}

--- a/.sqlx/query-80df8947b7230ea7ab2bd08206c7ad00f4a16c3964bbd1e71ce646186be20c4e.json
+++ b/.sqlx/query-80df8947b7230ea7ab2bd08206c7ad00f4a16c3964bbd1e71ce646186be20c4e.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM crates WHERE id = $1;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "80df8947b7230ea7ab2bd08206c7ad00f4a16c3964bbd1e71ce646186be20c4e"
+}

--- a/.sqlx/query-8f1900a52809215672eb6c5ca684082c77a81874c88cab453681eaa660a13ae0.json
+++ b/.sqlx/query-8f1900a52809215672eb6c5ca684082c77a81874c88cab453681eaa660a13ae0.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT pattern, priority FROM crate_priorities",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pattern",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "8f1900a52809215672eb6c5ca684082c77a81874c88cab453681eaa660a13ae0"
+}

--- a/.sqlx/query-90ff19a8b5452159a09930f450d614fd5f516c362bb2c195bcbea917775b9b54.json
+++ b/.sqlx/query-90ff19a8b5452159a09930f450d614fd5f516c362bb2c195bcbea917775b9b54.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT pattern, priority FROM crate_priorities WHERE $1 LIKE pattern LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pattern",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "90ff19a8b5452159a09930f450d614fd5f516c362bb2c195bcbea917775b9b54"
+}

--- a/.sqlx/query-92ea6c595b720132a0c3da609414e499a13b3c2c74be2e530fb55bd27aa070e4.json
+++ b/.sqlx/query-92ea6c595b720132a0c3da609414e499a13b3c2c74be2e530fb55bd27aa070e4.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM owner_rels WHERE cid = $1;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "92ea6c595b720132a0c3da609414e499a13b3c2c74be2e530fb55bd27aa070e4"
+}

--- a/.sqlx/query-9d0cc50d980892931cad27d226b1a81864b4ee2f21315556356419c8356bb92b.json
+++ b/.sqlx/query-9d0cc50d980892931cad27d226b1a81864b4ee2f21315556356419c8356bb92b.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE releases\n             SET yanked = $3\n             FROM crates\n             WHERE crates.id = releases.crate_id\n                 AND name = $1\n                 AND version = $2\n            RETURNING crates.id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9d0cc50d980892931cad27d226b1a81864b4ee2f21315556356419c8356bb92b"
+}

--- a/.sqlx/query-9e7595c7b9b336b24241c133870b99e1ee70e750849956d268ef1cb6df4f53d4.json
+++ b/.sqlx/query-9e7595c7b9b336b24241c133870b99e1ee70e750849956d268ef1cb6df4f53d4.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE queue\n                         SET\n                            attempt = attempt + 1,\n                            last_attempt = NOW()\n                         WHERE id = $1\n                         RETURNING attempt;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "attempt",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9e7595c7b9b336b24241c133870b99e1ee70e750849956d268ef1cb6df4f53d4"
+}

--- a/.sqlx/query-a68160fad4a1adbfe54d44f5efcc53c9583651187631d656c779e6d08676e5a4.json
+++ b/.sqlx/query-a68160fad4a1adbfe54d44f5efcc53c9583651187631d656c779e6d08676e5a4.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM releases WHERE id = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "a68160fad4a1adbfe54d44f5efcc53c9583651187631d656c779e6d08676e5a4"
+}

--- a/.sqlx/query-a76e4776415625ee9d323db74a68a8670070276be0cea27a46a73f487430c5a3.json
+++ b/.sqlx/query-a76e4776415625ee9d323db74a68a8670070276be0cea27a46a73f487430c5a3.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT\n                    priority,\n                    COUNT(*) as \"count!\"\n                FROM queue\n                WHERE attempt < $1\n                GROUP BY priority",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "a76e4776415625ee9d323db74a68a8670070276be0cea27a46a73f487430c5a3"
+}

--- a/.sqlx/query-aaa2cc1b0b88255cb0be16259e6b53571ead374e51fc62b9a646a77fc84b4d6d.json
+++ b/.sqlx/query-aaa2cc1b0b88255cb0be16259e6b53571ead374e51fc62b9a646a77fc84b4d6d.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM releases WHERE crate_id = $1;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "aaa2cc1b0b88255cb0be16259e6b53571ead374e51fc62b9a646a77fc84b4d6d"
+}

--- a/.sqlx/query-b2266a1d32ffedec1b35d94404d3747632ee3144ebe16cfa11d852f73a4ebbff.json
+++ b/.sqlx/query-b2266a1d32ffedec1b35d94404d3747632ee3144ebe16cfa11d852f73a4ebbff.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO queue (name, version, priority, registry)\n                 VALUES ($1, $2, $3, $4)\n                 ON CONFLICT (name, version) DO UPDATE\n                    SET priority = EXCLUDED.priority,\n                        registry = EXCLUDED.registry,\n                        attempt = 0,\n                        last_attempt = NULL\n                ;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b2266a1d32ffedec1b35d94404d3747632ee3144ebe16cfa11d852f73a4ebbff"
+}

--- a/.sqlx/query-bcb6953f312804ebdad0370c2eaf2c816378c236c5d2028c3882a1b12c6362a1.json
+++ b/.sqlx/query-bcb6953f312804ebdad0370c2eaf2c816378c236c5d2028c3882a1b12c6362a1.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE queue SET attempt = 6",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "bcb6953f312804ebdad0370c2eaf2c816378c236c5d2028c3882a1b12c6362a1"
+}

--- a/.sqlx/query-c8328ef704887faa486f9caebba0ba39a115b8e278ac4c6bb6b67f2dafefcfbb.json
+++ b/.sqlx/query-c8328ef704887faa486f9caebba0ba39a115b8e278ac4c6bb6b67f2dafefcfbb.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM queue WHERE id = $1;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c8328ef704887faa486f9caebba0ba39a115b8e278ac4c6bb6b67f2dafefcfbb"
+}

--- a/.sqlx/query-cd568b56b5d3e43427218845ee19c4e9d598f61cf18eab47b36205b1aa1be301.json
+++ b/.sqlx/query-cd568b56b5d3e43427218845ee19c4e9d598f61cf18eab47b36205b1aa1be301.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM crate_priorities WHERE pattern = $1 RETURNING priority",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "priority",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "cd568b56b5d3e43427218845ee19c4e9d598f61cf18eab47b36205b1aa1be301"
+}

--- a/.sqlx/query-d16fc68c2607f6a1c94e92ca7cf95d26725b4fa8cc664a0c1474eceb67c31570.json
+++ b/.sqlx/query-d16fc68c2607f6a1c94e92ca7cf95d26725b4fa8cc664a0c1474eceb67c31570.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) as \"count!\" FROM queue WHERE attempt >= $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "d16fc68c2607f6a1c94e92ca7cf95d26725b4fa8cc664a0c1474eceb67c31570"
+}

--- a/.sqlx/query-daaad33196fdd4e48f6bd9c4153f689d8d22a3d022eef9bae74a5590395d3fce.json
+++ b/.sqlx/query-daaad33196fdd4e48f6bd9c4153f689d8d22a3d022eef9bae74a5590395d3fce.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cdn_invalidation_queue (\n                 crate, cdn_distribution_id, path_pattern, queued, created_in_cdn, cdn_reference\n             ) VALUES (\n                 'dummy',\n                 $1,\n                 '/doesnt_matter',\n                 CURRENT_TIMESTAMP,\n                 CURRENT_TIMESTAMP,\n                 $2\n             )",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "daaad33196fdd4e48f6bd9c4153f689d8d22a3d022eef9bae74a5590395d3fce"
+}

--- a/.sqlx/query-dd166cd7a74629273eee01c62640f0fbf063b196803b8c5605356d40a31fc636.json
+++ b/.sqlx/query-dd166cd7a74629273eee01c62640f0fbf063b196803b8c5605356d40a31fc636.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT login FROM owners\n                    INNER JOIN owner_rels ON owners.id = owner_rels.oid\n                    WHERE owner_rels.cid = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "login",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "dd166cd7a74629273eee01c62640f0fbf063b196803b8c5605356d40a31fc636"
+}

--- a/.sqlx/query-e323820d9273ae10886a7a5db1864e11f94477ddef83a14b16f420c2f7b02bd0.json
+++ b/.sqlx/query-e323820d9273ae10886a7a5db1864e11f94477ddef83a14b16f420c2f7b02bd0.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT priority, attempt, last_attempt\n                     FROM queue\n                     WHERE name = $1 AND version = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "attempt",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "last_attempt",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "e323820d9273ae10886a7a5db1864e11f94477ddef83a14b16f420c2f7b02bd0"
+}

--- a/.sqlx/query-ebb47544b1090567139f3bdf2c22993c3a3aaef41c6520095a2c3bfaf6035da6.json
+++ b/.sqlx/query-ebb47544b1090567139f3bdf2c22993c3a3aaef41c6520095a2c3bfaf6035da6.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, name, version, priority, registry\n                 FROM queue\n                 WHERE attempt < $1\n                 ORDER BY priority ASC, attempt ASC, id ASC",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "registry",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "ebb47544b1090567139f3bdf2c22993c3a3aaef41c6520095a2c3bfaf6035da6"
+}

--- a/.sqlx/query-ed950d8a94ec1003506542c4d6f5cfd911b99d9d893fa9185f347cf048b0d888.json
+++ b/.sqlx/query-ed950d8a94ec1003506542c4d6f5cfd911b99d9d893fa9185f347cf048b0d888.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n         SELECT\n            crate as \"krate\",\n            cdn_distribution_id,\n            path_pattern,\n            queued,\n            created_in_cdn,\n            cdn_reference\n         FROM cdn_invalidation_queue\n         ORDER BY queued, id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "krate",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "cdn_distribution_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "path_pattern",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "queued",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_in_cdn",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "cdn_reference",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "ed950d8a94ec1003506542c4d6f5cfd911b99d9d893fa9185f347cf048b0d888"
+}

--- a/.sqlx/query-f4765711eacc30103180cabe501b9c37ae3bbe46dceaa7e9332e8c898aed659c.json
+++ b/.sqlx/query-f4765711eacc30103180cabe501b9c37ae3bbe46dceaa7e9332e8c898aed659c.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id\n             FROM queue\n             WHERE\n                attempt < $1 AND\n                name = $2 AND\n                version = $3\n             ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "f4765711eacc30103180cabe501b9c37ae3bbe46dceaa7e9332e8c898aed659c"
+}

--- a/.sqlx/query-f8cb592ce46398544f35bafe57abb0abbf27ebba1645489e9e8142a0f3c1df93.json
+++ b/.sqlx/query-f8cb592ce46398544f35bafe57abb0abbf27ebba1645489e9e8142a0f3c1df93.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE queue SET last_attempt = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f8cb592ce46398544f35bafe57abb0abbf27ebba1645489e9e8142a0f3c1df93"
+}

--- a/.sqlx/query-fb676021517a96bb24578088e2c3f59de57198c61a0aae5e8c783e5d2f511cc6.json
+++ b/.sqlx/query-fb676021517a96bb24578088e2c3f59de57198c61a0aae5e8c783e5d2f511cc6.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO cdn_invalidation_queue (crate, cdn_distribution_id, path_pattern)\n                 VALUES ($1, $2, $3)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fb676021517a96bb24578088e2c3f59de57198c61a0aae5e8c783e5d2f511cc6"
+}

--- a/.sqlx/query-fe722f4ac37ede24ffd1dd0cb736895567b750b025e4848c54a8cda7d872c48b.json
+++ b/.sqlx/query-fe722f4ac37ede24ffd1dd0cb736895567b750b025e4848c54a8cda7d872c48b.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM crates WHERE name = $1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "fe722f4ac37ede24ffd1dd0cb736895567b750b025e4848c54a8cda7d872c48b"
+}

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -1,13 +1,15 @@
 use crate::db::{delete_crate, delete_version, update_latest_version_id, Pool};
 use crate::docbuilder::PackageKind;
 use crate::error::Result;
-use crate::storage::Storage;
+use crate::storage::AsyncStorage;
 use crate::utils::{get_config, get_crate_priority, report_error, retry, set_config, ConfigName};
 use crate::Context;
 use crate::{cdn, BuildPackageSummary};
 use crate::{Config, Index, InstanceMetrics, RustwideBuilder};
 use anyhow::Context as _;
 use fn_error_context::context;
+use futures_util::stream::TryStreamExt;
+use sqlx::Connection as _;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
@@ -26,7 +28,7 @@ pub(crate) struct QueuedCrate {
 #[derive(Debug)]
 pub struct BuildQueue {
     config: Arc<Config>,
-    storage: Arc<Storage>,
+    storage: Arc<AsyncStorage>,
     pub(crate) db: Pool,
     metrics: Arc<InstanceMetrics>,
     runtime: Arc<Runtime>,
@@ -38,8 +40,8 @@ impl BuildQueue {
         db: Pool,
         metrics: Arc<InstanceMetrics>,
         config: Arc<Config>,
-        storage: Arc<Storage>,
         runtime: Arc<Runtime>,
+        storage: Arc<AsyncStorage>,
     ) -> Self {
         BuildQueue {
             max_attempts: config.build_attempts.into(),
@@ -52,23 +54,30 @@ impl BuildQueue {
     }
 
     pub fn last_seen_reference(&self) -> Result<Option<crates_index_diff::gix::ObjectId>> {
-        let mut conn = self.db.get()?;
-        if let Some(value) = get_config::<String>(&mut conn, ConfigName::LastSeenIndexReference)? {
-            return Ok(Some(crates_index_diff::gix::ObjectId::from_hex(
-                value.as_bytes(),
-            )?));
-        }
-        Ok(None)
+        self.runtime.block_on(async {
+            let mut conn = self.db.get_async().await?;
+            if let Some(value) =
+                get_config::<String>(&mut conn, ConfigName::LastSeenIndexReference).await?
+            {
+                return Ok(Some(crates_index_diff::gix::ObjectId::from_hex(
+                    value.as_bytes(),
+                )?));
+            }
+            Ok(None)
+        })
     }
 
     pub fn set_last_seen_reference(&self, oid: crates_index_diff::gix::ObjectId) -> Result<()> {
-        let mut conn = self.db.get()?;
-        set_config(
-            &mut conn,
-            ConfigName::LastSeenIndexReference,
-            oid.to_string(),
-        )?;
-        Ok(())
+        self.runtime.block_on(async {
+            let mut conn = self.db.get_async().await?;
+            set_config(
+                &mut conn,
+                ConfigName::LastSeenIndexReference,
+                oid.to_string(),
+            )
+            .await?;
+            Ok(())
+        })
     }
 
     #[context("error trying to add {name}-{version} to build queue")]
@@ -79,18 +88,28 @@ impl BuildQueue {
         priority: i32,
         registry: Option<&str>,
     ) -> Result<()> {
-        self.db.get()?.execute(
-            "INSERT INTO queue (name, version, priority, registry)
-             VALUES ($1, $2, $3, $4)
-             ON CONFLICT (name, version) DO UPDATE
-                SET priority = EXCLUDED.priority,
-                    registry = EXCLUDED.registry,
-                    attempt = 0,
-                    last_attempt = NULL
-            ;",
-            &[&name, &version, &priority, &registry],
-        )?;
-        Ok(())
+        self.runtime.block_on(async {
+            let mut conn = self.db.get_async().await?;
+
+            sqlx::query!(
+                "INSERT INTO queue (name, version, priority, registry)
+                 VALUES ($1, $2, $3, $4)
+                 ON CONFLICT (name, version) DO UPDATE
+                    SET priority = EXCLUDED.priority,
+                        registry = EXCLUDED.registry,
+                        attempt = 0,
+                        last_attempt = NULL
+                ;",
+                name,
+                version,
+                priority,
+                registry,
+            )
+            .execute(&mut *conn)
+            .await?;
+
+            Ok(())
+        })
     }
 
     pub(crate) fn pending_count(&self) -> Result<usize> {
@@ -107,73 +126,81 @@ impl BuildQueue {
     }
 
     pub(crate) fn pending_count_by_priority(&self) -> Result<HashMap<i32, usize>> {
-        let res = self.db.get()?.query(
-            "SELECT
-                priority,
-                COUNT(*)
-            FROM queue
-            WHERE attempt < $1
-            GROUP BY priority",
-            &[&self.max_attempts],
-        )?;
-        Ok(res
-            .iter()
-            .map(|row| (row.get::<_, i32>(0), row.get::<_, i64>(1) as usize))
-            .collect())
+        self.runtime.block_on(async {
+            let mut conn = self.db.get_async().await?;
+
+            Ok(sqlx::query!(
+                r#"
+                SELECT
+                    priority,
+                    COUNT(*) as "count!"
+                FROM queue
+                WHERE attempt < $1
+                GROUP BY priority"#,
+                self.max_attempts,
+            )
+            .fetch(&mut *conn)
+            .map_ok(|row| (row.priority, row.count as usize))
+            .try_collect()
+            .await?)
+        })
     }
 
     pub(crate) fn failed_count(&self) -> Result<usize> {
-        let res = self.db.get()?.query(
-            "SELECT COUNT(*) FROM queue WHERE attempt >= $1;",
-            &[&self.max_attempts],
-        )?;
-        Ok(res[0].get::<_, i64>(0) as usize)
+        self.runtime.block_on(async {
+            let mut conn = self.db.get_async().await?;
+
+            Ok(sqlx::query_scalar!(
+                r#"SELECT COUNT(*) as "count!" FROM queue WHERE attempt >= $1;"#,
+                self.max_attempts,
+            )
+            .fetch_one(&mut *conn)
+            .await? as usize)
+        })
     }
 
     pub(crate) fn queued_crates(&self) -> Result<Vec<QueuedCrate>> {
-        let query = self.db.get()?.query(
-            "SELECT id, name, version, priority, registry
-             FROM queue
-             WHERE attempt < $1
-             ORDER BY priority ASC, attempt ASC, id ASC",
-            &[&self.max_attempts],
-        )?;
+        self.runtime.block_on(async {
+            let mut conn = self.db.get_async().await?;
 
-        Ok(query
-            .into_iter()
-            .map(|row| QueuedCrate {
-                id: row.get("id"),
-                name: row.get("name"),
-                version: row.get("version"),
-                priority: row.get("priority"),
-                registry: row.get("registry"),
-            })
-            .collect())
+            Ok(sqlx::query_as!(
+                QueuedCrate,
+                "SELECT id, name, version, priority, registry
+                 FROM queue
+                 WHERE attempt < $1
+                 ORDER BY priority ASC, attempt ASC, id ASC",
+                self.max_attempts
+            )
+            .fetch_all(&mut *conn)
+            .await?)
+        })
     }
 
-    pub(crate) fn has_build_queued(&self, name: &str, version: &str) -> Result<bool> {
-        Ok(self
-            .db
-            .get()?
-            .query_opt(
-                "SELECT id
-                 FROM queue
-                 WHERE
-                    attempt < $1 AND
-                    name = $2 AND
-                    version = $3
-                 ",
-                &[&self.max_attempts, &name, &version],
-            )?
-            .is_some())
+    pub(crate) async fn has_build_queued(&self, name: &str, version: &str) -> Result<bool> {
+        let mut conn = self.db.get_async().await?;
+        Ok(sqlx::query_scalar!(
+            "SELECT id
+             FROM queue
+             WHERE
+                attempt < $1 AND
+                name = $2 AND
+                version = $3
+             ",
+            self.max_attempts,
+            name,
+            version,
+        )
+        .fetch_optional(&mut *conn)
+        .await?
+        .is_some())
     }
 
     fn process_next_crate(
         &self,
         f: impl FnOnce(&QueuedCrate) -> Result<BuildPackageSummary>,
     ) -> Result<()> {
-        let mut conn = self.db.get()?;
-        let mut transaction = conn.transaction()?;
+        let mut conn = self.runtime.block_on(self.db.get_async())?;
+        let mut transaction = self.runtime.block_on(conn.begin())?;
 
         // fetch the next available crate from the queue table.
         // We are using `SELECT FOR UPDATE` inside a transaction so
@@ -181,8 +208,9 @@ impl BuildQueue {
         // `SKIP LOCKED` here will enable another build-server to just
         // skip over taken (=locked) rows and start building the first
         // available one.
-        let to_process = match transaction
-            .query_opt(
+        let to_process = match self.runtime.block_on(
+            sqlx::query_as!(
+                QueuedCrate,
                 "SELECT id, name, version, priority, registry
                  FROM queue
                  WHERE
@@ -191,18 +219,11 @@ impl BuildQueue {
                  ORDER BY priority ASC, attempt ASC, id ASC
                  LIMIT 1
                  FOR UPDATE SKIP LOCKED",
-                &[
-                    &self.max_attempts,
-                    &self.config.delay_between_build_attempts.as_secs_f64(),
-                ],
-            )?
-            .map(|row| QueuedCrate {
-                id: row.get("id"),
-                name: row.get("name"),
-                version: row.get("version"),
-                priority: row.get("priority"),
-                registry: row.get("registry"),
-            }) {
+                self.max_attempts,
+                self.config.delay_between_build_attempts.as_secs_f64(),
+            )
+            .fetch_optional(&mut *transaction),
+        )? {
             Some(krate) => krate,
             None => return Ok(()),
         };
@@ -213,24 +234,27 @@ impl BuildQueue {
             .observe_closure_duration(|| f(&to_process));
 
         self.metrics.total_builds.inc();
-        if let Err(err) =
-            cdn::queue_crate_invalidation(&mut transaction, &self.config, &to_process.name)
-        {
+        if let Err(err) = self.runtime.block_on(cdn::queue_crate_invalidation(
+            &mut transaction,
+            &self.config,
+            &to_process.name,
+        )) {
             report_error(&err);
         }
 
         let mut increase_attempt_count = || -> Result<()> {
-            let attempt: i32 = transaction
-                .query_one(
+            let attempt: i32 = self.runtime.block_on(
+                sqlx::query_scalar!(
                     "UPDATE queue
                          SET
                             attempt = attempt + 1,
                             last_attempt = NOW()
                          WHERE id = $1
                          RETURNING attempt;",
-                    &[&to_process.id],
-                )?
-                .get(0);
+                    to_process.id,
+                )
+                .fetch_one(&mut *transaction),
+            )?;
 
             if attempt >= self.max_attempts {
                 self.metrics.failed_builds.inc();
@@ -243,7 +267,10 @@ impl BuildQueue {
                 should_reattempt: false,
                 successful: _,
             }) => {
-                transaction.execute("DELETE FROM queue WHERE id = $1;", &[&to_process.id])?;
+                self.runtime.block_on(
+                    sqlx::query!("DELETE FROM queue WHERE id = $1;", to_process.id)
+                        .execute(&mut *transaction),
+                )?;
             }
             Ok(BuildPackageSummary {
                 should_reattempt: true,
@@ -260,8 +287,7 @@ impl BuildQueue {
             }
         }
 
-        transaction.commit()?;
-
+        self.runtime.block_on(transaction.commit())?;
         Ok(())
     }
 }
@@ -270,21 +296,29 @@ impl BuildQueue {
 impl BuildQueue {
     /// Checks for the lock and returns whether it currently exists.
     pub fn is_locked(&self) -> Result<bool> {
-        let mut conn = self.db.get()?;
+        self.runtime.block_on(async {
+            let mut conn = self.db.get_async().await?;
 
-        Ok(get_config::<bool>(&mut conn, ConfigName::QueueLocked)?.unwrap_or(false))
+            Ok(get_config::<bool>(&mut conn, ConfigName::QueueLocked)
+                .await?
+                .unwrap_or(false))
+        })
     }
 
     /// lock the queue. Daemon will check this lock and stop operating if it exists.
     pub fn lock(&self) -> Result<()> {
-        let mut conn = self.db.get()?;
-        set_config(&mut conn, ConfigName::QueueLocked, true)
+        self.runtime.block_on(async {
+            let mut conn = self.db.get_async().await?;
+            set_config(&mut conn, ConfigName::QueueLocked, true).await
+        })
     }
 
     /// unlock the queue.
     pub fn unlock(&self) -> Result<()> {
-        let mut conn = self.db.get()?;
-        set_config(&mut conn, ConfigName::QueueLocked, false)
+        self.runtime.block_on(async {
+            let mut conn = self.db.get_async().await?;
+            set_config(&mut conn, ConfigName::QueueLocked, false).await
+        })
     }
 }
 
@@ -294,7 +328,6 @@ impl BuildQueue {
     ///
     /// Returns the number of crates added
     pub fn get_new_crates(&self, index: &Index) -> Result<usize> {
-        let mut conn = self.db.get()?;
         let diff = index.diff()?;
 
         let last_seen_reference = self
@@ -303,13 +336,17 @@ impl BuildQueue {
         diff.set_last_seen_reference(last_seen_reference)?;
 
         let (changes, new_reference) = diff.peek_changes_ordered()?;
+
+        let mut conn = self.runtime.block_on(self.db.get_async())?;
         let mut crates_added = 0;
 
         debug!("queueing changes from {last_seen_reference} to {new_reference}");
 
         for change in &changes {
             if let Some((ref krate, ..)) = change.crate_deleted() {
-                match delete_crate(&mut conn, &self.storage, &self.config, krate)
+                match self
+                    .runtime
+                    .block_on(delete_crate(&mut conn, &self.storage, &self.config, krate))
                     .with_context(|| format!("failed to delete crate {krate}"))
                 {
                     Ok(_) => info!(
@@ -318,42 +355,52 @@ impl BuildQueue {
                     ),
                     Err(err) => report_error(&err),
                 }
-                if let Err(err) = cdn::queue_crate_invalidation(&mut *conn, &self.config, krate) {
+                if let Err(err) = self.runtime.block_on(cdn::queue_crate_invalidation(
+                    &mut conn,
+                    &self.config,
+                    krate,
+                )) {
                     report_error(&err);
                 }
                 continue;
             }
 
             if let Some(release) = change.version_deleted() {
-                match delete_version(
-                    &mut conn,
-                    &self.storage,
-                    &self.config,
-                    &release.name,
-                    &release.version,
-                )
-                .with_context(|| {
-                    format!(
-                        "failed to delete version {}-{}",
-                        release.name, release.version
-                    )
-                }) {
+                match self
+                    .runtime
+                    .block_on(delete_version(
+                        &mut conn,
+                        &self.storage,
+                        &self.config,
+                        &release.name,
+                        &release.version,
+                    ))
+                    .with_context(|| {
+                        format!(
+                            "failed to delete version {}-{}",
+                            release.name, release.version
+                        )
+                    }) {
                     Ok(_) => info!(
                         "release {}-{} was deleted from the index and the database",
                         release.name, release.version
                     ),
                     Err(err) => report_error(&err),
                 }
-                if let Err(err) =
-                    cdn::queue_crate_invalidation(&mut *conn, &self.config, &release.name)
-                {
+                if let Err(err) = self.runtime.block_on(cdn::queue_crate_invalidation(
+                    &mut conn,
+                    &self.config,
+                    &release.name,
+                )) {
                     report_error(&err);
                 }
                 continue;
             }
 
             if let Some(release) = change.added() {
-                let priority = get_crate_priority(&mut conn, &release.name)?;
+                let priority = self
+                    .runtime
+                    .block_on(get_crate_priority(&mut conn, &release.name))?;
 
                 match self
                     .add_crate(
@@ -385,18 +432,20 @@ impl BuildQueue {
             if let Some(release) = yanked.or(unyanked) {
                 // FIXME: delay yanks of crates that have not yet finished building
                 // https://github.com/rust-lang/docs.rs/issues/1934
-                if let Err(err) = self.set_yanked(
+                if let Err(err) = self.runtime.block_on(self.set_yanked_inner(
                     &mut conn,
                     release.name.as_str(),
                     release.version.as_str(),
                     yanked.is_some(),
-                ) {
+                )) {
                     report_error(&err);
                 }
 
-                if let Err(err) =
-                    cdn::queue_crate_invalidation(&mut *conn, &self.config, &release.name)
-                {
+                if let Err(err) = self.runtime.block_on(cdn::queue_crate_invalidation(
+                    &mut conn,
+                    &self.config,
+                    &release.name,
+                )) {
                     report_error(&err);
                 }
             }
@@ -410,17 +459,25 @@ impl BuildQueue {
         Ok(crates_added)
     }
 
+    pub fn set_yanked(&self, name: &str, version: &str, yanked: bool) -> Result<()> {
+        self.runtime.block_on(async {
+            let mut conn = self.db.get_async().await?;
+            self.set_yanked_inner(&mut conn, name, version, yanked)
+                .await
+        })
+    }
+
     #[context("error trying to set {name}-{version} to yanked: {yanked}")]
-    pub fn set_yanked(
+    async fn set_yanked_inner(
         &self,
-        conn: &mut postgres::Client,
+        conn: &mut sqlx::PgConnection,
         name: &str,
         version: &str,
         yanked: bool,
     ) -> Result<()> {
         let activity = if yanked { "yanked" } else { "unyanked" };
 
-        let result = conn.query(
+        if let Some(crate_id) = sqlx::query_scalar!(
             "UPDATE releases
              SET yanked = $3
              FROM crates
@@ -429,39 +486,36 @@ impl BuildQueue {
                  AND version = $2
             RETURNING crates.id
             ",
-            &[&name, &version, &yanked],
-        )?;
-        if result.len() != 1 {
+            name,
+            version,
+            yanked,
+        )
+        .fetch_optional(&mut *conn)
+        .await?
+        {
+            debug!("{}-{} {}", name, version, activity);
+            update_latest_version_id(&mut *conn, crate_id).await?;
+        } else {
             match self
                 .has_build_queued(name, version)
+                .await
                 .context("error trying to fetch build queue")
             {
                 Ok(false) => {
-                    // the rustwide builder will fetch the current yank state from
-                    // crates.io, so and missed update here will be fixed after the
-                    // build is finished.
                     error!(
                         "tried to yank or unyank non-existing release: {} {}",
                         name, version
                     );
                 }
-                Ok(true) => {}
+                Ok(true) => {
+                    // the rustwide builder will fetch the current yank state from
+                    // crates.io, so and missed update here will be fixed after the
+                    // build is finished.
+                }
                 Err(err) => {
                     report_error(&err);
                 }
             }
-        } else {
-            debug!("{}-{} {}", name, version, activity);
-        }
-
-        if let Some(row) = result.first() {
-            let crate_id: i32 = row.get(0);
-
-            self.runtime.block_on(async {
-                let mut conn = self.db.get_async().await?;
-
-                update_latest_version_id(&mut conn, crate_id).await
-            })?;
         }
 
         Ok(())
@@ -546,7 +600,7 @@ impl BuildQueue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{DateTime, Utc};
+    use chrono::Utc;
     use std::time::Duration;
 
     #[test]
@@ -574,13 +628,16 @@ mod tests {
 
             let queue = env.build_queue();
 
-            let mut conn = env.db().conn();
-            conn.execute(
-                "
+            env.runtime().block_on(async {
+                let mut conn = env.async_db().await.async_conn().await;
+                sqlx::query!(
+                    "
                 INSERT INTO queue (name, version, priority, attempt, last_attempt )
                 VALUES ('failed_crate', '0.1.1', 0, 99, NOW())",
-                &[],
-            )?;
+                )
+                .execute(&mut *conn)
+                .await
+            })?;
 
             assert_eq!(queue.pending_count()?, 0);
 
@@ -588,17 +645,23 @@ mod tests {
 
             assert_eq!(queue.pending_count()?, 1);
 
-            let row = conn
-                .query_opt(
+            let row = env.runtime().block_on(async {
+                let mut conn = env.async_db().await.async_conn().await;
+                sqlx::query!(
                     "SELECT priority, attempt, last_attempt
                      FROM queue
                      WHERE name = $1 AND version = $2",
-                    &[&"failed_crate", &"0.1.1"],
-                )?
-                .unwrap();
-            assert_eq!(row.get::<_, i32>(0), 9);
-            assert_eq!(row.get::<_, i32>(1), 0);
-            assert!(row.get::<_, Option<DateTime<Utc>>>(2).is_none());
+                    "failed_crate",
+                    "0.1.1",
+                )
+                .fetch_one(&mut *conn)
+                .await
+                .unwrap()
+            });
+
+            assert_eq!(row.priority, 9);
+            assert_eq!(row.attempt, 0);
+            assert!(row.last_attempt.is_none());
             Ok(())
         })
     }
@@ -609,13 +672,17 @@ mod tests {
             let queue = env.build_queue();
 
             queue.add_crate("dummy", "0.1.1", 0, None)?;
-            assert!(queue.has_build_queued("dummy", "0.1.1")?);
+            env.runtime().block_on(async {
+                let mut conn = env.async_db().await.async_conn().await;
+                assert!(queue.has_build_queued("dummy", "0.1.1").await.unwrap());
 
-            env.db()
-                .conn()
-                .execute("UPDATE queue SET attempt = 6", &[])?;
+                sqlx::query!("UPDATE queue SET attempt = 6")
+                    .execute(&mut *conn)
+                    .await
+                    .unwrap();
 
-            assert!(!queue.has_build_queued("dummy", "0.1.1")?);
+                assert!(!queue.has_build_queued("dummy", "0.1.1").await.unwrap());
+            });
 
             Ok(())
         })
@@ -628,6 +695,8 @@ mod tests {
                 config.build_attempts = 99;
                 config.delay_between_build_attempts = Duration::from_secs(1);
             });
+
+            let runtime = env.runtime();
 
             let queue = env.build_queue();
 
@@ -644,14 +713,16 @@ mod tests {
                 unreachable!();
             })?;
 
-            {
+            runtime.block_on(async {
                 // fake the build-attempt timestamp so it's older
-                let mut conn = env.db().conn();
-                conn.execute(
+                let mut conn = env.async_db().await.async_conn().await;
+                sqlx::query!(
                     "UPDATE queue SET last_attempt = $1",
-                    &[&(Utc::now() - chrono::Duration::try_seconds(60).unwrap())],
-                )?;
-            }
+                    Utc::now() - chrono::Duration::try_seconds(60).unwrap()
+                )
+                .execute(&mut *conn)
+                .await
+            })?;
 
             let mut handled = false;
             // now we can process it again
@@ -745,7 +816,17 @@ mod tests {
             assert_eq!(metrics.build_time.get_sample_count(), 9);
 
             // no invalidations were run since we don't have a distribution id configured
-            assert!(cdn::queued_or_active_crate_invalidations(&mut *env.db().conn())?.is_empty());
+            assert!(env
+                .runtime()
+                .block_on(async {
+                    dbg!(
+                        cdn::queued_or_active_crate_invalidations(
+                            &mut *env.async_db().await.async_conn().await,
+                        )
+                        .await
+                    )
+                })?
+                .is_empty());
 
             Ok(())
         })
@@ -764,15 +845,23 @@ mod tests {
             queue.add_crate("will_succeed", "1.0.0", -1, None)?;
             queue.add_crate("will_fail", "1.0.0", 0, None)?;
 
-            let mut conn = env.db().conn();
-            cdn::queued_or_active_crate_invalidations(&mut *conn)?.is_empty();
+            let fetch_invalidations = || {
+                env.runtime()
+                    .block_on(async {
+                        let mut conn = env.async_db().await.async_conn().await;
+                        cdn::queued_or_active_crate_invalidations(&mut conn).await
+                    })
+                    .unwrap()
+            };
+
+            assert!(fetch_invalidations().is_empty());
 
             queue.process_next_crate(|krate| {
                 assert_eq!("will_succeed", krate.name);
                 Ok(BuildPackageSummary::default())
             })?;
 
-            let queued_invalidations = cdn::queued_or_active_crate_invalidations(&mut *conn)?;
+            let queued_invalidations = fetch_invalidations();
             assert_eq!(queued_invalidations.len(), 3);
             assert!(queued_invalidations
                 .iter()
@@ -783,7 +872,7 @@ mod tests {
                 anyhow::bail!("simulate a failure");
             })?;
 
-            let queued_invalidations = cdn::queued_or_active_crate_invalidations(&mut *conn)?;
+            let queued_invalidations = fetch_invalidations();
             assert_eq!(queued_invalidations.len(), 6);
             assert!(queued_invalidations
                 .iter()
@@ -990,8 +1079,12 @@ mod tests {
     #[test]
     fn test_broken_db_reference_breaks() {
         crate::test::wrapper(|env| {
-            let mut conn = env.db().conn();
-            set_config(&mut conn, ConfigName::LastSeenIndexReference, "invalid")?;
+            env.runtime().block_on(async {
+                let mut conn = env.async_db().await.async_conn().await;
+                set_config(&mut conn, ConfigName::LastSeenIndexReference, "invalid")
+                    .await
+                    .unwrap();
+            });
 
             let queue = env.build_queue();
             assert!(queue.last_seen_reference().is_err());

--- a/src/context.rs
+++ b/src/context.rs
@@ -15,7 +15,7 @@ pub trait Context {
     fn build_queue(&self) -> Result<Arc<BuildQueue>>;
     fn storage(&self) -> Result<Arc<Storage>>;
     async fn async_storage(&self) -> Result<Arc<AsyncStorage>>;
-    fn cdn(&self) -> Result<Arc<CdnBackend>>;
+    async fn cdn(&self) -> Result<Arc<CdnBackend>>;
     fn pool(&self) -> Result<Pool>;
     fn service_metrics(&self) -> Result<Arc<ServiceMetrics>>;
     fn instance_metrics(&self) -> Result<Arc<InstanceMetrics>>;

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,11 +1,10 @@
-use std::sync::atomic::AtomicBool;
-use std::{path::PathBuf, process::Command};
-
-use anyhow::Context;
-use crates_index_diff::gix;
-
 use crate::error::Result;
 use crate::utils::report_error;
+use anyhow::Context;
+use crates_index_diff::gix;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::AtomicBool;
 
 pub struct Index {
     path: PathBuf,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -400,7 +400,10 @@ fn apply_middleware(
 ) -> Result<AxumRouter> {
     let config = context.config()?;
     let has_templates = template_data.is_some();
-    let async_storage = context.runtime()?.block_on(context.async_storage())?;
+    let runtime = context.runtime()?;
+    let async_storage = runtime.block_on(context.async_storage())?;
+    let build_queue = context.build_queue()?;
+
     Ok(router.layer(
         ServiceBuilder::new()
             .layer(TraceLayer::new_for_http())
@@ -417,7 +420,7 @@ fn apply_middleware(
             ))
             .layer(option_layer(config.request_timeout.map(TimeoutLayer::new)))
             .layer(Extension(context.pool()?))
-            .layer(Extension(context.build_queue()?))
+            .layer(Extension(build_queue))
             .layer(Extension(context.service_metrics()?))
             .layer(Extension(context.instance_metrics()?))
             .layer(Extension(context.config()?))


### PR DESCRIPTION
Next block of migrations. 

I intentionally kept the `BuilldQueue` methods sync so `process_next_crate` works seamlessly for now. 

Apart from some small usages in the tests, the consistency check, this is the last piece of the sqlx migration. ( the PR for the rest is ready too). 

I still don't like the amount of `block_on` in the tests, but that's a topic for more refactorings. 