### PR TITLE
hotfix: don't fail on invalid font-awesome icons, just report

### DIFF
--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
-use crate::web::rustdoc::RustdocPage;
-use anyhow::Context;
+use crate::web::{report_error, rustdoc::RustdocPage};
+use anyhow::{anyhow, Context};
 use rinja::Template;
 use std::{fmt, sync::Arc};
 use tracing::trace;
@@ -267,8 +267,16 @@ impl IconType {
             IconType::Brand => font_awesome_as_a_crate::Type::Brands,
         };
 
-        let icon_file_string = font_awesome_as_a_crate::svg(type_, icon_name)
-            .map_err(|err| rinja::Error::Custom(Box::new(err)))?;
+        let icon_file_string = match font_awesome_as_a_crate::svg(type_, icon_name) {
+            Ok(s) => s,
+            Err(err) => {
+                report_error(&anyhow!(err).context(format!(
+                    "error trying to render icon with name \"{}\"",
+                    icon_name
+                )));
+                ""
+            }
+        };
 
         let mut classes = vec!["fa-svg"];
         if fw {


### PR DESCRIPTION
hotfix for https://rust-lang.sentry.io/issues/5894026542/?environment=production&project=5499376&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=0, 

partially reinstating the old behaviour, where we just return an empty string / don't render the icon. 

The sentry error will make debugging easier, 

I'll probably re-add the hard error with better reporting. Or a design where we have compile-time checks :) 