### PR TITLE
start queueing rebuilds for the latest version of each crate, if we had docs

### DIFF
--- a/.sqlx/query-007c5f49470ce1bc503f82003377d80cc4be3282ca1b9c37c1b2e8c28dff53d0.json
+++ b/.sqlx/query-007c5f49470ce1bc503f82003377d80cc4be3282ca1b9c37c1b2e8c28dff53d0.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) as \"count!\" FROM queue WHERE priority >= $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "007c5f49470ce1bc503f82003377d80cc4be3282ca1b9c37c1b2e8c28dff53d0"
+}

--- a/.sqlx/query-dd1b692e4dc6aaa210f53b1cf3f57a4282b79c6c20859bb88a451afc3b1a404d.json
+++ b/.sqlx/query-dd1b692e4dc6aaa210f53b1cf3f57a4282b79c6c20859bb88a451afc3b1a404d.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT i.* FROM (\n             SELECT\n                 c.name,\n                 r.version,\n                 max(b.rustc_nightly_date) as rustc_nightly_date\n\n             FROM crates AS c\n             INNER JOIN releases AS r ON c.latest_version_id = r.id\n             INNER JOIN builds AS b ON r.id = b.rid\n\n             WHERE\n                 r.rustdoc_status = TRUE\n\n             GROUP BY c.name, r.version\n         ) as i\n         WHERE i.rustc_nightly_date < $1\n         ORDER BY i.rustc_nightly_date ASC\n         LIMIT $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "rustc_nightly_date",
+        "type_info": "Date"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Date",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "dd1b692e4dc6aaa210f53b1cf3f57a4282b79c6c20859bb88a451afc3b1a404d"
+}

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -155,6 +155,8 @@ enum CommandLine {
         repository_stats_updater: Toggle,
         #[arg(long = "cdn-invalidator", default_value = "enabled", value_enum)]
         cdn_invalidator: Toggle,
+        #[arg(long = "queue-rebuilds", default_value = "enabled", value_enum)]
+        queue_rebuilds: Toggle,
     },
 
     StartBuildServer {
@@ -192,12 +194,16 @@ impl CommandLine {
                 metric_server_socket_addr,
                 repository_stats_updater,
                 cdn_invalidator,
+                queue_rebuilds,
             } => {
                 if repository_stats_updater == Toggle::Enabled {
                     docs_rs::utils::daemon::start_background_repository_stats_updater(&ctx)?;
                 }
                 if cdn_invalidator == Toggle::Enabled {
                     docs_rs::utils::daemon::start_background_cdn_invalidator(&ctx)?;
+                }
+                if queue_rebuilds == Toggle::Enabled {
+                    docs_rs::utils::daemon::start_background_queue_rebuild(&ctx)?;
                 }
 
                 start_background_metrics_webserver(Some(metric_server_socket_addr), &ctx)?;

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -15,6 +15,10 @@ use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tracing::{debug, error, info, instrument};
 
+/// The static prioriry for background rebuilds.
+/// Used when queueing rebuilds, and when rendering them
+/// collapsed in the UI.
+/// For Normal build priorities we use smaller values.
 pub(crate) const REBUILD_PRIORITY: i32 = 20;
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize)]

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -15,10 +15,10 @@ use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tracing::{debug, error, info, instrument};
 
-/// The static prioriry for background rebuilds.
+/// The static priority for background rebuilds.
 /// Used when queueing rebuilds, and when rendering them
 /// collapsed in the UI.
-/// For Normal build priorities we use smaller values.
+/// For normal build priorities we use smaller values.
 pub(crate) const REBUILD_PRIORITY: i32 = 20;
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use crate::{cdn::CdnKind, storage::StorageKind};
 use anyhow::{anyhow, bail, Context, Result};
+use chrono::NaiveDate;
 use std::{env::VarError, error::Error, path::PathBuf, str::FromStr, time::Duration};
 use tracing::trace;
 use url::Url;
@@ -113,6 +114,10 @@ pub struct Config {
     pub(crate) build_default_memory_limit: Option<usize>,
     pub(crate) include_default_targets: bool,
     pub(crate) disable_memory_limit: bool,
+
+    // automatic rebuild configuration
+    pub(crate) max_queued_rebuilds: Option<u16>,
+    pub(crate) rebuild_up_to_date: Option<NaiveDate>,
 }
 
 impl Config {
@@ -230,6 +235,8 @@ impl Config {
                 "DOCSRS_BUILD_WORKSPACE_REINITIALIZATION_INTERVAL",
                 86400,
             )?),
+            max_queued_rebuilds: maybe_env("DOCSRS_MAX_QUEUED_REBUILDS")?,
+            rebuild_up_to_date: maybe_env("DOCSRS_REBUILD_UP_TO_DATE")?,
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! documentation of crates for the Rust Programming Language.
 #![allow(clippy::cognitive_complexity)]
 
-pub use self::build_queue::{AsyncBuildQueue, BuildQueue};
+pub use self::build_queue::{queue_rebuilds, AsyncBuildQueue, BuildQueue};
 pub use self::config::Config;
 pub use self::context::Context;
 pub use self::docbuilder::PackageKind;


### PR DESCRIPTION
Resolves #464 

Based on https://github.com/rust-lang/docs.rs/pull/2639 , will un-draft & rebase this PR when #2639 is merged. 

This is an hourly job which continiously keeps a rebuild queue full to prevent having a too full queue, and with the idea in the future to continiously rebuild old docs. 

The priority makes sure we're only using spare build capacity. A queue limit makes the queue manageable. For now I would like to define a max version to rebuild up to, we could think about setting this version depending on major rustdoc changes, or drop it at some point in favor of a flexible limit (like: rebuild everything older than X months). 

So make the S3 bucket more manageable we might also either rebuild _all_ releases, or run a re-package job that converts non-archive docs to archive ones. 