### PR TITLE
Update to new rinja version (askama 0.13)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "askama"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a4e46abb203e00ef226442d452769233142bbfdd79c3941e84c8e61c4112543"
+dependencies = [
+ "askama_derive",
+ "itoa 1.0.15",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54398906821fd32c728135f7b351f0c7494ab95ae421d41b6f5a020e158f28a6"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_derive",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,6 +1800,7 @@ name = "docs-rs"
 version = "0.6.0"
 dependencies = [
  "anyhow",
+ "askama",
  "async-stream",
  "async-trait",
  "aws-config",
@@ -1812,7 +1855,6 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
- "rinja",
  "rusqlite",
  "rustwide",
  "semver",
@@ -3396,15 +3438,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humansize"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
-dependencies = [
- "libm",
-]
 
 [[package]]
 name = "hyper"
@@ -5211,47 +5244,6 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rinja"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc4940d00595430b3d7d5a01f6222b5e5b51395d1120bdb28d854bb8abb17a5"
-dependencies = [
- "humansize",
- "itoa 1.0.15",
- "percent-encoding",
- "rinja_derive",
-]
-
-[[package]]
-name = "rinja_derive"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d9ed0146aef6e2825f1b1515f074510549efba38d71f4554eec32eb36ba18b"
-dependencies = [
- "basic-toml",
- "memchr",
- "mime",
- "mime_guess",
- "proc-macro2",
- "quote",
- "rinja_parser",
- "rustc-hash 2.1.1",
- "serde",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "rinja_parser"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f9a866e2e00a7a1fb27e46e9e324a6f7c0e7edc4543cae1d38f4e4a100c610"
-dependencies = [
- "memchr",
- "nom",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ tempfile = "3.1.0"
 fn-error-context = "0.2.0"
 
 # Templating
-rinja = "0.3.4"
+askama = "0.13"
 walkdir = "2"
 
 # Date and Time utilities

--- a/src/utils/html.rs
+++ b/src/utils/html.rs
@@ -1,8 +1,8 @@
 use crate::web::page::templates::{Body, Head, Vendored};
 use crate::web::rustdoc::RustdocPage;
+use askama::Template;
 use lol_html::element;
 use lol_html::errors::RewritingError;
-use rinja::Template;
 
 /// Rewrite a rustdoc page to have the docs.rs topbar
 ///
@@ -45,7 +45,7 @@ pub(crate) fn rewrite_lol(
         rustdoc_body_class.set_attribute("tabindex", "-1")?;
         // Change the `body` to a `div`
         rustdoc_body_class.set_tag_name("div")?;
-        // Prepend the rinja content
+        // Prepend the askama content
         rustdoc_body_class.prepend(&body_html, ContentType::Html);
         // Wrap the transformed body and topbar into a <body> element
         rustdoc_body_class.before(r#"<body class="rustdoc-page">"#, ContentType::Html);

--- a/src/web/build_details.rs
+++ b/src/web/build_details.rs
@@ -12,10 +12,10 @@ use crate::{
     },
 };
 use anyhow::Context as _;
+use askama::Template;
 use axum::{extract::Extension, response::IntoResponse};
 use chrono::{DateTime, Utc};
 use futures_util::TryStreamExt;
-use rinja::Template;
 use semver::Version;
 use serde::Deserialize;
 use std::sync::Arc;

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -17,6 +17,7 @@ use crate::{
     },
 };
 use anyhow::{Result, anyhow};
+use askama::Template;
 use axum::{
     Json, extract::Extension, http::header::ACCESS_CONTROL_ALLOW_ORIGIN, response::IntoResponse,
 };
@@ -27,7 +28,6 @@ use axum_extra::{
 use chrono::{DateTime, Utc};
 use constant_time_eq::constant_time_eq;
 use http::StatusCode;
-use rinja::Template;
 use semver::Version;
 use std::sync::Arc;
 

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -670,7 +670,7 @@ mod tests {
             dbg!(&values);
             assert!(values.contains(&"6.44 GB"));
             assert!(values.contains(&"2 hours"));
-            assert!(values.contains(&"102.40 kB"));
+            assert!(values.contains(&"102.4 kB"));
             assert!(values.contains(&"blocked"));
             assert!(values.contains(&"1"));
 

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -18,6 +18,7 @@ use crate::{
     },
 };
 use anyhow::{Context, Result, anyhow};
+use askama::Template;
 use axum::{
     extract::Extension,
     response::{IntoResponse, Response as AxumResponse},
@@ -25,7 +26,6 @@ use axum::{
 use chrono::{DateTime, Utc};
 use futures_util::stream::TryStreamExt;
 use log::warn;
-use rinja::Template;
 use semver::Version;
 use serde::Deserialize;
 use serde_json::Value;

--- a/src/web/features.rs
+++ b/src/web/features.rs
@@ -13,8 +13,8 @@ use crate::{
     },
 };
 use anyhow::anyhow;
+use askama::Template;
 use axum::response::IntoResponse;
-use rinja::Template;
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -10,8 +10,8 @@ use crate::utils::get_correct_docsrs_style_file;
 use crate::utils::report_error;
 use crate::web::page::templates::{RenderSolid, filters};
 use anyhow::{Context as _, Result, anyhow, bail};
+use askama::Template;
 use axum_extra::middleware::option_layer;
-use rinja::Template;
 use serde_json::Value;
 use tracing::{info, instrument};
 

--- a/src/web/page/templates.rs
+++ b/src/web/page/templates.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 use crate::web::rustdoc::RustdocPage;
 use anyhow::Context;
-use rinja::Template;
+use askama::Template;
 use std::sync::Arc;
 use tracing::trace;
 
@@ -88,12 +88,12 @@ impl TemplateData {
 }
 
 pub mod filters {
+    use askama::filters::Safe;
     use chrono::{DateTime, Utc};
-    use rinja::filters::Safe;
     use std::borrow::Cow;
 
     // Copied from `tera`.
-    pub fn escape_html(input: &str) -> rinja::Result<Cow<'_, str>> {
+    pub fn escape_html(input: &str) -> askama::Result<Cow<'_, str>> {
         if !input.chars().any(|c| "&<>\"'/".contains(c)) {
             return Ok(Cow::Borrowed(input));
         }
@@ -115,7 +115,7 @@ pub mod filters {
     }
 
     // Copied from `tera`.
-    pub fn escape_xml(input: &str) -> rinja::Result<Cow<'_, str>> {
+    pub fn escape_xml(input: &str) -> askama::Result<Cow<'_, str>> {
         if !input.chars().any(|c| "&<>\"'".contains(c)) {
             return Ok(Cow::Borrowed(input));
         }
@@ -135,11 +135,11 @@ pub mod filters {
 
     /// Prettily format a timestamp
     // TODO: This can be replaced by chrono
-    pub fn timeformat(value: &DateTime<Utc>) -> rinja::Result<String> {
+    pub fn timeformat(value: &DateTime<Utc>) -> askama::Result<String> {
         Ok(crate::web::duration_to_str(*value))
     }
 
-    pub fn format_secs(mut value: f32) -> rinja::Result<String> {
+    pub fn format_secs(mut value: f32) -> askama::Result<String> {
         const TIMES: &[&str] = &["seconds", "minutes", "hours"];
 
         let mut chosen_time = &TIMES[0];
@@ -167,7 +167,7 @@ pub mod filters {
     pub fn dedent<T: std::fmt::Display, I: Into<Option<i32>>>(
         value: T,
         levels: I,
-    ) -> rinja::Result<String> {
+    ) -> askama::Result<String> {
         let string = value.to_string();
 
         let unindented = if let Some(levels) = levels.into() {
@@ -200,7 +200,7 @@ pub mod filters {
         Ok(unindented)
     }
 
-    pub fn highlight(code: impl std::fmt::Display, lang: &str) -> rinja::Result<Safe<String>> {
+    pub fn highlight(code: impl std::fmt::Display, lang: &str) -> askama::Result<Safe<String>> {
         let highlighted_code =
             crate::web::highlight::with_lang(Some(lang), &code.to_string(), None);
         Ok(Safe(format!(
@@ -209,7 +209,7 @@ pub mod filters {
         )))
     }
 
-    pub fn round(value: &f32, precision: u32) -> rinja::Result<String> {
+    pub fn round(value: &f32, precision: u32) -> askama::Result<String> {
         let multiplier = if precision == 0 {
             1.0
         } else {
@@ -218,11 +218,11 @@ pub mod filters {
         Ok(((multiplier * *value).round() / multiplier).to_string())
     }
 
-    pub fn split_first<'a>(value: &'a str, pat: &str) -> rinja::Result<Option<&'a str>> {
+    pub fn split_first<'a>(value: &'a str, pat: &str) -> askama::Result<Option<&'a str>> {
         Ok(value.split(pat).next())
     }
 
-    pub fn json_encode<T: ?Sized + serde::Serialize>(value: &T) -> rinja::Result<Safe<String>> {
+    pub fn json_encode<T: ?Sized + serde::Serialize>(value: &T) -> askama::Result<Safe<String>> {
         Ok(Safe(
             serde_json::to_string(value).expect("`encode_json` failed"),
         ))
@@ -230,31 +230,31 @@ pub mod filters {
 }
 
 pub trait RenderSolid {
-    fn render_solid(&self, fw: bool, spin: bool, extra: &str) -> rinja::filters::Safe<String>;
+    fn render_solid(&self, fw: bool, spin: bool, extra: &str) -> askama::filters::Safe<String>;
 }
 
 impl<T: font_awesome_as_a_crate::Solid> RenderSolid for T {
-    fn render_solid(&self, fw: bool, spin: bool, extra: &str) -> rinja::filters::Safe<String> {
+    fn render_solid(&self, fw: bool, spin: bool, extra: &str) -> askama::filters::Safe<String> {
         render("fa-solid", self.icon_name(), fw, spin, extra)
     }
 }
 
 pub trait RenderRegular {
-    fn render_regular(&self, fw: bool, spin: bool, extra: &str) -> rinja::filters::Safe<String>;
+    fn render_regular(&self, fw: bool, spin: bool, extra: &str) -> askama::filters::Safe<String>;
 }
 
 impl<T: font_awesome_as_a_crate::Regular> RenderRegular for T {
-    fn render_regular(&self, fw: bool, spin: bool, extra: &str) -> rinja::filters::Safe<String> {
+    fn render_regular(&self, fw: bool, spin: bool, extra: &str) -> askama::filters::Safe<String> {
         render("fa-regular", self.icon_name(), fw, spin, extra)
     }
 }
 
 pub trait RenderBrands {
-    fn render_brands(&self, fw: bool, spin: bool, extra: &str) -> rinja::filters::Safe<String>;
+    fn render_brands(&self, fw: bool, spin: bool, extra: &str) -> askama::filters::Safe<String>;
 }
 
 impl<T: font_awesome_as_a_crate::Brands> RenderBrands for T {
-    fn render_brands(&self, fw: bool, spin: bool, extra: &str) -> rinja::filters::Safe<String> {
+    fn render_brands(&self, fw: bool, spin: bool, extra: &str) -> askama::filters::Safe<String> {
         render("fa-brands", self.icon_name(), fw, spin, extra)
     }
 }
@@ -265,7 +265,7 @@ fn render(
     fw: bool,
     spin: bool,
     extra: &str,
-) -> rinja::filters::Safe<String> {
+) -> askama::filters::Safe<String> {
     let mut classes = Vec::new();
     if fw {
         classes.push("fa-fw");
@@ -281,5 +281,5 @@ fn render(
         classes = classes.join(" "),
     );
 
-    rinja::filters::Safe(icon)
+    askama::filters::Safe(icon)
 }

--- a/src/web/page/web_page.rs
+++ b/src/web/page/web_page.rs
@@ -10,7 +10,7 @@ use http::header::CONTENT_LENGTH;
 use std::sync::Arc;
 
 pub(crate) trait AddCspNonce: IntoResponse {
-    fn render_with_csp_nonce(&mut self, csp_nonce: String) -> rinja::Result<String>;
+    fn render_with_csp_nonce(&mut self, csp_nonce: String) -> askama::Result<String>;
 }
 
 #[macro_export]
@@ -25,7 +25,7 @@ macro_rules! impl_axum_webpage {
         $(,)?
     ) => {
         impl $crate::web::page::web_page::AddCspNonce for $page {
-            fn render_with_csp_nonce(&mut self, csp_nonce: String) -> rinja::Result<String> {
+            fn render_with_csp_nonce(&mut self, csp_nonce: String) -> askama::Result<String> {
                 self.csp_nonce = csp_nonce;
                 self.render()
             }

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -14,6 +14,7 @@ use crate::{
     },
 };
 use anyhow::{Context as _, Result, anyhow};
+use askama::Template;
 use axum::{
     extract::{Extension, Query},
     response::{IntoResponse, Response as AxumResponse},
@@ -22,7 +23,6 @@ use base64::{Engine, engine::general_purpose::STANDARD as b64};
 use chrono::{DateTime, Utc};
 use futures_util::stream::TryStreamExt;
 use itertools::Itertools;
-use rinja::Template;
 use serde::{Deserialize, Serialize};
 use sqlx::Row;
 use std::collections::{BTreeMap, HashMap, HashSet};

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -1,6 +1,7 @@
 use super::{
     cache::CachePolicy, error::AxumNope, metrics::request_recorder, statics::build_static_router,
 };
+use askama::Template;
 use axum::{
     Router as AxumRouter,
     extract::Request as AxumHttpRequest,
@@ -10,7 +11,6 @@ use axum::{
     routing::{MethodRouter, get, post},
 };
 use axum_extra::routing::RouterExt;
-use rinja::Template;
 use std::convert::Infallible;
 use tracing::{debug, instrument};
 

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -22,6 +22,7 @@ use crate::{
     },
 };
 use anyhow::{Context as _, anyhow};
+use askama::Template;
 use axum::{
     extract::{Extension, Query},
     http::{StatusCode, Uri},
@@ -29,7 +30,6 @@ use axum::{
 };
 use lol_html::errors::RewritingError;
 use once_cell::sync::Lazy;
-use rinja::Template;
 use semver::Version;
 use serde::Deserialize;
 use std::{

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -10,10 +10,10 @@ use crate::{
         page::templates::{RenderBrands, RenderSolid, filters},
     },
 };
+use askama::Template;
 use axum::{extract::Extension, http::StatusCode, response::IntoResponse};
 use chrono::{TimeZone, Utc};
 use futures_util::stream::TryStreamExt;
-use rinja::Template;
 use std::sync::Arc;
 
 /// sitemap index

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -15,10 +15,10 @@ use crate::{
     },
 };
 use anyhow::{Context as _, Result};
+use askama::Template;
 use axum::{Extension, response::IntoResponse};
 use axum_extra::headers::HeaderMapExt;
 use mime::Mime;
-use rinja::Template;
 use semver::Version;
 use serde::Deserialize;
 use std::{cmp::Ordering, sync::Arc};


### PR DESCRIPTION
Askama maintenance was handed over to rinja maintainers so new `rinja` release is actually `askama`. More information [here](https://blog.guillaume-gomez.fr/articles/2025-03-19+Askama+and+Rinja+merge).
