### PR TITLE
upgrade to edition 2024

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,6 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/audit-check@v1
+      - id: install
+        run: |
+          rustup override set stable
+          rustup update stable
+      - uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = "MIT"
 repository = "https://github.com/rust-lang/docs.rs"
 build = "build.rs"
-edition = "2021"
+edition = "2024"
 
 [workspace]
 exclude = [

--- a/benches/compression.rs
+++ b/benches/compression.rs
@@ -1,5 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use docs_rs::storage::{compress, decompress, CompressionAlgorithm};
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use docs_rs::storage::{CompressionAlgorithm, compress, decompress};
 
 pub fn regex_capture_matches(c: &mut Criterion) {
     // this isn't a great benchmark because it only tests on one file

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -5,30 +5,30 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context as _, Error, Result};
+use anyhow::{Context as _, Error, Result, anyhow};
 use clap::{Parser, Subcommand, ValueEnum};
 use docs_rs::cdn::CdnBackend;
-use docs_rs::db::{self, add_path_into_database, CrateId, Overrides, Pool};
+use docs_rs::db::{self, CrateId, Overrides, Pool, add_path_into_database};
 use docs_rs::repositories::RepositoryStatsUpdater;
 use docs_rs::utils::{
-    get_config, get_crate_pattern_and_priority, list_crate_priorities, queue_builder,
-    remove_crate_priority, set_config, set_crate_priority, ConfigName,
+    ConfigName, get_config, get_crate_pattern_and_priority, list_crate_priorities, queue_builder,
+    remove_crate_priority, set_config, set_crate_priority,
 };
 use docs_rs::{
-    start_background_metrics_webserver, start_web_server, AsyncBuildQueue, AsyncStorage,
-    BuildQueue, Config, Context, Index, InstanceMetrics, PackageKind, RegistryApi, RustwideBuilder,
-    ServiceMetrics, Storage,
+    AsyncBuildQueue, AsyncStorage, BuildQueue, Config, Context, Index, InstanceMetrics,
+    PackageKind, RegistryApi, RustwideBuilder, ServiceMetrics, Storage,
+    start_background_metrics_webserver, start_web_server,
 };
 use futures_util::StreamExt;
 use humantime::Duration;
 use once_cell::sync::OnceCell;
 use sentry::{
-    integrations::panic as sentry_panic, integrations::tracing as sentry_tracing,
-    TransactionContext,
+    TransactionContext, integrations::panic as sentry_panic,
+    integrations::tracing as sentry_tracing,
 };
 use tokio::runtime::{Builder, Runtime};
 use tracing_log::LogTracer;
-use tracing_subscriber::{filter::Directive, prelude::*, EnvFilter};
+use tracing_subscriber::{EnvFilter, filter::Directive, prelude::*};
 
 fn main() {
     // set the global log::logger for backwards compatibility

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -1,14 +1,14 @@
-use crate::db::{delete_crate, delete_version, update_latest_version_id, CrateId, Pool};
+use crate::Context;
+use crate::db::{CrateId, Pool, delete_crate, delete_version, update_latest_version_id};
 use crate::docbuilder::PackageKind;
 use crate::error::Result;
 use crate::storage::AsyncStorage;
-use crate::utils::{get_config, get_crate_priority, report_error, retry, set_config, ConfigName};
-use crate::Context;
-use crate::{cdn, BuildPackageSummary};
+use crate::utils::{ConfigName, get_config, get_crate_priority, report_error, retry, set_config};
+use crate::{BuildPackageSummary, cdn};
 use crate::{Config, Index, InstanceMetrics, RustwideBuilder};
 use anyhow::Context as _;
 use fn_error_context::context;
-use futures_util::{stream::TryStreamExt, StreamExt};
+use futures_util::{StreamExt, stream::TryStreamExt};
 use sqlx::Connection as _;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -125,7 +125,7 @@ impl AsyncBuildQueue {
             .pending_count_by_priority()
             .await?
             .iter()
-            .filter(|(&priority, _)| priority <= 0)
+            .filter(|&(&priority, _)| priority <= 0)
             .map(|(_, count)| count)
             .sum::<usize>())
     }
@@ -756,8 +756,10 @@ mod tests {
                 .await
                 .name("foo")
                 .version("0.1.0")
-                .builds(vec![FakeBuild::default()
-                    .rustc_version("rustc 1.84.0-nightly (e7c0d2750 2020-10-15)")])
+                .builds(vec![
+                    FakeBuild::default()
+                        .rustc_version("rustc 1.84.0-nightly (e7c0d2750 2020-10-15)"),
+                ])
                 .create()
                 .await?;
 
@@ -785,8 +787,10 @@ mod tests {
                 .await
                 .name("foo")
                 .version("0.1.0")
-                .builds(vec![FakeBuild::default()
-                    .rustc_version("rustc 1.84.0-nightly (e7c0d2750 2020-10-15)")])
+                .builds(vec![
+                    FakeBuild::default()
+                        .rustc_version("rustc 1.84.0-nightly (e7c0d2750 2020-10-15)"),
+                ])
                 .create()
                 .await?;
 
@@ -833,8 +837,10 @@ mod tests {
                 .await
                 .name("foo")
                 .version("0.1.0")
-                .builds(vec![FakeBuild::default()
-                    .rustc_version("rustc 1.84.0-nightly (e7c0d2750 2020-10-15)")])
+                .builds(vec![
+                    FakeBuild::default()
+                        .rustc_version("rustc 1.84.0-nightly (e7c0d2750 2020-10-15)"),
+                ])
                 .create()
                 .await?;
 
@@ -867,8 +873,10 @@ mod tests {
                 .await
                 .name("foo")
                 .version("0.1.0")
-                .builds(vec![FakeBuild::default()
-                    .rustc_version("rustc 1.84.0-nightly (e7c0d2750 2020-10-15)")])
+                .builds(vec![
+                    FakeBuild::default()
+                        .rustc_version("rustc 1.84.0-nightly (e7c0d2750 2020-10-15)"),
+                ])
                 .create()
                 .await?;
 
@@ -1090,15 +1098,16 @@ mod tests {
             assert_eq!(metrics.build_time.get_sample_count(), 9);
 
             // no invalidations were run since we don't have a distribution id configured
-            assert!(env
-                .runtime()
-                .block_on(async {
-                    cdn::queued_or_active_crate_invalidations(
-                        &mut *env.async_db().await.async_conn().await,
-                    )
-                    .await
-                })?
-                .is_empty());
+            assert!(
+                env.runtime()
+                    .block_on(async {
+                        cdn::queued_or_active_crate_invalidations(
+                            &mut *env.async_db().await.async_conn().await,
+                        )
+                        .await
+                    })?
+                    .is_empty()
+            );
 
             Ok(())
         })
@@ -1135,9 +1144,11 @@ mod tests {
 
             let queued_invalidations = fetch_invalidations();
             assert_eq!(queued_invalidations.len(), 3);
-            assert!(queued_invalidations
-                .iter()
-                .all(|i| i.krate == "will_succeed"));
+            assert!(
+                queued_invalidations
+                    .iter()
+                    .all(|i| i.krate == "will_succeed")
+            );
 
             queue.process_next_crate(|krate| {
                 assert_eq!("will_fail", krate.name);
@@ -1146,10 +1157,12 @@ mod tests {
 
             let queued_invalidations = fetch_invalidations();
             assert_eq!(queued_invalidations.len(), 6);
-            assert!(queued_invalidations
-                .iter()
-                .skip(3)
-                .all(|i| i.krate == "will_fail"));
+            assert!(
+                queued_invalidations
+                    .iter()
+                    .skip(3)
+                    .all(|i| i.krate == "will_fail")
+            );
 
             Ok(())
         })

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use crate::{cdn::CdnKind, storage::StorageKind};
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use chrono::NaiveDate;
 use std::{env::VarError, error::Error, path::PathBuf, str::FromStr, time::Duration};
 use tracing::trace;

--- a/src/db/add_package.rs
+++ b/src/db/add_package.rs
@@ -4,10 +4,10 @@ use crate::{
     error::Result,
     registry_api::{CrateData, CrateOwner, ReleaseData},
     storage::CompressionAlgorithm,
-    utils::{rustc_version::parse_rustc_date, MetadataPackage},
+    utils::{MetadataPackage, rustc_version::parse_rustc_date},
     web::crate_details::{latest_release, releases_for_crate},
 };
-use anyhow::{anyhow, Context};
+use anyhow::{Context, anyhow};
 use derive_more::Display;
 use futures_util::stream::TryStreamExt;
 use serde::Serialize;

--- a/src/db/delete.rs
+++ b/src/db/delete.rs
@@ -1,13 +1,13 @@
 use crate::{
-    error::Result,
-    storage::{rustdoc_archive_path, source_archive_path, AsyncStorage},
     Config,
+    error::Result,
+    storage::{AsyncStorage, rustdoc_archive_path, source_archive_path},
 };
 use anyhow::Context as _;
 use fn_error_context::context;
 use sqlx::Connection;
 
-use super::{update_latest_version_id, CrateId};
+use super::{CrateId, update_latest_version_id};
 
 /// List of directories in docs.rs's underlying storage (either the database or S3) containing a
 /// subdirectory named after the crate. Those subdirectories will be deleted.
@@ -480,11 +480,12 @@ mod tests {
                 // local and remote index are gone too
                 let archive_index = format!("{rustdoc_archive}.index");
                 assert!(!env.async_storage().await.exists(&archive_index).await?);
-                assert!(!env
-                    .config()
-                    .local_archive_cache_path
-                    .join(&archive_index)
-                    .exists());
+                assert!(
+                    !env.config()
+                        .local_archive_cache_path
+                        .join(&archive_index)
+                        .exists()
+                );
             } else {
                 assert!(
                     !env.async_storage()

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -9,7 +9,7 @@ pub(crate) use self::add_package::{
 };
 pub use self::{
     add_package::{
-        update_build_status, update_crate_data_in_database, BuildId, CrateId, ReleaseId,
+        BuildId, CrateId, ReleaseId, update_build_status, update_crate_data_in_database,
     },
     delete::{delete_crate, delete_version},
     file::{add_path_into_database, add_path_into_remote_archive},

--- a/src/db/overrides.rs
+++ b/src/db/overrides.rs
@@ -40,7 +40,9 @@ impl Overrides {
 
     pub async fn save(conn: &mut sqlx::PgConnection, krate: &str, overrides: Self) -> Result<()> {
         if overrides.timeout.is_some() && overrides.targets.is_none() {
-            tracing::warn!("setting `Overrides::timeout` implies a default `Overrides::targets = 1`, prefer setting this explicitly");
+            tracing::warn!(
+                "setting `Overrides::timeout` implies a default `Overrides::targets = 1`, prefer setting this explicitly"
+            );
         }
 
         if sqlx::query_scalar!("SELECT id FROM crates WHERE crates.name = $1", krate)

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -1,7 +1,7 @@
-use crate::metrics::InstanceMetrics;
 use crate::Config;
+use crate::metrics::InstanceMetrics;
 use futures_util::{future::BoxFuture, stream::BoxStream};
-use sqlx::{postgres::PgPoolOptions, Executor};
+use sqlx::{Executor, postgres::PgPoolOptions};
 use std::{
     ops::{Deref, DerefMut},
     sync::Arc,

--- a/src/docbuilder/limits.rs
+++ b/src/docbuilder/limits.rs
@@ -1,4 +1,4 @@
-use crate::{db::Overrides, error::Result, Config};
+use crate::{Config, db::Overrides, error::Result};
 use serde::Serialize;
 use std::time::Duration;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! documentation of crates for the Rust Programming Language.
 #![allow(clippy::cognitive_complexity)]
 
-pub use self::build_queue::{queue_rebuilds, AsyncBuildQueue, BuildQueue};
+pub use self::build_queue::{AsyncBuildQueue, BuildQueue, queue_rebuilds};
 pub use self::config::Config;
 pub use self::context::Context;
 pub use self::docbuilder::PackageKind;

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -3,10 +3,9 @@ mod macros;
 
 use self::macros::MetricFromOpts;
 use crate::{
-    cdn,
+    AsyncBuildQueue, Config, cdn,
     db::{CrateId, Pool, ReleaseId},
     target::TargetAtom,
-    AsyncBuildQueue, Config,
 };
 use anyhow::Error;
 use dashmap::DashMap;

--- a/src/registry_api.rs
+++ b/src/registry_api.rs
@@ -1,7 +1,7 @@
 use crate::{error::Result, utils::retry_async};
-use anyhow::{anyhow, bail, Context};
+use anyhow::{Context, anyhow, bail};
 use chrono::{DateTime, Utc};
-use reqwest::header::{HeaderValue, ACCEPT, USER_AGENT};
+use reqwest::header::{ACCEPT, HeaderValue, USER_AGENT};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::fmt;

--- a/src/repositories/github.rs
+++ b/src/repositories/github.rs
@@ -1,17 +1,17 @@
-use crate::error::Result;
 use crate::Config;
+use crate::error::Result;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use reqwest::{
-    header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT},
     Client as HttpClient,
+    header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT},
 };
 use serde::Deserialize;
 use tracing::{trace, warn};
 
 use crate::repositories::{
-    FetchRepositoriesResult, RateLimitReached, Repository, RepositoryForge, RepositoryName,
-    APP_USER_AGENT,
+    APP_USER_AGENT, FetchRepositoriesResult, RateLimitReached, Repository, RepositoryForge,
+    RepositoryName,
 };
 
 const GRAPHQL_UPDATE: &str = "query($ids: [ID!]!) {
@@ -267,8 +267,8 @@ struct GraphIssues {
 #[cfg(test)]
 mod tests {
     use super::{Config, GitHub};
-    use crate::repositories::updater::{repository_name, RepositoryForge};
     use crate::repositories::RateLimitReached;
+    use crate::repositories::updater::{RepositoryForge, repository_name};
 
     async fn mock_server_and_github(config: &Config) -> (mockito::ServerGuard, GitHub) {
         let server = mockito::Server::new_async().await;

--- a/src/repositories/gitlab.rs
+++ b/src/repositories/gitlab.rs
@@ -2,8 +2,8 @@ use crate::error::Result;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use reqwest::{
-    header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT},
     Client as HttpClient,
+    header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT},
 };
 use serde::Deserialize;
 use std::collections::HashSet;
@@ -11,8 +11,8 @@ use std::str::FromStr;
 use tracing::warn;
 
 use crate::repositories::{
-    FetchRepositoriesResult, RateLimitReached, Repository, RepositoryForge, RepositoryName,
-    APP_USER_AGENT,
+    APP_USER_AGENT, FetchRepositoriesResult, RateLimitReached, Repository, RepositoryForge,
+    RepositoryName,
 };
 
 const GRAPHQL_UPDATE: &str = "query($ids: [ID!]!) {
@@ -265,8 +265,8 @@ struct GraphProject {
 #[cfg(test)]
 mod tests {
     use super::GitLab;
-    use crate::repositories::updater::{repository_name, RepositoryForge};
     use crate::repositories::RateLimitReached;
+    use crate::repositories::updater::{RepositoryForge, repository_name};
 
     async fn mock_server_and_gitlab() -> (mockito::ServerGuard, GitLab) {
         let server = mockito::Server::new_async().await;

--- a/src/repositories/updater.rs
+++ b/src/repositories/updater.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 use crate::repositories::{GitHub, GitLab, RateLimitReached};
 use crate::utils::MetadataPackage;
-use crate::{db::Pool, Config};
+use crate::{Config, db::Pool};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures_util::stream::TryStreamExt;
@@ -258,8 +258,7 @@ impl RepositoryStatsUpdater {
     ) -> Result<i32> {
         trace!(
             "storing {} repository stats for {}",
-            host,
-            repo.name_with_owner,
+            host, repo.name_with_owner,
         );
         Ok(sqlx::query_scalar!(
             "INSERT INTO repositories (
@@ -296,8 +295,7 @@ impl RepositoryStatsUpdater {
     ) -> Result<()> {
         trace!(
             "removing repository stats for host ID `{}` and host `{}`",
-            host_id,
-            host
+            host_id, host
         );
         sqlx::query!(
             "DELETE FROM repositories WHERE host_id = $1 AND host = $2;",

--- a/src/storage/archive_index.rs
+++ b/src/storage/archive_index.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
-use crate::storage::{compression::CompressionAlgorithm, FileRange};
-use anyhow::{bail, Context as _};
+use crate::storage::{FileRange, compression::CompressionAlgorithm};
+use anyhow::{Context as _, bail};
 use rusqlite::{Connection, OpenFlags, OptionalExtension};
 use std::{fs, io, path::Path};
 use tracing::instrument;
@@ -150,9 +150,11 @@ mod tests {
         assert_eq!(fi.range, FileRange::new(39, 459));
         assert_eq!(fi.compression, CompressionAlgorithm::Bzip2);
 
-        assert!(find_in_file(&tempfile, "some_other_file",)
-            .unwrap()
-            .is_none());
+        assert!(
+            find_in_file(&tempfile, "some_other_file",)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/storage/compression.rs
+++ b/src/storage/compression.rs
@@ -1,6 +1,6 @@
 use anyhow::Error;
-use bzip2::read::{BzDecoder, BzEncoder};
 use bzip2::Compression;
+use bzip2::read::{BzDecoder, BzEncoder};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashSet,
@@ -125,11 +125,12 @@ mod tests {
 
             // Ensure decompressing a file over the limit returns a SizeLimitReached error.
             let err = decompress(compressed_big.as_slice(), alg, MAX_SIZE).unwrap_err();
-            assert!(err
-                .downcast_ref::<std::io::Error>()
-                .and_then(|io| io.get_ref())
-                .and_then(|err| err.downcast_ref::<crate::error::SizeLimitReached>())
-                .is_some());
+            assert!(
+                err.downcast_ref::<std::io::Error>()
+                    .and_then(|io| io.get_ref())
+                    .and_then(|err| err.downcast_ref::<crate::error::SizeLimitReached>())
+                    .is_some()
+            );
         }
     }
 

--- a/src/storage/database.rs
+++ b/src/storage/database.rs
@@ -1,5 +1,5 @@
 use super::{Blob, FileRange};
-use crate::{db::Pool, error::Result, InstanceMetrics};
+use crate::{InstanceMetrics, db::Pool, error::Result};
 use chrono::{DateTime, Utc};
 use futures_util::stream::{Stream, TryStreamExt};
 use sqlx::Acquire;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3,17 +3,18 @@ mod compression;
 mod database;
 mod s3;
 
-pub use self::compression::{compress, decompress, CompressionAlgorithm, CompressionAlgorithms};
+pub use self::compression::{CompressionAlgorithm, CompressionAlgorithms, compress, decompress};
 use self::database::DatabaseBackend;
 use self::s3::S3Backend;
 use crate::{
+    Config, InstanceMetrics,
     db::{
-        file::{detect_mime, FileEntry},
-        mimes, BuildId, Pool,
+        BuildId, Pool,
+        file::{FileEntry, detect_mime},
+        mimes,
     },
     error::Result,
     utils::spawn_blocking,
-    Config, InstanceMetrics,
 };
 use anyhow::anyhow;
 use chrono::{DateTime, Utc};
@@ -907,11 +908,13 @@ mod backend_tests {
         assert!(!storage.get_public_access(path)?);
 
         for path in &["bar.txt", "baz.txt", "foo/baz.txt"] {
-            assert!(storage
-                .set_public_access(path, true)
-                .unwrap_err()
-                .downcast_ref::<PathNotFoundError>()
-                .is_some());
+            assert!(
+                storage
+                    .set_public_access(path, true)
+                    .unwrap_err()
+                    .downcast_ref::<PathNotFoundError>()
+                    .is_some()
+            );
         }
 
         Ok(())
@@ -937,17 +940,21 @@ mod backend_tests {
         assert!(!storage.get_public_access(path)?);
 
         for path in &["bar.txt", "baz.txt", "foo/baz.txt"] {
-            assert!(storage
-                .get(path, usize::MAX)
-                .unwrap_err()
-                .downcast_ref::<PathNotFoundError>()
-                .is_some());
+            assert!(
+                storage
+                    .get(path, usize::MAX)
+                    .unwrap_err()
+                    .downcast_ref::<PathNotFoundError>()
+                    .is_some()
+            );
 
-            assert!(storage
-                .get_public_access(path)
-                .unwrap_err()
-                .downcast_ref::<PathNotFoundError>()
-                .is_some());
+            assert!(
+                storage
+                    .get_public_access(path)
+                    .unwrap_err()
+                    .downcast_ref::<PathNotFoundError>()
+                    .is_some()
+            );
         }
 
         Ok(())
@@ -978,11 +985,13 @@ mod backend_tests {
         );
 
         for path in &["bar.txt", "baz.txt", "foo/baz.txt"] {
-            assert!(storage
-                .get_range(path, usize::MAX, 0..=4, None)
-                .unwrap_err()
-                .downcast_ref::<PathNotFoundError>()
-                .is_some());
+            assert!(
+                storage
+                    .get_range(path, usize::MAX, 0..=4, None)
+                    .unwrap_err()
+                    .downcast_ref::<PathNotFoundError>()
+                    .is_some()
+            );
         }
 
         Ok(())
@@ -1024,10 +1033,12 @@ mod backend_tests {
         // When testing, minio just gave me `XMinioInvalidObjectName`, so I'll check that too.
         let long_filename = "ATCG".repeat(512);
 
-        assert!(storage
-            .get(&long_filename, 42)
-            .unwrap_err()
-            .is::<PathNotFoundError>());
+        assert!(
+            storage
+                .get(&long_filename, 42)
+                .unwrap_err()
+                .is::<PathNotFoundError>()
+        );
 
         Ok(())
     }
@@ -1055,13 +1066,15 @@ mod backend_tests {
         let blob = storage.get("small-blob.bin", MAX_SIZE)?;
         assert_eq!(blob.content.len(), small_blob.content.len());
 
-        assert!(storage
-            .get("big-blob.bin", MAX_SIZE)
-            .unwrap_err()
-            .downcast_ref::<std::io::Error>()
-            .and_then(|io| io.get_ref())
-            .and_then(|err| err.downcast_ref::<crate::error::SizeLimitReached>())
-            .is_some());
+        assert!(
+            storage
+                .get("big-blob.bin", MAX_SIZE)
+                .unwrap_err()
+                .downcast_ref::<std::io::Error>()
+                .and_then(|io| io.get_ref())
+                .and_then(|err| err.downcast_ref::<crate::error::SizeLimitReached>())
+                .is_some()
+        );
 
         Ok(())
     }
@@ -1299,11 +1312,13 @@ mod backend_tests {
             assert!(storage.get(existing, usize::MAX).is_ok());
         }
         for missing in missing {
-            assert!(storage
-                .get(missing, usize::MAX)
-                .unwrap_err()
-                .downcast_ref::<PathNotFoundError>()
-                .is_some());
+            assert!(
+                storage
+                    .get(missing, usize::MAX)
+                    .unwrap_err()
+                    .downcast_ref::<PathNotFoundError>()
+                    .is_some()
+            );
         }
 
         Ok(())

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -4,10 +4,10 @@ use anyhow::{Context as _, Error};
 use async_stream::try_stream;
 use aws_config::BehaviorVersion;
 use aws_sdk_s3::{
-    config::{retry::RetryConfig, Region},
+    Client,
+    config::{Region, retry::RetryConfig},
     error::{ProvideErrorMetadata, SdkError},
     types::{Delete, ObjectIdentifier, Tag, Tagging},
-    Client,
 };
 use aws_smithy_types_convert::date_time::DateTimeExt;
 use chrono::Utc;

--- a/src/test/fakes.rs
+++ b/src/test/fakes.rs
@@ -1,19 +1,19 @@
 use super::TestDatabase;
 
-use crate::db::file::{file_list_to_json, FileEntry};
+use crate::db::file::{FileEntry, file_list_to_json};
 use crate::db::types::BuildStatus;
 use crate::db::{
-    initialize_build, initialize_crate, initialize_release, update_build_status, BuildId, ReleaseId,
+    BuildId, ReleaseId, initialize_build, initialize_crate, initialize_release, update_build_status,
 };
 use crate::docbuilder::DocCoverage;
 use crate::error::Result;
 use crate::registry_api::{CrateData, CrateOwner, ReleaseData};
 use crate::storage::{
-    rustdoc_archive_path, source_archive_path, AsyncStorage, CompressionAlgorithm,
+    AsyncStorage, CompressionAlgorithm, rustdoc_archive_path, source_archive_path,
 };
 use crate::utils::{Dependency, MetadataPackage, Target};
-use anyhow::{bail, Context};
-use base64::{engine::general_purpose::STANDARD as b64, Engine};
+use anyhow::{Context, bail};
+use base64::{Engine, engine::general_purpose::STANDARD as b64};
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::iter;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,6 +1,6 @@
 mod fakes;
 
-pub(crate) use self::fakes::{fake_release_that_failed_before_build, FakeBuild};
+pub(crate) use self::fakes::{FakeBuild, fake_release_that_failed_before_build};
 use crate::cdn::CdnBackend;
 use crate::db::{self, AsyncPoolClient, Pool};
 use crate::error::Result;
@@ -13,9 +13,9 @@ use crate::{
 };
 use anyhow::Context as _;
 use axum::body::Bytes;
-use axum::{body::Body, http::Request, response::Response as AxumResponse, Router};
+use axum::{Router, body::Body, http::Request, response::Response as AxumResponse};
 use fn_error_context::context;
-use futures_util::{stream::TryStreamExt, FutureExt};
+use futures_util::{FutureExt, stream::TryStreamExt};
 use http_body_util::BodyExt; // for `collect`
 use once_cell::sync::OnceCell;
 use serde::de::DeserializeOwned;
@@ -365,7 +365,7 @@ pub(crate) struct TestEnvironment {
 }
 
 pub(crate) fn init_logger() {
-    use tracing_subscriber::{filter::Directive, EnvFilter};
+    use tracing_subscriber::{EnvFilter, filter::Directive};
 
     rustwide::logging::init_with(tracing_log::LogTracer::new());
     let subscriber = tracing_subscriber::FmtSubscriber::builder()

--- a/src/utils/cargo_metadata.rs
+++ b/src/utils/cargo_metadata.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
-use anyhow::{bail, Context};
-use rustwide::{cmd::Command, Toolchain, Workspace};
+use anyhow::{Context, bail};
+use rustwide::{Toolchain, Workspace, cmd::Command};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;

--- a/src/utils/consistency/mod.rs
+++ b/src/utils/consistency/mod.rs
@@ -1,4 +1,4 @@
-use crate::{db::delete, utils::spawn_blocking, Context};
+use crate::{Context, db::delete, utils::spawn_blocking};
 use anyhow::{Context as _, Result};
 use itertools::Itertools;
 use tracing::{info, warn};
@@ -159,7 +159,7 @@ where
 mod tests {
     use super::diff::Difference;
     use super::*;
-    use crate::test::{async_wrapper, TestEnvironment};
+    use crate::test::{TestEnvironment, async_wrapper};
     use sqlx::Row as _;
 
     async fn count(env: &TestEnvironment, sql: &str) -> Result<i64> {

--- a/src/utils/daemon.rs
+++ b/src/utils/daemon.rs
@@ -3,12 +3,11 @@
 //! This daemon will start web server, track new packages and build them
 
 use crate::{
-    cdn, queue_rebuilds,
+    AsyncBuildQueue, Config, Context, Index, RustwideBuilder, cdn, queue_rebuilds,
     utils::{queue_builder, report_error},
     web::start_web_server,
-    AsyncBuildQueue, Config, Context, Index, RustwideBuilder,
 };
-use anyhow::{anyhow, Context as _, Error};
+use anyhow::{Context as _, Error, anyhow};
 use std::future::Future;
 use std::sync::Arc;
 use std::thread;

--- a/src/utils/html.rs
+++ b/src/utils/html.rs
@@ -107,7 +107,7 @@ pub(crate) fn rewrite_lol(
 
 #[cfg(test)]
 mod test {
-    use crate::test::{async_wrapper, AxumResponseTestExt, AxumRouterTestExt};
+    use crate::test::{AxumResponseTestExt, AxumRouterTestExt, async_wrapper};
 
     #[test]
     fn rewriting_only_injects_css_once() {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -23,10 +23,10 @@ mod queue;
 pub(crate) mod queue_builder;
 pub(crate) mod rustc_version;
 use anyhow::Result;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use std::panic;
-use tracing::{error, warn, Span};
+use tracing::{Span, error, warn};
 pub(crate) mod sized_buffer;
 
 use std::{future::Future, thread, time::Duration};
@@ -196,9 +196,11 @@ mod tests {
                 .execute(&mut *conn)
                 .await?;
 
-            assert!(get_config::<String>(&mut conn, ConfigName::RustcVersion)
-                .await?
-                .is_none());
+            assert!(
+                get_config::<String>(&mut conn, ConfigName::RustcVersion)
+                    .await?
+                    .is_none()
+            );
             Ok(())
         });
     }
@@ -211,9 +213,11 @@ mod tests {
                 .execute(&mut *conn)
                 .await?;
 
-            assert!(get_config::<String>(&mut conn, ConfigName::RustcVersion)
-                .await?
-                .is_none());
+            assert!(
+                get_config::<String>(&mut conn, ConfigName::RustcVersion)
+                    .await?
+                    .is_none()
+            );
 
             set_config(
                 &mut conn,

--- a/src/utils/queue_builder.rs
+++ b/src/utils/queue_builder.rs
@@ -1,7 +1,7 @@
 use crate::Context;
-use crate::{docbuilder::RustwideBuilder, utils::report_error, BuildQueue, Config};
+use crate::{BuildQueue, Config, docbuilder::RustwideBuilder, utils::report_error};
 use anyhow::{Context as _, Error};
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 use std::time::Duration;
 use std::{fs, io, path::Path, thread};

--- a/src/utils/rustc_version.rs
+++ b/src/utils/rustc_version.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use anyhow::{anyhow, Context};
+use anyhow::{Context, anyhow};
 use chrono::prelude::*;
 use once_cell::sync::Lazy;
 use regex::Regex;

--- a/src/utils/sized_buffer.rs
+++ b/src/utils/sized_buffer.rs
@@ -57,10 +57,12 @@ mod tests {
 
         // Ensure adding a third chunk fails
         let error = buffer.write(&[0; 500]).unwrap_err();
-        assert!(error
-            .get_ref()
-            .unwrap()
-            .is::<crate::error::SizeLimitReached>());
+        assert!(
+            error
+                .get_ref()
+                .unwrap()
+                .is::<crate::error::SizeLimitReached>()
+        );
 
         // Ensure all the third chunk was discarded
         assert_eq!(1000, buffer.inner.len());

--- a/src/web/build_details.rs
+++ b/src/web/build_details.rs
@@ -1,15 +1,15 @@
 use crate::{
-    db::{types::BuildStatus, BuildId},
+    AsyncStorage, Config,
+    db::{BuildId, types::BuildStatus},
     impl_axum_webpage,
     web::{
+        MetaData,
         error::{AxumNope, AxumResult},
         extractors::{DbConnection, Path},
         file::File,
         filters,
         page::templates::{RenderRegular, RenderSolid},
-        MetaData,
     },
-    AsyncStorage, Config,
 };
 use anyhow::Context as _;
 use axum::{extract::Extension, response::IntoResponse};
@@ -163,8 +163,8 @@ pub(crate) async fn build_details_handler(
 #[cfg(test)]
 mod tests {
     use crate::test::{
-        async_wrapper, fake_release_that_failed_before_build, AxumResponseTestExt,
-        AxumRouterTestExt, FakeBuild,
+        AxumResponseTestExt, AxumRouterTestExt, FakeBuild, async_wrapper,
+        fake_release_that_failed_before_build,
     };
     use kuchikiki::traits::TendrilSink;
     use test_case::test_case;
@@ -258,9 +258,11 @@ mod tests {
                 .await
                 .name("foo")
                 .version("0.1.0")
-                .builds(vec![FakeBuild::default()
-                    .no_s3_build_log()
-                    .db_build_log("A build log")])
+                .builds(vec![
+                    FakeBuild::default()
+                        .no_s3_build_log()
+                        .db_build_log("A build log"),
+                ])
                 .create()
                 .await?;
 
@@ -350,12 +352,11 @@ mod tests {
                 .await
                 .name("foo")
                 .version("0.1.0")
-                .builds(vec![FakeBuild::default()
-                    .s3_build_log("A build log")
-                    .build_log_for_other_target(
-                        "other_target",
-                        "other target build log",
-                    )])
+                .builds(vec![
+                    FakeBuild::default()
+                        .s3_build_log("A build log")
+                        .build_log_for_other_target("other_target", "other target build log"),
+                ])
                 .create()
                 .await?;
 
@@ -417,9 +418,11 @@ mod tests {
                 .await
                 .name("foo")
                 .version("0.1.0")
-                .builds(vec![FakeBuild::default()
-                    .s3_build_log("A build log")
-                    .db_build_log("Another build log")])
+                .builds(vec![
+                    FakeBuild::default()
+                        .s3_build_log("A build log")
+                        .db_build_log("Another build log"),
+                ])
                 .create()
                 .await?;
 

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -4,25 +4,25 @@ use super::{
     headers::CanonicalUrl,
 };
 use crate::{
-    db::{types::BuildStatus, BuildId},
+    AsyncBuildQueue, Config,
+    db::{BuildId, types::BuildStatus},
     docbuilder::Limits,
     impl_axum_webpage,
     web::{
+        MetaData, ReqVersion,
         error::AxumResult,
         extractors::{DbConnection, Path},
         filters, match_version,
         page::templates::{RenderRegular, RenderSolid},
-        MetaData, ReqVersion,
     },
-    AsyncBuildQueue, Config,
 };
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use axum::{
-    extract::Extension, http::header::ACCESS_CONTROL_ALLOW_ORIGIN, response::IntoResponse, Json,
+    Json, extract::Extension, http::header::ACCESS_CONTROL_ALLOW_ORIGIN, response::IntoResponse,
 };
 use axum_extra::{
-    headers::{authorization::Bearer, Authorization},
     TypedHeader,
+    headers::{Authorization, authorization::Bearer},
 };
 use chrono::{DateTime, Utc};
 use constant_time_eq::constant_time_eq;
@@ -256,8 +256,8 @@ mod tests {
     use crate::{
         db::Overrides,
         test::{
-            async_wrapper, fake_release_that_failed_before_build, AxumResponseTestExt,
-            AxumRouterTestExt, FakeBuild,
+            AxumResponseTestExt, AxumRouterTestExt, FakeBuild, async_wrapper,
+            fake_release_that_failed_before_build,
         },
         web::cache::CachePolicy,
     };
@@ -389,10 +389,12 @@ mod tests {
                 Some(&"rustc (blabla 2021-01-01)".into())
             );
             assert!(value.pointer("/0/id").unwrap().is_i64());
-            assert!(serde_json::from_value::<DateTime<Utc>>(
-                value.pointer("/0/build_time").unwrap().clone()
-            )
-            .is_ok());
+            assert!(
+                serde_json::from_value::<DateTime<Utc>>(
+                    value.pointer("/0/build_time").unwrap().clone()
+                )
+                .is_ok()
+            );
 
             assert_eq!(value.pointer("/1/build_status"), Some(&false.into()));
             assert_eq!(
@@ -404,10 +406,12 @@ mod tests {
                 Some(&"rustc (blabla 2020-01-01)".into())
             );
             assert!(value.pointer("/1/id").unwrap().is_i64());
-            assert!(serde_json::from_value::<DateTime<Utc>>(
-                value.pointer("/1/build_time").unwrap().clone()
-            )
-            .is_ok());
+            assert!(
+                serde_json::from_value::<DateTime<Utc>>(
+                    value.pointer("/1/build_time").unwrap().clone()
+                )
+                .is_ok()
+            );
 
             assert_eq!(value.pointer("/2/build_status"), Some(&true.into()));
             assert_eq!(
@@ -419,10 +423,12 @@ mod tests {
                 Some(&"rustc (blabla 2019-01-01)".into())
             );
             assert!(value.pointer("/2/id").unwrap().is_i64());
-            assert!(serde_json::from_value::<DateTime<Utc>>(
-                value.pointer("/2/build_time").unwrap().clone()
-            )
-            .is_ok());
+            assert!(
+                serde_json::from_value::<DateTime<Utc>>(
+                    value.pointer("/2/build_time").unwrap().clone()
+                )
+                .is_ok()
+            );
 
             assert!(
                 value.pointer("/1/build_time").unwrap().as_str().unwrap()
@@ -679,9 +685,11 @@ mod tests {
                 .await
                 .name("aquarelle")
                 .version("0.1.0")
-                .builds(vec![FakeBuild::default()
-                    .rustc_version("rustc (blabla 2019-01-01)")
-                    .docsrs_version("docs.rs 1.0.0")])
+                .builds(vec![
+                    FakeBuild::default()
+                        .rustc_version("rustc (blabla 2019-01-01)")
+                        .docsrs_version("docs.rs 1.0.0"),
+                ])
                 .create()
                 .await?;
 
@@ -689,9 +697,11 @@ mod tests {
                 .await
                 .name("aquarelle")
                 .version("0.2.0")
-                .builds(vec![FakeBuild::default()
-                    .rustc_version("rustc (blabla 2019-01-01)")
-                    .docsrs_version("docs.rs 1.0.0")])
+                .builds(vec![
+                    FakeBuild::default()
+                        .rustc_version("rustc (blabla 2019-01-01)")
+                        .docsrs_version("docs.rs 1.0.0"),
+                ])
                 .create()
                 .await?;
 
@@ -722,9 +732,11 @@ mod tests {
                 .await
                 .name("foo")
                 .version("0.1.0")
-                .builds(vec![FakeBuild::default()
-                    .rustc_version("rustc (blabla 2019-01-01)")
-                    .docsrs_version("docs.rs 1.0.0")])
+                .builds(vec![
+                    FakeBuild::default()
+                        .rustc_version("rustc (blabla 2019-01-01)")
+                        .docsrs_version("docs.rs 1.0.0"),
+                ])
                 .create()
                 .await?;
 
@@ -741,9 +753,11 @@ mod tests {
                 .await
                 .name("foo")
                 .version("0.1.0")
-                .builds(vec![FakeBuild::default()
-                    .rustc_version("rustc (blabla 2019-01-01)")
-                    .docsrs_version("docs.rs 1.0.0")])
+                .builds(vec![
+                    FakeBuild::default()
+                        .rustc_version("rustc (blabla 2019-01-01)")
+                        .docsrs_version("docs.rs 1.0.0"),
+                ])
                 .create()
                 .await?;
 

--- a/src/web/cache.rs
+++ b/src/web/cache.rs
@@ -2,7 +2,7 @@ use crate::config::Config;
 use axum::{
     extract::Request as AxumHttpRequest, middleware::Next, response::Response as AxumResponse,
 };
-use http::{header::CACHE_CONTROL, HeaderValue};
+use http::{HeaderValue, header::CACHE_CONTROL};
 use std::sync::Arc;
 
 pub static NO_CACHING: HeaderValue = HeaderValue::from_static("max-age=0");
@@ -140,9 +140,11 @@ mod tests {
         wrapper(|env| {
             env.override_config(|config| config.cache_control_stale_while_revalidate = None);
 
-            assert!(CachePolicy::ForeverInCdnAndStaleInBrowser
-                .render(&env.config())
-                .is_none());
+            assert!(
+                CachePolicy::ForeverInCdnAndStaleInBrowser
+                    .render(&env.config())
+                    .is_none()
+            );
             Ok(())
         });
     }

--- a/src/web/csp.rs
+++ b/src/web/csp.rs
@@ -2,12 +2,12 @@ use crate::config::Config;
 use axum::{
     extract::Request as AxumHttpRequest, middleware::Next, response::Response as AxumResponse,
 };
-use base64::{engine::general_purpose::STANDARD as b64, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD as b64};
 use std::{
     fmt::Write,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
 };
 

--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -5,9 +5,9 @@ use crate::{
 };
 use anyhow::anyhow;
 use axum::{
+    Json,
     http::StatusCode,
     response::{IntoResponse, Response as AxumResponse},
-    Json,
 };
 use std::borrow::Cow;
 use tracing::error;
@@ -217,7 +217,7 @@ pub(crate) type JsonAxumResult<T> = Result<T, JsonAxumNope>;
 #[cfg(test)]
 mod tests {
     use super::{AxumNope, IntoResponse};
-    use crate::test::{async_wrapper, AxumResponseTestExt, AxumRouterTestExt};
+    use crate::test::{AxumResponseTestExt, AxumRouterTestExt, async_wrapper};
     use crate::web::cache::CachePolicy;
     use kuchikiki::traits::TendrilSink;
 

--- a/src/web/extractors.rs
+++ b/src/web/extractors.rs
@@ -1,9 +1,9 @@
 use crate::db::{AsyncPoolClient, Pool};
 use anyhow::Context as _;
 use axum::{
+    RequestPartsExt,
     extract::{Extension, FromRequestParts, OptionalFromRequestParts},
     http::request::Parts,
-    RequestPartsExt,
 };
 use std::ops::{Deref, DerefMut};
 

--- a/src/web/features.rs
+++ b/src/web/features.rs
@@ -2,6 +2,7 @@ use crate::{
     db::types::Feature as DbFeature,
     impl_axum_webpage,
     web::{
+        MetaData, ReqVersion,
         cache::CachePolicy,
         error::{AxumNope, AxumResult},
         extractors::{DbConnection, Path},
@@ -9,7 +10,6 @@ use crate::{
         headers::CanonicalUrl,
         match_version,
         page::templates::{RenderRegular, RenderSolid},
-        MetaData, ReqVersion,
     },
 };
 use anyhow::anyhow;
@@ -232,7 +232,7 @@ fn get_sorted_features(raw_features: Vec<DbFeature>) -> (Vec<Feature>, HashSet<S
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::{async_wrapper, AxumResponseTestExt, AxumRouterTestExt};
+    use crate::test::{AxumResponseTestExt, AxumRouterTestExt, async_wrapper};
     use reqwest::StatusCode;
 
     #[test]

--- a/src/web/file.rs
+++ b/src/web/file.rs
@@ -2,16 +2,16 @@
 
 use super::cache::CachePolicy;
 use crate::{
+    Config,
     error::Result,
     storage::{AsyncStorage, Blob},
-    Config,
 };
 
 use axum::{
     extract::Extension,
     http::{
-        header::{CONTENT_TYPE, LAST_MODIFIED},
         StatusCode,
+        header::{CONTENT_TYPE, LAST_MODIFIED},
     },
     response::{IntoResponse, Response as AxumResponse},
 };

--- a/src/web/highlight.rs
+++ b/src/web/highlight.rs
@@ -92,8 +92,8 @@ pub fn with_lang(lang: Option<&str>, code: &str, default: Option<&str>) -> Strin
 #[cfg(test)]
 mod tests {
     use super::{
-        select_syntax, try_with_lang, with_lang, LimitsExceeded, PER_LINE_BYTE_LENGTH_LIMIT,
-        TOTAL_CODE_BYTE_LENGTH_LIMIT,
+        LimitsExceeded, PER_LINE_BYTE_LENGTH_LIMIT, TOTAL_CODE_BYTE_LENGTH_LIMIT, select_syntax,
+        try_with_lang, with_lang,
     };
 
     #[test]

--- a/src/web/markdown.rs
+++ b/src/web/markdown.rs
@@ -1,6 +1,6 @@
 use crate::web::highlight;
 use comrak::{
-    adapters::SyntaxHighlighterAdapter, ExtensionOptions, Options, Plugins, RenderPlugins,
+    ExtensionOptions, Options, Plugins, RenderPlugins, adapters::SyntaxHighlighterAdapter,
 };
 use std::collections::HashMap;
 

--- a/src/web/metrics.rs
+++ b/src/web/metrics.rs
@@ -1,15 +1,15 @@
 use crate::{
-    db::Pool, metrics::duration_to_seconds, web::error::AxumResult, AsyncBuildQueue, Config,
-    InstanceMetrics, ServiceMetrics,
+    AsyncBuildQueue, Config, InstanceMetrics, ServiceMetrics, db::Pool,
+    metrics::duration_to_seconds, web::error::AxumResult,
 };
 use anyhow::{Context as _, Result};
 use axum::{
     extract::{Extension, MatchedPath, Request as AxumRequest},
-    http::{header::CONTENT_TYPE, StatusCode},
+    http::{StatusCode, header::CONTENT_TYPE},
     middleware::Next,
     response::IntoResponse,
 };
-use prometheus::{proto::MetricFamily, Encoder, TextEncoder};
+use prometheus::{Encoder, TextEncoder, proto::MetricFamily};
 use std::{borrow::Cow, future::Future, sync::Arc, time::Instant};
 
 async fn fetch_and_render_metrics<Fut>(fetch_metrics: Fut) -> AxumResult<impl IntoResponse>
@@ -110,8 +110,8 @@ pub(crate) async fn request_recorder(
 
 #[cfg(test)]
 mod tests {
-    use crate::test::{async_wrapper, AxumResponseTestExt, AxumRouterTestExt};
     use crate::Context;
+    use crate::test::{AxumResponseTestExt, AxumRouterTestExt, async_wrapper};
     use std::collections::HashMap;
 
     #[test]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -3,13 +3,13 @@
 pub mod page;
 // mod tmp;
 
-use crate::db::types::BuildStatus;
 use crate::db::CrateId;
 use crate::db::ReleaseId;
+use crate::db::types::BuildStatus;
 use crate::utils::get_correct_docsrs_style_file;
 use crate::utils::report_error;
-use crate::web::page::templates::{filters, RenderSolid};
-use anyhow::{anyhow, bail, Context as _, Result};
+use crate::web::page::templates::{RenderSolid, filters};
+use anyhow::{Context as _, Result, anyhow, bail};
 use axum_extra::middleware::option_layer;
 use rinja::Template;
 use serde_json::Value;
@@ -37,20 +37,20 @@ mod source;
 mod statics;
 mod status;
 
-use crate::{impl_axum_webpage, Context};
+use crate::{Context, impl_axum_webpage};
 use anyhow::Error;
 use axum::{
+    Router as AxumRouter,
     extract::{Extension, MatchedPath, Request as AxumRequest},
     http::StatusCode,
     middleware,
     middleware::Next,
     response::{IntoResponse, Response as AxumResponse},
-    Router as AxumRouter,
 };
 use chrono::{DateTime, Utc};
 use error::AxumNope;
 use page::TemplateData;
-use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 use semver::{Version, VersionReq};
 use sentry::integrations::tower as sentry_tower;
 use serde_with::{DeserializeFromStr, SerializeDisplay};
@@ -770,8 +770,8 @@ impl_axum_webpage! {
 mod test {
     use super::*;
     use crate::test::{
-        async_wrapper, AxumResponseTestExt, AxumRouterTestExt, FakeBuild, TestDatabase,
-        TestEnvironment,
+        AxumResponseTestExt, AxumRouterTestExt, FakeBuild, TestDatabase, TestEnvironment,
+        async_wrapper,
     };
     use crate::{db::ReleaseId, docbuilder::DocCoverage};
     use kuchikiki::traits::TendrilSink;
@@ -859,10 +859,12 @@ mod test {
 
             let foo_doc = kuchikiki::parse_html()
                 .one(web.assert_success("/foo/0.0.1/foo/").await?.text().await?);
-            assert!(foo_doc
-                .select(".pure-menu-link b")
-                .unwrap()
-                .any(|e| e.text_contents().contains("60%")));
+            assert!(
+                foo_doc
+                    .select(".pure-menu-link b")
+                    .unwrap()
+                    .any(|e| e.text_contents().contains("60%"))
+            );
 
             Ok(())
         });
@@ -1121,7 +1123,7 @@ mod test {
                 .name("foo")
                 .version("1.1.0")
                 .builds(vec![
-                    FakeBuild::default().build_status(BuildStatus::InProgress)
+                    FakeBuild::default().build_status(BuildStatus::InProgress),
                 ])
                 .create()
                 .await?;
@@ -1312,10 +1314,12 @@ mod test {
             response.headers().get(http::header::LOCATION).unwrap(),
             "/something"
         );
-        assert!(response
-            .headers()
-            .get(http::header::CACHE_CONTROL)
-            .is_none());
+        assert!(
+            response
+                .headers()
+                .get(http::header::CACHE_CONTROL)
+                .is_none()
+        );
         assert!(response.extensions().get::<cache::CachePolicy>().is_none());
     }
 

--- a/src/web/page/web_page.rs
+++ b/src/web/page/web_page.rs
@@ -1,4 +1,4 @@
-use crate::web::{csp::Csp, error::AxumNope, TemplateData};
+use crate::web::{TemplateData, csp::Csp, error::AxumNope};
 use axum::{
     body::Body,
     extract::Request as AxumRequest,

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -2,12 +2,12 @@ use super::{
     cache::CachePolicy, error::AxumNope, metrics::request_recorder, statics::build_static_router,
 };
 use axum::{
+    Router as AxumRouter,
     extract::Request as AxumHttpRequest,
     handler::Handler as AxumHandler,
     middleware::{self, Next},
     response::{IntoResponse, Redirect},
-    routing::{get, post, MethodRouter},
-    Router as AxumRouter,
+    routing::{MethodRouter, get, post},
 };
 use axum_extra::routing::RouterExt;
 use rinja::Template;
@@ -370,7 +370,7 @@ async fn fallback() -> impl IntoResponse {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::{async_wrapper, AxumResponseTestExt, AxumRouterTestExt};
+    use crate::test::{AxumResponseTestExt, AxumRouterTestExt, async_wrapper};
     use crate::web::cache::CachePolicy;
     use reqwest::StatusCode;
 

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -1,14 +1,14 @@
 use crate::{
+    Config,
     docbuilder::Limits,
     impl_axum_webpage,
-    utils::{get_config, ConfigName},
+    utils::{ConfigName, get_config},
     web::{
+        AxumErrorPage,
         error::{AxumNope, AxumResult},
         extractors::{DbConnection, Path},
-        page::templates::{filters, RenderBrands, RenderSolid},
-        AxumErrorPage,
+        page::templates::{RenderBrands, RenderSolid, filters},
     },
-    Config,
 };
 use axum::{extract::Extension, http::StatusCode, response::IntoResponse};
 use chrono::{TimeZone, Utc};
@@ -203,7 +203,7 @@ pub(crate) async fn about_handler(subpage: Option<Path<String>>) -> AxumResult<i
 
 #[cfg(test)]
 mod tests {
-    use crate::test::{async_wrapper, AxumResponseTestExt, AxumRouterTestExt};
+    use crate::test::{AxumResponseTestExt, AxumRouterTestExt, async_wrapper};
     use axum::http::StatusCode;
 
     #[test]

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -1,21 +1,21 @@
 use super::{error::AxumResult, match_version};
 use crate::{
+    AsyncStorage,
     db::{BuildId, Pool},
     impl_axum_webpage,
     storage::PathNotFoundError,
     web::{
+        MetaData, ReqVersion,
         cache::CachePolicy,
         error::AxumNope,
         extractors::Path,
         file::File as DbFile,
         headers::CanonicalUrl,
-        page::templates::{filters, RenderBrands, RenderRegular, RenderSolid},
-        MetaData, ReqVersion,
+        page::templates::{RenderBrands, RenderRegular, RenderSolid, filters},
     },
-    AsyncStorage,
 };
 use anyhow::{Context as _, Result};
-use axum::{response::IntoResponse, Extension};
+use axum::{Extension, response::IntoResponse};
 use axum_extra::headers::HeaderMapExt;
 use mime::Mime;
 use rinja::Template;
@@ -346,7 +346,7 @@ pub(crate) async fn source_browser_handler(
 #[cfg(test)]
 mod tests {
     use crate::{
-        test::{async_wrapper, AxumResponseTestExt, AxumRouterTestExt},
+        test::{AxumResponseTestExt, AxumRouterTestExt, async_wrapper},
         web::{cache::CachePolicy, encode_url_path},
     };
     use kuchikiki::traits::TendrilSink;
@@ -709,13 +709,15 @@ mod tests {
             let web = env.web_app().await;
 
             let response = web.get("/crate/fake/0.1.0/source/config.json").await?;
-            assert!(response
-                .headers()
-                .get("content-type")
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .starts_with("text/html"));
+            assert!(
+                response
+                    .headers()
+                    .get("content-type")
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .starts_with("text/html")
+            );
 
             let text = response.text().await?;
             assert!(text.starts_with(r#"<!DOCTYPE html>"#));
@@ -811,10 +813,12 @@ mod tests {
             let web = env.web_app().await;
             let response = web.get("/crate/fake/0.1.0/source/large_file.rs").await?;
             assert_eq!(response.status(), StatusCode::OK);
-            assert!(response
-                .text()
-                .await?
-                .contains("This file is too large to display"));
+            assert!(
+                response
+                    .text()
+                    .await?
+                    .contains("This file is too large to display")
+            );
             Ok(())
         });
     }

--- a/src/web/statics.rs
+++ b/src/web/statics.rs
@@ -1,12 +1,12 @@
 use super::{cache::CachePolicy, metrics::request_recorder, routes::get_static};
 use axum::{
+    Router as AxumRouter,
     extract::{Extension, Request},
     http::header::CONTENT_TYPE,
     middleware,
     middleware::Next,
     response::{IntoResponse, Response},
     routing::get_service,
-    Router as AxumRouter,
 };
 use axum_extra::headers::HeaderValue;
 use tower_http::services::ServeDir;
@@ -80,7 +80,7 @@ pub(crate) fn build_static_router() -> AxumRouter {
 mod tests {
     use super::{STYLE_CSS, VENDORED_CSS};
     use crate::{
-        test::{async_wrapper, AxumResponseTestExt, AxumRouterTestExt},
+        test::{AxumResponseTestExt, AxumRouterTestExt, async_wrapper},
         web::cache::CachePolicy,
     };
     use axum::response::Response as AxumResponse;

--- a/src/web/status.rs
+++ b/src/web/status.rs
@@ -1,11 +1,12 @@
 use super::{cache::CachePolicy, error::AxumNope};
 use crate::web::{
+    ReqVersion,
     error::AxumResult,
     extractors::{DbConnection, Path},
-    match_version, ReqVersion,
+    match_version,
 };
 use axum::{
-    extract::Extension, http::header::ACCESS_CONTROL_ALLOW_ORIGIN, response::IntoResponse, Json,
+    Json, extract::Extension, http::header::ACCESS_CONTROL_ALLOW_ORIGIN, response::IntoResponse,
 };
 
 pub(crate) async fn status_handler(
@@ -46,7 +47,7 @@ pub(crate) async fn status_handler(
 
 #[cfg(test)]
 mod tests {
-    use crate::test::{async_wrapper, AxumResponseTestExt, AxumRouterTestExt};
+    use crate::test::{AxumResponseTestExt, AxumRouterTestExt, async_wrapper};
     use crate::web::cache::CachePolicy;
     use reqwest::StatusCode;
     use test_case::test_case;


### PR DESCRIPTION
specifically _not_ using `cargo fix --edition`, which did very many (in my mind) unnecessary things like changing `if let` to `match` even though the current `if let` still compiles. 

Apart from that, most changes are formatting changes. 