### PR TITLE
Preserve full registry API path

### DIFF
--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -181,7 +181,7 @@ async fn get_search_results(
 
     let url = config
         .registry_api_host
-        .join(&format!("/api/v1/crates{query_params}"))?;
+        .join(&format!("api/v1/crates{query_params}"))?;
     debug!("fetching search results from {}", url);
 
     // extract the query from the query args.


### PR DESCRIPTION
`Url::join` will truncate the entire path if an absolute path is joined into it.

Given a custom registry API:
```
DOCSRS_REGISTRY_API_HOST=https://host/api/packages/cargo/
```

The query will hit this URL:
```
https://host/api/v1/crates
```

Instead of:
```
https://host/api/packages/cargo/api/v1/crates
```

Not quite sure if this is desired behavior or a bug but this seems inline with other uses of the registry API in `RegistryApi` where the full path is preserved.
