### PR TITLE
Fix crate-level docs not being rendered correctly if there is no readme:

### DIFF
--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -469,7 +469,10 @@ fn read_rust_doc(file_path: &Path) -> Result<Option<String>> {
         let line = line?;
         if line.starts_with("//!") {
             // some lines may or may not have a space between the `//!` and the start of the text
-            let line = line.trim_start_matches("//!").trim_start();
+            let mut line = line.trim_start_matches("//!");
+            if line.starts_with(' ') {
+                line = &line[1..];
+            }
             if !line.is_empty() {
                 rustdoc.push_str(line);
             }

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -231,6 +231,13 @@ impl<'a> FakeRelease<'a> {
         self
     }
 
+    pub(crate) fn target_source(mut self, path: &'a str) -> Self {
+        if let Some(target) = self.package.targets.first_mut() {
+            target.src_path = Some(path.into());
+        }
+        self
+    }
+
     pub(crate) fn no_cargo_toml(mut self) -> Self {
         self.no_cargo_toml = true;
         self
@@ -503,6 +510,7 @@ impl<'a> FakeRelease<'a> {
         if let Some(markdown) = self.readme {
             fs::write(crate_dir.join("README.md"), markdown)?;
         }
+        store_files_into(&self.source_files, crate_dir)?;
 
         // Many tests rely on the default-target being linux, so it should not
         // be set to docsrs_metadata::HOST_TARGET, because then tests fail on all

--- a/src/web/highlight.rs
+++ b/src/web/highlight.rs
@@ -51,6 +51,9 @@ fn try_with_syntax(syntax: &SyntaxReference, code: &str) -> Result<String> {
 
 fn select_syntax(name: Option<&str>, code: &str) -> &'static SyntaxReference {
     name.and_then(|name| {
+        if name.is_empty() {
+            return SYNTAXES.find_syntax_by_token("rust");
+        }
         SYNTAXES.find_syntax_by_token(name).or_else(|| {
             name.rsplit_once('.')
                 .and_then(|(_, ext)| SYNTAXES.find_syntax_by_token(ext))

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -201,7 +201,8 @@ pub mod filters {
     }
 
     pub fn highlight(code: impl std::fmt::Display, lang: &str) -> rinja::Result<Safe<String>> {
-        let highlighted_code = crate::web::highlight::with_lang(Some(lang), &code.to_string());
+        let highlighted_code =
+            crate::web::highlight::with_lang(Some(lang), &code.to_string(), None);
         Ok(Safe(format!(
             "<pre><code>{}</code></pre>",
             highlighted_code

--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -198,7 +198,7 @@
 
                 {# If there's not a readme then attempt to display the long description #}
                 {%- elif let Some(rustdoc) = rustdoc -%}
-                    {{ crate::web::markdown::render(rustdoc)|safe }}
+                    {{ crate::web::markdown::render_with_default(rustdoc, "rust")|safe }}
                 {%- endif -%}
             </div>
         </div>

--- a/templates/crate/details.html
+++ b/templates/crate/details.html
@@ -198,7 +198,7 @@
 
                 {# If there's not a readme then attempt to display the long description #}
                 {%- elif let Some(rustdoc) = rustdoc -%}
-                    {{ rustdoc|safe }}
+                    {{ crate::web::markdown::render(rustdoc)|safe }}
                 {%- endif -%}
             </div>
         </div>


### PR DESCRIPTION
Fixes https://github.com/rust-lang/docs.rs/issues/2725.

This is an interesting case since there is no README, so instead we tool the crate level docs. But we did a few things wrong:

 * Markdown was not rendered
 * Highlighting wasn't run as expected (it was never picking rust)
 * Lines start were completely trimmed whereas they shouldn't

All fixed in this PR.

@syphar Is there a way to test this except for GUI tests?