### PR TITLE
Fix display of documentation button icon

### DIFF
--- a/templates/style/style.scss
+++ b/templates/style/style.scss
@@ -719,7 +719,6 @@ div.docsrs-package-container {
             padding: 10px;
             border: 1px solid var(--color-doc-link-background);
             border-radius: 5px;
-            display: flex;
 
             .fas {
                 margin-top: 2px;


### PR DESCRIPTION
| before | after |
|-|-|
| ![Screenshot From 2024-11-04 16-06-20](https://github.com/user-attachments/assets/ab296196-4836-4136-b9c3-686cd2d88dd4) | ![Screenshot From 2024-11-04 16-06-23](https://github.com/user-attachments/assets/23877670-9d5b-4c94-a303-acbc2d26fe9c) |
