### PR TITLE
store date of nightly version in separate field

### DIFF
--- a/.sqlx/query-64d91ec806ed67d6cffd1a797da5059cc8fb44b37f94dc77877c88d266c5ac9b.json
+++ b/.sqlx/query-64d91ec806ed67d6cffd1a797da5059cc8fb44b37f94dc77877c88d266c5ac9b.json
@@ -1,0 +1,63 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n                rustc_version,\n                docsrs_version,\n                build_status as \"build_status: BuildStatus\",\n                documentation_size,\n                errors,\n                rustc_nightly_date\n                FROM builds\n                WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "rustc_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "docsrs_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "build_status: BuildStatus",
+        "type_info": {
+          "Custom": {
+            "name": "build_status",
+            "kind": {
+              "Enum": [
+                "in_progress",
+                "success",
+                "failure"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "documentation_size",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "errors",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "rustc_nightly_date",
+        "type_info": "Date"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      true,
+      true,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "64d91ec806ed67d6cffd1a797da5059cc8fb44b37f94dc77877c88d266c5ac9b"
+}

--- a/.sqlx/query-ac2450acd8bbec632668499a18c59644f6cfdc87bd6d280ca8db6a146929c8f5.json
+++ b/.sqlx/query-ac2450acd8bbec632668499a18c59644f6cfdc87bd6d280ca8db6a146929c8f5.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "UPDATE builds\n         SET\n             rustc_version = $1,\n             docsrs_version = $2,\n             build_status = $3,\n             build_server = $4,\n             errors = $5,\n             documentation_size = $6,\n             build_finished = NOW()\n         WHERE\n            id = $7\n         RETURNING rid",
+  "query": "UPDATE builds\n         SET\n             rustc_version = $1,\n             docsrs_version = $2,\n             build_status = $3,\n             build_server = $4,\n             errors = $5,\n             documentation_size = $6,\n             rustc_nightly_date = $7,\n             build_finished = NOW()\n         WHERE\n            id = $8\n         RETURNING rid",
   "describe": {
     "columns": [
       {
@@ -28,6 +28,7 @@
         "Text",
         "Text",
         "Int8",
+        "Date",
         "Int4"
       ]
     },
@@ -35,5 +36,5 @@
       false
     ]
   },
-  "hash": "f9151734057f3e6562b1a56d1665ad3707b0ca37bbfca2d75e6e05b350dade04"
+  "hash": "ac2450acd8bbec632668499a18c59644f6cfdc87bd6d280ca8db6a146929c8f5"
 }

--- a/.sqlx/query-c955871bcda914feac9cfb23fe010399c0b3f75e92ac425fa4ec337e9b250c26.json
+++ b/.sqlx/query-c955871bcda914feac9cfb23fe010399c0b3f75e92ac425fa4ec337e9b250c26.json
@@ -1,0 +1,57 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n                rustc_version,\n                docsrs_version,\n                build_status as \"build_status: BuildStatus\",\n                errors,\n                rustc_nightly_date\n                FROM builds\n                WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "rustc_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "docsrs_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "build_status: BuildStatus",
+        "type_info": {
+          "Custom": {
+            "name": "build_status",
+            "kind": {
+              "Enum": [
+                "in_progress",
+                "success",
+                "failure"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "errors",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "rustc_nightly_date",
+        "type_info": "Date"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      true,
+      true,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "c955871bcda914feac9cfb23fe010399c0b3f75e92ac425fa4ec337e9b250c26"
+}

--- a/migrations/20241018052241_builds-rustc-nightly-date.down.sql
+++ b/migrations/20241018052241_builds-rustc-nightly-date.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX builds_nightly_date_idx;
+
+ALTER TABLE builds 
+    DROP COLUMN rustc_nightly_date;

--- a/migrations/20241018052241_builds-rustc-nightly-date.up.sql
+++ b/migrations/20241018052241_builds-rustc-nightly-date.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE builds 
+    ADD COLUMN rustc_nightly_date DATE;
+
+CREATE INDEX builds_nightly_date_idx ON builds USING btree (rustc_nightly_date);
+
+UPDATE builds 
+    SET rustc_nightly_date = CAST(SUBSTRING(rustc_version FROM ' (\d+-\d+-\d+)\)$') AS DATE)
+    WHERE rustc_version IS NOT NULL;

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -251,6 +251,9 @@ pub(crate) async fn finish_build(
     let rustc_date = match parse_rustc_date(rustc_version) {
         Ok(date) => Some(date),
         Err(err) => {
+            // in the database we see cases where the rustc version is missing
+            // in the builds-table. In this case & if we can't parse the version
+            // we just want to log an error, but still finish the build.
             error!(
                 "Failed to parse date from rustc version \"{}\": {:?}",
                 rustc_version, err

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -21,7 +21,7 @@ pub mod daemon;
 mod html;
 mod queue;
 pub(crate) mod queue_builder;
-mod rustc_version;
+pub(crate) mod rustc_version;
 use anyhow::Result;
 use serde::de::DeserializeOwned;
 use serde::Serialize;

--- a/src/utils/rustc_version.rs
+++ b/src/utils/rustc_version.rs
@@ -21,7 +21,7 @@ pub fn parse_rustc_version<S: AsRef<str>>(version: S) -> Result<String> {
     ))
 }
 
-fn parse_rustc_date<S: AsRef<str>>(version: S) -> Result<NaiveDate> {
+pub(crate) fn parse_rustc_date<S: AsRef<str>>(version: S) -> Result<NaiveDate> {
     static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r" (\d+)-(\d+)-(\d+)\)$").unwrap());
 
     let cap = RE


### PR DESCRIPTION
this is helpful for two things I'm working on: 

1. automatic rebuilds for old releases. I want to configure a "max nightly date" to rebuild up to. 
2. a command to queue rebuilds for broken nightly versions, just via using the date. 

