### PR TITLE
upgrade rustwide to 0.18.0, capture output for more errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5453,9 +5453,9 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "rustwide"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af779495d93498c4a328950fe9e09c403dd5eb3beedd49dcfa9aa8fdd3b577c3"
+checksum = "a5bfcfc09bb16fa66d66fca9a8ea65471447bf9dbf76a28688922500c7937b0f"
 dependencies = [
  "anyhow",
  "attohttpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ comrak = { version = "0.29.0", default-features = false }
 syntect = { version = "5.0.0", default-features = false, features = ["parsing", "html", "dump-load", "regex-onig"] }
 toml = "0.8.0"
 prometheus = { version = "0.13.0", default-features = false }
-rustwide = { version = "0.17.0", features = ["unstable-toolchain-ci", "unstable"] }
+rustwide = { version = "0.18.0", features = ["unstable-toolchain-ci", "unstable"] }
 mime_guess = "2"
 zstd = "0.13.0"
 hostname = "0.4.0"

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -507,14 +507,14 @@ impl RustwideBuilder {
                         Command::new(&self.workspace, self.toolchain.cargo())
                             .cd(build.host_source_dir())
                             .args(&["generate-lockfile"])
-                            .run()?;
+                            .run_capture()?;
                     }
                     {
                         let _span = info_span!("cargo fetch --locked").entered();
                         Command::new(&self.workspace, self.toolchain.cargo())
                             .cd(build.host_source_dir())
                             .args(&["fetch", "--locked"])
-                            .run()?;
+                            .run_capture()?;
                     }
                     res =
                         self.execute_build(default_target, true, build, &limits, &metadata, false)?;


### PR DESCRIPTION
see https://github.com/rust-lang/rustwide/pull/91 

this should help with error messages in the prepare steps of the build, where we previously didn't show the full error to the users. 