### PR TITLE
fix build-details view for pre-build errors, when another build set the default target

### DIFF
--- a/.sqlx/query-86cb6c0a4d2e6b18df6339f12a98692cb4abb0a4b62d611679c956be3fb9494f.json
+++ b/.sqlx/query-86cb6c0a4d2e6b18df6339f12a98692cb4abb0a4b62d611679c956be3fb9494f.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE releases SET default_target = 'x86_64-unknown-linux-gnu' WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "86cb6c0a4d2e6b18df6339f12a98692cb4abb0a4b62d611679c956be3fb9494f"
+}


### PR DESCRIPTION
when looking at https://docs.rs/crate/defmt/0.3.9/builds/

we see that we can't access the older builds, even though that worked at some point. 

Reason is that we correctly don't have a build log for these, because they failed before starting the build, but the fallback logic trying to use the default target, if given, lead to a "resource not found" error, while we can show the pre-build error instead of the log. 

see also https://github.com/rust-lang/docs.rs/issues/2679