### PR TITLE
sentry: use native sentry-tower / axum integration for setting transaction name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5910,6 +5910,7 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcdaf9b1939589476bd57751d12a9653bbfe356610fc476d03d7683189183ab7"
 dependencies = [
+ "axum",
  "http 1.2.0",
  "pin-project",
  "sentry-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [dependencies]
-sentry = { version = "0.35.0", features = ["panic", "tracing", "tower-http", "anyhow", "backtrace"] }
+sentry = { version = "0.35.0", features = ["panic", "tracing", "tower-http", "anyhow", "backtrace", "tower-axum-matched-path"] }
 log = "0.4"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", default-features = false, features = ["ansi", "fmt", "json", "env-filter", "tracing-log"] }


### PR DESCRIPTION
coming from [this comment](https://github.com/rust-lang/docs.rs/pull/2705#discussion_r1901486013) I discovered there is [a feature that integrates with axum matched-paths](https://docs.rs/crate/sentry/latest/features#tower-axum-matched-path). 


This will change the transaction name, where previously we only used the matched path, while the native integration uses the HTTP verb + the matched path. 