### PR TITLE
Update rinja to 0.3.2 and do some template cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5006,9 +5006,9 @@ dependencies = [
 
 [[package]]
 name = "rinja"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277b2c2c91c4837a83e294e915853a3045bfc916940985e8bd6895bbc2805e0"
+checksum = "5bf96e290b3578af4ca20699abca2b90d5aba9eeae4acd123fd83c8547165eb4"
 dependencies = [
  "humansize",
  "itoa 1.0.11",
@@ -5019,9 +5019,9 @@ dependencies = [
 
 [[package]]
 name = "rinja_derive"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e122959e84d33680230169545c71498b8f162612c3a448006f746477c05062d7"
+checksum = "2fa31df46c7a8c125cfe8ec5f0b1d2689b65d4652fd8de9bf0ac41d6e0ac68f3"
 dependencies = [
  "basic-toml",
  "memchr",
@@ -5038,9 +5038,9 @@ dependencies = [
 
 [[package]]
 name = "rinja_parser"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "530f3486f922197485c273f317c73a547f9e358cd8f9f421acdd935dec4c845e"
+checksum = "4ee3ef25da2517861878f58ecbd7b8ba6bebd5634fe1b4421df20d100fb75745"
 dependencies = [
  "memchr",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5006,9 +5006,9 @@ dependencies = [
 
 [[package]]
 name = "rinja"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3762e3740cdbf2fd2be465cc2c26d643ad17353cc2e0223d211c1b096118bd"
+checksum = "a277b2c2c91c4837a83e294e915853a3045bfc916940985e8bd6895bbc2805e0"
 dependencies = [
  "humansize",
  "itoa 1.0.11",
@@ -5019,9 +5019,9 @@ dependencies = [
 
 [[package]]
 name = "rinja_derive"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd01fd8e15e7d19c8b8052c1d428325131e02ff1633cdcf695190c2e56ab682c"
+checksum = "e122959e84d33680230169545c71498b8f162612c3a448006f746477c05062d7"
 dependencies = [
  "basic-toml",
  "memchr",
@@ -5031,18 +5031,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rinja_parser",
+ "rustc-hash",
  "serde",
  "syn 2.0.72",
 ]
 
 [[package]]
 name = "rinja_parser"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f6bf7cef118c6de21206edf0b3f19f5ede60006be674a58ca21b6e003a1b57"
+checksum = "530f3486f922197485c273f317c73a547f9e358cd8f9f421acdd935dec4c845e"
 dependencies = [
  "memchr",
  "nom",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ tempfile = "3.1.0"
 fn-error-context = "0.2.0"
 
 # Templating
-rinja = "0.3"
+rinja = "0.3.1"
 walkdir = "2"
 
 # Date and Time utilities

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ tempfile = "3.1.0"
 fn-error-context = "0.2.0"
 
 # Templating
-rinja = "0.3.1"
+rinja = "0.3.2"
 walkdir = "2"
 
 # Date and Time utilities

--- a/src/utils/html.rs
+++ b/src/utils/html.rs
@@ -19,8 +19,8 @@ pub(crate) fn rewrite_lol(
     use lol_html::{HtmlRewriter, MemorySettings, Settings};
 
     let head_html = Head::new(data).render().unwrap();
-    let vendored_html = Vendored::new(data).render().unwrap();
-    let body_html = Body::new(data).render().unwrap();
+    let vendored_html = Vendored.render().unwrap();
+    let body_html = Body.render().unwrap();
     let topbar_html = Topbar::new(data).render().unwrap();
 
     // Before: <body> ... rustdoc content ... </body>

--- a/src/utils/html.rs
+++ b/src/utils/html.rs
@@ -1,5 +1,4 @@
-use crate::web::page::templates::{Body, Head, Topbar, Vendored};
-use crate::web::rustdoc::RustdocPage;
+use crate::web::page::templates::{Body, Head, RustdocPage, Vendored};
 use lol_html::element;
 use lol_html::errors::RewritingError;
 use rinja::Template;
@@ -21,7 +20,7 @@ pub(crate) fn rewrite_lol(
     let head_html = Head::new(data).render().unwrap();
     let vendored_html = Vendored.render().unwrap();
     let body_html = Body.render().unwrap();
-    let topbar_html = Topbar::new(data).render().unwrap();
+    let topbar_html = data.render().unwrap();
 
     // Before: <body> ... rustdoc content ... </body>
     // After:

--- a/src/utils/html.rs
+++ b/src/utils/html.rs
@@ -1,4 +1,5 @@
-use crate::web::page::templates::{Body, Head, RustdocPage, Vendored};
+use crate::web::page::templates::{Body, Head, Vendored};
+use crate::web::rustdoc::RustdocPage;
 use lol_html::element;
 use lol_html::errors::RewritingError;
 use rinja::Template;

--- a/src/web/build_details.rs
+++ b/src/web/build_details.rs
@@ -44,9 +44,6 @@ impl_axum_webpage! { BuildDetailsPage }
 
 // Used for template rendering.
 impl BuildDetailsPage {
-    pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
-        Some(&self.metadata)
-    }
     pub(crate) fn use_direct_platform_links(&self) -> bool {
         true
     }

--- a/src/web/build_details.rs
+++ b/src/web/build_details.rs
@@ -2,7 +2,6 @@ use crate::{
     db::types::BuildStatus,
     impl_axum_webpage,
     web::{
-        crate_details::CrateDetails,
         error::{AxumNope, AxumResult},
         extractors::{DbConnection, Path},
         file::File,
@@ -45,9 +44,6 @@ impl_axum_webpage! { BuildDetailsPage }
 
 // Used for template rendering.
 impl BuildDetailsPage {
-    pub(crate) fn krate(&self) -> Option<&CrateDetails> {
-        None
-    }
     pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
         Some(&self.metadata)
     }

--- a/src/web/build_details.rs
+++ b/src/web/build_details.rs
@@ -48,9 +48,6 @@ impl BuildDetailsPage {
     pub(crate) fn krate(&self) -> Option<&CrateDetails> {
         None
     }
-    pub(crate) fn permalink_path(&self) -> &str {
-        ""
-    }
     pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
         Some(&self.metadata)
     }

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -54,9 +54,6 @@ struct BuildsPage {
 impl_axum_webpage! { BuildsPage }
 
 impl BuildsPage {
-    pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
-        Some(&self.metadata)
-    }
     pub(crate) fn use_direct_platform_links(&self) -> bool {
         true
     }

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -58,9 +58,6 @@ impl BuildsPage {
     pub(crate) fn krate(&self) -> Option<&CrateDetails> {
         None
     }
-    pub(crate) fn permalink_path(&self) -> &str {
-        ""
-    }
     pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
         Some(&self.metadata)
     }

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -9,7 +9,6 @@ use crate::{
     impl_axum_webpage,
     utils::spawn_blocking,
     web::{
-        crate_details::CrateDetails,
         error::AxumResult,
         extractors::{DbConnection, Path},
         filters, match_version, MetaData, ReqVersion,
@@ -55,9 +54,6 @@ struct BuildsPage {
 impl_axum_webpage! { BuildsPage }
 
 impl BuildsPage {
-    pub(crate) fn krate(&self) -> Option<&CrateDetails> {
-        None
-    }
     pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
         Some(&self.metadata)
     }

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -430,10 +430,6 @@ impl CrateDetailsPage {
         None
     }
 
-    pub(crate) fn permalink_path(&self) -> &str {
-        ""
-    }
-
     pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
         Some(&self.details.metadata)
     }

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -426,10 +426,6 @@ impl_axum_webpage! {
 
 // Used by templates.
 impl CrateDetailsPage {
-    pub(crate) fn krate(&self) -> Option<&CrateDetails> {
-        None
-    }
-
     pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
         Some(&self.details.metadata)
     }

--- a/src/web/features.rs
+++ b/src/web/features.rs
@@ -112,9 +112,6 @@ impl_axum_webpage! {
 }
 
 impl FeaturesPage {
-    pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
-        Some(&self.metadata)
-    }
     pub(crate) fn use_direct_platform_links(&self) -> bool {
         true
     }

--- a/src/web/features.rs
+++ b/src/web/features.rs
@@ -116,9 +116,6 @@ impl FeaturesPage {
     pub(crate) fn krate(&self) -> Option<&CrateDetails> {
         None
     }
-    pub(crate) fn permalink_path(&self) -> &str {
-        ""
-    }
     pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
         Some(&self.metadata)
     }

--- a/src/web/features.rs
+++ b/src/web/features.rs
@@ -3,7 +3,6 @@ use crate::{
     impl_axum_webpage,
     web::{
         cache::CachePolicy,
-        crate_details::CrateDetails,
         error::{AxumNope, AxumResult},
         extractors::{DbConnection, Path},
         filters,
@@ -113,9 +112,6 @@ impl_axum_webpage! {
 }
 
 impl FeaturesPage {
-    pub(crate) fn krate(&self) -> Option<&CrateDetails> {
-        None
-    }
     pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
         Some(&self.metadata)
     }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -731,12 +731,6 @@ pub(crate) struct AxumErrorPage {
     pub csp_nonce: String,
 }
 
-impl AxumErrorPage {
-    pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
-        None
-    }
-}
-
 impl_axum_webpage! {
     AxumErrorPage,
     status = |err| err.status,

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -1,6 +1,5 @@
 use crate::error::Result;
-use crate::web::crate_details::CrateDetails;
-use crate::web::MetaData;
+use crate::web::rustdoc::RustdocPage;
 use anyhow::Context;
 use rinja::Template;
 use std::{fmt, sync::Arc};
@@ -27,24 +26,6 @@ pub struct Vendored;
 #[derive(Template)]
 #[template(path = "rustdoc/body.html")]
 pub struct Body;
-
-#[derive(Template)]
-#[template(path = "rustdoc/topbar.html")]
-#[derive(Debug, Clone)]
-pub struct RustdocPage {
-    pub latest_path: String,
-    pub permalink_path: String,
-    pub inner_path: String,
-    // true if we are displaying the latest version of the crate, regardless
-    // of whether the URL specifies a version number or the string "latest."
-    pub is_latest_version: bool,
-    // true if the URL specifies a version using the string "latest."
-    pub is_latest_url: bool,
-    pub is_prerelease: bool,
-    pub krate: CrateDetails,
-    pub metadata: MetaData,
-    pub current_target: String,
-}
 
 /// Holds all data relevant to templating
 #[derive(Debug)]

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -1,10 +1,9 @@
 use crate::error::Result;
 use crate::web::crate_details::CrateDetails;
-use crate::web::rustdoc::RustdocPage;
 use crate::web::MetaData;
 use anyhow::Context;
 use rinja::Template;
-use std::{fmt, ops::Deref, sync::Arc};
+use std::{fmt, sync::Arc};
 use tracing::trace;
 
 #[derive(Template)]
@@ -31,34 +30,20 @@ pub struct Body;
 
 #[derive(Template)]
 #[template(path = "rustdoc/topbar.html")]
-pub struct Topbar<'a> {
-    inner: &'a RustdocPage,
-    permalink_path: &'a str,
-    krate: &'a CrateDetails,
-    metadata: &'a MetaData,
-    current_target: &'a str,
-    latest_path: &'a str,
-}
-
-impl<'a> Topbar<'a> {
-    pub fn new(inner: &'a RustdocPage) -> Self {
-        Self {
-            inner,
-            permalink_path: &inner.permalink_path,
-            krate: &inner.krate,
-            metadata: &inner.metadata,
-            current_target: &inner.current_target,
-            latest_path: &inner.latest_path,
-        }
-    }
-}
-
-impl<'a> Deref for Topbar<'a> {
-    type Target = RustdocPage;
-
-    fn deref(&self) -> &Self::Target {
-        self.inner
-    }
+#[derive(Debug, Clone)]
+pub struct RustdocPage {
+    pub latest_path: String,
+    pub permalink_path: String,
+    pub inner_path: String,
+    // true if we are displaying the latest version of the crate, regardless
+    // of whether the URL specifies a version number or the string "latest."
+    pub is_latest_version: bool,
+    // true if the URL specifies a version using the string "latest."
+    pub is_latest_url: bool,
+    pub is_prerelease: bool,
+    pub krate: CrateDetails,
+    pub metadata: MetaData,
+    pub current_target: String,
 }
 
 /// Holds all data relevant to templating

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -1,4 +1,5 @@
 use crate::error::Result;
+use crate::web::crate_details::CrateDetails;
 use crate::web::rustdoc::RustdocPage;
 use crate::web::MetaData;
 use anyhow::Context;
@@ -33,6 +34,7 @@ pub struct Body;
 pub struct Topbar<'a> {
     inner: &'a RustdocPage,
     permalink_path: &'a str,
+    krate: &'a CrateDetails,
 }
 
 impl<'a> Topbar<'a> {
@@ -40,6 +42,7 @@ impl<'a> Topbar<'a> {
         Self {
             inner,
             permalink_path: &inner.permalink_path,
+            krate: &inner.krate,
         }
     }
 

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -35,6 +35,8 @@ pub struct Topbar<'a> {
     inner: &'a RustdocPage,
     permalink_path: &'a str,
     krate: &'a CrateDetails,
+    metadata: &'a MetaData,
+    current_target: &'a str,
 }
 
 impl<'a> Topbar<'a> {
@@ -43,11 +45,9 @@ impl<'a> Topbar<'a> {
             inner,
             permalink_path: &inner.permalink_path,
             krate: &inner.krate,
+            metadata: &inner.metadata,
+            current_target: &inner.current_target,
         }
-    }
-
-    pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
-        Some(&self.inner.metadata)
     }
 }
 

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -8,13 +8,13 @@ use tracing::trace;
 #[derive(Template)]
 #[template(path = "rustdoc/head.html")]
 pub struct Head<'a> {
-    rustdoc_css_file: &'a Option<String>,
+    rustdoc_css_file: Option<&'a str>,
 }
 
 impl<'a> Head<'a> {
     pub fn new(inner: &'a RustdocPage) -> Self {
         Self {
-            rustdoc_css_file: &inner.metadata.rustdoc_css_file,
+            rustdoc_css_file: inner.metadata.rustdoc_css_file.as_deref(),
         }
     }
 }

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -6,36 +6,6 @@ use rinja::Template;
 use std::{fmt, ops::Deref, sync::Arc};
 use tracing::trace;
 
-macro_rules! rustdoc_page {
-    ($name:ident, $path:literal $(, $meta:ident)?) => {
-        #[derive(Template)]
-        #[template(path = $path)]
-        pub struct $name<'a> {
-            inner: &'a RustdocPage,
-        }
-
-        impl<'a> $name<'a> {
-            pub fn new(inner: &'a RustdocPage) -> Self {
-                Self { inner }
-            }
-
-            $(
-                pub(crate) fn $meta(&self) -> Option<&MetaData> {
-                    Some(&self.inner.metadata)
-                }
-            )?
-        }
-
-        impl<'a> Deref for $name<'a> {
-            type Target = RustdocPage;
-
-            fn deref(&self) -> &Self::Target {
-                self.inner
-            }
-        }
-    };
-}
-
 #[derive(Template)]
 #[template(path = "rustdoc/head.html")]
 pub struct Head<'a> {
@@ -58,7 +28,33 @@ pub struct Vendored;
 #[template(path = "rustdoc/body.html")]
 pub struct Body;
 
-rustdoc_page!(Topbar, "rustdoc/topbar.html", get_metadata);
+#[derive(Template)]
+#[template(path = "rustdoc/topbar.html")]
+pub struct Topbar<'a> {
+    inner: &'a RustdocPage,
+    permalink_path: &'a str,
+}
+
+impl<'a> Topbar<'a> {
+    pub fn new(inner: &'a RustdocPage) -> Self {
+        Self {
+            inner,
+            permalink_path: &inner.permalink_path,
+        }
+    }
+
+    pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
+        Some(&self.inner.metadata)
+    }
+}
+
+impl<'a> Deref for Topbar<'a> {
+    type Target = RustdocPage;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner
+    }
+}
 
 /// Holds all data relevant to templating
 #[derive(Debug)]

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -37,6 +37,7 @@ pub struct Topbar<'a> {
     krate: &'a CrateDetails,
     metadata: &'a MetaData,
     current_target: &'a str,
+    latest_path: &'a str,
 }
 
 impl<'a> Topbar<'a> {
@@ -47,6 +48,7 @@ impl<'a> Topbar<'a> {
             krate: &inner.krate,
             metadata: &inner.metadata,
             current_target: &inner.current_target,
+            latest_path: &inner.latest_path,
         }
     }
 }

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -36,9 +36,28 @@ macro_rules! rustdoc_page {
     };
 }
 
-rustdoc_page!(Head, "rustdoc/head.html");
-rustdoc_page!(Vendored, "rustdoc/vendored.html");
-rustdoc_page!(Body, "rustdoc/body.html");
+#[derive(Template)]
+#[template(path = "rustdoc/head.html")]
+pub struct Head<'a> {
+    rustdoc_css_file: &'a Option<String>,
+}
+
+impl<'a> Head<'a> {
+    pub fn new(inner: &'a RustdocPage) -> Self {
+        Self {
+            rustdoc_css_file: &inner.metadata.rustdoc_css_file,
+        }
+    }
+}
+
+#[derive(Template)]
+#[template(path = "rustdoc/vendored.html")]
+pub struct Vendored;
+
+#[derive(Template)]
+#[template(path = "rustdoc/body.html")]
+pub struct Body;
+
 rustdoc_page!(Topbar, "rustdoc/topbar.html", get_metadata);
 
 /// Holds all data relevant to templating

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -12,7 +12,7 @@ use crate::{
         extractors::{DbConnection, Path},
         match_version,
         page::templates::filters,
-        MetaData, ReqVersion,
+        ReqVersion,
     },
     BuildQueue, Config, InstanceMetrics,
 };
@@ -312,12 +312,6 @@ impl_axum_webpage! {
     cache_policy = |_| CachePolicy::ShortInCdnAndBrowser,
 }
 
-impl HomePage {
-    pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
-        None
-    }
-}
-
 pub(crate) async fn home_page(mut conn: DbConnection) -> AxumResult<impl IntoResponse> {
     let recent_releases =
         get_releases(&mut conn, 1, RELEASES_IN_HOME, Order::ReleaseTime, true).await?;
@@ -365,12 +359,6 @@ struct ViewReleases {
 }
 
 impl_axum_webpage! { ViewReleases }
-
-impl ViewReleases {
-    pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
-        None
-    }
-}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum ReleaseType {
@@ -522,12 +510,6 @@ impl Default for Search {
             status: http::StatusCode::OK,
             csp_nonce: String::new(),
         }
-    }
-}
-
-impl Search {
-    pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
-        None
     }
 }
 
@@ -739,12 +721,6 @@ struct ReleaseActivity {
     csp_nonce: String,
 }
 
-impl ReleaseActivity {
-    pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
-        None
-    }
-}
-
 impl_axum_webpage! { ReleaseActivity }
 
 pub(crate) async fn activity_handler(mut conn: DbConnection) -> AxumResult<impl IntoResponse> {
@@ -813,12 +789,6 @@ struct BuildQueuePage {
 }
 
 impl_axum_webpage! { BuildQueuePage }
-
-impl BuildQueuePage {
-    pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
-        None
-    }
-}
 
 pub(crate) async fn build_queue_handler(
     Extension(build_queue): Extension<Arc<BuildQueue>>,

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -318,11 +318,6 @@ impl RustdocPage {
         Some(&self.krate)
     }
 
-    // Used for template rendering.
-    pub(crate) fn permalink_path(&self) -> &str {
-        &self.permalink_path
-    }
-
     pub(crate) fn use_direct_platform_links(&self) -> bool {
         !self.latest_path.contains("/target-redirect/")
     }

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -313,11 +313,6 @@ impl RustdocPage {
             .into_response())
     }
 
-    // Used for template rendering.
-    pub(crate) fn krate(&self) -> Option<&CrateDetails> {
-        Some(&self.krate)
-    }
-
     pub(crate) fn use_direct_platform_links(&self) -> bool {
         !self.latest_path.contains("/target-redirect/")
     }

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -14,8 +14,9 @@ use crate::{
         extractors::{DbConnection, Path},
         file::File,
         match_version,
+        page::templates::RustdocPage,
         page::TemplateData,
-        MetaData, ReqVersion,
+        ReqVersion,
     },
     AsyncStorage, Config, InstanceMetrics, RUSTDOC_STATIC_STORAGE_PREFIX,
 };
@@ -255,22 +256,6 @@ pub(crate) async fn rustdoc_redirector_handler(
         )?
         .into_response())
     }
-}
-
-#[derive(Debug, Clone)]
-pub struct RustdocPage {
-    pub latest_path: String,
-    pub permalink_path: String,
-    pub inner_path: String,
-    // true if we are displaying the latest version of the crate, regardless
-    // of whether the URL specifies a version number or the string "latest."
-    pub is_latest_version: bool,
-    // true if the URL specifies a version using the string "latest."
-    pub is_latest_url: bool,
-    pub is_prerelease: bool,
-    pub krate: CrateDetails,
-    pub metadata: MetaData,
-    pub current_target: String,
 }
 
 impl RustdocPage {

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -14,9 +14,9 @@ use crate::{
         extractors::{DbConnection, Path},
         file::File,
         match_version,
-        page::templates::RustdocPage,
+        page::templates::filters,
         page::TemplateData,
-        ReqVersion,
+        MetaData, ReqVersion,
     },
     AsyncStorage, Config, InstanceMetrics, RUSTDOC_STATIC_STORAGE_PREFIX,
 };
@@ -28,6 +28,7 @@ use axum::{
 };
 use lol_html::errors::RewritingError;
 use once_cell::sync::Lazy;
+use rinja::Template;
 use semver::Version;
 use serde::Deserialize;
 use std::{
@@ -256,6 +257,24 @@ pub(crate) async fn rustdoc_redirector_handler(
         )?
         .into_response())
     }
+}
+
+#[derive(Template)]
+#[template(path = "rustdoc/topbar.html")]
+#[derive(Debug, Clone)]
+pub struct RustdocPage {
+    pub latest_path: String,
+    pub permalink_path: String,
+    pub inner_path: String,
+    // true if we are displaying the latest version of the crate, regardless
+    // of whether the URL specifies a version number or the string "latest."
+    pub is_latest_version: bool,
+    // true if the URL specifies a version using the string "latest."
+    pub is_latest_url: bool,
+    pub is_prerelease: bool,
+    pub krate: CrateDetails,
+    pub metadata: MetaData,
+    pub current_target: String,
 }
 
 impl RustdocPage {

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -7,7 +7,7 @@ use crate::{
         error::{AxumNope, AxumResult},
         extractors::{DbConnection, Path},
         page::templates::filters,
-        AxumErrorPage, MetaData,
+        AxumErrorPage,
     },
     Config,
 };
@@ -122,12 +122,6 @@ struct AboutBuilds {
     csp_nonce: String,
 }
 
-impl AboutBuilds {
-    pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
-        None
-    }
-}
-
 impl_axum_webpage!(AboutBuilds);
 
 pub(crate) async fn about_builds_handler(
@@ -158,12 +152,6 @@ macro_rules! about_page {
         }
 
         impl_axum_webpage! { $ty }
-
-        impl $ty {
-            pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
-                None
-            }
-        }
     };
 }
 

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -4,8 +4,8 @@ use crate::{
     impl_axum_webpage,
     storage::PathNotFoundError,
     web::{
-        cache::CachePolicy, crate_details::CrateDetails, error::AxumNope, extractors::Path,
-        file::File as DbFile, filters, headers::CanonicalUrl, MetaData, ReqVersion,
+        cache::CachePolicy, error::AxumNope, extractors::Path, file::File as DbFile, filters,
+        headers::CanonicalUrl, MetaData, ReqVersion,
     },
     AsyncStorage,
 };
@@ -173,9 +173,6 @@ impl_axum_webpage! {
 impl SourcePage {
     pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
         Some(&self.metadata)
-    }
-    pub(crate) fn krate(&self) -> Option<&CrateDetails> {
-        None
     }
     pub(crate) fn use_direct_platform_links(&self) -> bool {
         true

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -171,9 +171,6 @@ impl_axum_webpage! {
 
 // Used in templates.
 impl SourcePage {
-    pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
-        Some(&self.metadata)
-    }
     pub(crate) fn use_direct_platform_links(&self) -> bool {
         true
     }

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -174,9 +174,6 @@ impl SourcePage {
     pub(crate) fn get_metadata(&self) -> Option<&MetaData> {
         Some(&self.metadata)
     }
-    pub(crate) fn permalink_path(&self) -> &str {
-        ""
-    }
     pub(crate) fn krate(&self) -> Option<&CrateDetails> {
         None
     }

--- a/templates/crate/build_details.html
+++ b/templates/crate/build_details.html
@@ -10,7 +10,6 @@
 {%- endblock body_classes -%}
 
 {%- block topbar -%}
-  {%- set current_target = String::new() -%}
   {%- set latest_version = "" -%}
   {%- set latest_path = "" -%}
   {%- set target = "" -%}

--- a/templates/crate/build_details.html
+++ b/templates/crate/build_details.html
@@ -11,7 +11,6 @@
 
 {%- block topbar -%}
   {%- set latest_version = "" -%}
-  {%- set latest_path = "" -%}
   {%- set target = "" -%}
   {%- set inner_path = metadata.target_name_url() -%}
   {%- set is_latest_version = true -%}

--- a/templates/crate/builds.html
+++ b/templates/crate/builds.html
@@ -14,7 +14,6 @@
 {%- endblock body_classes -%}
 
 {%- block topbar -%}
-  {%- set current_target = String::new() -%}
   {%- set latest_version = "" -%}
   {%- set latest_path = "" -%}
   {%- set target = "" -%}

--- a/templates/crate/builds.html
+++ b/templates/crate/builds.html
@@ -15,7 +15,6 @@
 
 {%- block topbar -%}
   {%- set latest_version = "" -%}
-  {%- set latest_path = "" -%}
   {%- set target = "" -%}
   {%- set inner_path = metadata.target_name_url() -%}
   {%- set is_latest_version = true -%}

--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -130,30 +130,30 @@
                 {# If the release is not a library #}
                 {%- if is_library == Some(false) -%}
                     <div class="warning">
-                        {{ self.name }}-{{ version }} is not a library.
+                        {{ name }}-{{ version }} is not a library.
                     </div>
 
                 {# If the release has been yanked and is a library #}
                 {%- elif metadata.yanked.unwrap_or_default() -%}
                     <div class="warning">
-                        {{ self.name }}-{{ version }} has been yanked.
+                        {{ name }}-{{ version }} has been yanked.
                     </div>
 
                 {# If the build succeeded, isn't yanked and is a library #}
                 {%- elif build_status == "success" -%}
                     {# If there are no docs display a warning #}
                     {%- if !rustdoc_status.unwrap_or_default() -%}
-                        <div class="warning">{{ self.name }}-{{ version }} doesn't have any documentation.</div>
+                        <div class="warning">{{ name }}-{{ version }} doesn't have any documentation.</div>
                     {%- endif -%}
 
                 {# If the build failed, the release isn't yanked and the release is a library #}
                 {%- elif build_status == "failure" -%}
                     {# Display a warning telling the user we failed to build the docs #}
                     <div class="warning">
-                        docs.rs failed to build {{ self.name }}-{{ version }}
+                        docs.rs failed to build {{ name }}-{{ version }}
                         <br>
                         Please check the
-                        <a href="/crate/{{ self.name }}/{{ version }}/builds">build logs</a> for more information.
+                        <a href="/crate/{{ name }}/{{ version }}/builds">build logs</a> for more information.
                         <br>
                         See <a href="/about/builds">Builds</a> for ideas on how to fix a failed build,
                         or <a href="/about/metadata">Metadata</a> for how to configure docs.rs builds.
@@ -171,8 +171,8 @@
                 {%- if let Some(last_successful_build) = last_successful_build -%}
                     <div class="info">
                         Visit the last successful build:
-                        <a href="/crate/{{ self.name }}/{{ last_successful_build }}">
-                            {{ self.name }}-{{ last_successful_build }}
+                        <a href="/crate/{{ name }}/{{ last_successful_build }}">
+                            {{ name }}-{{ last_successful_build }}
                         </a>
                     </div>
                 {%- endif -%}

--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -2,18 +2,16 @@
 {%- import "header/package_navigation.html" as navigation -%}
 
 {%- block title -%}
-    {% call macros::doc_title(name=details.name, version=details.version) %}
+    {% call macros::doc_title(name=name, version=version) %}
 {%- endblock title -%}
 
 {%- block meta -%}
-    <link rel="canonical" href="https://docs.rs/crate/{{ details.name }}/latest" />
+    <link rel="canonical" href="https://docs.rs/crate/{{ name }}/latest" />
 {%- endblock meta -%}
 
 {%- block topbar -%}
-  {%- set current_target = String::new() -%}
-  {%- set metadata = details.metadata -%}
   {%- set latest_path = "" -%}
-  {%- set inner_path = details.metadata.target_name_url() -%}
+  {%- set inner_path = metadata.target_name_url() -%}
   {%- set is_latest_version = true -%}
   {%- set is_prerelease = false -%}
   {%- include "rustdoc/topbar.html" -%}
@@ -21,7 +19,7 @@
 
 {%- block header -%}
     {# Set the active tab to the `crate` tab #}
-    {% call navigation::package_navigation(metadata=details.metadata, active_tab="crate") %}
+    {% call navigation::package_navigation(metadata=metadata, active_tab="crate") %}
 {%- endblock header -%}
 
 {%- block body -%}
@@ -30,14 +28,14 @@
             <div class="pure-u-1 pure-u-sm-7-24 pure-u-md-5-24">
                 <div class="pure-menu package-menu">
                     <ul class="pure-menu-list">
-                        {%- if let (Some(documented), Some(total)) = (details.documented_items, details.total_items) -%}
+                        {%- if let (Some(documented), Some(total)) = (documented_items, total_items) -%}
                             {% set documented_f32 = documented|as_f32 %}
                             {% set total_f32 = total|as_f32 %}
                             {% set percent = documented_f32 * 100f32 / total_f32 %}
                             <li class="pure-menu-heading">Coverage</li>
                             <li class="pure-menu-item text-center"><b>{{ percent|round(2) }}%</b><br>
                                 <span class="documented-info"><b>{{ documented }}</b> out of <b>{{ total }}</b> items documented</span>
-                                {%- if let (Some(needing_examples), Some(with_examples)) = (details.total_items_needing_examples, details.items_with_examples) -%}
+                                {%- if let (Some(needing_examples), Some(with_examples)) = (total_items_needing_examples, items_with_examples) -%}
                                     <span class="documented-info"><b>{{ with_examples }}</b> out of <b>{{ needing_examples }}</b> items with examples</span>
                                 {%- endif -%}
                             </li>
@@ -45,7 +43,7 @@
                         <li class="pure-menu-heading">Links</li>
 
                         {# If the crate has a homepage, show it #}
-                        {%- if let Some(homepage_url) = details.homepage_url -%}
+                        {%- if let Some(homepage_url) = homepage_url -%}
                             <li class="pure-menu-item">
                                 <a href="{{ homepage_url }}" class="pure-menu-link">
                                     {{ "house"|fas(false, false, "") }} Homepage
@@ -54,7 +52,7 @@
                         {%- endif -%}
 
                         {# If the crate has a custom doc url, show it #}
-                        {%- if let Some(documentation_url) = details.documentation_url -%}
+                        {%- if let Some(documentation_url) = documentation_url -%}
                             <li class="pure-menu-item">
                                 <a href="{{ documentation_url }}" title="Canonical documentation" class="pure-menu-link">
                                     {{ "file-lines"|far(false, false, "") }} Documentation
@@ -63,12 +61,12 @@
                         {%- endif -%}
 
                         {# If the release has a repository, show it #}
-                        {%- if let Some(repository_url) = details.repository_url -%}
+                        {%- if let Some(repository_url) = repository_url -%}
                             <li class="pure-menu-item">
                                 <a href="{{ repository_url }}" class="pure-menu-link">
                                     {# If the repo link is for github or gitlab, show some stats #}
                                     {# TODO: add support for hosts besides github and gitlab (#35) #}
-                                    {%- if let Some(repository_metadata) = details.repository_metadata -%}
+                                    {%- if let Some(repository_metadata) = repository_metadata -%}
                                         {{ "code-branch"|fab(false, false, "") }}
                                         {% if let Some(name) = repository_metadata.name %}
                                             {{name}}
@@ -90,8 +88,8 @@
 
                         {# Show a link to the crate's crates.io page #}
                         <li class="pure-menu-item">
-                            <a href="https://crates.io/crates/{{ details.name }}" class="pure-menu-link"
-                                title="See {{ details.name }} on crates.io">
+                            <a href="https://crates.io/crates/{{ name }}" class="pure-menu-link"
+                                title="See {{ name }} on crates.io">
                                 {{ "cube"|fas(false, false, "") }} crates.io
                             </a>
                         </li>
@@ -101,7 +99,7 @@
                             <div class="pure-menu pure-menu-scrollable sub-menu">
                                 <ul class="pure-menu-list">
                                     {# List all dependencies that the current release has #}
-                                    {% call macros::dependencies_list(link_prefix="/crate", dependencies=details.dependencies, if_empty="&mdash;") %}
+                                    {% call macros::dependencies_list(link_prefix="/crate", dependencies=dependencies, if_empty="&mdash;") %}
                                 </ul>
                             </div>
                         </li>
@@ -111,7 +109,7 @@
                             <div class="pure-menu pure-menu-scrollable sub-menu">
                                 <ul class="pure-menu-list">
                                     {# Display all releases of this crate #}
-                                    {% call macros::releases_list(name=details.name, releases=details.releases, target="", inner_path="") %}
+                                    {% call macros::releases_list(name=name, releases=releases, target="", inner_path="") %}
                                 </ul>
                             </div>
                         </li>
@@ -119,7 +117,7 @@
                         {# Display the crate owner's profile picture and a link to their docs.rs profile #}
                         <li class="pure-menu-heading">Owners</li>
                         <li class="pure-menu-item">
-                            {%- for owner in details.owners -%}
+                            {%- for owner in owners -%}
                                 <a href="https://crates.io/users/{{ owner.0 }}">
                                     <img src="{{ owner.1 }}" alt="{{ owner.0 }}" class="owner">
                                 </a>
@@ -131,39 +129,39 @@
 
             <div class="pure-u-1 pure-u-sm-17-24 pure-u-md-19-24 package-details" id="main">
                 {# If the release is not a library #}
-                {%- if details.is_library == Some(false) -%}
+                {%- if is_library == Some(false) -%}
                     <div class="warning">
-                        {{ details.name }}-{{ details.version }} is not a library.
+                        {{ self.name }}-{{ version }} is not a library.
                     </div>
 
                 {# If the release has been yanked and is a library #}
-                {%- elif details.metadata.yanked.unwrap_or_default() -%}
+                {%- elif metadata.yanked.unwrap_or_default() -%}
                     <div class="warning">
-                        {{ details.name }}-{{ details.version }} has been yanked.
+                        {{ self.name }}-{{ version }} has been yanked.
                     </div>
 
                 {# If the build succeeded, isn't yanked and is a library #}
-                {%- elif details.build_status == "success" -%}
+                {%- elif build_status == "success" -%}
                     {# If there are no docs display a warning #}
-                    {%- if !details.rustdoc_status.unwrap_or_default() -%}
-                        <div class="warning">{{ details.name }}-{{ details.version }} doesn't have any documentation.</div>
+                    {%- if !rustdoc_status.unwrap_or_default() -%}
+                        <div class="warning">{{ self.name }}-{{ version }} doesn't have any documentation.</div>
                     {%- endif -%}
 
                 {# If the build failed, the release isn't yanked and the release is a library #}
-                {%- elif details.build_status == "failure" -%}
+                {%- elif build_status == "failure" -%}
                     {# Display a warning telling the user we failed to build the docs #}
                     <div class="warning">
-                        docs.rs failed to build {{ details.name }}-{{ details.version }}
+                        docs.rs failed to build {{ self.name }}-{{ version }}
                         <br>
                         Please check the
-                        <a href="/crate/{{ details.name }}/{{ details.version }}/builds">build logs</a> for more information.
+                        <a href="/crate/{{ self.name }}/{{ version }}/builds">build logs</a> for more information.
                         <br>
                         See <a href="/about/builds">Builds</a> for ideas on how to fix a failed build,
                         or <a href="/about/metadata">Metadata</a> for how to configure docs.rs builds.
                         <br>
                         If you believe this is docs.rs' fault, <a href="https://github.com/rust-lang/docs.rs/issues/new/choose">open an issue</a>.
                     </div>
-                {%- elif details.build_status == "in_progress" -%}
+                {%- elif build_status == "in_progress" -%}
                     <div class="info">
                         {{ "gear"|fas(false, true, "") }}
                         Build is in progress, it will be available soon
@@ -171,21 +169,21 @@
                 {%- endif -%}
 
                 {# If there is one, display the next most recent successful build #}
-                {%- if let Some(last_successful_build) = details.last_successful_build -%}
+                {%- if let Some(last_successful_build) = last_successful_build -%}
                     <div class="info">
                         Visit the last successful build:
-                        <a href="/crate/{{ details.name }}/{{ last_successful_build }}">
-                            {{ details.name }}-{{ last_successful_build }}
+                        <a href="/crate/{{ self.name }}/{{ last_successful_build }}">
+                            {{ self.name }}-{{ last_successful_build }}
                         </a>
                     </div>
                 {%- endif -%}
 
                 {# If there's a readme, display it #}
-                {%- if let Some(readme) = details.readme -%}
+                {%- if let Some(readme) = readme -%}
                     {{ crate::web::markdown::render(readme)|safe }}
 
                 {# If there's not a readme then attempt to display the long description #}
-                {%- elif let Some(rustdoc) = details.rustdoc -%}
+                {%- elif let Some(rustdoc) = rustdoc -%}
                     {{ rustdoc|safe }}
                 {%- endif -%}
             </div>

--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -10,7 +10,6 @@
 {%- endblock meta -%}
 
 {%- block topbar -%}
-  {%- set latest_path = "" -%}
   {%- set inner_path = metadata.target_name_url() -%}
   {%- set is_latest_version = true -%}
   {%- set is_prerelease = false -%}

--- a/templates/crate/features.html
+++ b/templates/crate/features.html
@@ -10,7 +10,6 @@
 {%- endblock -%}
 
 {%- block topbar -%}
-  {%- set current_target = String::new() -%}
   {%- set latest_version = "" -%}
   {%- set latest_path = "" -%}
   {%- set target = "" -%}

--- a/templates/crate/features.html
+++ b/templates/crate/features.html
@@ -11,7 +11,6 @@
 
 {%- block topbar -%}
   {%- set latest_version = "" -%}
-  {%- set latest_path = "" -%}
   {%- set target = "" -%}
   {%- set inner_path = metadata.target_name_url() -%}
   {%- set is_latest_version = true -%}

--- a/templates/crate/source.html
+++ b/templates/crate/source.html
@@ -6,7 +6,6 @@
 {%- endblock title -%}
 
 {%- block topbar -%}
-  {%- set current_target = String::new() -%}
   {%- set latest_version = "" -%}
   {%- set latest_path = "" -%}
   {%- set target = "" -%}

--- a/templates/crate/source.html
+++ b/templates/crate/source.html
@@ -6,7 +6,6 @@
 {%- endblock title -%}
 
 {%- block topbar -%}
-  {%- set metadata = metadata -%}
   {%- set current_target = String::new() -%}
   {%- set latest_version = "" -%}
   {%- set latest_path = "" -%}

--- a/templates/crate/source.html
+++ b/templates/crate/source.html
@@ -7,7 +7,6 @@
 
 {%- block topbar -%}
   {%- set latest_version = "" -%}
-  {%- set latest_path = "" -%}
   {%- set target = "" -%}
   {%- set inner_path = metadata.target_name_url() -%}
   {%- set is_latest_version = true -%}

--- a/templates/header/topbar_begin.html
+++ b/templates/header/topbar_begin.html
@@ -11,7 +11,7 @@
                   id="nav-search-form"
                   class="landing-search-form-nav {%
                   if !is_latest_version %}not-latest{% endif
-                  %} {% if let Some(meta) = get_metadata() %}{% if meta.yanked.unwrap_or_default() %}yanked{% endif %}{% endif %}">
+                  %} {% if metadata is defined && metadata.yanked.unwrap_or_default() %}yanked{% endif %}">
 
                 {# The top-left logo and name #}
                 <a href="/" class="pure-menu-heading pure-menu-link docsrs-logo" aria-label="Docs.rs">

--- a/templates/rustdoc/head.html
+++ b/templates/rustdoc/head.html
@@ -1,5 +1,5 @@
 {%- import "macros.html" as macros -%}
-        <link rel="stylesheet" href="/-/static/{{metadata.rustdoc_css_file|unwrap}}?{{ crate::BUILD_VERSION|slugify }}" media="all" />
+        <link rel="stylesheet" href="/-/static/{{rustdoc_css_file|unwrap}}?{{ crate::BUILD_VERSION|slugify }}" media="all" />
 
         <link rel="search" href="/-/static/opensearch.xml" type="application/opensearchdescription+xml" title="Docs.rs" />
 

--- a/templates/rustdoc/platforms.html
+++ b/templates/rustdoc/platforms.html
@@ -16,7 +16,7 @@
         {%- endif -%}
 
         {%- set current -%}
-        {%- if current_target == target|deref -%}
+        {%- if current_target is defined && current_target == target|deref -%}
             {%- set current = " current" -%}
         {%- else -%}
             {%- set current = "" -%}

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -4,7 +4,12 @@
 {% set search_query = Some(String::new()) %}
 {%- include "header/topbar_begin.html" -%}
 {%- set crate_url = "/crate/{}/{}"|format(metadata.name, metadata.req_version) -%}
-{%- set rest_menu_url = current_target|rest_menu_url(inner_path) -%}
+{%- set rest_menu_url -%}
+{%- if current_target is defined -%}
+    {%- set rest_menu_url = current_target|rest_menu_url(inner_path) -%}
+{%- else -%}
+    {%- set rest_menu_url = ""|rest_menu_url(inner_path) -%}
+{%- endif -%}
 {%- set platform_menu_url = "{}/menus/platforms{}"|format(crate_url, rest_menu_url) -%}
 {%- set releases_menu_url = "{}/menus/releases{}"|format(crate_url, rest_menu_url) -%}
 <ul class="pure-menu-list">

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -16,7 +16,7 @@
             "version": {{ metadata.version|json_encode|safe }}
         }
     </script>
-    {%- if let Some(krate) = krate() -%}
+    {%- if krate is defined -%}
         <li class="pure-menu-item pure-menu-has-children">
             <a href="#" class="pure-menu-link crate-name" title="{{ krate.description.as_deref().unwrap_or_default() }}">
                 {{ "cube"|fas(false, false, "") }}

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -34,7 +34,7 @@
 
                     {%- if metadata.req_version|to_string == "latest" -%}
                     <li class="pure-menu-item">
-                        <a href="{{permalink_path()|safe}}" class="pure-menu-link description" id="permalink" title="Get a link to this specific version">
+                        <a href="{% if permalink_path is defined %}{{permalink_path|safe}}{% endif %}" class="pure-menu-link description" id="permalink" title="Get a link to this specific version">
                             {{ "link"|fas(false, false, "") }} Permalink
                         </a>
                     </li>

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -203,7 +203,7 @@
         {%- endif -%}
 
         <li class="pure-menu-item">
-            <a href="{{ latest_path|safe }}" class="pure-menu-link warn"
+            <a href="{% if latest_path is defined %}{{ latest_path|safe }}{% endif %}" class="pure-menu-link warn"
                 data-fragment="retain"
                 title="{{ tooltip }}">
                 {{ "triangle-exclamation"|fas(false, false, "") }}


### PR DESCRIPTION
The `is (not) defined` feature was improved, allowing to start some cleanups in the templates. I'm not completely done yet but I think it's big enough for now.