### PR TITLE
fix the link to the docs.rs team on rust-lang.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,5 +278,5 @@ When updating Font Awesome, make sure to change `$fa-font-path` in `scss/_variab
 
 ### Contact
 
-Docs.rs is run and maintained by the [docs.rs team](https://www.rust-lang.org/governance/teams/dev-tools#docs-rs).
+Docs.rs is run and maintained by the [docs.rs team](https://www.rust-lang.org/governance/teams/dev-tools#team-docs-rs).
 You can find us in #t-docs-rs on [zulip](https://rust-lang.zulipchat.com/#narrow/stream/t-docs-rs)

--- a/templates/core/about/index.html
+++ b/templates/core/about/index.html
@@ -56,7 +56,7 @@
         </p>
 
         <h3 id="contact"> <a href="#contact">Contact</a> </h3>
-        {%- set governance_link = "https://www.rust-lang.org/governance/teams/dev-tools#docs-rs" -%}
+        {%- set governance_link = "https://www.rust-lang.org/governance/teams/dev-tools#team-docs-rs" -%}
         <p>
             Docs.rs is run and maintained by the <a href="{{ governance_link|safe }}">Docs.rs team</a>.
             You can find us in #t-docs-rs on <a href="https://rust-lang.zulipchat.com/#narrow/stream/356853-t-docs-rs">Zulip</a>.


### PR DESCRIPTION
the link to the docs.rs team on https://www.rust-lang.org should be https://www.rust-lang.org/governance/teams/dev-tools#team-docs-rs

The anchor seems to have changed from `#docs-rs` to `#team-docs-rs`