### PR TITLE
fix regression when showing search results with a failed crate

### DIFF
--- a/templates/releases/releases.html
+++ b/templates/releases/releases.html
@@ -59,10 +59,14 @@ centered
                                         {{ release.stars }}
                                         {{ "star" | fas }}
                                     </div>
-                                {%- else -%}
+                                {%- elif release.build_time -%}
                                     <div class="pure-u-1 pure-u-sm-4-24 pure-u-md-3-24 date"
                                         title="{{ release.build_time | date(format='%FT%TZ') }}">
                                         {{ release.build_time | timeformat(relative=true) }}
+                                    </div>
+                                {%- else -%}
+                                    <div class="pure-u-1 pure-u-sm-4-24 pure-u-md-3-24 date">
+                                        &mdash;
                                     </div>
                                 {%- endif %}
                             </div>


### PR DESCRIPTION
Fix for [this sentry error](https://rust-lang.sentry.io/issues/5529909736/?environment=production&project=5499376&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=0). 

We tried to access the `build_time` when rendering the search results, but this field is only filled when a build actually finished. 

( I'll probably start tracking `build_start` or `release_time` as a better number