### PR TITLE
extend owners.avatar field length

### DIFF
--- a/.sqlx/query-16dfb0d87266568fb8a84585614387c8bfa4790b9e8d317159b37397e42b7ceb.json
+++ b/.sqlx/query-16dfb0d87266568fb8a84585614387c8bfa4790b9e8d317159b37397e42b7ceb.json
@@ -11,7 +11,7 @@
       {
         "ordinal": 1,
         "name": "avatar",
-        "type_info": "Varchar"
+        "type_info": "Text"
       },
       {
         "ordinal": 2,

--- a/.sqlx/query-1e48486ba272a4e2ea8793114e412c14ed13f652419b1467c21e1829f31cd573.json
+++ b/.sqlx/query-1e48486ba272a4e2ea8793114e412c14ed13f652419b1467c21e1829f31cd573.json
@@ -11,7 +11,7 @@
       {
         "ordinal": 1,
         "name": "avatar",
-        "type_info": "Varchar"
+        "type_info": "Text"
       },
       {
         "ordinal": 2,

--- a/.sqlx/query-87952bd450ed2c13b99bd502a73a84edd7d17e6171523ebbd57f1d9dd7c9b46c.json
+++ b/.sqlx/query-87952bd450ed2c13b99bd502a73a84edd7d17e6171523ebbd57f1d9dd7c9b46c.json
@@ -12,7 +12,7 @@
     "parameters": {
       "Left": [
         "Varchar",
-        "Varchar",
+        "Text",
         {
           "Custom": {
             "name": "owner_kind",

--- a/.sqlx/query-d87220d3f4503e99fa17815db0058ab7883bf28f216d5b5fd720c56fd8889eed.json
+++ b/.sqlx/query-d87220d3f4503e99fa17815db0058ab7883bf28f216d5b5fd720c56fd8889eed.json
@@ -11,7 +11,7 @@
       {
         "ordinal": 1,
         "name": "avatar",
-        "type_info": "Varchar"
+        "type_info": "Text"
       },
       {
         "ordinal": 2,

--- a/migrations/20241219091521_owner-avatar-longer.down.sql
+++ b/migrations/20241219091521_owner-avatar-longer.down.sql
@@ -1,0 +1,2 @@
+UPDATE owners SET avatar = '' WHERE LENGTH(avatar) > 255;
+ALTER TABLE owners ALTER COLUMN avatar TYPE VARCHAR(255);

--- a/migrations/20241219091521_owner-avatar-longer.up.sql
+++ b/migrations/20241219091521_owner-avatar-longer.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE owners ALTER COLUMN avatar TYPE TEXT;


### PR DESCRIPTION
I think this is the reason for build errors like https://docs.rs/crate/aws-sdk-workspacesweb/1.55.0/builds/1593306 

I compared fields with lengths 255 and checked crates.io API results for this version to find places where the content in the API is longer than 255. 

This is one place. 