### PR TITLE
create rebuild queue

### DIFF
--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -15,6 +15,8 @@ use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tracing::{debug, error, info};
 
+pub(crate) const REBUILD_PRIORITY: i32 = 20;
+
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize)]
 pub(crate) struct QueuedCrate {
     #[serde(skip)]

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -15,6 +15,8 @@ use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tracing::{debug, error, info};
 
+// Threshold priority to decide whether a crate will in the rebuild-queue-list.
+// If crate is in the rebuild-queue-list it won't in the build-queue-list.
 pub(crate) const REBUILD_PRIORITY: i32 = 20;
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize)]

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -22,6 +22,7 @@ use axum::{
 use base64::{engine::general_purpose::STANDARD as b64, Engine};
 use chrono::{DateTime, Utc};
 use futures_util::stream::TryStreamExt;
+use itertools::Itertools;
 use once_cell::sync::Lazy;
 use rinja::Template;
 use serde::{Deserialize, Serialize};
@@ -832,7 +833,7 @@ pub(crate) async fn build_queue_handler(
     .collect();
 
     let mut rebuild_queue = Vec::new();
-    let queue: Vec<QueuedCrate> = build_queue
+    let mut queue = build_queue
         .queued_crates()
         .await?
         .into_iter()
@@ -842,19 +843,20 @@ pub(crate) async fn build_queue_handler(
                 *name == krate.name && *version == krate.version
             })
         })
-        .map(|mut krate| {
-            if krate.priority >= REBUILD_PRIORITY {
-                rebuild_queue.push(krate.clone());
-            } else {
-                // The priority here is inverted: in the database if a crate has a higher priority it
-                // will be built after everything else, which is counter-intuitive for people not
-                // familiar with docs.rs's inner workings.
-                krate.priority = -krate.priority;
-            }
+        .collect_vec();
 
-            krate
-        })
-        .collect();
+    queue.retain_mut(|krate| {
+        if krate.priority >= REBUILD_PRIORITY {
+            rebuild_queue.push(krate.clone());
+            false
+        } else {
+            // The priority here is inverted: in the database if a crate has a higher priority it
+            // will be built after everything else, which is counter-intuitive for people not
+            // familiar with docs.rs's inner workings.
+            krate.priority = -krate.priority;
+            true
+        }
+    });
 
     Ok(BuildQueuePage {
         description: "crate documentation scheduled to build & deploy",
@@ -1900,15 +1902,29 @@ mod tests {
 
             let full =
                 kuchikiki::parse_html().one(web.get("/releases/queue?expand=1").send()?.text()?);
-            let items = full
+            let build_queue_list = full
+                .select(".queue-list > li")
+                .expect("missing list items")
+                .collect::<Vec<_>>();
+            let rebuild_queue_list = full
                 .select(".rebuild-queue-list > li")
                 .expect("missing list items")
                 .collect::<Vec<_>>();
 
-            assert_eq!(items.len(), 2);
-            assert!(items.iter().any(|li| li.text_contents().contains("foo")));
-            assert!(items.iter().any(|li| li.text_contents().contains("bar")));
-            assert!(!items.iter().any(|li| li.text_contents().contains("baz")));
+            assert_eq!(build_queue_list.len(), 1);
+            assert_eq!(rebuild_queue_list.len(), 2);
+            assert!(rebuild_queue_list
+                .iter()
+                .any(|li| li.text_contents().contains("foo")));
+            assert!(rebuild_queue_list
+                .iter()
+                .any(|li| li.text_contents().contains("bar")));
+            assert!(build_queue_list
+                .iter()
+                .any(|li| li.text_contents().contains("baz")));
+            assert!(!rebuild_queue_list
+                .iter()
+                .any(|li| li.text_contents().contains("baz")));
 
             Ok(())
         });

--- a/templates/releases/build_queue.html
+++ b/templates/releases/build_queue.html
@@ -84,7 +84,7 @@
                         </li>
                     {%- endfor %}
                 {%- else %}
-                    <strong>There is nothing in the queue</strong>
+                    <strong>There is nothing in the build queue</strong>
                 {%- endif %}
             </ol>
 

--- a/templates/releases/build_queue.html
+++ b/templates/releases/build_queue.html
@@ -87,6 +87,37 @@
                     <strong>There is nothing in the queue</strong>
                 {%- endif %}
             </ol>
+
+            <div class="release">
+                <strong>Rebuild Queue</strong>
+            </div>
+
+            <div class="about">
+                <p>
+                    We continiously rebuild the latest versions for all crates so they can
+                    benefit from new features in rustdoc.
+                </p>
+                {%- if !expand_rebuild_queue -%}
+                    <p>There are currently {{ rebuild_queue.len() }} crates in the rebuild queue.</p>
+                    <p><a href="?expand=1">Show</a></p>
+                {%- endif -%}
+            </div>
+
+            {%- if expand_rebuild_queue -%}
+                <ol class="queue-list">
+                    {%- if !rebuild_queue.is_empty() -%}
+                        {% for crate_item in rebuild_queue -%}
+                            <li>
+                                <a href="https://crates.io/crates/{{ crate_item.name }}">
+                                    {{- crate_item.name }} {{ crate_item.version -}}
+                                </a>
+                            </li>
+                        {%- endfor %}
+                    {%- else %}
+                        <strong>There is nothing in the rebuild queue</strong>
+                    {%- endif %}
+                </ol>
+            {%- endif -%}
         </div>
     </div>
 {%- endblock body -%}

--- a/templates/releases/build_queue.html
+++ b/templates/releases/build_queue.html
@@ -98,7 +98,8 @@
                     benefit from new features in rustdoc.
                 </p>
                 {%- if !expand_rebuild_queue -%}
-                    <p>There are currently {{ rebuild_queue.len() }} crate{{ rebuild_queue.len()|pluralize }} in the rebuild queue.</p>
+                    {% let rebuild_queue_len = rebuild_queue.len() %}
+                    <p>There are currently {{ rebuild_queue_len }} crate{{ rebuild_queue_len|pluralize }} in the rebuild queue.</p>
                     <p><a href="?expand=1">Show</a></p>
                 {%- endif -%}
             </div>

--- a/templates/releases/build_queue.html
+++ b/templates/releases/build_queue.html
@@ -98,7 +98,7 @@
                     benefit from new features in rustdoc.
                 </p>
                 {%- if !expand_rebuild_queue -%}
-                    <p>There are currently {{ rebuild_queue.len() }} crates in the rebuild queue.</p>
+                    <p>There are currently {{ rebuild_queue.len() }} crate{{ rebuild_queue.len()|pluralize }} in the rebuild queue.</p>
                     <p><a href="?expand=1">Show</a></p>
                 {%- endif -%}
             </div>

--- a/templates/releases/build_queue.html
+++ b/templates/releases/build_queue.html
@@ -94,7 +94,7 @@
 
             <div class="about">
                 <p>
-                    We continiously rebuild the latest versions for all crates so they can
+                    We continuously rebuild the latest versions for all crates so they can
                     benefit from new features in rustdoc.
                 </p>
                 {%- if !expand_rebuild_queue -%}
@@ -104,7 +104,7 @@
             </div>
 
             {%- if expand_rebuild_queue -%}
-                <ol class="queue-list">
+                <ol class="rebuild-queue-list">
                     {%- if !rebuild_queue.is_empty() -%}
                         {% for crate_item in rebuild_queue -%}
                             <li>

--- a/templates/style/style.scss
+++ b/templates/style/style.scss
@@ -7,19 +7,18 @@
     font-style: normal;
     font-weight: 400;
     src:
-        local('Fira Sans'),
-        url("FiraSans-Regular.woff2") format('woff2'),
-        url("FiraSans-Regular.woff") format('woff');
+      local('Fira Sans'),
+      url("FiraSans-Regular.woff2") format('woff2'),
+      url("FiraSans-Regular.woff") format('woff');
 }
-
 @font-face {
     font-family: 'Fira Sans';
     font-style: normal;
     font-weight: 500;
     src:
-        local('Fira Sans Medium'),
-        url("FiraSans-Medium.woff2") format('woff2'),
-        url("FiraSans-Medium.woff") format('woff');
+      local('Fira Sans Medium'),
+      url("FiraSans-Medium.woff2") format('woff2'),
+      url("FiraSans-Medium.woff") format('woff');
 }
 
 /* See SourceSerif4-LICENSE.md for the Source Serif 4 license. */
@@ -28,29 +27,27 @@
     font-style: normal;
     font-weight: 400;
     src:
-        local('Source Serif 4'),
-        url("SourceSerif4-Regular.ttf.woff2") format('woff2'),
-        url("SourceSerif4-Regular.ttf.woff") format('woff');
+      local('Source Serif 4'),
+      url("SourceSerif4-Regular.ttf.woff2") format('woff2'),
+      url("SourceSerif4-Regular.ttf.woff") format('woff');
 }
-
 @font-face {
     font-family: 'Source Serif';
     font-style: italic;
     font-weight: 400;
     src:
-        local('Source Serif 4'),
-        url("SourceSerif4-It.ttf.woff2") format('woff2'),
-        url("SourceSerif4-It.ttf.woff") format('woff');
+      local('Source Serif 4'),
+      url("SourceSerif4-It.ttf.woff2") format('woff2'),
+      url("SourceSerif4-It.ttf.woff") format('woff');
 }
-
 @font-face {
     font-family: 'Source Serif';
     font-style: normal;
     font-weight: 700;
     src:
-        local('Source Serif 4'),
-        url("SourceSerif4-Bold.ttf.woff2") format('woff2'),
-        url("SourceSerif4-Bold.ttf.woff") format('woff');
+      local('Source Serif 4'),
+      url("SourceSerif4-Bold.ttf.woff2") format('woff2'),
+      url("SourceSerif4-Bold.ttf.woff") format('woff');
 }
 
 /* See SourceCodePro-LICENSE.md for the Source Code Pro license. */
@@ -61,26 +58,24 @@
     /* Avoid using locally installed font because bad versions are in circulation:
      * see https://github.com/rust-lang/rust/issues/24355 */
     src:
-        url("SourceCodePro-Regular.ttf.woff2") format('woff2'),
-        url("SourceCodePro-Regular.ttf.woff") format('woff');
+      url("SourceCodePro-Regular.ttf.woff2") format('woff2'),
+      url("SourceCodePro-Regular.ttf.woff") format('woff');
 }
-
 @font-face {
     font-family: 'Source Code Pro';
     font-style: normal;
     font-weight: 600;
     src:
-        url("SourceCodePro-Semibold.ttf.woff2") format('woff2'),
-        url("SourceCodePro-Semibold.ttf.woff") format('woff');
+      url("SourceCodePro-Semibold.ttf.woff2") format('woff2'),
+      url("SourceCodePro-Semibold.ttf.woff") format('woff');
 }
-
 @font-face {
     font-family: 'Source Code Pro';
     font-style: italic;
     font-weight: 400;
     src:
-        url("SourceCodePro-It.ttf.woff2") format('woff2'),
-        url("SourceCodePro-It.ttf.woff") format('woff');
+      url("SourceCodePro-It.ttf.woff2") format('woff2'),
+      url("SourceCodePro-It.ttf.woff") format('woff');
 }
 
 html,
@@ -107,8 +102,7 @@ body {
     padding: 0;
     margin: 0;
     position: relative;
-    min-height: 100vh;
-    /* Tall enough to stick the footer to the bottom */
+    min-height: 100vh; /* Tall enough to stick the footer to the bottom */
 
     * {
         -webkit-box-sizing: border-box;
@@ -119,55 +113,37 @@ body {
     h1 {
         font-size: 1.5em;
     }
-
     h3 {
         font-size: 1.3em;
     }
-
-    h1,
-    h2,
-    h3,
-    h4 {
-        font-family: "Fira Sans", sans-serif;
+    h1, h2, h3, h4 {
+        font-family: "Fira Sans",sans-serif;
         font-weight: 500;
         margin: 20px 0 15px 0;
         padding-bottom: 6px;
     }
-
-    h2,
-    h3,
-    h4 {
+    h2, h3, h4 {
         border-bottom: 1px solid;
     }
-
     pre {
         background-color: var(--color-background-code);
         padding: 14px;
     }
-
-    code,
-    kbd,
-    pre,
-    samp {
-        font-family: "Source Code Pro", monospace;
+    code, kbd, pre, samp {
+        font-family: "Source Code Pro",monospace;
     }
-
     a {
         text-decoration: none;
         background: transparent;
     }
-
     p {
         margin: 0 0 .6em 0;
     }
-
-    ol,
-    ul {
+    ol, ul {
         padding-left: 25px;
     }
 
-    input,
-    #search {
+    input, #search {
         background-color: var(--color-background-input);
         color: var(--input-color);
         line-height: normal;
@@ -201,7 +177,7 @@ body {
     background-color: var(--color-background);
     color: var(--color-standard);
 
-    >h1 {
+    > h1 {
         color: var(--color-standard);
     }
 
@@ -210,16 +186,15 @@ body {
         fill: var(--color-background);
     }
 
-    text.highcharts-title,
-    g.highcharts-axis-labels>text {
+    text.highcharts-title, g.highcharts-axis-labels > text {
         fill: var(--chart-title-color) !important;
     }
 
-    g.highcharts-legend-item>text {
+    g.highcharts-legend-item > text {
         fill: var(--chart-grid) !important;
     }
 
-    g.highcharts-grid>path {
+    g.highcharts-grid > path {
         stroke: var(--chart-grid) !important;
     }
 }
@@ -287,8 +262,7 @@ div.recent-releases-container {
         padding: 0;
     }
 
-    ol.queue-list li,
-    ol.rebuild-queue-list li {
+    ol.queue-list li, ol.rebuild-queue-list li {
         list-style-type: decimal;
         margin-left: 20px;
 
@@ -296,7 +270,7 @@ div.recent-releases-container {
             color: var(--color-url);
         }
     }
-
+    
     .about p {
         margin-left: 20px;
     }
@@ -310,8 +284,7 @@ div.recent-releases-container {
         background-color: var(--background-color);
     }
 
-    .release,
-    .build-in-progress {
+    .release, .build-in-progress {
         display: block;
         border-bottom: 1px solid var(--color-border);
         padding: 0.4em $search-result-right-left-padding;
@@ -369,7 +342,6 @@ div.recent-releases-container {
         span.fa-check {
             color: var(--color-macro);
         }
-
         span.fa-times {
             color: var(--color-struct);
         }
@@ -416,10 +388,10 @@ div.recent-releases-container {
     }
 
     .yanked {
-        color: var(--color-warn-msg);
-        background-color: var(--color-warn-background);
-        padding: .2em .8em .2em .5em;
-        border-radius: 1em;
+      color: var(--color-warn-msg);
+      background-color: var(--color-warn-background);
+      padding: .2em .8em .2em .5em;
+      border-radius: 1em;
     }
 }
 
@@ -431,7 +403,6 @@ div.package-container {
         margin: 0;
         padding: 20px 0 0 16px;
     }
-
     p {
         margin: 0;
         padding: 0 0 20px 16px;
@@ -502,7 +473,7 @@ div.package-page-container {
             margin: 20px 5px 15px 5px;
         }
 
-        li.pure-menu-item>.documented-info {
+        li.pure-menu-item > .documented-info {
             font-size: 13px;
             display: block;
             width: 100%;
@@ -608,7 +579,7 @@ div.package-page-container {
                 border-bottom: 1px solid var(--color-menu-border);
             }
 
-            tbody>tr:last-child>td {
+            tbody > tr:last-child > td {
                 border-bottom-width: 0;
             }
 
@@ -730,7 +701,7 @@ div.docsrs-package-container {
                     border-radius: 2px;
                 }
 
-                .pure-menu-has-children>.pure-menu-link:after {
+                .pure-menu-has-children > .pure-menu-link:after {
                     font-size: 14px;
                 }
 
@@ -807,12 +778,7 @@ div.search-page-search-form {
         background-color: inherit;
     }
 
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
+    h1, h2, h3, h4, h5, h6 {
         border-bottom-color: var(--color-border) !important;
         color: var(--color-standard) !important;
     }
@@ -827,8 +793,8 @@ div.search-page-search-form {
 }
 
 /* Don't put a newline after code fragments in headers */
-h3>code,
-h4>code {
+h3 > code,
+h4 > code {
     display: inline-block;
 }
 
@@ -911,17 +877,13 @@ ul.pure-menu-list {
         max-width: 46px;
 
         ul {
-
-            li:not(.toggle-source),
-            .text {
+            li:not(.toggle-source), .text {
                 display: none;
             }
-
             li.toggle-source {
                 .left {
                     display: none;
                 }
-
                 .right {
                     display: inline-block;
                     margin-left: -4px;
@@ -939,16 +901,13 @@ ul.pure-menu-list {
     display: inline-flex;
     overflow: scroll;
 }
-
 #line-numbers {
     text-align: right;
     letter-spacing: normal;
 }
-
-#line-numbers>code>a {
+#line-numbers > code > a  {
     padding: 0 8px;
 }
-
 // This class is used to the source code and the line number container in the
 // `crate/**/source/*` view
 .source-code {
@@ -966,7 +925,6 @@ ul.pure-menu-list {
         width: calc(100% - 46px);
     }
 }
-
 #source-code {
     overflow: scroll;
     width: 100%;

--- a/templates/style/style.scss
+++ b/templates/style/style.scss
@@ -7,18 +7,19 @@
     font-style: normal;
     font-weight: 400;
     src:
-      local('Fira Sans'),
-      url("FiraSans-Regular.woff2") format('woff2'),
-      url("FiraSans-Regular.woff") format('woff');
+        local('Fira Sans'),
+        url("FiraSans-Regular.woff2") format('woff2'),
+        url("FiraSans-Regular.woff") format('woff');
 }
+
 @font-face {
     font-family: 'Fira Sans';
     font-style: normal;
     font-weight: 500;
     src:
-      local('Fira Sans Medium'),
-      url("FiraSans-Medium.woff2") format('woff2'),
-      url("FiraSans-Medium.woff") format('woff');
+        local('Fira Sans Medium'),
+        url("FiraSans-Medium.woff2") format('woff2'),
+        url("FiraSans-Medium.woff") format('woff');
 }
 
 /* See SourceSerif4-LICENSE.md for the Source Serif 4 license. */
@@ -27,27 +28,29 @@
     font-style: normal;
     font-weight: 400;
     src:
-      local('Source Serif 4'),
-      url("SourceSerif4-Regular.ttf.woff2") format('woff2'),
-      url("SourceSerif4-Regular.ttf.woff") format('woff');
+        local('Source Serif 4'),
+        url("SourceSerif4-Regular.ttf.woff2") format('woff2'),
+        url("SourceSerif4-Regular.ttf.woff") format('woff');
 }
+
 @font-face {
     font-family: 'Source Serif';
     font-style: italic;
     font-weight: 400;
     src:
-      local('Source Serif 4'),
-      url("SourceSerif4-It.ttf.woff2") format('woff2'),
-      url("SourceSerif4-It.ttf.woff") format('woff');
+        local('Source Serif 4'),
+        url("SourceSerif4-It.ttf.woff2") format('woff2'),
+        url("SourceSerif4-It.ttf.woff") format('woff');
 }
+
 @font-face {
     font-family: 'Source Serif';
     font-style: normal;
     font-weight: 700;
     src:
-      local('Source Serif 4'),
-      url("SourceSerif4-Bold.ttf.woff2") format('woff2'),
-      url("SourceSerif4-Bold.ttf.woff") format('woff');
+        local('Source Serif 4'),
+        url("SourceSerif4-Bold.ttf.woff2") format('woff2'),
+        url("SourceSerif4-Bold.ttf.woff") format('woff');
 }
 
 /* See SourceCodePro-LICENSE.md for the Source Code Pro license. */
@@ -58,24 +61,26 @@
     /* Avoid using locally installed font because bad versions are in circulation:
      * see https://github.com/rust-lang/rust/issues/24355 */
     src:
-      url("SourceCodePro-Regular.ttf.woff2") format('woff2'),
-      url("SourceCodePro-Regular.ttf.woff") format('woff');
+        url("SourceCodePro-Regular.ttf.woff2") format('woff2'),
+        url("SourceCodePro-Regular.ttf.woff") format('woff');
 }
+
 @font-face {
     font-family: 'Source Code Pro';
     font-style: normal;
     font-weight: 600;
     src:
-      url("SourceCodePro-Semibold.ttf.woff2") format('woff2'),
-      url("SourceCodePro-Semibold.ttf.woff") format('woff');
+        url("SourceCodePro-Semibold.ttf.woff2") format('woff2'),
+        url("SourceCodePro-Semibold.ttf.woff") format('woff');
 }
+
 @font-face {
     font-family: 'Source Code Pro';
     font-style: italic;
     font-weight: 400;
     src:
-      url("SourceCodePro-It.ttf.woff2") format('woff2'),
-      url("SourceCodePro-It.ttf.woff") format('woff');
+        url("SourceCodePro-It.ttf.woff2") format('woff2'),
+        url("SourceCodePro-It.ttf.woff") format('woff');
 }
 
 html,
@@ -102,7 +107,8 @@ body {
     padding: 0;
     margin: 0;
     position: relative;
-    min-height: 100vh; /* Tall enough to stick the footer to the bottom */
+    min-height: 100vh;
+    /* Tall enough to stick the footer to the bottom */
 
     * {
         -webkit-box-sizing: border-box;
@@ -113,37 +119,55 @@ body {
     h1 {
         font-size: 1.5em;
     }
+
     h3 {
         font-size: 1.3em;
     }
-    h1, h2, h3, h4 {
-        font-family: "Fira Sans",sans-serif;
+
+    h1,
+    h2,
+    h3,
+    h4 {
+        font-family: "Fira Sans", sans-serif;
         font-weight: 500;
         margin: 20px 0 15px 0;
         padding-bottom: 6px;
     }
-    h2, h3, h4 {
+
+    h2,
+    h3,
+    h4 {
         border-bottom: 1px solid;
     }
+
     pre {
         background-color: var(--color-background-code);
         padding: 14px;
     }
-    code, kbd, pre, samp {
-        font-family: "Source Code Pro",monospace;
+
+    code,
+    kbd,
+    pre,
+    samp {
+        font-family: "Source Code Pro", monospace;
     }
+
     a {
         text-decoration: none;
         background: transparent;
     }
+
     p {
         margin: 0 0 .6em 0;
     }
-    ol, ul {
+
+    ol,
+    ul {
         padding-left: 25px;
     }
 
-    input, #search {
+    input,
+    #search {
         background-color: var(--color-background-input);
         color: var(--input-color);
         line-height: normal;
@@ -177,7 +201,7 @@ body {
     background-color: var(--color-background);
     color: var(--color-standard);
 
-    > h1 {
+    >h1 {
         color: var(--color-standard);
     }
 
@@ -186,15 +210,16 @@ body {
         fill: var(--color-background);
     }
 
-    text.highcharts-title, g.highcharts-axis-labels > text {
+    text.highcharts-title,
+    g.highcharts-axis-labels>text {
         fill: var(--chart-title-color) !important;
     }
 
-    g.highcharts-legend-item > text {
+    g.highcharts-legend-item>text {
         fill: var(--chart-grid) !important;
     }
 
-    g.highcharts-grid > path {
+    g.highcharts-grid>path {
         stroke: var(--chart-grid) !important;
     }
 }
@@ -262,7 +287,8 @@ div.recent-releases-container {
         padding: 0;
     }
 
-    ol.queue-list li {
+    ol.queue-list li,
+    ol.rebuild-queue-list li {
         list-style-type: decimal;
         margin-left: 20px;
 
@@ -280,7 +306,8 @@ div.recent-releases-container {
         background-color: var(--background-color);
     }
 
-    .release, .build-in-progress {
+    .release,
+    .build-in-progress {
         display: block;
         border-bottom: 1px solid var(--color-border);
         padding: 0.4em $search-result-right-left-padding;
@@ -338,6 +365,7 @@ div.recent-releases-container {
         span.fa-check {
             color: var(--color-macro);
         }
+
         span.fa-times {
             color: var(--color-struct);
         }
@@ -384,10 +412,10 @@ div.recent-releases-container {
     }
 
     .yanked {
-      color: var(--color-warn-msg);
-      background-color: var(--color-warn-background);
-      padding: .2em .8em .2em .5em;
-      border-radius: 1em;
+        color: var(--color-warn-msg);
+        background-color: var(--color-warn-background);
+        padding: .2em .8em .2em .5em;
+        border-radius: 1em;
     }
 }
 
@@ -399,6 +427,7 @@ div.package-container {
         margin: 0;
         padding: 20px 0 0 16px;
     }
+
     p {
         margin: 0;
         padding: 0 0 20px 16px;
@@ -469,7 +498,7 @@ div.package-page-container {
             margin: 20px 5px 15px 5px;
         }
 
-        li.pure-menu-item > .documented-info {
+        li.pure-menu-item>.documented-info {
             font-size: 13px;
             display: block;
             width: 100%;
@@ -575,7 +604,7 @@ div.package-page-container {
                 border-bottom: 1px solid var(--color-menu-border);
             }
 
-            tbody > tr:last-child > td {
+            tbody>tr:last-child>td {
                 border-bottom-width: 0;
             }
 
@@ -697,7 +726,7 @@ div.docsrs-package-container {
                     border-radius: 2px;
                 }
 
-                .pure-menu-has-children > .pure-menu-link:after {
+                .pure-menu-has-children>.pure-menu-link:after {
                     font-size: 14px;
                 }
 
@@ -774,7 +803,12 @@ div.search-page-search-form {
         background-color: inherit;
     }
 
-    h1, h2, h3, h4, h5, h6 {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
         border-bottom-color: var(--color-border) !important;
         color: var(--color-standard) !important;
     }
@@ -789,8 +823,8 @@ div.search-page-search-form {
 }
 
 /* Don't put a newline after code fragments in headers */
-h3 > code,
-h4 > code {
+h3>code,
+h4>code {
     display: inline-block;
 }
 
@@ -873,13 +907,17 @@ ul.pure-menu-list {
         max-width: 46px;
 
         ul {
-            li:not(.toggle-source), .text {
+
+            li:not(.toggle-source),
+            .text {
                 display: none;
             }
+
             li.toggle-source {
                 .left {
                     display: none;
                 }
+
                 .right {
                     display: inline-block;
                     margin-left: -4px;
@@ -897,13 +935,16 @@ ul.pure-menu-list {
     display: inline-flex;
     overflow: scroll;
 }
+
 #line-numbers {
     text-align: right;
     letter-spacing: normal;
 }
-#line-numbers > code > a  {
+
+#line-numbers>code>a {
     padding: 0 8px;
 }
+
 // This class is used to the source code and the line number container in the
 // `crate/**/source/*` view
 .source-code {
@@ -921,6 +962,7 @@ ul.pure-menu-list {
         width: calc(100% - 46px);
     }
 }
+
 #source-code {
     overflow: scroll;
     width: 100%;

--- a/templates/style/style.scss
+++ b/templates/style/style.scss
@@ -297,6 +297,10 @@ div.recent-releases-container {
         }
     }
 
+    .about p {
+        margin-left: 20px;
+    }
+
     strong {
         font-weight: 500;
     }


### PR DESCRIPTION
# Descripton
This PR addresses the issue #2328 

Creates a new section under: releases/queue page called Rebuild queue. By default it only shows the count with an option to click "Show" would reveal the queue. 

#### Example screenshots:
##### Queue with 3 items expand unset:
![20241022_08h19m51s_grim](https://github.com/user-attachments/assets/da920018-39f0-4e08-98ea-c3315d209751)

##### Queue with 3 items and expand=1:
![20241024_01h03m37s_grim](https://github.com/user-attachments/assets/9d6fe375-7d7c-4910-8eb1-1e2394d21b41)