### PR TITLE
Handle SizeLimit error

### DIFF
--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -737,4 +737,23 @@ mod tests {
             Ok(())
         });
     }
+
+    #[test]
+    fn large_file_test() {
+        wrapper(|env| {
+            env.fake_release()
+                .name("fake")
+                .version("0.1.0")
+                .source_file("large_file.rs", &[0; 50 * 1024 * 1024 + 1]) // 50MB + 1 byte
+                .create()?;
+
+            let web = env.frontend();
+            let response = web.get("/crate/fake/0.1.0/source/large_file.rs").send()?;
+            assert_eq!(response.status(), StatusCode::OK);
+            assert!(response
+                .text()?
+                .contains("This file is too large to display"));
+            Ok(())
+        });
+    }
 }

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -741,10 +741,14 @@ mod tests {
     #[test]
     fn large_file_test() {
         wrapper(|env| {
+            env.override_config(|config| {
+                config.max_file_size = 1;
+                config.max_file_size_html = 1;
+            });
             env.fake_release()
                 .name("fake")
                 .version("0.1.0")
-                .source_file("large_file.rs", &[0; 50 * 1024 * 1024 + 1]) // 50MB + 1 byte
+                .source_file("large_file.rs", b"some_random_content")
                 .create()?;
 
             let web = env.frontend();

--- a/templates/crate/source.html
+++ b/templates/crate/source.html
@@ -28,6 +28,17 @@
 {%- block body -%}
     <div class="container package-page-container small-bottom-pad">
         <div class="pure-g">
+            {# If the file exeeded the maximum size, display a warning #}
+            {%- if is_file_too_large -%}
+                <div class="pure-u-1 pure-u-sm-17-24 pure-u-md-19-24">
+                    <div class="warning">
+                        <p>
+                            This file is too large to display.
+                        </p>
+                    </div>
+                </div>
+            {%- endif -%}
+
             <div id="side-menu" class="pure-u-1 {% if file_content %}pure-u-sm-7-24 pure-u-md-5-24 source-view{% endif %}">
                 <div class="pure-menu package-menu">
                     <ul class="pure-menu-list">

--- a/templates/crate/source.html
+++ b/templates/crate/source.html
@@ -28,18 +28,7 @@
 {%- block body -%}
     <div class="container package-page-container small-bottom-pad">
         <div class="pure-g">
-            {# If the file exeeded the maximum size, display a warning #}
-            {%- if is_file_too_large -%}
-                <div class="pure-u-1 pure-u-sm-17-24 pure-u-md-19-24">
-                    <div class="warning">
-                        <p>
-                            This file is too large to display.
-                        </p>
-                    </div>
-                </div>
-            {%- endif -%}
-
-            <div id="side-menu" class="pure-u-1 {% if file_content %}pure-u-sm-7-24 pure-u-md-5-24 source-view{% endif %}">
+            <div id="side-menu" class="pure-u-1 {% if file_content or is_file_too_large %}pure-u-sm-7-24 pure-u-md-5-24 {% endif %}{% if file_content %}source-view{% endif %}">
                 <div class="pure-menu package-menu">
                     <ul class="pure-menu-list">
                         {# If we are displaying a file, we also add a button to hide the file sidebar #}
@@ -116,6 +105,17 @@
                     </ul>
                 </div>
             </div>
+
+            {# If the file exeeded the maximum size, display a warning #}
+            {%- if is_file_too_large -%}
+                <div id="source-warning" class="pure-u-1 pure-u-sm-17-24 pure-u-md-19-24">
+                    <div class="warning">
+                        <p>
+                            This file is too large to display.
+                        </p>
+                    </div>
+                </div>
+            {%- endif -%}
 
             {# If the file has content, then display it in a codeblock #}
             {%- if file_content -%}

--- a/templates/style/style.scss
+++ b/templates/style/style.scss
@@ -901,4 +901,8 @@ ul.pure-menu-list {
             width: calc(100% - 46px);
         }
     }
+
+    #source-warning {
+        height: 100%;
+    }
 }


### PR DESCRIPTION
This solves #2481. Handle if `AsyncStorage::fetch_source_file` returnes `SizeLimitReached` error.

The message shown in the page will be like the screen shot.

![image](https://github.com/rust-lang/docs.rs/assets/26602565/7422c362-2402-4067-b027-4bfd6d9a74e2)
