### PR TITLE
ignore sqlx security alert for audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -10,6 +10,13 @@ ignore = [
 
     "RUSTSEC-2024-0320", # yaml-rust is unmaintained. 
     # https://github.com/rust-lang/docs.rs/issues/2469
+
+    "RUSTSEC-2024-0363", # sqlx, Binary Protocol Misinterpretation caused by Truncating or Overflowing Cast
+    # https://github.com/rust-lang/docs.rs/issues/2588
+    # SECURITY: 
+    # We have plenty of places where user input ends up in sql, for example the inner doc path for doc pages, crate names etc.
+    # But in all these places, the user content is part of the path of the URL.
+    # Since URL length is limited by cloudfront, and also by nginx, to something much smaller than 4 GiB, I don't think this issue affects us.
 ]
 informational_warnings = ["unmaintained"] # warn for categories of informational advisories
 severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "critical")


### PR DESCRIPTION
see https://github.com/rust-lang/docs.rs/issues/2588

We have plenty of places where user input ends up in sql, for example the inner doc path for doc pages, crate names etc. 

But in all these places, the user content is part of the _path_ of the URL. 

Since URL length is limited by cloudfront, and also by nginx, to something much smaller than 4 GiB, I don't think this issue affects us. 