### PR TITLE
Use RegistryApi in releases

### DIFF
--- a/src/registry_api.rs
+++ b/src/registry_api.rs
@@ -249,7 +249,7 @@ impl RegistryApi {
     }
 
     /// Fetch crates from the registry's API
-    pub(crate) async fn get_crates(&self, query: Option<&str>) -> Result<Search> {
+    pub(crate) async fn search(&self, query_params: &str) -> Result<Search> {
         #[derive(Deserialize, Debug)]
         struct SearchError {
             detail: String,
@@ -267,7 +267,7 @@ impl RegistryApi {
             url.path_segments_mut()
                 .map_err(|()| anyhow!("Invalid API url"))?
                 .extend(&["api", "v1", "crates"]);
-            url.set_query(query);
+            url.set_query(Some(query_params));
             url
         };
 

--- a/src/registry_api.rs
+++ b/src/registry_api.rs
@@ -86,7 +86,6 @@ pub(crate) struct SearchMeta {
 pub(crate) struct Search {
     pub(crate) crates: Vec<SearchCrate>,
     pub(crate) meta: SearchMeta,
-    pub(crate) executed_query: Option<String>,
 }
 
 impl RegistryApi {
@@ -271,15 +270,6 @@ impl RegistryApi {
             url
         };
 
-        // Extract the query from the query args
-        let executed_query = url.query_pairs().find_map(|(key, value)| {
-            if key == "q" {
-                Some(value.to_string())
-            } else {
-                None
-            }
-        });
-
         let response: SearchResponse = retry_async(
             || async {
                 Ok(self
@@ -308,10 +298,6 @@ impl RegistryApi {
             bail!("missing metadata in crates.io response");
         };
 
-        Ok(Search {
-            crates,
-            meta,
-            executed_query,
-        })
+        Ok(Search { crates, meta })
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -31,12 +31,6 @@ pub(crate) mod sized_buffer;
 
 use std::{future::Future, thread, time::Duration};
 
-pub(crate) const APP_USER_AGENT: &str = concat!(
-    env!("CARGO_PKG_NAME"),
-    " ",
-    include_str!(concat!(env!("OUT_DIR"), "/git_version"))
-);
-
 pub(crate) fn report_error(err: &anyhow::Error) {
     // Debug-format for anyhow errors includes context & backtrace
     if std::env::var("SENTRY_DSN").is_ok() {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -424,6 +424,7 @@ async fn apply_middleware(
             .layer(Extension(context.service_metrics()?))
             .layer(Extension(context.instance_metrics()?))
             .layer(Extension(context.config()?))
+            .layer(Extension(context.registry_api()?))
             .layer(Extension(async_storage))
             .layer(option_layer(template_data.map(Extension)))
             .layer(middleware::from_fn(csp::csp_middleware))


### PR DESCRIPTION
Follows https://github.com/rust-lang/docs.rs/pull/2642

After further testing I found further inconsistencies in URL handling so I made the jump and added this functionality to `RegistryApi` as @syphar suggested.