### PR TITLE
fix archive-download endpoint tests dependency on config

### DIFF
--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -2549,6 +2549,9 @@ mod test {
     #[test]
     fn download_semver() {
         wrapper(|env| {
+            env.override_config(|config| {
+                config.s3_static_root_path = "https://static.docs.rs".into()
+            });
             env.fake_release()
                 .name("dummy")
                 .version("0.1.0")
@@ -2572,6 +2575,9 @@ mod test {
     #[test]
     fn download_specific_version() {
         wrapper(|env| {
+            env.override_config(|config| {
+                config.s3_static_root_path = "https://static.docs.rs".into()
+            });
             env.fake_release()
                 .name("dummy")
                 .version("0.1.0")
@@ -2599,6 +2605,9 @@ mod test {
     #[test]
     fn download_latest_version() {
         wrapper(|env| {
+            env.override_config(|config| {
+                config.s3_static_root_path = "https://static.docs.rs".into()
+            });
             env.fake_release()
                 .name("dummy")
                 .version("0.1.0")


### PR DESCRIPTION
This happens when someone sets `DOCSRS_S3_STATIC_ROOT_PATH` to a non-default value. 

But tests shouldn't depend on config in this way. 