### PR TITLE
Fix display of warnings in generated crate docs

### DIFF
--- a/templates/style/_utils.scss
+++ b/templates/style/_utils.scss
@@ -25,6 +25,10 @@ div {
     }
 }
 
+.content .docblock .warning {
+    text-align: inherit;
+}
+
 .text-center {
     text-align: center;
 }


### PR DESCRIPTION
Fixes #2696.

Issue was that we add `text-align` CSS value whereas the "more specific CSS class" doesn't, so it gets changed. To prevent this bug, we just need to add the missing value in the "more specific CSS class".

Now it looks as expected:

![image](https://github.com/user-attachments/assets/e192902d-e9a8-4f51-9143-954bca8c53fb)
