### PR TITLE
feat: set documentation_url to None when url starts with https://docs.rs

### DIFF
--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -321,6 +321,11 @@ impl<'a> FakeRelease<'a> {
         self
     }
 
+    pub(crate) fn documentation_url(mut self, documentation_url: Option<String>) -> Self {
+        self.package.documentation = documentation_url;
+        self
+    }
+
     pub(crate) fn create(self) -> Result<i32> {
         let runtime = self.runtime.clone();
         runtime.block_on(self.create_async())


### PR DESCRIPTION
## Description
Issue: #2184 

Documentation URL is mainly used for the external documentation websites. When the url starts with https://docs.rs we don't need to include it on the page.

## How to test
With branch checked out run: 
```
cargo run -- build crate diesel 0.13.0
cargo run -- build crate diesel 2.2.4
``` 

- [ ] go to http://localhost:3000/crate/diesel/0.13.0 Make sure that Links section -> Documentation points to http://docs.diesel.rs/
- [ ] go to http://localhost:3000/crate/diesel/2.2.4 Make sure that Links section doesn't have Documentation anymore.

