### PR TITLE
use crate name normalization when trying to delete crates / releases

### DIFF
--- a/.sqlx/query-cec7e0053fc9710683bb8b2c7f74d9b1b4acd434f966d1da2db30c509c6089d8.json
+++ b/.sqlx/query-cec7e0053fc9710683bb8b2c7f74d9b1b4acd434f966d1da2db30c509c6089d8.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM crates WHERE normalize_crate_name(name) = normalize_crate_name($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "cec7e0053fc9710683bb8b2c7f74d9b1b4acd434f966d1da2db30c509c6089d8"
+}


### PR DESCRIPTION
There was a case with a crate called `Horizon_Data_Types`, which then was deleted on crate.io (I assume via support request). 

Interestingly we had the crate in our db as `Horizon_Data_Types`, while the delete change from the crates.io index came as `horizon_data_types`. That delete-request then failed because we didn't find the name. 
See https://rust-lang.sentry.io/issues/5128144333/?environment=production&project=5499376&query=&referrer=issue-stream&statsPeriod=90d&stream_index=4

The following build of the same crate as a new crate with a different name (`horizon-data-types`) then lead to a conflict error because we check uniqueness of crate names _after normalization_. 
Error: https://rust-lang.sentry.io/issues/5913176075/?environment=production&project=5499376&query=&referrer=issue-stream&statsPeriod=90d&stream_index=1 

This change will use normalization when handling deletes. 