### PR TITLE
Increase the width of search input in navbar

### DIFF
--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -132,7 +132,6 @@ div.nav-container {
                 box-shadow: none;
                 background-color: var(--color-background);
                 height: 100%;
-                width: 50%;
             }
         }
 


### PR DESCRIPTION
This PR just removes the limitation of navbar search input width, allowing it to extend all the way to the end of flex container.

Before:
![before](https://github.com/user-attachments/assets/a2c86ab2-1caf-4620-a67f-997f3eeee8da)

After:
![after](https://github.com/user-attachments/assets/e07255e6-15c1-4a9d-a5f9-614edca5a28c)
