### PR TITLE
show in-progress builds in build queue & build-list pages

### DIFF
--- a/.sqlx/query-162c05df1f44bb48d087b6e6e4b3a8ab868b6d0cc20143b176522c0791a7023c.json
+++ b/.sqlx/query-162c05df1f44bb48d087b6e6e4b3a8ab868b6d0cc20143b176522c0791a7023c.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT\n             releases.id,\n             releases.version,\n             release_build_status.build_status as \"build_status!: BuildStatus\",\n             releases.yanked,\n             releases.is_library,\n             releases.rustdoc_status,\n             releases.target_name\n         FROM releases\n         INNER JOIN release_build_status ON releases.id = release_build_status.rid\n         WHERE\n             releases.crate_id = $1 AND\n             release_build_status.build_status != 'in_progress'",
+  "query": "SELECT\n             releases.id,\n             releases.version,\n             release_build_status.build_status as \"build_status!: BuildStatus\",\n             releases.yanked,\n             releases.is_library,\n             releases.rustdoc_status,\n             releases.target_name\n         FROM releases\n         INNER JOIN release_build_status ON releases.id = release_build_status.rid\n         WHERE\n             releases.crate_id = $1",
   "describe": {
     "columns": [
       {
@@ -65,5 +65,5 @@
       true
     ]
   },
-  "hash": "1dae7bb925d677bb997ec28130f7de41c195510e87fa643a4cae57864552962c"
+  "hash": "162c05df1f44bb48d087b6e6e4b3a8ab868b6d0cc20143b176522c0791a7023c"
 }

--- a/.sqlx/query-3cb4dcb5778c77148aeb8dfc7f942ad45269ad7aab9e9c08fdaa9cb218dbc752.json
+++ b/.sqlx/query-3cb4dcb5778c77148aeb8dfc7f942ad45269ad7aab9e9c08fdaa9cb218dbc752.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n            crates.name,\n            releases.version\n         FROM builds\n         INNER JOIN releases ON releases.id = builds.rid\n         INNER JOIN crates ON releases.crate_id = crates.id\n         WHERE\n            builds.build_status = 'in_progress'\n         ORDER BY builds.id ASC",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "3cb4dcb5778c77148aeb8dfc7f942ad45269ad7aab9e9c08fdaa9cb218dbc752"
+}

--- a/.sqlx/query-771731efe02694173d758c04a4ec616e0171b05f09b71795af14270961fa8bd0.json
+++ b/.sqlx/query-771731efe02694173d758c04a4ec616e0171b05f09b71795af14270961fa8bd0.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT\n            builds.id,\n            builds.rustc_version,\n            builds.docsrs_version,\n            builds.build_status as \"build_status: BuildStatus\",\n            builds.build_time,\n            builds.errors\n         FROM builds\n         INNER JOIN releases ON releases.id = builds.rid\n         INNER JOIN crates ON releases.crate_id = crates.id\n         WHERE\n            crates.name = $1 AND\n            releases.version = $2 AND\n            builds.build_status != 'in_progress'\n         ORDER BY id DESC",
+  "query": "SELECT\n            builds.id,\n            builds.rustc_version,\n            builds.docsrs_version,\n            builds.build_status as \"build_status: BuildStatus\",\n            builds.build_time,\n            builds.errors\n         FROM builds\n         INNER JOIN releases ON releases.id = builds.rid\n         INNER JOIN crates ON releases.crate_id = crates.id\n         WHERE\n            crates.name = $1 AND\n            releases.version = $2\n         ORDER BY id DESC",
   "describe": {
     "columns": [
       {
@@ -60,5 +60,5 @@
       true
     ]
   },
-  "hash": "e579486925d3d1927232675b2a03d5f8dd826d7136cdbba1331faf6e64c1f5eb"
+  "hash": "771731efe02694173d758c04a4ec616e0171b05f09b71795af14270961fa8bd0"
 }

--- a/migrations/20240624085737_build-status-idx.down.sql
+++ b/migrations/20240624085737_build-status-idx.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX builds_build_status_idx;

--- a/migrations/20240624085737_build-status-idx.up.sql
+++ b/migrations/20240624085737_build-status-idx.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX builds_build_status_idx ON builds USING btree (build_status ASC);

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -374,8 +374,7 @@ pub(crate) async fn releases_for_crate(
          FROM releases
          INNER JOIN release_build_status ON releases.id = release_build_status.rid
          WHERE
-             releases.crate_id = $1 AND
-             release_build_status.build_status != 'in_progress'"#,
+             releases.crate_id = $1"#,
         crate_id,
     )
     .fetch(&mut *conn)
@@ -1341,25 +1340,22 @@ mod tests {
                 .create()?;
 
             let response = env.frontend().get("/crate/foo/latest").send()?;
-            // FIXME: temporarily we don't show in-progress releases anywhere, which means we don't
-            // show releases without builds anywhere.
-            assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
-            // let page = kuchikiki::parse_html().one(response.text()?);
-            // let link = page
-            //     .select_first("a.pure-menu-link[href='/crate/foo/0.1.0']")
-            //     .unwrap();
+            let page = kuchikiki::parse_html().one(response.text()?);
+            let link = page
+                .select_first("a.pure-menu-link[href='/crate/foo/0.1.0']")
+                .unwrap();
 
-            // assert_eq!(
-            //     link.as_node()
-            //         .as_element()
-            //         .unwrap()
-            //         .attributes
-            //         .borrow()
-            //         .get("title")
-            //         .unwrap(),
-            //     "foo-0.1.0 is currently being built"
-            // );
+            assert_eq!(
+                link.as_node()
+                    .as_element()
+                    .unwrap()
+                    .attributes
+                    .borrow()
+                    .get("title")
+                    .unwrap(),
+                "foo-0.1.0 is currently being built"
+            );
 
             Ok(())
         });

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -241,6 +241,7 @@ fn semver_match<'a, F: Fn(&Release) -> bool>(
     req: &VersionReq,
     filter: F,
 ) -> Option<&'a Release> {
+    // first try standard semver match using `VersionReq::match`, should handle most cases.
     if let Some(release) = releases
         .iter()
         .filter(|release| filter(release))
@@ -249,8 +250,9 @@ fn semver_match<'a, F: Fn(&Release) -> bool>(
         Some(release)
     } else if req == &VersionReq::STAR {
         // semver `*` does not match pre-releases.
-        // When someone wants the latest release and we have only pre-releases
-        // just return the latest prerelease.
+        // So when we only have pre-releases, `VersionReq::STAR` would lead to an
+        // empty result.
+        // In this case we just return the latest latest prerelase instead of nothing.
         return releases.iter().find(|release| filter(release));
     } else {
         None

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -308,7 +308,7 @@ async fn match_version(
     };
 
     // when matching semver requirements, we only want to look at non-yanked releases.
-    let flt = |r: &&Release| r.yanked == Some(false);
+    let flt = |r: &&Release| r.yanked.is_none() || r.yanked == Some(false);
 
     if let Some(release) = releases
         .iter()

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -274,7 +274,8 @@ impl IconType {
             IconType::Brand => font_awesome_as_a_crate::Type::Brands,
         };
 
-        let icon_file_string = font_awesome_as_a_crate::svg(type_, icon_name).unwrap_or("");
+        let icon_file_string = font_awesome_as_a_crate::svg(type_, icon_name)
+            .map_err(|err| rinja::Error::Custom(Box::new(err)))?;
 
         let mut classes = vec!["fa-svg"];
         if fw {

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -1717,7 +1717,7 @@ mod tests {
             assert!(empty
                 .select(".release > div > strong")
                 .expect("missing heading")
-                .any(|el| dbg!(el.text_contents()).contains("active CDN deployments")));
+                .any(|el| el.text_contents().contains("active CDN deployments")));
 
             let full = kuchikiki::parse_html().one(web.get("/releases/queue").send()?.text()?);
             let items = full

--- a/templates/crate/builds.html
+++ b/templates/crate/builds.html
@@ -32,11 +32,14 @@
 
                 <ul>
                     {%- for build in builds -%}
+                        {% set close_tag %}
                         <li>
                             {%- if build.build_status != "in_progress" %}
                             <a href="/crate/{{ metadata.name }}/{{ metadata.version }}/builds/{{ build.id }}" class="release">
+                            {% set close_tag = "a" %}
                             {%- else -%}
                             <div class="build-in-progress">
+                            {% set close_tag = "div" %}
                             {%- endif %}
                                 <div class="pure-g">
                                     <div class="pure-u-1 pure-u-sm-1-24 build">
@@ -72,11 +75,7 @@
                                         {%- endif -%}
                                     </div>
                                 </div>
-                            {%- if build.build_status != "in_progress" %}
-                            </a>
-                            {%- else -%}
-                            </div>
-                            {%- endif %}
+                            </{{ close_tag }}>
                         </li>
                     {%- endfor -%}
                 </ul>

--- a/templates/crate/builds.html
+++ b/templates/crate/builds.html
@@ -33,7 +33,11 @@
                 <ul>
                     {%- for build in builds -%}
                         <li>
+                            {%- if build.build_status != "in_progress" %}
                             <a href="/crate/{{ metadata.name }}/{{ metadata.version }}/builds/{{ build.id }}" class="release">
+                            {%- else -%}
+                            <div class="build-in-progress">
+                            {%- endif %}
                                 <div class="pure-g">
                                     <div class="pure-u-1 pure-u-sm-1-24 build">
                                         {%- if build.build_status == "success" -%}
@@ -68,12 +72,15 @@
                                         {%- endif -%}
                                     </div>
                                 </div>
+                            {%- if build.build_status != "in_progress" %}
                             </a>
+                            {%- else -%}
+                            </div>
+                            {%- endif %}
                         </li>
                     {%- endfor -%}
                 </ul>
             {%- else -%}
-                {# FIXME: temporarily this will never be shown since we hide in-progress releases for now #}
                 <div class="warning">
                     docs.rs has not built {{ metadata.name }}-{{ metadata.version }}
                     <br>

--- a/templates/crate/builds.html
+++ b/templates/crate/builds.html
@@ -43,7 +43,7 @@
                                         {%- if build.build_status == "success" -%}
                                             {{ "check"|fas(false, false, "") }}
                                         {%- elif build.build_status == "failure" -%}
-                                            {{ "times"|fas(false, false, "") }}
+                                            {{ "triangle-exclamation"|fas(false, false, "") }}
                                         {%- elif build.build_status == "in_progress" -%}
                                             {{ "gear"|fas(false, true, "") }}
                                         {%- else -%}

--- a/templates/crate/source.html
+++ b/templates/crate/source.html
@@ -86,11 +86,11 @@
 
                                     {# Text files or files which mime starts with `text` #}
                                     {%- elif file.mime == "text/plain" || file.mime|split_first("/") == Some("text") -%}
-                                        {{ "file-alt"|far(false, false, "") }}
+                                        {{ "file-lines"|far(false, false, "") }}
 
                                         {# Binary files and any unrecognized types #}
                                     {% else -%}
-                                        {{ "file-archive"|far(false, false, "") }}
+                                        {{ "file"|far(false, false, "") }}
                                     {%- endif -%}
 
                                     <span class="text">{{ file.name }}</span>

--- a/templates/releases/build_queue.html
+++ b/templates/releases/build_queue.html
@@ -15,56 +15,56 @@
 {%- block body -%}
     <div class="container">
         <div class="recent-releases-container">
-                <div class="release pure-g">
-                    <div class="pure-u-1-2">
-                        <strong>currently being built</strong>
-                    </div>
-                    <div class="pure-u-1-2">
-                        {%- if !active_cdn_deployments.is_empty() %}
-                            <strong>active CDN deployments</strong>
-                        {%- endif %}
-                    </div>
+            <div class="release pure-g">
+                <div class="pure-u-1-2">
+                    <strong>currently being built</strong>
                 </div>
+                <div class="pure-u-1-2">
+                    {%- if !active_cdn_deployments.is_empty() %}
+                        <strong>active CDN deployments</strong>
+                    {%- endif %}
+                </div>
+            </div>
 
-                <div class = "pure-g">
-                    <div class="pure-u-1-2">
-                        {%- if !in_progress_builds.is_empty() %}
-                            <ol class="queue-list">
-                                {% for release in in_progress_builds -%}
-                                    <li>
-                                        <a href="/crate/{{ release.0 }}/{{ release.1 }}/builds">
-                                            {{ release.0 }} {{ release.1 }}
-                                        </a>
-                                    </li>
-                                {%- endfor %}
-                            </ol>
-                        {%- else %}
-                            <div class="about">
-                                <p><strong>There is nothing currently being built</strong></p>
-                            </div>
-                        {%- endif %}
-                    </div>
-                    <div class="pure-u-1-2">
-                        {%- if !active_cdn_deployments.is_empty() %}
-                            <ol class="queue-list">
-                                {% for krate in active_cdn_deployments -%}
-                                    <li>
-                                        <a href="/{{ krate }}">
-                                            {{ krate }}
-                                        </a>
-                                    </li>
-                                {%- endfor %}
-                            </ol>
-                            <div class="about">
-                                <p>
-                                    After the build finishes it may take up to 20 minutes for all documentation
-                                    pages to be up-to-date and available to everybody.
-                                </p>
-                                <p>Especially <code>/latest/</code> URLs might be affected.</p>
-                            </div>
-                        {%- endif %}
-                    </div>
+            <div class = "pure-g">
+                <div class="pure-u-1-2">
+                    {%- if !in_progress_builds.is_empty() %}
+                        <ol class="queue-list">
+                            {% for release in in_progress_builds -%}
+                                <li>
+                                    <a href="/crate/{{ release.0 }}/{{ release.1 }}/builds">
+                                        {{ release.0 }} {{ release.1 }}
+                                    </a>
+                                </li>
+                            {%- endfor %}
+                        </ol>
+                    {%- else %}
+                        <div class="about">
+                            <p><strong>There is nothing currently being built</strong></p>
+                        </div>
+                    {%- endif %}
                 </div>
+                <div class="pure-u-1-2">
+                    {%- if !active_cdn_deployments.is_empty() %}
+                        <ol class="queue-list">
+                            {% for krate in active_cdn_deployments -%}
+                                <li>
+                                    <a href="/{{ krate }}">
+                                        {{ krate }}
+                                    </a>
+                                </li>
+                            {%- endfor %}
+                        </ol>
+                        <div class="about">
+                            <p>
+                                After the build finishes it may take up to 20 minutes for all documentation
+                                pages to be up-to-date and available to everybody.
+                            </p>
+                            <p>Especially <code>/latest/</code> URLs might be affected.</p>
+                        </div>
+                    {%- endif %}
+                </div>
+            </div>
 
             <div class="release">
                 <strong>Build Queue</strong>

--- a/templates/releases/build_queue.html
+++ b/templates/releases/build_queue.html
@@ -15,34 +15,56 @@
 {%- block body -%}
     <div class="container">
         <div class="recent-releases-container">
-            {%- if !active_deployments.is_empty() %}
-                <div class="release">
-                    <strong>active CDN deployments</strong>
+                <div class="release pure-g">
+                    <div class="pure-u-1-2">
+                        <strong>currently being built</strong>
+                    </div>
+                    <div class="pure-u-1-2">
+                        {%- if !active_cdn_deployments.is_empty() %}
+                            <strong>active CDN deployments</strong>
+                        {%- endif %}
+                    </div>
                 </div>
 
                 <div class = "pure-g">
                     <div class="pure-u-1-2">
-                        <ol class="queue-list">
-                            {% for krate in active_deployments -%}
-                                <li>
-                                    <a href="https://docs.rs/{{ krate }}">
-                                        {{ krate }}
-                                    </a>
-                                </li>
-                            {%- endfor %}
-                        </ol>
+                        {%- if !in_progress_builds.is_empty() %}
+                            <ol class="queue-list">
+                                {% for release in in_progress_builds -%}
+                                    <li>
+                                        <a href="/crate/{{ release.0 }}/{{ release.1 }}/builds">
+                                            {{ release.0 }} {{ release.1 }}
+                                        </a>
+                                    </li>
+                                {%- endfor %}
+                            </ol>
+                        {%- else %}
+                            <div class="about">
+                                <p><strong>There is nothing currently being built</strong></p>
+                            </div>
+                        {%- endif %}
                     </div>
                     <div class="pure-u-1-2">
-                        <div class="about">
-                            <p>
-                                After the build finishes it may take up to 20 minutes for all documentation
-                                pages to be up-to-date and available to everybody.
-                            </p>
-                            <p>Especially <code>/latest/</code> URLs might be affected.</p>
-                        </div>
+                        {%- if !active_cdn_deployments.is_empty() %}
+                            <ol class="queue-list">
+                                {% for krate in active_cdn_deployments -%}
+                                    <li>
+                                        <a href="/{{ krate }}">
+                                            {{ krate }}
+                                        </a>
+                                    </li>
+                                {%- endfor %}
+                            </ol>
+                            <div class="about">
+                                <p>
+                                    After the build finishes it may take up to 20 minutes for all documentation
+                                    pages to be up-to-date and available to everybody.
+                                </p>
+                                <p>Especially <code>/latest/</code> URLs might be affected.</p>
+                            </div>
+                        {%- endif %}
                     </div>
                 </div>
-            {%- endif %}
 
             <div class="release">
                 <strong>Build Queue</strong>

--- a/templates/style/style.scss
+++ b/templates/style/style.scss
@@ -280,7 +280,7 @@ div.recent-releases-container {
         background-color: var(--background-color);
     }
 
-    .release {
+    .release, .build-in-progress {
         display: block;
         border-bottom: 1px solid var(--color-border);
         padding: 0.4em $search-result-right-left-padding;
@@ -297,11 +297,13 @@ div.recent-releases-container {
     }
 
     .release:hover,
-    a.release:focus {
+    a.release:focus,
+    .build-in-progress:hover {
         background-color: var(--color-background-code);
     }
 
-    li:last-of-type .release {
+    li:last-of-type .release,
+    li:last-of-type .build-in-progress {
         border-bottom: none;
     }
 


### PR DESCRIPTION
Resolves #1011. 
( last piece IMO)

this will start showing in-progress builds mainly in: 
- the build queue (linking to the build-list)
- the build-list for each crate (not linking to any logs). 

on top of already redirecting to the build-list when someone tried to access a new in-progress crate. 

I'm not 100% certain if we will open up the handlers to some new errors when called on a in-progress crate, but IMO we just have to see and act when there are errors. 


#### One caveat: 
Perhaps I'm missing something, but I believe we will have an issue around server restarts and in-progress builds. When we stop / restart our server process we will just stop building without updating our build-status in the database. So we might have "orphaned" in-progress builds. 

I'm not sure yet how to solve this the best way, I think the correct solution is a proper graceful shutdown involving rustwide doesn't feel simple. The shutdown would also have to be per build-server, so autoscaling buildservers in the future doesn't reset the build status for builds on other build-servers. 

A workaround if we see this happening would probably be to manually reset the build-status for in-progress builds in our deploy-script. 