### PR TITLE
Fix pagination for recent failures

### DIFF
--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -319,7 +319,7 @@ impl ReleaseType {
         match self {
             Self::Recent => "recent",
             Self::Stars => "stars",
-            Self::RecentFailures => "recent_failures",
+            Self::RecentFailures => "recent-failures",
             Self::Failures => "failures",
             Self::Search => "search",
         }


### PR DESCRIPTION
Currently, on the "recent failures" page, pagination links are broken - they lead to something like https://docs.rs/releases/recent_failures/2 instead of https://docs.rs/releases/recent-failures/2. I've attempted to change the corresponding string representation - it seems to be not used otherwise.