### PR TITLE
split build queue into async / sync structs for separate usage

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,8 @@ use crate::db::Pool;
 use crate::error::Result;
 use crate::repositories::RepositoryStatsUpdater;
 use crate::{
-    AsyncStorage, BuildQueue, Config, Index, InstanceMetrics, RegistryApi, ServiceMetrics, Storage,
+    AsyncBuildQueue, AsyncStorage, BuildQueue, Config, Index, InstanceMetrics, RegistryApi,
+    ServiceMetrics, Storage,
 };
 use axum::async_trait;
 use std::sync::Arc;
@@ -12,6 +13,7 @@ use tokio::runtime::Runtime;
 #[async_trait]
 pub trait Context {
     fn config(&self) -> Result<Arc<Config>>;
+    async fn async_build_queue(&self) -> Result<Arc<AsyncBuildQueue>>;
     fn build_queue(&self) -> Result<Arc<BuildQueue>>;
     fn storage(&self) -> Result<Arc<Storage>>;
     async fn async_storage(&self) -> Result<Arc<AsyncStorage>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! documentation of crates for the Rust Programming Language.
 #![allow(clippy::cognitive_complexity)]
 
-pub use self::build_queue::BuildQueue;
+pub use self::build_queue::{AsyncBuildQueue, BuildQueue};
 pub use self::config::Config;
 pub use self::context::Context;
 pub use self::docbuilder::PackageKind;

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -402,7 +402,7 @@ fn apply_middleware(
     let has_templates = template_data.is_some();
     let runtime = context.runtime()?;
     let async_storage = runtime.block_on(context.async_storage())?;
-    let build_queue = context.build_queue()?;
+    let build_queue = runtime.block_on(context.async_build_queue())?;
 
     Ok(router.layer(
         ServiceBuilder::new()


### PR DESCRIPTION
I want to repare some other refactor which will makes writing webserver tests easier. 

But for this I need to split the build queue methods into full async ones that also can be used from the webserver, and some sync methods for the builder & queue handlers. 