### PR TITLE
upgrade crates-index-diff to get fast-path, make fetch frequency configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,15 +1212,16 @@ dependencies = [
 
 [[package]]
 name = "crates-index-diff"
-version = "25.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cba9039b1f66170132de4dd380fe493ef6e966bf7d79c4b8bff6b64c599ab54"
+checksum = "940bcd23378477a9f6c4e3522bc046aa1ad7d668b8dd7c92d85446396a117479"
 dependencies = [
  "ahash",
  "bstr",
- "gix 0.63.0",
+ "gix 0.67.0",
  "hashbrown 0.14.5",
  "hex",
+ "reqwest",
  "serde",
  "serde_json",
  "smartstring",
@@ -1294,19 +1295,6 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
-]
-
-[[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1898,6 +1886,9 @@ name = "faster-hex"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "fastrand"
@@ -2196,101 +2187,48 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.63.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984c5018adfa7a4536ade67990b3ebc6e11ab57b3d6cd9968de0947ca99b4b06"
-dependencies = [
- "gix-actor 0.31.5",
- "gix-attributes",
- "gix-command",
- "gix-commitgraph",
- "gix-config 0.37.0",
- "gix-credentials",
- "gix-date 0.8.7",
- "gix-diff 0.44.1",
- "gix-discover 0.32.0",
- "gix-features",
- "gix-filter 0.11.3",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-hashtable",
- "gix-ignore",
- "gix-index 0.33.1",
- "gix-lock",
- "gix-macros",
- "gix-negotiate 0.13.2",
- "gix-object 0.42.3",
- "gix-odb 0.61.1",
- "gix-pack 0.51.1",
- "gix-path",
- "gix-pathspec",
- "gix-prompt",
- "gix-protocol",
- "gix-ref 0.44.1",
- "gix-refspec 0.23.1",
- "gix-revision 0.27.2",
- "gix-revwalk 0.13.2",
- "gix-sec",
- "gix-submodule 0.11.0",
- "gix-tempfile",
- "gix-trace",
- "gix-transport",
- "gix-traverse 0.39.2",
- "gix-url",
- "gix-utils",
- "gix-validate 0.8.5",
- "gix-worktree 0.34.1",
- "once_cell",
- "parking_lot",
- "smallvec",
- "thiserror",
-]
-
-[[package]]
-name = "gix"
 version = "0.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9048b8d1ae2104f045cb37e5c450fc49d5d8af22609386bfc739c11ba88995eb"
 dependencies = [
  "gix-actor 0.32.0",
- "gix-attributes",
+ "gix-attributes 0.22.5",
  "gix-command",
- "gix-commitgraph",
+ "gix-commitgraph 0.24.3",
  "gix-config 0.40.0",
- "gix-credentials",
- "gix-date 0.9.0",
+ "gix-credentials 0.24.5",
+ "gix-date",
  "gix-diff 0.46.0",
  "gix-discover 0.35.0",
- "gix-features",
+ "gix-features 0.38.2",
  "gix-filter 0.13.0",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-hashtable",
- "gix-ignore",
+ "gix-fs 0.11.3",
+ "gix-glob 0.16.5",
+ "gix-hash 0.14.2",
+ "gix-hashtable 0.5.2",
+ "gix-ignore 0.11.4",
  "gix-index 0.35.0",
- "gix-lock",
+ "gix-lock 14.0.0",
  "gix-negotiate 0.15.0",
  "gix-object 0.44.0",
  "gix-odb 0.63.0",
  "gix-pack 0.53.0",
  "gix-path",
- "gix-pathspec",
+ "gix-pathspec 0.7.7",
  "gix-prompt",
- "gix-protocol",
+ "gix-protocol 0.45.3",
  "gix-ref 0.47.0",
  "gix-refspec 0.25.0",
  "gix-revision 0.29.0",
  "gix-revwalk 0.15.0",
  "gix-sec",
  "gix-submodule 0.14.0",
- "gix-tempfile",
+ "gix-tempfile 14.0.2",
  "gix-trace",
  "gix-traverse 0.41.0",
- "gix-url",
+ "gix-url 0.27.5",
  "gix-utils",
- "gix-validate 0.9.0",
+ "gix-validate",
  "gix-worktree 0.36.0",
  "once_cell",
  "smallvec",
@@ -2298,17 +2236,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-actor"
-version = "0.31.5"
+name = "gix"
+version = "0.67.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e454357e34b833cc3a00b6efbbd3dd4d18b24b9fb0c023876ec2645e8aa3f2"
+checksum = "c7d3e78ddac368d3e3bfbc2862bc2aafa3d89f1b15fed898d9761e1ec6f3f17f"
 dependencies = [
- "bstr",
- "gix-date 0.8.7",
+ "gix-actor 0.33.0",
+ "gix-attributes 0.23.0",
+ "gix-command",
+ "gix-commitgraph 0.25.0",
+ "gix-config 0.41.0",
+ "gix-credentials 0.25.0",
+ "gix-date",
+ "gix-diff 0.47.0",
+ "gix-discover 0.36.0",
+ "gix-features 0.39.0",
+ "gix-filter 0.14.0",
+ "gix-fs 0.12.0",
+ "gix-glob 0.17.0",
+ "gix-hash 0.15.0",
+ "gix-hashtable 0.6.0",
+ "gix-ignore 0.12.0",
+ "gix-index 0.36.0",
+ "gix-lock 15.0.0",
+ "gix-negotiate 0.16.0",
+ "gix-object 0.45.0",
+ "gix-odb 0.64.0",
+ "gix-pack 0.54.0",
+ "gix-path",
+ "gix-pathspec 0.8.0",
+ "gix-prompt",
+ "gix-protocol 0.46.0",
+ "gix-ref 0.48.0",
+ "gix-refspec 0.26.0",
+ "gix-revision 0.30.0",
+ "gix-revwalk 0.16.0",
+ "gix-sec",
+ "gix-submodule 0.15.0",
+ "gix-tempfile 15.0.0",
+ "gix-trace",
+ "gix-transport 0.43.0",
+ "gix-traverse 0.42.0",
+ "gix-url 0.28.0",
  "gix-utils",
- "itoa 1.0.11",
+ "gix-validate",
+ "gix-worktree 0.37.0",
+ "once_cell",
+ "smallvec",
  "thiserror",
- "winnow",
 ]
 
 [[package]]
@@ -2318,7 +2293,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc19e312cd45c4a66cd003f909163dc2f8e1623e30a0c0c6df3776e89b308665"
 dependencies = [
  "bstr",
- "gix-date 0.9.0",
+ "gix-date",
+ "gix-utils",
+ "itoa 1.0.11",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59226ef06661c756e664b46b1d3b2c198f6adc5407a484c086d0171108a70027"
+dependencies = [
+ "bstr",
+ "gix-date",
  "gix-utils",
  "itoa 1.0.11",
  "thiserror",
@@ -2332,7 +2321,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebccbf25aa4a973dd352564a9000af69edca90623e8a16dad9cbc03713131311"
 dependencies = [
  "bstr",
- "gix-glob",
+ "gix-glob 0.16.5",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31a102d201ef0e5a848458a82292581e7641e52f0f52e693b6cbdd05a652c029"
+dependencies = [
+ "bstr",
+ "gix-glob 0.17.0",
  "gix-path",
  "gix-quote",
  "gix-trace",
@@ -2344,27 +2350,27 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a371db66cbd4e13f0ed9dc4c0fea712d7276805fccc877f77e96374d317e87ae"
+checksum = "10f78312288bd02052be5dbc2ecbc342c9f4eb791986d86c0a5c06b92dc72efa"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "gix-chunk"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c8751169961ba7640b513c3b24af61aa962c967aaf04116734975cd5af0c52"
+checksum = "6c28b58ba04f0c004722344390af9dbc85888fbb84be1981afb934da4114d4cf"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff2e692b36bbcf09286c70803006ca3fd56551a311de450be317a0ab8ea92e7"
+checksum = "c201d2b9e9cce2365a6638fd0a966f751ed92d74be5c0727ac331e6a29ef5846"
 dependencies = [
  "bstr",
  "gix-path",
@@ -2380,31 +2386,24 @@ checksum = "133b06f67f565836ec0c473e2116a60fb74f80b6435e21d88013ac0e3c60fc78"
 dependencies = [
  "bstr",
  "gix-chunk",
- "gix-features",
- "gix-hash",
+ "gix-features 0.38.2",
+ "gix-hash 0.14.2",
  "memmap2",
  "thiserror",
 ]
 
 [[package]]
-name = "gix-config"
-version = "0.37.0"
+name = "gix-commitgraph"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fafe42957e11d98e354a66b6bd70aeea00faf2f62dd11164188224a507c840"
+checksum = "41db900b189e62dc61575f06fdf1a3b6901d264a99be9d32b286af6b2e3984e1"
 dependencies = [
  "bstr",
- "gix-config-value",
- "gix-features",
- "gix-glob",
- "gix-path",
- "gix-ref 0.44.1",
- "gix-sec",
- "memchr",
- "once_cell",
- "smallvec",
+ "gix-chunk",
+ "gix-features 0.39.0",
+ "gix-hash 0.15.0",
+ "memmap2",
  "thiserror",
- "unicode-bom",
- "winnow",
 ]
 
 [[package]]
@@ -2415,8 +2414,8 @@ checksum = "78e797487e6ca3552491de1131b4f72202f282fb33f198b1c34406d765b42bb0"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features",
- "gix-glob",
+ "gix-features 0.38.2",
+ "gix-glob 0.16.5",
  "gix-path",
  "gix-ref 0.47.0",
  "gix-sec",
@@ -2429,10 +2428,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-config-value"
-version = "0.14.8"
+name = "gix-config"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f76169faa0dec598eac60f83d7fcdd739ec16596eca8fb144c88973dbe6f8c"
+checksum = "0bedd1bf1c7b994be9d57207e8e0de79016c05e2e8701d3015da906e65ac445e"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features 0.39.0",
+ "gix-glob 0.17.0",
+ "gix-path",
+ "gix-ref 0.48.0",
+ "gix-sec",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+ "winnow",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3de3fdca9c75fa4b83a76583d265fa49b1de6b088ebcd210749c24ceeb74660"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
@@ -2454,51 +2474,36 @@ dependencies = [
  "gix-prompt",
  "gix-sec",
  "gix-trace",
- "gix-url",
+ "gix-url 0.27.5",
  "thiserror",
 ]
 
 [[package]]
-name = "gix-date"
-version = "0.8.7"
+name = "gix-credentials"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eed6931f21491ee0aeb922751bd7ec97b4b2fe8fbfedcb678e2a2dce5f3b8c0"
+checksum = "d713bac4bf7df5801012285366dae6625d675baec4ba6e443d64e83559bec068"
 dependencies = [
  "bstr",
- "itoa 1.0.11",
+ "gix-command",
+ "gix-config-value",
+ "gix-path",
+ "gix-prompt",
+ "gix-sec",
+ "gix-trace",
+ "gix-url 0.28.0",
  "thiserror",
- "time",
 ]
 
 [[package]]
 name = "gix-date"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c84b7af01e68daf7a6bb8bb909c1ff5edb3ce4326f1f43063a5a96d3c3c8a5"
+checksum = "d10d543ac13c97292a15e8e8b7889cd006faf739777437ed95362504b8fe81a0"
 dependencies = [
  "bstr",
  "itoa 1.0.11",
  "jiff",
- "thiserror",
-]
-
-[[package]]
-name = "gix-diff"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996d5c8a305b59709467d80617c9fde48d9d75fd1f4179ea970912630886c9d"
-dependencies = [
- "bstr",
- "gix-command",
- "gix-filter 0.11.3",
- "gix-fs",
- "gix-hash",
- "gix-object 0.42.3",
- "gix-path",
- "gix-tempfile",
- "gix-trace",
- "gix-worktree 0.34.1",
- "imara-diff",
  "thiserror",
 ]
 
@@ -2509,24 +2514,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92c9afd80fff00f8b38b1c1928442feb4cd6d2232a6ed806b6b193151a3d336c"
 dependencies = [
  "bstr",
- "gix-hash",
+ "gix-hash 0.14.2",
  "gix-object 0.44.0",
  "thiserror",
 ]
 
 [[package]]
-name = "gix-discover"
-version = "0.32.0"
+name = "gix-diff"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc27c699b63da66b50d50c00668bc0b7e90c3a382ef302865e891559935f3dbf"
+checksum = "c9850fd0c15af113db6f9e130d13091ba0d3754e570a2afdff9e2f3043da260e"
 dependencies = [
  "bstr",
- "dunce",
- "gix-fs",
- "gix-hash",
+ "gix-command",
+ "gix-filter 0.14.0",
+ "gix-fs 0.12.0",
+ "gix-hash 0.15.0",
+ "gix-object 0.45.0",
  "gix-path",
- "gix-ref 0.44.1",
- "gix-sec",
+ "gix-tempfile 15.0.0",
+ "gix-trace",
+ "gix-traverse 0.42.0",
+ "gix-worktree 0.37.0",
+ "imara-diff",
  "thiserror",
 ]
 
@@ -2538,10 +2548,26 @@ checksum = "0577366b9567376bc26e815fd74451ebd0e6218814e242f8e5b7072c58d956d2"
 dependencies = [
  "bstr",
  "dunce",
- "gix-fs",
- "gix-hash",
+ "gix-fs 0.11.3",
+ "gix-hash 0.14.2",
  "gix-path",
  "gix-ref 0.47.0",
+ "gix-sec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c522e31f458f50af09dfb014e10873c5378f702f8049c96f508989aad59671f6"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs 0.12.0",
+ "gix-hash 0.15.0",
+ "gix-path",
+ "gix-ref 0.48.0",
  "gix-sec",
  "thiserror",
 ]
@@ -2552,18 +2578,16 @@ version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac7045ac9fe5f9c727f38799d002a7ed3583cd777e3322a7c4b43e3cf437dc69"
 dependencies = [
- "bytes",
  "crc32fast",
  "crossbeam-channel",
  "flate2",
- "gix-hash",
+ "gix-hash 0.14.2",
  "gix-trace",
  "gix-utils",
- "jwalk",
  "libc",
  "once_cell",
  "parking_lot",
- "prodash",
+ "prodash 28.0.0",
  "sha1",
  "sha1_smol",
  "thiserror",
@@ -2571,24 +2595,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-filter"
-version = "0.11.3"
+name = "gix-features"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6547738da28275f4dff4e9f3a0f28509f53f94dd6bd822733c91cb306bca61a"
+checksum = "8e0eb9efdf96c35c0bed7596d1bef2d4ce6360a1d09738001f9d3e402aa7ba3e"
 dependencies = [
- "bstr",
- "encoding_rs",
- "gix-attributes",
- "gix-command",
- "gix-hash",
- "gix-object 0.42.3",
- "gix-packetline-blocking",
- "gix-path",
- "gix-quote",
+ "bytes",
+ "crc32fast",
+ "crossbeam-channel",
+ "flate2",
+ "gix-hash 0.15.0",
  "gix-trace",
  "gix-utils",
- "smallvec",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash 29.0.0",
+ "sha1",
+ "sha1_smol",
  "thiserror",
+ "walkdir",
 ]
 
 [[package]]
@@ -2599,11 +2625,32 @@ checksum = "4121790ae140066e5b953becc72e7496278138d19239be2e63b5067b0843119e"
 dependencies = [
  "bstr",
  "encoding_rs",
- "gix-attributes",
+ "gix-attributes 0.22.5",
  "gix-command",
- "gix-hash",
+ "gix-hash 0.14.2",
  "gix-object 0.44.0",
- "gix-packetline-blocking",
+ "gix-packetline-blocking 0.17.5",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b37f82359a4485770ed8993ae715ced1bf674f2a63e45f5a0786d38310665ea"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes 0.23.0",
+ "gix-command",
+ "gix-hash 0.15.0",
+ "gix-object 0.45.0",
+ "gix-packetline-blocking 0.18.0",
  "gix-path",
  "gix-quote",
  "gix-trace",
@@ -2619,7 +2666,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2bfe6249cfea6d0c0e0990d5226a4cb36f030444ba9e35e0639275db8f98575"
 dependencies = [
  "fastrand",
- "gix-features",
+ "gix-features 0.38.2",
+ "gix-utils",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34740384d8d763975858fa2c176b68652a6fcc09f616e24e3ce967b0d370e4d8"
+dependencies = [
+ "fastrand",
+ "gix-features 0.39.0",
  "gix-utils",
 ]
 
@@ -2631,7 +2689,19 @@ checksum = "74908b4bbc0a0a40852737e5d7889f676f081e340d5451a16e5b4c50d592f111"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-features",
+ "gix-features 0.38.2",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "254b5101cf7facc00d9b5ff564cf46302ca76695cca23d33bc958a707b6fc857"
+dependencies = [
+ "bitflags 2.6.0",
+ "bstr",
+ "gix-features 0.39.0",
  "gix-path",
 ]
 
@@ -2646,12 +2716,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-hash"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "952c3a29f1bc1007cc901abce7479943abfa42016db089de33d0a4fa3c85bfe8"
+dependencies = [
+ "faster-hex",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-hashtable"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddf80e16f3c19ac06ce415a38b8591993d3f73aede049cb561becb5b3a8e242"
 dependencies = [
- "gix-hash",
+ "gix-hash 0.14.2",
+ "hashbrown 0.14.5",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef65b256631078ef733bc5530c4e6b1c2e7d5c2830b75d4e9034ab3997d18fe"
+dependencies = [
+ "gix-hash 0.15.0",
  "hashbrown 0.14.5",
  "parking_lot",
 ]
@@ -2663,38 +2754,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e447cd96598460f5906a0f6c75e950a39f98c2705fc755ad2f2020c9e937fab7"
 dependencies = [
  "bstr",
- "gix-glob",
+ "gix-glob 0.16.5",
  "gix-path",
  "gix-trace",
  "unicode-bom",
 ]
 
 [[package]]
-name = "gix-index"
-version = "0.33.1"
+name = "gix-ignore"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9a44eb55bd84bb48f8a44980e951968ced21e171b22d115d1cdcef82a7d73f"
+checksum = "ba55a9b582dc26a639875497615959a8127ac5c37b2426dc50f037fada33a4b7"
 dependencies = [
- "bitflags 2.6.0",
  "bstr",
- "filetime",
- "fnv",
- "gix-bitmap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object 0.42.3",
- "gix-traverse 0.39.2",
- "gix-utils",
- "gix-validate 0.8.5",
- "hashbrown 0.14.5",
- "itoa 1.0.11",
- "libc",
- "memmap2",
- "rustix 0.38.37",
- "smallvec",
- "thiserror",
+ "gix-glob 0.17.0",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
 ]
 
 [[package]]
@@ -2708,14 +2784,42 @@ dependencies = [
  "filetime",
  "fnv",
  "gix-bitmap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
+ "gix-features 0.38.2",
+ "gix-fs 0.11.3",
+ "gix-hash 0.14.2",
+ "gix-lock 14.0.0",
  "gix-object 0.44.0",
  "gix-traverse 0.41.0",
  "gix-utils",
- "gix-validate 0.9.0",
+ "gix-validate",
+ "hashbrown 0.14.5",
+ "itoa 1.0.11",
+ "libc",
+ "memmap2",
+ "rustix 0.38.37",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27619009ca1ea33fd885041273f5fa5a09163a5c1d22a913b28d7b985e66fe29"
+dependencies = [
+ "bitflags 2.6.0",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features 0.39.0",
+ "gix-fs 0.12.0",
+ "gix-hash 0.15.0",
+ "gix-lock 15.0.0",
+ "gix-object 0.45.0",
+ "gix-traverse 0.42.0",
+ "gix-utils",
+ "gix-validate",
  "hashbrown 0.14.5",
  "itoa 1.0.11",
  "libc",
@@ -2731,35 +2835,19 @@ version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bc7fe297f1f4614774989c00ec8b1add59571dc9b024b4c00acb7dedd4e19d"
 dependencies = [
- "gix-tempfile",
+ "gix-tempfile 14.0.2",
  "gix-utils",
  "thiserror",
 ]
 
 [[package]]
-name = "gix-macros"
-version = "0.1.5"
+name = "gix-lock"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "999ce923619f88194171a67fb3e6d613653b8d4d6078b529b15a765da0edcc17"
+checksum = "5102acdf4acae2644e38dbbd18cdfba9597a218f7d85f810fe5430207e03c2de"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.82",
-]
-
-[[package]]
-name = "gix-negotiate"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec879fb6307bb63519ba89be0024c6f61b4b9d61f1a91fd2ce572d89fe9c224"
-dependencies = [
- "bitflags 2.6.0",
- "gix-commitgraph",
- "gix-date 0.8.7",
- "gix-hash",
- "gix-object 0.42.3",
- "gix-revwalk 0.13.2",
- "smallvec",
+ "gix-tempfile 15.0.0",
+ "gix-utils",
  "thiserror",
 ]
 
@@ -2770,9 +2858,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4063bf329a191a9e24b6f948a17ccf6698c0380297f5e169cee4f1d2ab9475b"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph",
- "gix-date 0.9.0",
- "gix-hash",
+ "gix-commitgraph 0.24.3",
+ "gix-date",
+ "gix-hash 0.14.2",
  "gix-object 0.44.0",
  "gix-revwalk 0.15.0",
  "smallvec",
@@ -2780,22 +2868,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-object"
-version = "0.42.3"
+name = "gix-negotiate"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25da2f46b4e7c2fa7b413ce4dffb87f69eaf89c2057e386491f4c55cadbfe386"
+checksum = "414806291838c3349ea939c6d840ff854f84cd29bd3dde8f904f60b0e5b7d0bd"
 dependencies = [
- "bstr",
- "gix-actor 0.31.5",
- "gix-date 0.8.7",
- "gix-features",
- "gix-hash",
- "gix-utils",
- "gix-validate 0.8.5",
- "itoa 1.0.11",
+ "bitflags 2.6.0",
+ "gix-commitgraph 0.25.0",
+ "gix-date",
+ "gix-hash 0.15.0",
+ "gix-object 0.45.0",
+ "gix-revwalk 0.16.0",
  "smallvec",
  "thiserror",
- "winnow",
 ]
 
 [[package]]
@@ -2806,11 +2891,11 @@ checksum = "2f5b801834f1de7640731820c2df6ba88d95480dc4ab166a5882f8ff12b88efa"
 dependencies = [
  "bstr",
  "gix-actor 0.32.0",
- "gix-date 0.9.0",
- "gix-features",
- "gix-hash",
+ "gix-date",
+ "gix-features 0.38.2",
+ "gix-hash 0.14.2",
  "gix-utils",
- "gix-validate 0.9.0",
+ "gix-validate",
  "itoa 1.0.11",
  "smallvec",
  "thiserror",
@@ -2818,23 +2903,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-odb"
-version = "0.61.1"
+name = "gix-object"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d384fe541d93d8a3bb7d5d5ef210780d6df4f50c4e684ccba32665a5e3bc9b"
+checksum = "2a77b6e7753d298553d9ae8b1744924481e7a49170983938bb578dccfbc6fc1a"
 dependencies = [
- "arc-swap",
- "gix-date 0.8.7",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-object 0.42.3",
- "gix-pack 0.51.1",
- "gix-path",
- "gix-quote",
- "parking_lot",
- "tempfile",
+ "bstr",
+ "gix-actor 0.33.0",
+ "gix-date",
+ "gix-features 0.39.0",
+ "gix-hash 0.15.0",
+ "gix-hashtable 0.6.0",
+ "gix-utils",
+ "gix-validate",
+ "itoa 1.0.11",
+ "smallvec",
  "thiserror",
+ "winnow",
 ]
 
 [[package]]
@@ -2844,10 +2929,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3158068701c17df54f0ab2adda527f5a6aca38fd5fd80ceb7e3c0a2717ec747"
 dependencies = [
  "arc-swap",
- "gix-date 0.9.0",
- "gix-features",
- "gix-fs",
- "gix-hash",
+ "gix-date",
+ "gix-features 0.38.2",
+ "gix-fs 0.11.3",
+ "gix-hash 0.14.2",
  "gix-object 0.44.0",
  "gix-pack 0.53.0",
  "gix-path",
@@ -2858,24 +2943,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-pack"
-version = "0.51.1"
+name = "gix-odb"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0594491fffe55df94ba1c111a6566b7f56b3f8d2e1efc750e77d572f5f5229"
+checksum = "0bb86aadf7f1b2f980601b4fc94309706f9700f8008f935dc512d556c9e60f61"
 dependencies = [
- "clru",
- "gix-chunk",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-object 0.42.3",
+ "arc-swap",
+ "gix-date",
+ "gix-features 0.39.0",
+ "gix-fs 0.12.0",
+ "gix-hash 0.15.0",
+ "gix-hashtable 0.6.0",
+ "gix-object 0.45.0",
+ "gix-pack 0.54.0",
  "gix-path",
- "gix-tempfile",
- "memmap2",
+ "gix-quote",
  "parking_lot",
- "smallvec",
+ "tempfile",
  "thiserror",
- "uluru",
 ]
 
 [[package]]
@@ -2886,12 +2971,33 @@ checksum = "3223aa342eee21e1e0e403cad8ae9caf9edca55ef84c347738d10681676fd954"
 dependencies = [
  "clru",
  "gix-chunk",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
+ "gix-features 0.38.2",
+ "gix-hash 0.14.2",
+ "gix-hashtable 0.5.2",
  "gix-object 0.44.0",
  "gix-path",
- "gix-tempfile",
+ "gix-tempfile 14.0.2",
+ "memmap2",
+ "parking_lot",
+ "smallvec",
+ "thiserror",
+ "uluru",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "363e6e59a855ba243672408139db68e2478126cdcfeabb420777df4a1f20026b"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-features 0.39.0",
+ "gix-hash 0.15.0",
+ "gix-hashtable 0.6.0",
+ "gix-object 0.45.0",
+ "gix-path",
+ "gix-tempfile 15.0.0",
  "memmap2",
  "parking_lot",
  "smallvec",
@@ -2912,6 +3018,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-packetline"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f14a110eb16e27b4ebdae4ca8b389df3ad637d3020077e6b606b1d078745b65"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-packetline-blocking"
 version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2924,10 +3042,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-path"
-version = "0.10.11"
+name = "gix-packetline-blocking"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebfc4febd088abdcbc9f1246896e57e37b7a34f6909840045a1767c6dafac7af"
+checksum = "decace940e8ba8e29d29b73b843a6cbae67503887f3e5fb7e688d0f4f6ee0757"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.10.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c04e5a94fdb56b1e91eb7df2658ad16832428b8eeda24ff1a0f0288de2bce554"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -2944,18 +3074,33 @@ checksum = "5d23bf239532b4414d0e63b8ab3a65481881f7237ed9647bb10c1e3cc54c5ceb"
 dependencies = [
  "bitflags 2.6.0",
  "bstr",
- "gix-attributes",
+ "gix-attributes 0.22.5",
  "gix-config-value",
- "gix-glob",
+ "gix-glob 0.16.5",
+ "gix-path",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f02bf7625dbf15bf9fedbeace2ac1ce1c5177806bdbc24c441d664c75c00e4"
+dependencies = [
+ "bitflags 2.6.0",
+ "bstr",
+ "gix-attributes 0.23.0",
+ "gix-config-value",
+ "gix-glob 0.17.0",
  "gix-path",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-prompt"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fde865cdb46b30d8dad1293385d9bcf998d3a39cbf41bee67d0dab026fe6b1"
+checksum = "57944bbdb87f7a9893907032276e99ff4eba3640d8db1bdfb1eba8c07edfd006"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -2971,11 +3116,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc43a1006f01b5efee22a003928c9eb83dde2f52779ded9d4c0732ad93164e3e"
 dependencies = [
  "bstr",
- "gix-credentials",
- "gix-date 0.9.0",
- "gix-features",
- "gix-hash",
- "gix-transport",
+ "gix-credentials 0.24.5",
+ "gix-date",
+ "gix-features 0.38.2",
+ "gix-hash 0.14.2",
+ "gix-transport 0.42.3",
+ "gix-utils",
+ "maybe-async",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac4ebf25f20ac6055728eaa80951acf2cf83948a64af6565b98e7d42b1ab6691"
+dependencies = [
+ "bstr",
+ "gix-credentials 0.25.0",
+ "gix-date",
+ "gix-features 0.39.0",
+ "gix-hash 0.15.0",
+ "gix-transport 0.43.0",
  "gix-utils",
  "maybe-async",
  "thiserror",
@@ -2984,35 +3147,13 @@ dependencies = [
 
 [[package]]
 name = "gix-quote"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbff4f9b9ea3fa7a25a70ee62f545143abef624ac6aa5884344e70c8b0a1d9ff"
+checksum = "f89f9a1525dcfd9639e282ea939f5ab0d09d93cf2b90c1fc6104f1b9582a8e49"
 dependencies = [
  "bstr",
  "gix-utils",
  "thiserror",
-]
-
-[[package]]
-name = "gix-ref"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3394a2997e5bc6b22ebc1e1a87b41eeefbcfcff3dbfa7c4bd73cb0ac8f1f3e2e"
-dependencies = [
- "gix-actor 0.31.5",
- "gix-date 0.8.7",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object 0.42.3",
- "gix-path",
- "gix-tempfile",
- "gix-utils",
- "gix-validate 0.8.5",
- "memmap2",
- "thiserror",
- "winnow",
 ]
 
 [[package]]
@@ -3022,32 +3163,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae0d8406ebf9aaa91f55a57f053c5a1ad1a39f60fdf0303142b7be7ea44311e5"
 dependencies = [
  "gix-actor 0.32.0",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
+ "gix-features 0.38.2",
+ "gix-fs 0.11.3",
+ "gix-hash 0.14.2",
+ "gix-lock 14.0.0",
  "gix-object 0.44.0",
  "gix-path",
- "gix-tempfile",
+ "gix-tempfile 14.0.2",
  "gix-utils",
- "gix-validate 0.9.0",
+ "gix-validate",
  "memmap2",
  "thiserror",
  "winnow",
 ]
 
 [[package]]
-name = "gix-refspec"
-version = "0.23.1"
+name = "gix-ref"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6868f8cd2e62555d1f7c78b784bece43ace40dd2a462daf3b588d5416e603f37"
+checksum = "a47385e71fa2d9da8c35e642ef4648808ddf0a52bc93425879088c706dfeaea2"
 dependencies = [
- "bstr",
- "gix-hash",
- "gix-revision 0.27.2",
- "gix-validate 0.8.5",
- "smallvec",
+ "gix-actor 0.33.0",
+ "gix-features 0.39.0",
+ "gix-fs 0.12.0",
+ "gix-hash 0.15.0",
+ "gix-lock 15.0.0",
+ "gix-object 0.45.0",
+ "gix-path",
+ "gix-tempfile 15.0.0",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
  "thiserror",
+ "winnow",
 ]
 
 [[package]]
@@ -3057,26 +3205,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebb005f82341ba67615ffdd9f7742c87787544441c88090878393d0682869ca6"
 dependencies = [
  "bstr",
- "gix-hash",
+ "gix-hash 0.14.2",
  "gix-revision 0.29.0",
- "gix-validate 0.9.0",
+ "gix-validate",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
-name = "gix-revision"
-version = "0.27.2"
+name = "gix-refspec"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b13e43c2118c4b0537ddac7d0821ae0dfa90b7b8dbf20c711e153fb749adce"
+checksum = "0022038a09d80d9abf773be8efcbb502868d97f6972b8633bfb52ab6edaac442"
 dependencies = [
  "bstr",
- "gix-date 0.8.7",
- "gix-hash",
- "gix-hashtable",
- "gix-object 0.42.3",
- "gix-revwalk 0.13.2",
- "gix-trace",
+ "gix-hash 0.15.0",
+ "gix-revision 0.30.0",
+ "gix-validate",
+ "smallvec",
  "thiserror",
 ]
 
@@ -3087,25 +3233,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba4621b219ac0cdb9256883030c3d56a6c64a6deaa829a92da73b9a576825e1e"
 dependencies = [
  "bstr",
- "gix-date 0.9.0",
- "gix-hash",
+ "gix-date",
+ "gix-hash 0.14.2",
  "gix-object 0.44.0",
  "gix-revwalk 0.15.0",
  "thiserror",
 ]
 
 [[package]]
-name = "gix-revwalk"
-version = "0.13.2"
+name = "gix-revision"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b030ccaab71af141f537e0225f19b9e74f25fefdba0372246b844491cab43e0"
+checksum = "4ee8eb4088fece3562af4a5d751e069f90e93345524ad730512185234c4b55f1"
 dependencies = [
- "gix-commitgraph",
- "gix-date 0.8.7",
- "gix-hash",
- "gix-hashtable",
- "gix-object 0.42.3",
- "smallvec",
+ "bitflags 2.6.0",
+ "bstr",
+ "gix-commitgraph 0.25.0",
+ "gix-date",
+ "gix-hash 0.15.0",
+ "gix-hashtable 0.6.0",
+ "gix-object 0.45.0",
+ "gix-revwalk 0.16.0",
+ "gix-trace",
  "thiserror",
 ]
 
@@ -3115,40 +3264,40 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41e72544b93084ee682ef3d5b31b1ba4d8fa27a017482900e5e044d5b1b3984"
 dependencies = [
- "gix-commitgraph",
- "gix-date 0.9.0",
- "gix-hash",
- "gix-hashtable",
+ "gix-commitgraph 0.24.3",
+ "gix-date",
+ "gix-hash 0.14.2",
+ "gix-hashtable 0.5.2",
  "gix-object 0.44.0",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
-name = "gix-sec"
-version = "0.10.8"
+name = "gix-revwalk"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe4d52f30a737bbece5276fab5d3a8b276dc2650df963e293d0673be34e7a5f"
+checksum = "e6c9a9496da98d36ff19063a8576bf09a87425583b709a56dc5594fffa9d39b2"
+dependencies = [
+ "gix-commitgraph 0.25.0",
+ "gix-date",
+ "gix-hash 0.15.0",
+ "gix-hashtable 0.6.0",
+ "gix-object 0.45.0",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2007538eda296445c07949cf04f4a767307d887184d6b3e83e2d636533ddc6e"
 dependencies = [
  "bitflags 2.6.0",
  "gix-path",
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "gix-submodule"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921cd49924ac14b6611b22e5fb7bbba74d8780dc7ad26153304b64d1272460ac"
-dependencies = [
- "bstr",
- "gix-config 0.37.0",
- "gix-path",
- "gix-pathspec",
- "gix-refspec 0.23.1",
- "gix-url",
- "thiserror",
 ]
 
 [[package]]
@@ -3160,9 +3309,24 @@ dependencies = [
  "bstr",
  "gix-config 0.40.0",
  "gix-path",
- "gix-pathspec",
+ "gix-pathspec 0.7.7",
  "gix-refspec 0.25.0",
- "gix-url",
+ "gix-url 0.27.5",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed099621873cd36c580fc822176a32a7e50fef15a5c2ed81aaa087296f0497a"
+dependencies = [
+ "bstr",
+ "gix-config 0.41.0",
+ "gix-path",
+ "gix-pathspec 0.8.0",
+ "gix-refspec 0.26.0",
+ "gix-url 0.28.0",
  "thiserror",
 ]
 
@@ -3172,8 +3336,21 @@ version = "14.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046b4927969fa816a150a0cda2e62c80016fe11fb3c3184e4dddf4e542f108aa"
 dependencies = [
+ "gix-fs 0.11.3",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2feb86ef094cc77a4a9a5afbfe5de626897351bbbd0de3cb9314baf3049adb82"
+dependencies = [
  "dashmap",
- "gix-fs",
+ "gix-fs 0.12.0",
  "libc",
  "once_cell",
  "parking_lot",
@@ -3182,9 +3359,9 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cae0e8661c3ff92688ce1c8b8058b3efb312aba9492bbe93661a21705ab431b"
+checksum = "04bdde120c29f1fc23a24d3e115aeeea3d60d8e65bab92cc5f9d90d9302eb952"
 
 [[package]]
 name = "gix-transport"
@@ -3192,33 +3369,32 @@ version = "0.42.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "421dcccab01b41a15d97b226ad97a8f9262295044e34fbd37b10e493b0a6481f"
 dependencies = [
- "base64 0.22.1",
  "bstr",
- "curl",
  "gix-command",
- "gix-credentials",
- "gix-features",
- "gix-packetline",
+ "gix-features 0.38.2",
+ "gix-packetline 0.17.6",
  "gix-quote",
  "gix-sec",
- "gix-url",
+ "gix-url 0.27.5",
  "thiserror",
 ]
 
 [[package]]
-name = "gix-traverse"
-version = "0.39.2"
+name = "gix-transport"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e499a18c511e71cf4a20413b743b9f5bcf64b3d9e81e9c3c6cd399eae55a8840"
+checksum = "4c485a345f41b8c0256cb86e95ed93e0692d203fd6c769b0433f7352c13608ad"
 dependencies = [
- "bitflags 2.6.0",
- "gix-commitgraph",
- "gix-date 0.8.7",
- "gix-hash",
- "gix-hashtable",
- "gix-object 0.42.3",
- "gix-revwalk 0.13.2",
- "smallvec",
+ "base64 0.22.1",
+ "bstr",
+ "curl",
+ "gix-command",
+ "gix-credentials 0.25.0",
+ "gix-features 0.39.0",
+ "gix-packetline 0.18.0",
+ "gix-quote",
+ "gix-sec",
+ "gix-url 0.28.0",
  "thiserror",
 ]
 
@@ -3229,12 +3405,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030da39af94e4df35472e9318228f36530989327906f38e27807df305fccb780"
 dependencies = [
  "bitflags 2.6.0",
- "gix-commitgraph",
- "gix-date 0.9.0",
- "gix-hash",
- "gix-hashtable",
+ "gix-commitgraph 0.24.3",
+ "gix-date",
+ "gix-hash 0.14.2",
+ "gix-hashtable 0.5.2",
  "gix-object 0.44.0",
  "gix-revwalk 0.15.0",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f20f1b13cc4fa6ba92b24e6aa0c2fb6a34beb4458ef88c6300212db504e818df"
+dependencies = [
+ "bitflags 2.6.0",
+ "gix-commitgraph 0.25.0",
+ "gix-date",
+ "gix-hash 0.15.0",
+ "gix-hashtable 0.6.0",
+ "gix-object 0.45.0",
+ "gix-revwalk 0.16.0",
  "smallvec",
  "thiserror",
 ]
@@ -3246,7 +3439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd280c5e84fb22e128ed2a053a0daeacb6379469be6a85e3d518a0636e160c89"
 dependencies = [
  "bstr",
- "gix-features",
+ "gix-features 0.38.2",
  "gix-path",
  "home",
  "thiserror",
@@ -3254,10 +3447,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-utils"
-version = "0.1.12"
+name = "gix-url"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35192df7fd0fa112263bad8021e2df7167df4cc2a6e6d15892e1e55621d3d4dc"
+checksum = "33e7c297c3265015c133a2c02199610b6e1373a09dc4be057d0c1b5285737f06"
+dependencies = [
+ "bstr",
+ "gix-features 0.39.0",
+ "gix-path",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba427e3e9599508ed98a6ddf8ed05493db114564e338e41f6a996d2e4790335f"
 dependencies = [
  "fastrand",
  "unicode-normalization",
@@ -3265,41 +3471,12 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.8.5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c27dd34a49b1addf193c92070bcbf3beaf6e10f16a78544de6372e146a0acf"
+checksum = "e187b263461bc36cea17650141567753bc6207d036cedd1de6e81a52f277ff68"
 dependencies = [
  "bstr",
  "thiserror",
-]
-
-[[package]]
-name = "gix-validate"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f2badbb64e57b404593ee26b752c26991910fd0d81fe6f9a71c1a8309b6c86"
-dependencies = [
- "bstr",
- "thiserror",
-]
-
-[[package]]
-name = "gix-worktree"
-version = "0.34.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f7326ebe0b9172220694ea69d344c536009a9b98fb0f9de092c440f3efe7a6"
-dependencies = [
- "bstr",
- "gix-attributes",
- "gix-features",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-ignore",
- "gix-index 0.33.1",
- "gix-object 0.42.3",
- "gix-path",
- "gix-validate 0.8.5",
 ]
 
 [[package]]
@@ -3309,16 +3486,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c312ad76a3f2ba8e865b360d5cb3aa04660971d16dec6dd0ce717938d903149a"
 dependencies = [
  "bstr",
- "gix-attributes",
- "gix-features",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-ignore",
+ "gix-attributes 0.22.5",
+ "gix-features 0.38.2",
+ "gix-fs 0.11.3",
+ "gix-glob 0.16.5",
+ "gix-hash 0.14.2",
+ "gix-ignore 0.11.4",
  "gix-index 0.35.0",
  "gix-object 0.44.0",
  "gix-path",
- "gix-validate 0.9.0",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d345e5b523550fe4fa0e912bf957de752011ccfc87451968fda1b624318f29c"
+dependencies = [
+ "bstr",
+ "gix-attributes 0.23.0",
+ "gix-features 0.39.0",
+ "gix-fs 0.12.0",
+ "gix-glob 0.17.0",
+ "gix-hash 0.15.0",
+ "gix-ignore 0.12.0",
+ "gix-index 0.36.0",
+ "gix-object 0.45.0",
+ "gix-path",
+ "gix-validate",
 ]
 
 [[package]]
@@ -3938,16 +4134,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jwalk"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
-dependencies = [
- "crossbeam",
- "rayon",
-]
-
-[[package]]
 name = "kstring"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4434,15 +4620,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi 0.3.9",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
  "libc",
 ]
 
@@ -4959,6 +5136,16 @@ name = "prodash"
 version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744a264d26b88a6a7e37cbad97953fa233b94d585236310bcbc88474b4092d79"
+
+[[package]]
+name = "prodash"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a266d8d6020c61a437be704c5e618037588e1985c7dbb7bf8d265db84cffe325"
+dependencies = [
+ "log",
+ "parking_lot",
+]
 
 [[package]]
 name = "prometheus"
@@ -6503,9 +6690,7 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa 1.0.11",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ clap = { version = "4.0.22", features = [ "derive" ] }
 crates-index = { version = "3.0.0", default-features = false, features = ["git", "git-performance", "parallel"] }
 rayon = "1.6.1"
 num_cpus = "1.15.0"
-crates-index-diff = { version = "25.0.0", features = [ "max-performance" ]}
+crates-index-diff = { version = "26.0.0", features = [ "max-performance" ]}
 reqwest = { version = "0.12", features = ["json", "gzip"] }
 semver = { version = "1.0.4", features = ["serde"] }
 slug = "0.1.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,9 @@ pub struct Config {
     pub registry_url: Option<String>,
     pub registry_api_host: Url,
 
+    /// How long to wait between registry checks
+    pub(crate) delay_between_registry_fetches: Duration,
+
     // Database connection params
     pub(crate) database_url: String,
     pub(crate) max_pool_size: u32,
@@ -143,6 +146,10 @@ impl Config {
             build_attempts: env("DOCSRS_BUILD_ATTEMPTS", 5)?,
             delay_between_build_attempts: Duration::from_secs(env::<u64>(
                 "DOCSRS_DELAY_BETWEEN_BUILD_ATTEMPTS",
+                60,
+            )?),
+            delay_between_registry_fetches: Duration::from_secs(env::<u64>(
+                "DOCSRS_DELAY_BETWEEN_REGISTRY_FETCHES",
                 60,
             )?),
 

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -49,7 +49,7 @@ pub async fn watch_registry(
             .await?;
             last_gc = Instant::now();
         }
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        tokio::time::sleep(config.delay_between_registry_fetches).await;
     }
 }
 


### PR DESCRIPTION
see https://github.com/Byron/crates-index-diff-rs/pull/47 

With this we could increase the check frequency without adding too much load to github. 