### PR TITLE
add index on releases.rustdoc_status for rebuild query

### DIFF
--- a/migrations/20241106085600_releases-rustdoc-status-idx.down.sql
+++ b/migrations/20241106085600_releases-rustdoc-status-idx.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX releases_rustdoc_status_idx;

--- a/migrations/20241106085600_releases-rustdoc-status-idx.up.sql
+++ b/migrations/20241106085600_releases-rustdoc-status-idx.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX releases_rustdoc_status_idx ON releases USING btree (rustdoc_status ASC);


### PR DESCRIPTION
The query executes quite slow on production, I saw that an index was missing on a field we're querying. 