### PR TITLE
add now necessary permissions to github action jobs using labels/issues

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   security_audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-pr-review-approve.yml
+++ b/.github/workflows/on-pr-review-approve.yml
@@ -2,6 +2,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   update-labels:
     if: github.event.review.state == 'approved'

--- a/.github/workflows/on-pr-review-submit.yml
+++ b/.github/workflows/on-pr-review-submit.yml
@@ -2,6 +2,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   update-labels:
     if: github.event.review.state == 'changes_requested'

--- a/.github/workflows/tag-merged-pr.yml
+++ b/.github/workflows/tag-merged-pr.yml
@@ -4,6 +4,10 @@ on:
       - master
     types: [closed]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   update-labels:
     if: ${{ github.event.pull_request.merged }}

--- a/.github/workflows/tag-new-pr.yml
+++ b/.github/workflows/tag-new-pr.yml
@@ -4,6 +4,10 @@ on:
       - master
     types: [opened, reopened, review_requested]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   update-labels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
From my research these are the necessary permissions for these jobs. 

I had difficulties testing this, but right now I just wouldn't invest more time and just test it when it's merged. 

Related: https://github.com/actions/labeler?tab=readme-ov-file#permissions