### PR TITLE
robots: also disallow %5E (urlencoded caret)

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -4,4 +4,7 @@ Sitemap: https://docs.rs/sitemap.xml
 # https://docs.rs/about/redirections
 User-Agent: *
 Disallow: */^
+# %5E is '^', URL-encoded. Based on the Search Console, Google
+# may be encoding '^' before checking against robots.txt.
+Disallow: */%5E
 Disallow: */~


### PR DESCRIPTION
Part of #1438
Followup to #2695 

https://www.ietf.org/rfc/rfc1738.txt says:

>  Other characters are unsafe because
>   gateways and other transport agents are known to sometimes modify
>   such characters. These characters are "{", "}", "|", "\", "^", "~",
>   "[", "]", and "`".
>
>   All unsafe characters must always be encoded within a URL.

https://datatracker.ietf.org/doc/html/rfc3986, which updates it, doesn't mention `^`. 🤷🏻