### PR TITLE
Shorthand URLs: document usage of `::`

### DIFF
--- a/templates/core/about/redirections.html
+++ b/templates/core/about/redirections.html
@@ -28,6 +28,11 @@
                 </tr>
 
                 <tr>
+                    <td><a href="https://docs.rs/clap::Command">docs.rs/clap::Command</a></td>
+                    <td>Latest version of clap, and search for "Command" within the crate</td>
+                </tr>
+
+                <tr>
                     <td>
                         <a href="https://docs.rs/clap/%7E2">docs.rs/clap/~2</a>
                     </td>


### PR DESCRIPTION
This adds documentation for redirects such as from https://docs.rs/clap::Command to the Shorthand URLs page.