### PR TITLE
Fix display of "branch icon" in crate page

### DIFF
--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -69,7 +69,7 @@
                                     {# If the repo link is for github or gitlab, show some stats #}
                                     {# TODO: add support for hosts besides github and gitlab (#35) #}
                                     {%- if let Some(repository_metadata) = details.repository_metadata -%}
-                                        {{ "code-branch"|fab(false, false, "") }}
+                                        {{ "code-branch"|fab(false, false, "")|safe }}
                                         {% if let Some(name) = repository_metadata.name %}
                                             {{name}}
                                         {% else %}


### PR DESCRIPTION
Fixes:

![image](https://github.com/user-attachments/assets/fe71ecae-4403-4824-9e8c-93dcbd9f4ed1)
