### PR TITLE
Improve display of licenses link in topbar

### DIFF
--- a/templates/rustdoc/topbar.html
+++ b/templates/rustdoc/topbar.html
@@ -50,23 +50,23 @@
                         </a>
                     </li>
 
-                    <li class="pure-menu-item">
-                        <span class="pure-menu-text description">
-                        {{ crate::icons::IconScaleUnbalancedFlip.render_solid(false, false, "") }}
-                        {%- if let Some(parsed_licenses) = krate.parsed_license -%}
-                            {%- for item in parsed_licenses -%}
+                    {%- if let Some(parsed_licenses) = krate.parsed_license -%}
+                        <li class="pure-menu-item">
+                            <span class="pure-menu-link description">
+                            {{- crate::icons::IconScaleUnbalancedFlip.render_solid(false, false, "") }}
+                            {%+ for item in parsed_licenses -%}
                                 {%- match item -%}
-                                    {%- when crate::web::licenses::LicenseSegment::Spdx with (license) -%}
+                                    {%- when crate::web::licenses::LicenseSegment::Spdx(license) -%}
                                         <a href="https://spdx.org/licenses/{{ license|safe }}" class="pure-menu-sublink">{{ license }}</a>
-                                    {%- when crate::web::licenses::LicenseSegment::UnknownLicense with (license) -%}
+                                    {%- when crate::web::licenses::LicenseSegment::UnknownLicense(license) -%}
                                         {{ license }}
-                                    {%- when crate::web::licenses::LicenseSegment::GlueTokens with (tokens) -%}
+                                    {%- when crate::web::licenses::LicenseSegment::GlueTokens(tokens) -%}
                                         {{ tokens }}
                                 {%- endmatch -%}
                             {%- endfor -%}
-                        {%- endif -%}
-                        </span>
-                    </li>
+                            </span>
+                        </li>
+                    {%- endif -%}
                 </ul>
 
                 <div class="pure-g menu-item-divided">

--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -140,9 +140,13 @@ div.nav-container {
             outline: unset;
         }
 
-       .docsrs-logo, .pure-menu-item a.pure-menu-link, .pure-menu-item .pure-menu-text {
+        .docsrs-logo, .pure-menu-item a.pure-menu-link, .pure-menu-item .pure-menu-text {
             padding: 6.4px 16px 6.4px 16px;
-       }
+        }
+
+        .pure-menu-link, .pure-menu-text {
+            display: block;
+        }
 
        .docsrs-logo, .pure-menu-item, .pure-menu-item a {
             height: 100%;


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/docs.rs/pull/2739.

It now looks like this:

![Screenshot From 2025-02-20 13-46-15](https://github.com/user-attachments/assets/ba67a9d1-297e-458b-a625-1fb4ac0dafb7)

cc @Manishearth 