### PR TITLE
do not replace old docs if rebuild failed

### DIFF
--- a/.sqlx/query-e00a426fa250609748b3013a2a4f80844b1091964e8bdb0f55e55209077d15b1.json
+++ b/.sqlx/query-e00a426fa250609748b3013a2a4f80844b1091964e8bdb0f55e55209077d15b1.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT rustdoc_status FROM releases WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "rustdoc_status",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "e00a426fa250609748b3013a2a4f80844b1091964e8bdb0f55e55209077d15b1"
+}

--- a/.sqlx/query-e3216009b040994f88958082b518e2bbdb89147a2ef8b29e85bb9695c4bc8374.json
+++ b/.sqlx/query-e3216009b040994f88958082b518e2bbdb89147a2ef8b29e85bb9695c4bc8374.json
@@ -1,0 +1,33 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    SELECT build_status AS \"build_status: BuildStatus\"\n                    FROM release_build_status\n                    WHERE rid = $1\n                    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "build_status: BuildStatus",
+        "type_info": {
+          "Custom": {
+            "name": "build_status",
+            "kind": {
+              "Enum": [
+                "in_progress",
+                "success",
+                "failure"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "e3216009b040994f88958082b518e2bbdb89147a2ef8b29e85bb9695c4bc8374"
+}

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -447,7 +447,7 @@ fn get_readme(pkg: &MetadataPackage, source_dir: &Path) -> Result<Option<String>
 }
 
 fn get_rustdoc(pkg: &MetadataPackage, source_dir: &Path) -> Result<Option<String>> {
-    if let Some(src_path) = &pkg.targets[0].src_path {
+    if let Some(src_path) = &pkg.targets.first().and_then(|t| t.src_path.clone()) {
         let src_path = Path::new(src_path);
         if src_path.is_absolute() {
             read_rust_doc(src_path)

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -447,7 +447,7 @@ fn get_readme(pkg: &MetadataPackage, source_dir: &Path) -> Result<Option<String>
 }
 
 fn get_rustdoc(pkg: &MetadataPackage, source_dir: &Path) -> Result<Option<String>> {
-    if let Some(src_path) = &pkg.targets.first().and_then(|t| t.src_path.clone()) {
+    if let Some(src_path) = &pkg.targets.first().and_then(|t| t.src_path.as_ref()) {
         let src_path = Path::new(src_path);
         if src_path.is_absolute() {
             read_rust_doc(src_path)

--- a/src/utils/cargo_metadata.rs
+++ b/src/utils/cargo_metadata.rs
@@ -90,8 +90,12 @@ impl Package {
     }
 
     pub(crate) fn package_name(&self) -> String {
-        self.library_name()
-            .unwrap_or_else(|| self.normalize_package_name(&self.targets[0].name))
+        self.library_name().unwrap_or_else(|| {
+            self.targets
+                .first()
+                .map(|t| self.normalize_package_name(&t.name))
+                .unwrap_or_default()
+        })
     }
 
     pub(crate) fn library_name(&self) -> Option<String> {


### PR DESCRIPTION
Resolves #2675 

In case of pre-build errors we already are just returning from the method via `?`, 
so I thought we could just do the same in this case, after moving `finish_build` above the `finish_release` call I want to skip. 

