### PR TITLE
add API for crates.io to trigger rebuilds

### DIFF
--- a/.sqlx/query-648ce6ae0bfbdc28ad7f4099f8141380bd83a93829e8a89d083c263bf621ed5f.json
+++ b/.sqlx/query-648ce6ae0bfbdc28ad7f4099f8141380bd83a93829e8a89d083c263bf621ed5f.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT COUNT(*) as \"count!\"\n        FROM releases\n        INNER JOIN crates ON crates.id = releases.crate_id\n        WHERE crates.name = $1 AND releases.version = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "648ce6ae0bfbdc28ad7f4099f8141380bd83a93829e8a89d083c263bf621ed5f"
+}

--- a/.sqlx/query-d5353f99e2f09d4264d925f26b70198ec623b7fc7a9f386dd108f2d0fcdab50c.json
+++ b/.sqlx/query-d5353f99e2f09d4264d925f26b70198ec623b7fc7a9f386dd108f2d0fcdab50c.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT 1 as \"dummy\"\n        FROM releases\n        INNER JOIN crates ON crates.id = releases.crate_id\n        WHERE crates.name = $1 AND releases.version = $2\n        LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "dummy",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "d5353f99e2f09d4264d925f26b70198ec623b7fc7a9f386dd108f2d0fcdab50c"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,6 +1098,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1592,7 @@ dependencies = [
  "chrono",
  "clap",
  "comrak",
+ "constant_time_eq",
  "crates-index",
  "crates-index-diff",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ chrono = { version = "0.4.11", default-features = false, features = ["clock", "s
 # Transitive dependencies we don't use directly but need to have specific versions of
 thread_local = "1.1.3"
 humantime = "2.1.0"
+constant_time_eq = "0.3.0"
 
 [dependencies.postgres]
 version = "0.19"

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -151,7 +151,7 @@ impl BuildQueue {
             .collect())
     }
 
-    fn has_build_queued(&self, name: &str, version: &str) -> Result<bool> {
+    pub(crate) fn has_build_queued(&self, name: &str, version: &str) -> Result<bool> {
         Ok(self
             .db
             .get()?

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,9 @@ pub struct Config {
     // Gitlab authentication
     pub(crate) gitlab_accesstoken: Option<String>,
 
+    // Access token for APIs for crates.io
+    pub(crate) cratesio_token: Option<String>,
+
     // amount of retries for external API calls, mostly crates.io
     pub crates_io_api_call_retries: u32,
 
@@ -175,6 +178,8 @@ impl Config {
             github_updater_min_rate_limit: env("DOCSRS_GITHUB_UPDATER_MIN_RATE_LIMIT", 2500)?,
 
             gitlab_accesstoken: maybe_env("DOCSRS_GITLAB_ACCESSTOKEN")?,
+
+            cratesio_token: maybe_env("DOCSRS_CRATESIO_TOKEN")?,
 
             max_file_size: env("DOCSRS_MAX_FILE_SIZE", 50 * 1024 * 1024)?,
             max_file_size_html: env("DOCSRS_MAX_FILE_SIZE_HTML", 50 * 1024 * 1024)?,

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,7 +41,8 @@ pub struct Config {
     // Gitlab authentication
     pub(crate) gitlab_accesstoken: Option<String>,
 
-    // Access token for APIs for crates.io
+    // Access token for APIs for crates.io (careful: use
+    // constant_time_eq for comparisons!)
     pub(crate) cratesio_token: Option<String>,
 
     // amount of retries for external API calls, mostly crates.io

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -777,6 +777,12 @@ impl TestFrontend {
         self.client.request(Method::GET, url)
     }
 
+    pub(crate) fn post(&self, url: &str) -> RequestBuilder {
+        let url = self.build_url(url);
+        debug!("posting {url}");
+        self.client.request(Method::POST, url)
+    }
+
     pub(crate) fn get_no_redirect(&self, url: &str) -> RequestBuilder {
         let url = self.build_url(url);
         debug!("getting {url} (no redirects)");

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -1,22 +1,34 @@
-use super::{cache::CachePolicy, error::AxumNope, headers::CanonicalUrl};
+use super::{
+    cache::CachePolicy,
+    error::{AxumNope, JsonAxumNope, JsonAxumResult},
+    headers::CanonicalUrl,
+};
 use crate::{
     db::types::BuildStatus,
     docbuilder::Limits,
     impl_axum_webpage,
+    utils::spawn_blocking,
     web::{
+        crate_details::CrateDetails,
         error::AxumResult,
         extractors::{DbConnection, Path},
         match_version, MetaData, ReqVersion,
     },
-    Config,
+    BuildQueue, Config,
 };
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use axum::{
     extract::Extension, http::header::ACCESS_CONTROL_ALLOW_ORIGIN, response::IntoResponse, Json,
 };
+use axum_extra::{
+    headers::{authorization::Bearer, Authorization},
+    TypedHeader,
+};
 use chrono::{DateTime, Utc};
+use http::StatusCode;
 use semver::Version;
 use serde::Serialize;
+use serde_json::json;
 use std::sync::Arc;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -109,6 +121,83 @@ pub(crate) async fn build_list_json_handler(
         ),
     )
         .into_response())
+}
+
+async fn build_trigger_check(
+    mut conn: DbConnection,
+    name: &String,
+    version: &Version,
+    build_queue: &Arc<BuildQueue>,
+) -> AxumResult<impl IntoResponse> {
+    let _ = CrateDetails::new(&mut *conn, &name, &version, None, vec![])
+        .await?
+        .ok_or(AxumNope::VersionNotFound)?;
+
+    let crate_version_is_in_queue = spawn_blocking({
+        let name = name.clone();
+        let version_string = version.to_string();
+        let build_queue = build_queue.clone();
+        move || build_queue.has_build_queued(&name, &version_string)
+    })
+    .await?;
+    if crate_version_is_in_queue {
+        return Err(AxumNope::BadRequest(anyhow!(
+            "crate {name} {version} already queued for rebuild"
+        )));
+    }
+
+    Ok(())
+}
+
+// Priority according to issue #2442; positive here as it's inverted.
+// FUTURE: move to a crate-global enum with all special priorities?
+const TRIGGERED_REBUILD_PRIORITY: i32 = 5;
+
+pub(crate) async fn build_trigger_rebuild_handler(
+    Path((name, version)): Path<(String, Version)>,
+    conn: DbConnection,
+    Extension(build_queue): Extension<Arc<BuildQueue>>,
+    Extension(config): Extension<Arc<Config>>,
+    opt_auth_header: Option<TypedHeader<Authorization<Bearer>>>,
+) -> JsonAxumResult<impl IntoResponse> {
+    let expected_token =
+        config
+            .cratesio_token
+            .as_ref()
+            .ok_or(JsonAxumNope(AxumNope::Unauthorized(
+                "Endpoint is not configured",
+            )))?;
+
+    // (Future: would it be better to have standard middleware handle auth?)
+    let TypedHeader(auth_header) = opt_auth_header.ok_or(JsonAxumNope(AxumNope::Unauthorized(
+        "Missing authentication token",
+    )))?;
+    if auth_header.token() != expected_token {
+        return Err(JsonAxumNope(AxumNope::Unauthorized(
+            "The token used for authentication is not valid",
+        )));
+    }
+
+    build_trigger_check(conn, &name, &version, &build_queue)
+        .await
+        .map_err(JsonAxumNope)?;
+
+    spawn_blocking({
+        let name = name.clone();
+        let version_string = version.to_string();
+        move || {
+            build_queue.add_crate(
+                &name,
+                &version_string,
+                TRIGGERED_REBUILD_PRIORITY,
+                None, /* because crates.io is the only service that calls this endpoint */
+            )
+        }
+    })
+    .await
+    .map_err(|e| JsonAxumNope(e.into()))?;
+
+    Ok((StatusCode::CREATED, Json(json!({}))))
 }
 
 async fn get_builds(
@@ -271,6 +360,113 @@ mod tests {
                 value.pointer("/2/build_time").unwrap().as_str().unwrap()
                     < value.pointer("/1/build_time").unwrap().as_str().unwrap()
             );
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn build_trigger_rebuild_missing_config() {
+        wrapper(|env| {
+            env.fake_release().name("foo").version("0.1.0").create()?;
+
+            {
+                let response = env.frontend().get("/crate/regex/1.3.1/rebuild").send()?;
+                // Needs POST
+                assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+            }
+
+            {
+                let response = env.frontend().post("/crate/regex/1.3.1/rebuild").send()?;
+                assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+                let json: serde_json::Value = response.json()?;
+                assert_eq!(
+                    json,
+                    serde_json::json!({
+                        "title": "Unauthorized",
+                        "message": "Endpoint is not configured"
+                    })
+                );
+            }
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn build_trigger_rebuild_with_config() {
+        wrapper(|env| {
+            let correct_token = "foo137";
+            env.override_config(|config| config.cratesio_token = Some(correct_token.into()));
+
+            env.fake_release().name("foo").version("0.1.0").create()?;
+
+            {
+                let response = env.frontend().post("/crate/regex/1.3.1/rebuild").send()?;
+                assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+                let json: serde_json::Value = response.json()?;
+                assert_eq!(
+                    json,
+                    serde_json::json!({
+                        "title": "Unauthorized",
+                        "message": "Missing authentication token"
+                    })
+                );
+            }
+
+            {
+                let response = env
+                    .frontend()
+                    .post("/crate/regex/1.3.1/rebuild")
+                    .bearer_auth("someinvalidtoken")
+                    .send()?;
+                assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+                let json: serde_json::Value = response.json()?;
+                assert_eq!(
+                    json,
+                    serde_json::json!({
+                        "title": "Unauthorized",
+                        "message": "The token used for authentication is not valid"
+                    })
+                );
+            }
+
+            assert_eq!(env.build_queue().pending_count()?, 0);
+            assert!(!env.build_queue().has_build_queued("foo", "0.1.0")?);
+
+            {
+                let response = env
+                    .frontend()
+                    .post("/crate/foo/0.1.0/rebuild")
+                    .bearer_auth(correct_token)
+                    .send()?;
+                assert_eq!(response.status(), StatusCode::CREATED);
+                let json: serde_json::Value = response.json()?;
+                assert_eq!(json, serde_json::json!({}));
+            }
+
+            assert_eq!(env.build_queue().pending_count()?, 1);
+            assert!(env.build_queue().has_build_queued("foo", "0.1.0")?);
+
+            {
+                let response = env
+                    .frontend()
+                    .post("/crate/foo/0.1.0/rebuild")
+                    .bearer_auth(correct_token)
+                    .send()?;
+                assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+                let json: serde_json::Value = response.json()?;
+                assert_eq!(
+                    json,
+                    serde_json::json!({
+                        "title": "Bad request",
+                        "message": "crate foo 0.1.0 already queued for rebuild"
+                    })
+                );
+            }
+
+            assert_eq!(env.build_queue().pending_count()?, 1);
+            assert!(env.build_queue().has_build_queued("foo", "0.1.0")?);
 
             Ok(())
         });

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -9,7 +9,6 @@ use crate::{
     impl_axum_webpage,
     utils::spawn_blocking,
     web::{
-        crate_details::CrateDetails,
         error::AxumResult,
         extractors::{DbConnection, Path},
         match_version, MetaData, ReqVersion,
@@ -123,15 +122,35 @@ pub(crate) async fn build_list_json_handler(
         .into_response())
 }
 
-async fn build_trigger_check(
+async fn crate_version_exists(
     mut conn: DbConnection,
+    name: &String,
+    version: &Version,
+) -> Result<bool, anyhow::Error> {
+    let row = sqlx::query!(
+        r#"
+        SELECT 1 as "dummy"
+        FROM releases
+        INNER JOIN crates ON crates.id = releases.crate_id
+        WHERE crates.name = $1 AND releases.version = $2
+        LIMIT 1"#,
+        name,
+        version.to_string(),
+    )
+    .fetch_optional(&mut *conn)
+    .await?;
+    Ok(row.is_some())
+}
+
+async fn build_trigger_check(
+    conn: DbConnection,
     name: &String,
     version: &Version,
     build_queue: &Arc<BuildQueue>,
 ) -> AxumResult<impl IntoResponse> {
-    let _ = CrateDetails::new(&mut *conn, &name, &version, None, vec![])
-        .await?
-        .ok_or(AxumNope::VersionNotFound)?;
+    if !crate_version_exists(conn, name, version).await? {
+        return Err(AxumNope::VersionNotFound);
+    }
 
     let crate_version_is_in_queue = spawn_blocking({
         let name = name.clone();

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -24,6 +24,7 @@ use axum_extra::{
     TypedHeader,
 };
 use chrono::{DateTime, Utc};
+use constant_time_eq::constant_time_eq;
 use http::StatusCode;
 use semver::Version;
 use serde::Serialize;
@@ -191,7 +192,7 @@ pub(crate) async fn build_trigger_rebuild_handler(
     let TypedHeader(auth_header) = opt_auth_header.ok_or(JsonAxumNope(AxumNope::Unauthorized(
         "Missing authentication token",
     )))?;
-    if auth_header.token() != expected_token {
+    if !constant_time_eq(auth_header.token().as_bytes(), expected_token.as_bytes()) {
         return Err(JsonAxumNope(AxumNope::Unauthorized(
             "The token used for authentication is not valid",
         )));

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -126,7 +126,7 @@ impl CrateDetails {
         .unwrap())
     }
 
-    async fn new(
+    pub(crate) async fn new(
         conn: &mut sqlx::PgConnection,
         name: &str,
         version: &Version,

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -126,7 +126,7 @@ impl CrateDetails {
         .unwrap())
     }
 
-    pub(crate) async fn new(
+    async fn new(
         conn: &mut sqlx::PgConnection,
         name: &str,
         version: &Version,

--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -28,6 +28,8 @@ pub enum AxumNope {
     VersionNotFound,
     #[error("Search yielded no results")]
     NoResults,
+    #[error("Unauthorized: {0}")]
+    Unauthorized(&'static str),
     #[error("internal error")]
     InternalError(anyhow::Error),
     #[error("bad request")]
@@ -92,6 +94,11 @@ impl AxumNope {
                 title: "Bad request",
                 message: Cow::Owned(source.to_string()),
                 status: StatusCode::BAD_REQUEST,
+            }),
+            AxumNope::Unauthorized(what) => ErrorResponse::ErrorInfo(ErrorInfo {
+                title: "Unauthorized",
+                message: what.into(),
+                status: StatusCode::UNAUTHORIZED,
             }),
             AxumNope::InternalError(source) => {
                 crate::utils::report_error(&source);

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -572,7 +572,7 @@ where
 fn axum_cached_redirect<U>(
     uri: U,
     cache_policy: cache::CachePolicy,
-) -> Result<impl IntoResponse, Error>
+) -> Result<axum::response::Response, Error>
 where
     U: TryInto<http::Uri> + std::fmt::Debug,
     <U as TryInto<http::Uri>>::Error: std::fmt::Debug,

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -225,6 +225,10 @@ pub(super) fn build_axum_routes() -> AxumRouter {
             get_internal(super::builds::build_list_json_handler),
         )
         .route(
+            "/crate/:name/:version/rebuild",
+            post_internal(super::builds::build_trigger_rebuild_handler),
+        )
+        .route(
             "/crate/:name/:version/status.json",
             get_internal(super::status::status_handler),
         )

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -6,7 +6,7 @@ use axum::{
     handler::Handler as AxumHandler,
     middleware::{self, Next},
     response::{IntoResponse, Redirect},
-    routing::{get, MethodRouter},
+    routing::{get, post, MethodRouter},
     Router as AxumRouter,
 };
 use axum_extra::routing::RouterExt;
@@ -35,6 +35,18 @@ where
     S: Clone + Send + Sync + 'static,
 {
     get(handler).route_layer(middleware::from_fn(|request, next| async {
+        request_recorder(request, next, None).await
+    }))
+}
+
+#[instrument(skip_all)]
+fn post_internal<H, T, S>(handler: H) -> MethodRouter<S, Infallible>
+where
+    H: AxumHandler<T, S>,
+    T: 'static,
+    S: Clone + Send + Sync + 'static,
+{
+    post(handler).route_layer(middleware::from_fn(|request, next| async {
         request_recorder(request, next, None).await
     }))
 }


### PR DESCRIPTION
relates to #2442.

- adds config variable `DOCSRS_TRIGGER_REBUILD_TOKEN` /
    `Config.trigger_rebuild_token`

- adds `build_trigger_rebuild_handler` and route
    "/crate/:name/:version/rebuild"

Note: does not yet contain any kind of rate limiting!
