### PR TITLE
fix panic in target-redirect when called with corrected name

### DIFF
--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -116,7 +116,7 @@ impl CrateDetails {
     ) -> Result<Self> {
         Ok(Self::new(
             conn,
-            &release.name,
+            &release.corrected_name.unwrap_or(release.name),
             &release.release.version,
             Some(release.req_version),
             release.all_releases,

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -1860,6 +1860,25 @@ mod test {
     }
 
     #[test]
+    fn test_target_redirect_with_corrected_name() {
+        wrapper(|env| {
+            env.fake_release()
+                .name("foo_ab")
+                .version("0.0.1")
+                .archive_storage(true)
+                .create()?;
+
+            let web = env.frontend();
+            assert_redirect_unchecked(
+                "/crate/foo-ab/0.0.1/target-redirect/x86_64-unknown-linux-gnu",
+                "/foo-ab/0.0.1/foo_ab/",
+                web,
+            )?;
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_target_redirect_not_found() {
         wrapper(|env| {
             let web = env.frontend();


### PR DESCRIPTION
This fixed [this panic / sentry error](https://rust-lang.sentry.io/issues/5254202984/?environment=production&project=5499376&referrer=issue-stream&statsPeriod=90d&stream_index=2) 

> called `Option::unwrap()` on a `None` value

coming from `CrateDetails::from_matched_release`. 

It happens when the handler is called with different dash/underscores than the crate has. 

