### PR TITLE
replace unwrap in templates with expect for debugging

### DIFF
--- a/templates/macros.html
+++ b/templates/macros.html
@@ -159,8 +159,8 @@
         {%- for dependency in deps -%}
             {%- if let serde_json::Value::Array(dep) = dependency -%}
                 <li class="pure-menu-item">
-                    {%- set first = dep[0].as_str().unwrap() -%}
-                    {%- set second = dep[1].as_str().unwrap() -%}
+                    {%- set first = dep[0].as_str().expect("dep[0] not a string in dependency") -%}
+                    {%- set second = dep[1].as_str().expect("dep[1] not a string in dependency") -%}
                     <a href="{{ link_prefix|safe }}/{{ first|safe }}/{{ second|safe }}" class="pure-menu-link">
                         {{ first|safe }} {{ second|safe }}
                         {% if let Some(serde_json::Value::String(third)) = dep.get(2) %}

--- a/templates/rustdoc/head.html
+++ b/templates/rustdoc/head.html
@@ -6,7 +6,7 @@
           {%- let build_slug2 =  slug::slugify(crate::BUILD_VERSION) -%}
         {%- endif -%}
 
-        <link rel="stylesheet" href="/-/static/{{rustdoc_css_file.as_ref().unwrap()}}?{{build_slug2}}" media="all" />
+        <link rel="stylesheet" href="/-/static/{{rustdoc_css_file.as_ref().expect("rustdoc_css_file missing")}}?{{build_slug2}}" media="all" />
         <link rel="stylesheet" href="/-/static/font-awesome.css?{{build_slug2}}" media="all" />
 
         <link rel="search" href="/-/static/opensearch.xml" type="application/opensearchdescription+xml" title="Docs.rs" />


### PR DESCRIPTION
[We're regularly getting a panic from `Option::unwrap` in some template](https://rust-lang.sentry.io/issues/5987559600/?environment=production&project=5499376&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=0), but I don't know which. 

So I'm replacing `.unwrap()` in templates with `.expect(...)` so see where it's coming from. 