### PR TITLE
migrate most tests to async, drop old testserver & blocking reqwests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,6 @@ http-body-util = "0.1.0"
 rand = "0.8"
 mockito = "1.0.2"
 test-case = "3.0.0"
-reqwest = { version = "0.12", features = ["blocking", "json"] }
 tower = { version = "0.5.1", features = ["util"] }
 aws-smithy-types = "1.0.1"
 aws-smithy-runtime = {version = "1.0.1", features = ["client", "test-util"]}

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -472,11 +472,6 @@ impl BuildQueue {
     pub(crate) fn queued_crates(&self) -> Result<Vec<QueuedCrate>> {
         self.runtime.block_on(self.inner.queued_crates())
     }
-    #[cfg(test)]
-    pub(crate) fn has_build_queued(&self, name: &str, version: &str) -> Result<bool> {
-        self.runtime
-            .block_on(self.inner.has_build_queued(name, version))
-    }
 }
 
 impl BuildQueue {

--- a/src/web/file.rs
+++ b/src/web/file.rs
@@ -57,25 +57,24 @@ impl IntoResponse for File {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::wrapper;
+    use crate::test::async_wrapper;
     use chrono::Utc;
     use http::header::CACHE_CONTROL;
 
     #[test]
     fn file_roundtrip_axum() {
-        wrapper(|env| {
+        async_wrapper(|env| async move {
             let now = Utc::now();
 
-            env.fake_release().create()?;
+            env.async_fake_release().await.create_async().await?;
 
-            let mut file = env
-                .runtime()
-                .block_on(File::from_path(
-                    &env.runtime().block_on(env.async_storage()),
-                    "rustdoc/fake-package/1.0.0/fake-package/index.html",
-                    &env.config(),
-                ))
-                .unwrap();
+            let mut file = File::from_path(
+                &*env.async_storage().await,
+                "rustdoc/fake-package/1.0.0/fake-package/index.html",
+                &env.config(),
+            )
+            .await
+            .unwrap();
             file.0.date_updated = now;
 
             let resp = file.into_response();
@@ -99,13 +98,14 @@ mod tests {
         const MAX_SIZE: usize = 1024;
         const MAX_HTML_SIZE: usize = 128;
 
-        wrapper(|env| {
+        async_wrapper(|env| async move {
             env.override_config(|config| {
                 config.max_file_size = MAX_SIZE;
                 config.max_file_size_html = MAX_HTML_SIZE;
             });
 
-            env.fake_release()
+            env.async_fake_release()
+                .await
                 .name("dummy")
                 .version("0.1.0")
                 .rustdoc_file_with("small.html", &[b'A'; MAX_HTML_SIZE / 2] as &[u8])
@@ -114,20 +114,26 @@ mod tests {
                 .rustdoc_file_with("small.js", &[b'A'; MAX_SIZE / 2] as &[u8])
                 .rustdoc_file_with("exact.js", &[b'A'; MAX_SIZE] as &[u8])
                 .rustdoc_file_with("big.js", &[b'A'; MAX_SIZE * 2] as &[u8])
-                .create()?;
+                .create_async()
+                .await?;
 
             let file = |path| {
-                env.runtime().block_on(File::from_path(
-                    &env.runtime().block_on(env.async_storage()),
-                    &format!("rustdoc/dummy/0.1.0/{path}"),
-                    &env.config(),
-                ))
+                let env = env.clone();
+                async move {
+                    File::from_path(
+                        &*env.async_storage().await,
+                        &format!("rustdoc/dummy/0.1.0/{path}"),
+                        &env.config(),
+                    )
+                    .await
+                }
             };
-            let assert_len = |len, path| {
-                assert_eq!(len, file(path).unwrap().0.content.len());
+            let assert_len = |len, path| async move {
+                assert_eq!(len, file(path).await.unwrap().0.content.len());
             };
-            let assert_too_big = |path| {
+            let assert_too_big = |path| async move {
                 file(path)
+                    .await
                     .unwrap_err()
                     .downcast_ref::<std::io::Error>()
                     .and_then(|io| io.get_ref())
@@ -135,13 +141,13 @@ mod tests {
                     .is_some()
             };
 
-            assert_len(MAX_HTML_SIZE / 2, "small.html");
-            assert_len(MAX_HTML_SIZE, "exact.html");
-            assert_len(MAX_SIZE / 2, "small.js");
-            assert_len(MAX_SIZE, "exact.js");
+            assert_len(MAX_HTML_SIZE / 2, "small.html").await;
+            assert_len(MAX_HTML_SIZE, "exact.html").await;
+            assert_len(MAX_SIZE / 2, "small.js").await;
+            assert_len(MAX_SIZE, "exact.js").await;
 
-            assert_too_big("big.html");
-            assert_too_big("big.js");
+            assert_too_big("big.html").await;
+            assert_too_big("big.js").await;
 
             Ok(())
         })

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -210,7 +210,8 @@ mod tests {
     fn sitemap_index() {
         async_wrapper(|env| async move {
             let app = env.web_app().await;
-            app.assert_success("/sitemap.xml").await
+            app.assert_success("/sitemap.xml").await?;
+            Ok(())
         })
     }
 
@@ -260,7 +261,7 @@ mod tests {
             let response = web.get("/-/sitemap/s/sitemap.xml").await?;
             assert!(response.status().is_success());
 
-            let content = response.text().await;
+            let content = response.text().await?;
             assert!(content.contains("some_random_crate"));
             assert!(!(content.contains("some_random_crate_that_failed")));
 
@@ -269,7 +270,7 @@ mod tests {
                 let response = web.get(&format!("/-/sitemap/{letter}/sitemap.xml")).await?;
 
                 assert!(response.status().is_success());
-                assert!(!(response.text().await.contains("some_random_crate")));
+                assert!(!(response.text().await?.contains("some_random_crate")));
             }
 
             Ok(())
@@ -292,7 +293,7 @@ mod tests {
             let response = web.get("/-/sitemap/s/sitemap.xml").await?;
             assert!(response.status().is_success());
 
-            let content = response.text().await;
+            let content = response.text().await?;
             assert!(content.contains("2022-08-28T00:00:00+00:00"));
             Ok(())
         })
@@ -315,7 +316,8 @@ mod tests {
                 let path = format!("/about/{filename}");
                 web.assert_success(&path).await?;
             }
-            web.assert_success("/about").await
+            web.assert_success("/about").await?;
+            Ok(())
         })
     }
 


### PR DESCRIPTION
This is a bigger refactor that was sitting in a branch for some time, so sorry for the size of the change. This migrates most tests to be async tests following the axum test framework, see also #2634 and [the axum test example](https://github.com/tokio-rs/axum/blob/269565ff931b133d850e20491983baf6b2f8c115/examples/testing/src/main.rs#L68-L82). 

This makes is possible that we don't have to run an actual TCP server for each test any more. 

There are only a handful of tests missing to migrate, mostly from sync parts of the code. 

A second change in there is that I didn't want the web tests to automatically follow redirects any more. So the tests have to be explicit when they expect the response directly, or via a redirect. 

The next improvement will be about the the database setup which hopefully make tests execute. 