### PR TITLE
Remove `humantime` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1700,7 +1700,6 @@ dependencies = [
  "http 0.2.12",
  "http 1.2.0",
  "http-body-util",
- "humantime",
  "indoc",
  "itertools 0.14.0",
  "kuchikiki",
@@ -4114,12 +4113,6 @@ checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
 dependencies = [
  "libm",
 ]
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -7836,7 +7829,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,6 @@ chrono = { version = "0.4.11", default-features = false, features = ["clock", "s
 
 # Transitive dependencies we don't use directly but need to have specific versions of
 thread_local = "1.1.3"
-humantime = "2.1.0"
 constant_time_eq = "0.3.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -20,7 +20,6 @@ use docs_rs::{
     start_background_metrics_webserver, start_web_server,
 };
 use futures_util::StreamExt;
-use humantime::Duration;
 use once_cell::sync::OnceCell;
 use sentry::{
     TransactionContext, integrations::panic as sentry_panic,
@@ -712,7 +711,7 @@ enum LimitsSubcommand {
         #[arg(long)]
         targets: Option<usize>,
         #[arg(long)]
-        timeout: Option<Duration>,
+        timeout: Option<usize>,
     },
 
     /// Remove sandbox limits overrides for a crate
@@ -748,7 +747,8 @@ impl LimitsSubcommand {
                     let overrides = Overrides {
                         memory,
                         targets,
-                        timeout: timeout.map(Into::into),
+                        timeout: timeout
+                            .map(|timeout| std::time::Duration::from_secs(timeout as _)),
                     };
                     Overrides::save(&mut conn, &crate_name, overrides).await?;
                     let overrides = Overrides::for_crate(&mut conn, &crate_name).await?;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/docs.rs/issues/2770.

The dependency is not used anywhere in our dependency tree, only for `cratesfyi`, so replacing it with `jiff`.