### PR TITLE
fix support for missing rustdoc CSS in header

### DIFF
--- a/templates/rustdoc/head.html
+++ b/templates/rustdoc/head.html
@@ -6,7 +6,9 @@
           {%- let build_slug2 =  slug::slugify(crate::BUILD_VERSION) -%}
         {%- endif -%}
 
-        <link rel="stylesheet" href="/-/static/{{rustdoc_css_file.as_ref().expect("rustdoc_css_file missing")}}?{{build_slug2}}" media="all" />
+        {%- if let Some(css_file) = rustdoc_css_file -%}
+            <link rel="stylesheet" href="/-/static/{{css_file}}?{{build_slug2}}" media="all" />
+        {%- endif -%}
         <link rel="stylesheet" href="/-/static/font-awesome.css?{{build_slug2}}" media="all" />
 
         <link rel="search" href="/-/static/opensearch.xml" type="application/opensearchdescription+xml" title="Docs.rs" />


### PR DESCRIPTION
I figured out the root cause for the panic we had, at least to a certain extend. 

https://rust-lang.sentry.io/issues/5987559600/?environment=production&project=5499376&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=2

In 71b5fb390f91cb2ae112c5d63d72f8fc88aeb343, an `if` check was removed, which now lead to the panic. 

The thing I'm not sure about right now is what kind of releases would lead to the rustdoc head being rendered, that don't have a rustc version in the build-table. 