### PR TITLE
Display crates not available on docs.rs in search results

### DIFF
--- a/templates/releases/releases.html
+++ b/templates/releases/releases.html
@@ -30,54 +30,64 @@ centered
             <ul>
                 {# TODO: If there are no releases, then display a message that says so #}
                 {%- for release in releases -%}
-                    {%- set release_version -%}
-                    {%- set has_unyanked_releases = release.has_unyanked_releases.unwrap_or(true) -%}
-                    {%- if release_type == "search" && has_unyanked_releases -%}
-                        {%- set release_version = "latest" -%}
-                    {%- else -%}
-                        {%- set release_version = release.version -%}
-                    {%- endif -%}
-                    {% set link %}
-                    {%- if release.rustdoc_status -%}
-                        {% set link = "/{}/{}/{}/"|format(release.name, release_version, release.target_name.as_deref().unwrap_or_default()) -%}
-                    {%- else -%}
-                        {% set link = "/crate/{}/{}"|format(release.name, release_version) -%}
-                    {%- endif -%}
                     <li>
-                        <a href="{{ link|safe }}" class="release">
-                            <div class="pure-g">
-                                <div class="pure-u-1 pure-u-sm-6-24 pure-u-md-5-24 name">
-                                    {{ release.name }}-{{ release.version }}
-                                    {% if !has_unyanked_releases %}
-                                        <span class="yanked" title="all releases of {{ release.name }} have been yanked">
-                                            {{ crate::icons::IconTrash.render_solid(false, false, "") }}
-                                            Yanked
-                                        </span>
-                                    {% endif %}
+                    {%- match release -%}
+                        {%- when ReleaseStatus::NotAvailable(name) -%}
+                            <div class="release">
+                                <div class="pure-g">
+                                    <div class="pure-u-1 pure-u-sm-6-24 pure-u-md-5-24 name not-available">{{ name }}</div>
+                                    <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description">Documentation not available on docs.rs</div>
                                 </div>
-
-                                <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description">
-                                    {{ release.description.as_deref().unwrap_or_default() }}
-                                </div>
-
-                                {% if release_type == "owner" -%}
-                                    <div class="pure-u-1 pure-u-sm-4-24 pure-u-md-3-24 date" {% if let Some(build_time) = release.build_time -%}
-                                        title="Published {{ build_time|timeformat }}" {%- endif -%}>
-                                        {{ release.stars }}
-                                        {{ crate::icons::IconStar.render_solid(false, false, "") }}
-                                    </div>
-                                {%- elif let Some(build_time) = release.build_time -%}
-                                    <div class="pure-u-1 pure-u-sm-4-24 pure-u-md-3-24 date"
-                                        title="{{ build_time.format("%FT%TZ") }}">
-                                        {{ build_time|timeformat }}
-                                    </div>
-                                {%- else -%}
-                                    <div class="pure-u-1 pure-u-sm-4-24 pure-u-md-3-24 date">
-                                        &mdash;
-                                    </div>
-                                {%- endif %}
                             </div>
-                        </a>
+                        {%- when ReleaseStatus::Available(release) -%}
+                            {%- set release_version -%}
+                            {%- set has_unyanked_releases = release.has_unyanked_releases.unwrap_or(true) -%}
+                            {%- if release_type == "search" && has_unyanked_releases -%}
+                                {%- set release_version = "latest" -%}
+                            {%- else -%}
+                                {%- set release_version = release.version -%}
+                            {%- endif -%}
+                            {% set link %}
+                            {%- if release.rustdoc_status -%}
+                                {% set link = "/{}/{}/{}/"|format(release.name, release_version, release.target_name.as_deref().unwrap_or_default()) -%}
+                            {%- else -%}
+                                {% set link = "/crate/{}/{}"|format(release.name, release_version) -%}
+                            {%- endif -%}
+                            <a href="{{ link|safe }}" class="release">
+                                <div class="pure-g">
+                                    <div class="pure-u-1 pure-u-sm-6-24 pure-u-md-5-24 name">
+                                        {{- release.name }}-{{ release.version }}
+                                        {%+ if !has_unyanked_releases -%}
+                                            <span class="yanked" title="all releases of {{ release.name }} have been yanked">
+                                                {{- crate::icons::IconTrash.render_solid(false, false, "") +}}
+                                                Yanked
+                                            </span>
+                                        {%- endif -%}
+                                    </div>
+
+                                    <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description">
+                                        {{- release.description.as_deref().unwrap_or_default() -}}
+                                    </div>
+
+                                    {%- if release_type == "owner" -%}
+                                        <div class="pure-u-1 pure-u-sm-4-24 pure-u-md-3-24 date" {% if let Some(build_time) = release.build_time -%}
+                                            title="Published {{ build_time|timeformat }}" {%- endif -%}>
+                                            {{- release.stars +}}
+                                            {{ crate::icons::IconStar.render_solid(false, false, "") -}}
+                                        </div>
+                                    {%- elif let Some(build_time) = release.build_time -%}
+                                        <div class="pure-u-1 pure-u-sm-4-24 pure-u-md-3-24 date"
+                                            title="{{ build_time.format("%FT%TZ") }}">
+                                            {{- build_time|timeformat -}}
+                                        </div>
+                                    {%- else -%}
+                                        <div class="pure-u-1 pure-u-sm-4-24 pure-u-md-3-24 date">
+                                            &mdash;
+                                        </div>
+                                    {%- endif %}
+                                </div>
+                            </a>
+                        {%- endmatch -%}
                     </li>
                 {%- endfor -%}
             </ul>

--- a/templates/releases/search_results.html
+++ b/templates/releases/search_results.html
@@ -11,14 +11,14 @@
 {%- endblock topbar -%}
 
 {% block sort_by %}
-<div id="search-select-nav"> 
+<div id="search-select-nav">
     <div class="item-end">
         <span>Sort by</span>
         <label for="nav-sort">
             {{ crate::icons::IconList.render_solid(false, false, "") }}
         </label>
         {% set search_sort_by_val = search_sort_by.as_deref().unwrap_or_default() %}
-        <select form="nav-search-form" name="sort" id="nav-sort" aria-label="Find crate by the sort by select-box"  tabindex="-1">
+        <select form="nav-search-form" name="sort" id="nav-sort" aria-label="Find crate by the sort by select-box" tabindex="-1">
             <option value="relevance" {%- if search_sort_by_val == "relevance" %} selected="selected" {%- endif %}>Relevance</option>
             <option value="downloads" {%- if search_sort_by_val == "downloads" %} selected="selected" {%- endif %}>All-Time Downloads</option>
             <option value="recent-downloads" {%- if search_sort_by_val == "recent-downloads" %} selected="selected" {%- endif %}>Recent Downloads</option>

--- a/templates/style/style.scss
+++ b/templates/style/style.scss
@@ -331,6 +331,10 @@ div.recent-releases-container {
         }
     }
 
+    .name.not-available {
+        color: var(--color-standard);
+    }
+
     .name:hover {
         overflow: visible;
         white-space: normal;


### PR DESCRIPTION
I'm frustrated in search sometimes, you can get empty results but still get "next page" links because it's actually not empty but just not available on docs.rs.

So instead of keeping this confusing situation, I preferred to make it more explicit:

![image](https://github.com/user-attachments/assets/0da16c96-394c-4c4c-9592-396e5163252f)
