### PR TITLE
log output for coverage command, fix span attributes for builder.build_package

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -340,7 +340,7 @@ impl RustwideBuilder {
         self.build_package(&package.name, &package.version, PackageKind::Local(path))
     }
 
-    #[instrument(name = "docbuilder.build_package", parent = None, skip(self))]
+    #[instrument(name = "docbuilder.build_package", parent = None, skip(self, name), fields(krate=name))]
     pub fn build_package(
         &mut self,
         name: &str,

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -734,7 +734,7 @@ impl RustwideBuilder {
                     }
                 }
             })
-            .log_output(false)
+            .log_output(true)
             .run()?;
 
         Ok(


### PR DESCRIPTION
- the `build_package` span didn't contain the crate name, because the parameter `name` conflicted with the span `name`. ( IMO this should error somehow instead of silently duplicating the JSON dict entry )
- the coverage command didn't log outputs, so we currently can't debug problems with it, like the _exit code 101_ we are currently seeing