### PR TITLE
fix build re-attempts after pre-build error

### DIFF
--- a/src/docbuilder/mod.rs
+++ b/src/docbuilder/mod.rs
@@ -3,4 +3,4 @@ mod rustwide_builder;
 
 pub(crate) use self::limits::Limits;
 pub(crate) use self::rustwide_builder::DocCoverage;
-pub use self::rustwide_builder::{PackageKind, RustwideBuilder};
+pub use self::rustwide_builder::{BuildPackageSummary, PackageKind, RustwideBuilder};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ pub use self::build_queue::BuildQueue;
 pub use self::config::Config;
 pub use self::context::Context;
 pub use self::docbuilder::PackageKind;
-pub use self::docbuilder::RustwideBuilder;
+pub use self::docbuilder::{BuildPackageSummary, RustwideBuilder};
 pub use self::index::Index;
 pub use self::metrics::{InstanceMetrics, ServiceMetrics};
 pub use self::registry_api::RegistryApi;


### PR DESCRIPTION
This fixes the build attempts that broke in #2467. See also #2556 ([this comment](https://github.com/rust-lang/docs.rs/issues/2556#issuecomment-2350848851)). 

Re-attempting builds was only ever done when we got an `Error` from `build_package`, so when I started catching and storing the error into the DB, the reattempts broke. 

I now add a `should_reattempt` to the `build_package` output, so we then can also reattempt in these cases. 

