### PR TITLE
Move fontawesome icons check at compile-time

### DIFF
--- a/crates/font-awesome-as-a-crate/build.rs
+++ b/crates/font-awesome-as-a-crate/build.rs
@@ -1,5 +1,7 @@
 use std::{
+    collections::HashMap,
     env,
+    fmt::Write as FmtWrite,
     fs::{read_dir, File},
     io::{Read, Write},
     path::Path,
@@ -11,13 +13,26 @@ fn main() {
     write_fontawesome_sprite();
 }
 
+fn capitalize_first_letter(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().chain(c).collect(),
+    }
+}
+
 fn write_fontawesome_sprite() {
+    let mut types = HashMap::new();
     let dest_path = Path::new(&env::var("OUT_DIR").unwrap()).join("fontawesome.rs");
     let mut dest_file = File::create(dest_path).unwrap();
     dest_file
         .write_all(b"const fn fontawesome_svg(dir:&str,file:&str)->&'static str{match(dir.as_bytes(),file.as_bytes()){")
         .expect("fontawesome fn write");
-    for dirname in &["brands", "regular", "solid"] {
+    for (dirname, trait_name) in &[
+        ("brands", "Brands"),
+        ("regular", "Regular"),
+        ("solid", "Solid"),
+    ] {
         let dir = read_dir(Path::new("fontawesome-free-6.2.0-desktop/svgs").join(dirname)).unwrap();
         let mut data = String::new();
         for file in dir {
@@ -32,20 +47,45 @@ fn write_fontawesome_sprite() {
                 .expect("fontawesome file read");
             // if this assert goes off, add more hashes here and in the format! below
             assert!(!data.contains("###"), "file {filename} breaks raw string");
+            let filename = filename.replace(".svg", "");
             dest_file
                 .write_all(
-                    format!(
-                        r####"(b"{dirname}",b"{filename}")=>r#"{data}"#,"####,
-                        data = data,
-                        dirname = dirname,
-                        filename = filename.replace(".svg", ""),
-                    )
-                    .as_bytes(),
+                    format!(r####"(b"{dirname}",b"{filename}")=>r#"{data}"#,"####).as_bytes(),
                 )
                 .expect("write fontawesome file");
+            types
+                .entry(filename)
+                .or_insert_with(|| (data.clone(), Vec::with_capacity(3)))
+                .1
+                .push(trait_name);
         }
     }
     dest_file
-        .write_all(b"_=>\"\"}}")
+        .write_all(b"_=>\"\"}} pub mod icons { use super::{IconStr, Regular, Brands, Solid};")
         .expect("fontawesome fn write");
+
+    for (icon, (data, kinds)) in types {
+        let mut type_name = "Icon".to_string();
+        type_name.extend(icon.split('-').map(capitalize_first_letter));
+        let kinds = kinds.iter().fold(String::new(), |mut acc, k| {
+            let _ = writeln!(acc, "impl {k} for {type_name} {{}}");
+            acc
+        });
+        dest_file
+            .write_all(
+                format!(
+                    "\n#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct {type_name};
+impl IconStr for {type_name} {{
+    fn icon_name(&self) -> &'static str {{ r#\"{icon}\"# }}
+    fn icon_str(&self) -> &'static str {{ r#\"{data}\"# }}
+}}
+{kinds}"
+                )
+                .as_bytes(),
+            )
+            .expect("write fontawesome file types");
+    }
+
+    dest_file.write_all(b"}").expect("fontawesome fn write");
 }

--- a/crates/font-awesome-as-a-crate/src/lib.rs
+++ b/crates/font-awesome-as-a-crate/src/lib.rs
@@ -87,6 +87,29 @@ pub const fn svg(type_: Type, name: &str) -> Result<&'static str, NameError> {
     Ok(svg)
 }
 
+pub trait IconStr {
+    /// Name of the icon, like "triangle-exclamation".
+    fn icon_name(&self) -> &'static str;
+    /// The SVG content of the icon.
+    fn icon_str(&self) -> &'static str;
+}
+
+pub trait Brands: IconStr {
+    fn get_type() -> Type {
+        Type::Brands
+    }
+}
+pub trait Regular: IconStr {
+    fn get_type() -> Type {
+        Type::Regular
+    }
+}
+pub trait Solid: IconStr {
+    fn get_type() -> Type {
+        Type::Solid
+    }
+}
+
 #[cfg(test)]
 mod tests {
     const fn usable_as_const_() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ pub use self::registry_api::RegistryApi;
 pub use self::storage::{AsyncStorage, Storage};
 pub use self::web::{start_background_metrics_webserver, start_web_server};
 
+pub(crate) use font_awesome_as_a_crate as f_a;
+
 mod build_queue;
 pub mod cdn;
 mod config;

--- a/src/web/page/mod.rs
+++ b/src/web/page/mod.rs
@@ -3,52 +3,10 @@ pub(crate) mod web_page;
 
 pub(crate) use templates::TemplateData;
 
-use crate::f_a::IconStr;
-use serde::ser::{Serialize, SerializeStruct, Serializer};
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) struct GlobalAlert {
     pub(crate) url: &'static str,
     pub(crate) text: &'static str,
     pub(crate) css_class: &'static str,
     pub(crate) fa_icon: crate::f_a::icons::IconTriangleExclamation,
-}
-
-impl Serialize for GlobalAlert {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut s = serializer.serialize_struct("GlobalAlert", 4)?;
-        s.serialize_field("url", &self.url)?;
-        s.serialize_field("text", &self.text)?;
-        s.serialize_field("css_class", &self.css_class)?;
-        s.serialize_field("fa_icon", &self.fa_icon.icon_name())?;
-        s.end()
-    }
-}
-
-#[cfg(test)]
-mod tera_tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn serialize_global_alert() {
-        let alert = GlobalAlert {
-            url: "http://www.hasthelargehadroncolliderdestroyedtheworldyet.com/",
-            text: "THE WORLD WILL SOON END",
-            css_class: "THE END IS NEAR",
-            fa_icon: crate::f_a::icons::IconTriangleExclamation,
-        };
-
-        let correct_json = json!({
-            "url": "http://www.hasthelargehadroncolliderdestroyedtheworldyet.com/",
-            "text": "THE WORLD WILL SOON END",
-            "css_class": "THE END IS NEAR",
-            "fa_icon": "triangle-exclamation"
-        });
-
-        assert_eq!(correct_json, serde_json::to_value(alert).unwrap());
-    }
 }

--- a/src/web/page/mod.rs
+++ b/src/web/page/mod.rs
@@ -3,14 +3,29 @@ pub(crate) mod web_page;
 
 pub(crate) use templates::TemplateData;
 
-use serde::Serialize;
+use crate::f_a::IconStr;
+use serde::ser::{Serialize, SerializeStruct, Serializer};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) struct GlobalAlert {
     pub(crate) url: &'static str,
     pub(crate) text: &'static str,
     pub(crate) css_class: &'static str,
-    pub(crate) fa_icon: &'static str,
+    pub(crate) fa_icon: crate::f_a::icons::IconTriangleExclamation,
+}
+
+impl Serialize for GlobalAlert {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut s = serializer.serialize_struct("GlobalAlert", 4)?;
+        s.serialize_field("url", &self.url)?;
+        s.serialize_field("text", &self.text)?;
+        s.serialize_field("css_class", &self.css_class)?;
+        s.serialize_field("fa_icon", &self.fa_icon.icon_name())?;
+        s.end()
+    }
 }
 
 #[cfg(test)]
@@ -24,14 +39,14 @@ mod tera_tests {
             url: "http://www.hasthelargehadroncolliderdestroyedtheworldyet.com/",
             text: "THE WORLD WILL SOON END",
             css_class: "THE END IS NEAR",
-            fa_icon: "https://gph.is/1uOvmqR",
+            fa_icon: crate::f_a::icons::IconTriangleExclamation,
         };
 
         let correct_json = json!({
             "url": "http://www.hasthelargehadroncolliderdestroyedtheworldyet.com/",
             "text": "THE WORLD WILL SOON END",
             "css_class": "THE END IS NEAR",
-            "fa_icon": "https://gph.is/1uOvmqR"
+            "fa_icon": "triangle-exclamation"
         });
 
         assert_eq!(correct_json, serde_json::to_value(alert).unwrap());

--- a/templates/about-base.html
+++ b/templates/about-base.html
@@ -11,27 +11,27 @@ centered
                 <h1 id="crate-title" class="no-description">Docs.rs documentation</h1>
                 <div class="pure-menu pure-menu-horizontal">
                     <ul class="pure-menu-list">
-                        {% set text = "circle-info"|fas(false, false, "") %}
+                        {% set text = crate::f_a::icons::IconCircleInfo|fas(false, false, "") %}
                         {% set text = "{} <span class='title'>About</span>"|format(text) %}
                         {% call macros::active_link(expected="index", href="/about", text=text) %}
 
-                        {% set text = "fonticons"|fab(false, false, "") %}
+                        {% set text = crate::f_a::icons::IconFonticons|fab(false, false, "") %}
                         {% set text = "{} <span class='title'>Badges</span>"|format(text) %}
                         {% call macros::active_link(expected="badges", href="/about/badges", text=text) %}
 
-                        {% set text = "gears"|fas(false, false, "") %}
+                        {% set text = crate::f_a::icons::IconGears|fas(false, false, "") %}
                         {% set text = "{} <span class='title'>Builds</span>"|format(text) %}
                         {% call macros::active_link(expected="builds", href="/about/builds", text=text) %}
 
-                        {% set text = "table"|fas(false, false, "") %}
+                        {% set text = crate::f_a::icons::IconTable|fas(false, false, "") %}
                         {% set text = "{} <span class='title'>Metadata</span>"|format(text) %}
                         {% call macros::active_link(expected="metadata", href="/about/metadata", text=text) %}
 
-                        {% set text = "road"|fas(false, false, "") %}
+                        {% set text = crate::f_a::icons::IconRoad|fas(false, false, "") %}
                         {% set text = "{} <span class='title'>Shorthand URLs</span>"|format(text) %}
                         {% call macros::active_link(expected="redirections", href="/about/redirections", text=text) %}
 
-                        {% set text = "download"|fas(false, false, "") %}
+                        {% set text = crate::f_a::icons::IconDownload|fas(false, false, "") %}
                         {% set text = "{} <span class='title'>Download</span>"|format(text) %}
                         {% call macros::active_link(expected="download", href="/about/download", text=text) %}
                     </ul>

--- a/templates/core/home.html
+++ b/templates/core/home.html
@@ -12,7 +12,7 @@ centered
 
 {%- block body -%}
     <div class="container landing">
-        <h1 class="brand">{{ "cubes"|fas(false, false, "") }} Docs.rs</h1>
+        <h1 class="brand">{{ crate::f_a::icons::IconCubes|fas(false, false, "") }} Docs.rs</h1>
 
         <form action="/releases/search" method="GET" class="landing-search-form">
             <div>
@@ -36,7 +36,7 @@ centered
                     <strong>Recent Releases</strong>
                 </a>
                 <a href="/releases/feed" title="Atom feed">
-                    {{ "square-rss"|fas(false, false, "") }}
+                    {{ crate::f_a::icons::IconSquareRss|fas(false, false, "") }}
                 </a>
             </div>
 

--- a/templates/crate/build_details.html
+++ b/templates/crate/build_details.html
@@ -30,7 +30,7 @@
                     <li>
                         <a href="/crate/{{ metadata.name }}/{{ metadata.version }}/builds/{{ build_details.id }}/{{ filename }}" class="release">
                             <div class="pure-g">
-                                <div class="pure-u-1 pure-u-sm-1-24 build">{{ "file-lines"|fas(false, false, "") }}</div>
+                                <div class="pure-u-1 pure-u-sm-1-24 build">{{ crate::f_a::icons::IconFileLines|fas(false, false, "") }}</div>
                                 <div class="pure-u-1 pure-u-sm-10-24">
                                     {% if current_filename.as_deref().unwrap_or_default() == filename.as_str() %}
                                         <b>{{ filename }}</b>

--- a/templates/crate/builds.html
+++ b/templates/crate/builds.html
@@ -44,13 +44,13 @@
                                 <div class="pure-g">
                                     <div class="pure-u-1 pure-u-sm-1-24 build">
                                         {%- if build.build_status == "success" -%}
-                                            {{ "check"|fas(false, false, "") }}
+                                            {{ crate::f_a::icons::IconCheck|fas(false, false, "") }}
                                         {%- elif build.build_status == "failure" -%}
-                                            {{ "triangle-exclamation"|fas(false, false, "") }}
+                                            {{ crate::f_a::icons::IconTriangleExclamation|fas(false, false, "") }}
                                         {%- elif build.build_status == "in_progress" -%}
-                                            {{ "gear"|fas(false, true, "") }}
+                                            {{ crate::f_a::icons::IconGear|fas(false, true, "") }}
                                         {%- else -%}
-                                            {{ "x"|fas(false, false, "") }}
+                                            {{ crate::f_a::icons::IconX|fas(false, false, "") }}
                                         {%- endif -%}
                                     </div>
                                     <div class="pure-u-1 pure-u-sm-10-24">

--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -43,7 +43,7 @@
                         {%- if let Some(homepage_url) = homepage_url -%}
                             <li class="pure-menu-item">
                                 <a href="{{ homepage_url }}" class="pure-menu-link">
-                                    {{ "house"|fas(false, false, "") }} Homepage
+                                    {{ crate::f_a::icons::IconHouse|fas(false, false, "") }} Homepage
                                 </a>
                             </li>
                         {%- endif -%}
@@ -52,7 +52,7 @@
                         {%- if let Some(documentation_url) = documentation_url -%}
                             <li class="pure-menu-item">
                                 <a href="{{ documentation_url }}" title="Canonical documentation" class="pure-menu-link">
-                                    {{ "file-lines"|far(false, false, "") }} Documentation
+                                    {{ crate::f_a::icons::IconFileLines|far(false, false, "") }} Documentation
                                 </a>
                             </li>
                         {%- endif -%}
@@ -64,20 +64,20 @@
                                     {# If the repo link is for github or gitlab, show some stats #}
                                     {# TODO: add support for hosts besides github and gitlab (#35) #}
                                     {%- if let Some(repository_metadata) = repository_metadata -%}
-                                        {{ "code-branch"|fas(false, false, "") }}
+                                        {{ crate::f_a::icons::IconCodeBranch|fas(false, false, "") }}
                                         {% if let Some(name) = repository_metadata.name %}
                                             {{name}}
                                         {% else %}
                                             Repository
                                         {% endif %}
                                         <br>
-                                        {{ "star"|fas(false, false, "left-margin") }} {{ repository_metadata.stars }}
-                                        {{ "code-branch"|fas(false, false, "") }} {{ repository_metadata.forks }}
-                                        {{ "circle-exclamation"|fas(false, false, "") }} {{ repository_metadata.issues }}
+                                        {{ crate::f_a::icons::IconStar|fas(false, false, "left-margin") }} {{ repository_metadata.stars }}
+                                        {{ crate::f_a::icons::IconCodeBranch|fas(false, false, "") }} {{ repository_metadata.forks }}
+                                        {{ crate::f_a::icons::IconCircleExclamation|fas(false, false, "") }} {{ repository_metadata.issues }}
 
                                     {# If the repo link is unknown, just show a normal link #}
                                     {%- else -%}
-                                        {{ "code-branch"|fas(false, false, "") }} Repository
+                                        {{ crate::f_a::icons::IconCodeBranch|fas(false, false, "") }} Repository
                                     {%- endif -%}
                                 </a>
                             </li>
@@ -87,7 +87,7 @@
                         <li class="pure-menu-item">
                             <a href="https://crates.io/crates/{{ name }}" class="pure-menu-link"
                                 title="See {{ name }} on crates.io">
-                                {{ "cube"|fas(false, false, "") }} crates.io
+                                {{ crate::f_a::icons::IconCube|fas(false, false, "") }} crates.io
                             </a>
                         </li>
 
@@ -160,7 +160,7 @@
                     </div>
                 {%- elif build_status == "in_progress" -%}
                     <div class="info">
-                        {{ "gear"|fas(false, true, "") }}
+                        {{ crate::f_a::icons::IconGear|fas(false, true, "") }}
                         Build is in progress, it will be available soon
                     </div>
                 {%- endif -%}

--- a/templates/crate/source.html
+++ b/templates/crate/source.html
@@ -29,13 +29,13 @@
                         {# If we are displaying a file, we also add a button to hide the file sidebar #}
                         {% if has_file_content %}
                             <li class="pure-menu-item toggle-source">
-                                <button aria-label="Hide source sidebar" title="Hide source sidebar" aria-expanded="true"><span class="left">{{ "chevron-left"|fas(false, false, "") }}</span><span class="right">{{ "chevron-right"|fas(false, false, "") }}</span> <span class="text">Hide files</span></button>
+                                <button aria-label="Hide source sidebar" title="Hide source sidebar" aria-expanded="true"><span class="left">{{ crate::f_a::icons::IconChevronLeft|fas(false, false, "") }}</span><span class="right">{{ crate::f_a::icons::IconChevronRight|fas(false, false, "") }}</span> <span class="text">Hide files</span></button>
                             </li>
                         {% endif %}
                         {# If this isn't the root folder, show a 'back' button #}
                         {%- if show_parent_link -%}
                             <li class="pure-menu-item">
-                                <a href="../" class="pure-menu-link">{{ "folder-open"|far(false, false, "") }} <span class="text">..</span></a>
+                                <a href="../" class="pure-menu-link">{{ crate::f_a::icons::IconFolderOpen|far(false, false, "") }} <span class="text">..</span></a>
                             </li>
                         {%- endif -%}
 
@@ -48,23 +48,23 @@
                                 <a href="./{{ file.name }}{% if file.mime == "dir" %}/{% endif %}" class="pure-menu-link">
                                     {# Directories #}
                                     {%- if file.mime == "dir" -%}
-                                        {{ "folder-open"|far(false, false, "") }}
+                                        {{ crate::f_a::icons::IconFolderOpen|far(false, false, "") }}
 
                                     {# Rust files #}
                                     {%- elif file.mime == "text/rust" -%}
-                                        {{ "rust"|fab(false, false, "") }}
+                                        {{ crate::f_a::icons::IconRust|fab(false, false, "") }}
 
                                     {# Cargo.lock #}
                                     {%- elif file.mime == "text/plain" && file.name == "Cargo.lock" -%}
-                                        {{ "lock"|fas(false, false, "") }}
+                                        {{ crate::f_a::icons::IconLock|fas(false, false, "") }}
 
                                     {# Markdown files #}
                                     {% elif file.mime == "text/markdown" %}
-                                        {{ "markdown"|fab(false, false, "") }}
+                                        {{ crate::f_a::icons::IconMarkdown|fab(false, false, "") }}
 
                                     {# .gitignore #}
                                     {% elif file.mime == "text/plain" && file.name == ".gitignore" %}
-                                        {{ "git-alt"|fab(false, false, "") }}
+                                        {{ crate::f_a::icons::IconGitAlt|fab(false, false, "") }}
 
                                     {#
                                         More ideas
@@ -86,11 +86,11 @@
 
                                     {# Text files or files which mime starts with `text` #}
                                     {%- elif file.mime == "text/plain" || file.mime|split_first("/") == Some("text") -%}
-                                        {{ "file-lines"|far(false, false, "") }}
+                                        {{ crate::f_a::icons::IconFileLines|far(false, false, "") }}
 
                                         {# Binary files and any unrecognized types #}
                                     {% else -%}
-                                        {{ "file"|far(false, false, "") }}
+                                        {{ crate::f_a::icons::IconFile|far(false, false, "") }}
                                     {%- endif -%}
 
                                     <span class="text">{{ file.name }}</span>

--- a/templates/header/global_alert.html
+++ b/templates/header/global_alert.html
@@ -4,7 +4,7 @@
 {%- if let Some(global_alert) = crate::GLOBAL_ALERT -%}
     <li class="pure-menu-item">
         <a href="{{ global_alert.url|safe }}" class="pure-menu-link {{ global_alert.css_class }}">
-            {{- global_alert.fa_icon|fas(false, false, "") }}
+            {{- global_alert.fa_icon.clone()|fas(false, false, "") }}
             {{ global_alert.text -}}
         </a>
     </li>

--- a/templates/header/package_navigation.html
+++ b/templates/header/package_navigation.html
@@ -39,7 +39,7 @@
                         {# The crate information tab #}
                         <li class="pure-menu-item"><a href="/crate/{{ crate_path|safe }}"
                                 class="pure-menu-link{% if active_tab == &"crate" %} pure-menu-active{% endif %}">
-                                {{ "cube"|fas(false, false, "") }}
+                                {{ crate::f_a::icons::IconCube|fas(false, false, "") }}
                                 <span class="title"> Crate</span>
                             </a>
                         </li>
@@ -48,7 +48,7 @@
                         <li class="pure-menu-item">
                             <a href="/crate/{{ crate_path|safe }}/source/"
                                 class="pure-menu-link{% if active_tab == &"source" %} pure-menu-active{% endif %}">
-                                {{ "folder-open"|far(false, false, "") }}
+                                {{ crate::f_a::icons::IconFolderOpen|far(false, false, "") }}
                                 <span class="title"> Source</span>
                             </a>
                         </li>
@@ -57,7 +57,7 @@
                         <li class="pure-menu-item">
                             <a href="/crate/{{ crate_path|safe }}/builds"
                                 class="pure-menu-link{% if active_tab == &"builds" %} pure-menu-active{% endif %}">
-                                {{ "gears"|fas(false, false, "") }}
+                                {{ crate::f_a::icons::IconGears|fas(false, false, "") }}
                                 <span class="title"> Builds</span>
                             </a>
                         </li>
@@ -66,7 +66,7 @@
                         <li class="pure-menu-item">
                             <a href="/crate/{{ crate_path|safe }}/features"
                                class="pure-menu-link{% if active_tab == &"features" %} pure-menu-active{% endif %}">
-                                {{ "flag"|fas(false, false, "") }}
+                                {{ crate::f_a::icons::IconFlag|fas(false, false, "") }}
                                 <span class="title">Feature flags</span>
                             </a>
                         </li>
@@ -76,7 +76,7 @@
 
             {%- if metadata.rustdoc_status.unwrap_or_default() -%}
                 <a href="/{{ crate_path|safe }}/{{ metadata.target_name.as_deref().unwrap_or_default() }}/" class="doc-link">
-                    {{ "book"|fas(false, false, "") }} Documentation
+                    {{ crate::f_a::icons::IconBook|fas(false, false, "") }} Documentation
                 </a>
             {%- endif -%}
         </div>

--- a/templates/header/topbar_begin.html
+++ b/templates/header/topbar_begin.html
@@ -15,7 +15,7 @@
 
                 {# The top-left logo and name #}
                 <a href="/" class="pure-menu-heading pure-menu-link docsrs-logo" aria-label="Docs.rs">
-                    <span title="Docs.rs">{{ "cubes"|fas(false, false, "") }}</span>
+                    <span title="Docs.rs">{{ crate::f_a::icons::IconCubes|fas(false, false, "") }}</span>
                     <span class="title">Docs.rs</span>
                 </a>{#
 

--- a/templates/header/topbar_end.html
+++ b/templates/header/topbar_end.html
@@ -60,7 +60,7 @@
                 {# The search bar #}
                 <div id="search-input-nav">
                     <label for="nav-search">
-                        {{ "magnifying-glass"|fas(false, false, "") }}
+                        {{ crate::f_a::icons::IconMagnifyingGlass|fas(false, false, "") }}
                     </label>
 
                     {# If there is a search query, put it in the search bar #}

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -143,10 +143,10 @@
                 {% if retain_fragment %}data-fragment="retain"{% endif %}
             >
                 {% if warning %}
-                    {{ "triangle-exclamation"|fas(false, false, "") }}
+                    {{ crate::f_a::icons::IconTriangleExclamation|fas(false, false, "") }}
                 {% endif %}
                 {% if release.build_status == "in_progress" %}
-                    {{ "gear"|fas(true, true, "") }}
+                    {{ crate::f_a::icons::IconGear|fas(true, true, "") }}
                 {% endif %}
                 {{ release.version }}
             </a>

--- a/templates/releases/header.html
+++ b/templates/releases/header.html
@@ -23,14 +23,14 @@
                     <ul class="pure-menu-list">
                         <li class="pure-menu-item">
                             <a href="/releases" class="pure-menu-link{% if *tab == "recent" %} pure-menu-active{% endif %}">
-                                {{ "leaf"|fas(false, false, "") }}
+                                {{ crate::f_a::icons::IconLeaf|fas(false, false, "") }}
                                 <span class="title">Recent</span>
                             </a>
                         </li>
 
                         <li class="pure-menu-item">
                             <a href="/releases/stars" class="pure-menu-link{% if *tab == "stars" %} pure-menu-active{% endif %}">
-                                {{ "star"|fas(false, false, "") }}
+                                {{ crate::f_a::icons::IconStar|fas(false, false, "") }}
                                 <span class="title">Stars</span>
                             </a>
                         </li>
@@ -38,7 +38,7 @@
                         <li class="pure-menu-item">
                             <a href="/releases/recent-failures"
                                 class="pure-menu-link{% if *tab == "recent-failures" %} pure-menu-active{% endif %}">
-                                {{ "triangle-exclamation"|fas(false, false, "") }}
+                                {{ crate::f_a::icons::IconTriangleExclamation|fas(false, false, "") }}
                                 <span class="title">Recent Failures</span>
                             </a>
                         </li>
@@ -46,7 +46,7 @@
                         <li class="pure-menu-item">
                             <a href="/releases/failures"
                                 class="pure-menu-link{% if *tab == "failures" %} pure-menu-active{% endif %}">
-                                {{ "star"|far(false, false, "") }}
+                                {{ crate::f_a::icons::IconStar|far(false, false, "") }}
                                 <span class="title">Failures By Stars</span>
                             </a>
                         </li>
@@ -54,14 +54,14 @@
                         <li class="pure-menu-item">
                             <a href="/releases/activity"
                                 class="pure-menu-link{% if *tab == "activity" %} pure-menu-active{% endif %}">
-                                {{ "chart-line"|fas(false, false, "") }}
+                                {{ crate::f_a::icons::IconChartLine|fas(false, false, "") }}
                                 <span class="title">Activity</span>
                             </a>
                         </li>
 
                         <li class="pure-menu-item">
                             <a href="/releases/queue" class="pure-menu-link{% if *tab == "queue" %} pure-menu-active{% endif %}">
-                                {{ "list"|fas(false, false, "") }}
+                                {{ crate::f_a::icons::IconList|fas(false, false, "") }}
                                 <span class="title">Queue</span>
                             </a>
                         </li>
@@ -69,7 +69,7 @@
                         {%- if !owner.is_empty() -%}
                             <li class="pure-menu-item">
                                 <a href="#" class="pure-menu-link{% if *tab == "owner" %} pure-menu-active{% endif %}">
-                                    {{ "user"|fas(false, false, "") }}
+                                    {{ crate::f_a::icons::IconUser|fas(false, false, "") }}
                                     <span class="title">{{ owner }}</span>
                                 </a>
                             </li>

--- a/templates/releases/releases.html
+++ b/templates/releases/releases.html
@@ -50,7 +50,7 @@ centered
                                     {{ release.name }}-{{ release.version }}
                                     {% if !has_unyanked_releases %}
                                         <span class="yanked" title="all releases of {{ release.name }} have been yanked">
-                                            {{ "trash"|fas(false, false, "") }}
+                                            {{ crate::f_a::icons::IconTrash|fas(false, false, "") }}
                                             Yanked
                                         </span>
                                     {% endif %}
@@ -64,7 +64,7 @@ centered
                                     <div class="pure-u-1 pure-u-sm-4-24 pure-u-md-3-24 date" {% if let Some(build_time) = release.build_time -%}
                                         title="Published {{ build_time|timeformat }}" {%- endif -%}>
                                         {{ release.stars }}
-                                        {{ "star"|fas(false, false, "") }}
+                                        {{ crate::f_a::icons::IconStar|fas(false, false, "") }}
                                     </div>
                                 {%- elif let Some(build_time) = release.build_time -%}
                                     <div class="pure-u-1 pure-u-sm-4-24 pure-u-md-3-24 date"
@@ -86,13 +86,13 @@ centered
                 {% block pagination %}
                     {%- if show_previous_page -%}
                         <a class="pure-button pure-button-normal" href="/releases/{{ release_type.as_str() }}/{{ page_number - 1 }}">
-                            {{ "arrow-left"|fas(false, false, "") }} Previous Page
+                            {{ crate::f_a::icons::IconArrowLeft|fas(false, false, "") }} Previous Page
                         </a>
                     {%- endif -%}
 
                     {%- if show_next_page -%}
                         <a class="pure-button pure-button-normal" href="/releases/{{ release_type.as_str() }}/{{ page_number + 1 }}">
-                            Next Page {{ "arrow-right"|fas(false, false, "") }}
+                            Next Page {{ crate::f_a::icons::IconArrowRight|fas(false, false, "") }}
                         </a>
                     {%- endif -%}
                 {% endblock pagination %}

--- a/templates/releases/search_results.html
+++ b/templates/releases/search_results.html
@@ -15,7 +15,7 @@
     <div class="item-end">
         <span>Sort by</span>
         <label for="nav-sort">
-            {{ "list"|fas(false, false, "") }}
+            {{ crate::f_a::icons::IconList|fas(false, false, "") }}
         </label>
         {% set search_sort_by_val = search_sort_by.as_deref().unwrap_or_default() %}
         <select form="nav-search-form" name="sort" id="nav-sort" aria-label="Find crate by the sort by select-box"  tabindex="-1">
@@ -32,13 +32,13 @@
 {% block pagination %}
     {%- if let Some(previous_page_link) = previous_page_link -%}
         <a class="pure-button pure-button-normal" href="{{ previous_page_link }}">
-            {{ "arrow-left"|fas(false, false, "") }} Previous Page
+            {{ crate::f_a::icons::IconArrowLeft|fas(false, false, "") }} Previous Page
         </a>
     {%- endif -%}
 
     {%- if let Some(next_page_link) = next_page_link -%}
         <a class="pure-button pure-button-normal" href="{{ next_page_link }}">
-            Next Page {{ "arrow-right"|fas(false, false, "") }}
+            Next Page {{ crate::f_a::icons::IconArrowRight|fas(false, false, "") }}
         </a>
     {%- endif -%}
 {% endblock pagination %}

--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -23,7 +23,7 @@
     {%- if krate is defined -%}
         <li class="pure-menu-item pure-menu-has-children">
             <a href="#" class="pure-menu-link crate-name" title="{{ krate.description.as_deref().unwrap_or_default() }}">
-                {{ "cube"|fas(false, false, "") }}
+                {{ crate::f_a::icons::IconCube|fas(false, false, "") }}
                 <span class="title">{{ krate.name }}-{{ krate.version }}</span>
             </a>
 
@@ -39,20 +39,20 @@
                     {%- if metadata.req_version.to_string() == "latest" -%}
                     <li class="pure-menu-item">
                         <a href="{% if permalink_path is defined %}{{permalink_path|safe}}{% endif %}" class="pure-menu-link description" id="permalink" title="Get a link to this specific version">
-                            {{ "link"|fas(false, false, "") }} Permalink
+                            {{ crate::f_a::icons::IconLink|fas(false, false, "") }} Permalink
                         </a>
                     </li>
                     {%- endif -%}
 
                     <li class="pure-menu-item">
                         <a href="{{ crate_url|safe }}" class="pure-menu-link description" title="See {{ krate.name }} in docs.rs">
-                            {{ "cube"|fas(false, false, "") }} Docs.rs crate page
+                            {{ crate::f_a::icons::IconCube|fas(false, false, "") }} Docs.rs crate page
                         </a>
                     </li>
 
                     <li class="pure-menu-item">
                         <a href="{{ crate_url|safe }}" class="pure-menu-link">
-                            {{ "scale-unbalanced-flip"|fas(false, false, "") }} {{ krate.license.as_deref().unwrap_or_default() }}
+                            {{ crate::f_a::icons::IconScaleUnbalancedFlip|fas(false, false, "") }} {{ krate.license.as_deref().unwrap_or_default() }}
                         </a>
                     </li>
                 </ul>
@@ -66,7 +66,7 @@
                             {%- if let Some(homepage_url) = krate.homepage_url -%}
                                 <li class="pure-menu-item">
                                     <a href="{{ homepage_url }}" class="pure-menu-link">
-                                        {{ "house"|fas(false, false, "") }} Homepage
+                                        {{ crate::f_a::icons::IconHouse|fas(false, false, "") }} Homepage
                                     </a>
                                 </li>
                             {%- endif -%}
@@ -75,7 +75,7 @@
                             {%- if let Some(documentation_url) = krate.documentation_url -%}
                                 <li class="pure-menu-item">
                                     <a href="{{ documentation_url }}" title="Canonical documentation" class="pure-menu-link">
-                                        {{ "file-lines"|far(false, false, "") }} Documentation
+                                        {{ crate::f_a::icons::IconFileLines|far(false, false, "") }} Documentation
                                     </a>
                                 </li>
                             {%- endif -%}
@@ -84,21 +84,21 @@
                             {%- if let Some(repository_url) = krate.repository_url -%}
                                 <li class="pure-menu-item">
                                     <a href="{{ repository_url }}" class="pure-menu-link">
-                                        {{ "code-branch"|fas(false, false, "") }} Repository
+                                        {{ crate::f_a::icons::IconCodeBranch|fas(false, false, "") }} Repository
                                     </a>
                                 </li>
                             {%- endif -%}
 
                             <li class="pure-menu-item">
                                 <a href="https://crates.io/crates/{{ krate.name }}" class="pure-menu-link" title="See {{ krate.name }} in crates.io">
-                                    {{ "cube"|fas(false, false, "") }} crates.io
+                                    {{ crate::f_a::icons::IconCube|fas(false, false, "") }} crates.io
                                 </a>
                             </li>
 
                             {# A link to the release's source view #}
                             <li class="pure-menu-item">
                                 <a href="{{ crate_url|safe }}/source/" title="Browse source of {{ metadata.name }}-{{ metadata.version }}" class="pure-menu-link">
-                                    {{ "folder-open"|fas(false, false, "") }} Source
+                                    {{ crate::f_a::icons::IconFolderOpen|fas(false, false, "") }} Source
                                 </a>
                             </li>
                         </ul>
@@ -112,7 +112,7 @@
                             {%- for owner in krate.owners -%}
                                 <li class="pure-menu-item">
                                     <a href="https://crates.io/{{ owner.2 }}s/{{ owner.0 }}" class="pure-menu-link">
-                                        {{ "user"|fas(false, false, "") }} {{ owner.0 }}
+                                        {{ crate::f_a::icons::IconUser|fas(false, false, "") }} {{ owner.0 }}
                                     </a>
                                 </li>
                             {%- endfor -%}
@@ -142,7 +142,7 @@
 
                             <li class="pure-menu-item">
                                 <div class="pure-menu pure-menu-scrollable sub-menu" id="releases-list" tabindex="-1" data-url="{{ releases_menu_url }}">
-                                    <span class="rotate">{{ "spinner"|fas(false, false, "") }}</span>
+                                    <span class="rotate">{{ crate::f_a::icons::IconSpinner|fas(false, false, "") }}</span>
                                 </div>
                             </li>
                         </ul>
@@ -170,7 +170,7 @@
     {%- else -%}
         <li class="pure-menu-item">
             <a href="{{ crate_url|safe }}" class="pure-menu-link crate-name" {% if let Some(description) = metadata.description %}title="{{description}}"{% endif %}>
-                {{ "cube"|fas(false, false, "") }}
+                {{ crate::f_a::icons::IconCube|fas(false, false, "") }}
                 <span class="title">{{ metadata.name }}-{{ metadata.version }}</span>
             </a>
         </li>
@@ -181,7 +181,7 @@
     {%- if (is_latest_version is not defined || is_latest_version) && yanked -%}
         <li class="pure-menu-item">
             <span class="pure-menu-link warn">
-                {{ "triangle-exclamation"|fas(false, false, "") }}
+                {{ crate::f_a::icons::IconTriangleExclamation|fas(false, false, "") }}
                 <span class="title">This release has been yanked</span>
             </span>
         </li>
@@ -205,7 +205,7 @@
             <a href="{% if latest_path is defined %}{{ latest_path|safe }}{% endif %}" class="pure-menu-link warn"
                 data-fragment="retain"
                 title="{{ tooltip }}">
-                {{ "triangle-exclamation"|fas(false, false, "") }}
+                {{ crate::f_a::icons::IconTriangleExclamation|fas(false, false, "") }}
                 <span class="title">{{ title }}</span>
             </a>
         </li>
@@ -216,7 +216,7 @@
         {%- if !doc_targets.is_empty() -%}
             <li class="pure-menu-item pure-menu-has-children">
                 <a href="#" class="pure-menu-link" aria-label="Platform">
-                    {{ "gears"|fas(false, false, "") }}
+                    {{ crate::f_a::icons::IconGears|fas(false, false, "") }}
                     <span class="title">Platform</span>
                 </a>
 
@@ -226,14 +226,14 @@
                         {%- set use_direct_platform_links = use_direct_platform_links() -%}
                         {%- include "rustdoc/platforms.html" -%}
                     {%- else -%}
-                        <span class="rotate">{{ "spinner"|fas(false, false, "") }}</span>
+                        <span class="rotate">{{ crate::f_a::icons::IconSpinner|fas(false, false, "") }}</span>
                     {%- endif -%}
                 </ul>
             </li>
             {#- Display the features available in current build -#}
             <li class="pure-menu-item">
                 <a href="{{ crate_url|safe }}/features" title="Browse available feature flags of {{ metadata.name }}-{{ metadata.version }}" class="pure-menu-link">
-                    {{ "flag"|fas(false, false, "") }}
+                    {{ crate::f_a::icons::IconFlag|fas(false, false, "") }}
                     <span class="title">Feature flags</span>
                 </a>
             </li>


### PR DESCRIPTION
Now, we have the list of icons we use with their "variant(s)" (ie Brands, Regular or Solid) represented by a trait. To render as one of the variant, the corresponding method needs to be called.