### PR TITLE
Remove `csp_nonce` field from all template types

### DIFF
--- a/src/web/build_details.rs
+++ b/src/web/build_details.rs
@@ -39,7 +39,6 @@ struct BuildDetailsPage {
     build_details: BuildDetails,
     all_log_filenames: Vec<String>,
     current_filename: Option<String>,
-    csp_nonce: String,
 }
 
 impl_axum_webpage! { BuildDetailsPage }
@@ -155,7 +154,6 @@ pub(crate) async fn build_details_handler(
         },
         all_log_filenames,
         current_filename,
-        csp_nonce: String::new(),
     }
     .into_response())
 }

--- a/src/web/builds.rs
+++ b/src/web/builds.rs
@@ -49,7 +49,6 @@ struct BuildsPage {
     builds: Vec<Build>,
     limits: Limits,
     canonical_url: CanonicalUrl,
-    csp_nonce: String,
 }
 
 impl_axum_webpage! { BuildsPage }
@@ -81,7 +80,6 @@ pub(crate) async fn build_list_handler(
         builds: get_builds(&mut conn, &name, &version).await?,
         limits: Limits::for_crate(&config, &mut conn, &name).await?,
         canonical_url: CanonicalUrl::from_path(format!("/crate/{name}/latest/builds")),
-        csp_nonce: String::new(),
     }
     .into_response())
 }

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -445,7 +445,6 @@ struct CrateDetailsPage {
     is_library: Option<bool>,
     last_successful_build: Option<String>,
     rustdoc: Option<String>, // this is description_long in database
-    csp_nonce: String,
     source_size: Option<i64>,
     documentation_size: Option<i64>,
 }
@@ -545,7 +544,6 @@ pub(crate) async fn crate_details_handler(
         is_library,
         last_successful_build,
         rustdoc,
-        csp_nonce: String::new(),
         source_size,
         documentation_size,
     }
@@ -567,7 +565,6 @@ struct ReleaseList {
     crate_name: String,
     inner_path: String,
     target: String,
-    csp_nonce: String,
 }
 
 impl_axum_webpage! {
@@ -649,7 +646,6 @@ pub(crate) async fn get_all_releases(
         target,
         inner_path,
         crate_name: params.name,
-        csp_nonce: String::new(),
     };
     Ok(res.into_response())
 }
@@ -677,7 +673,6 @@ struct PlatformList {
     inner_path: String,
     use_direct_platform_links: bool,
     current_target: String,
-    csp_nonce: String,
 }
 
 impl_axum_webpage! {
@@ -748,7 +743,6 @@ pub(crate) async fn get_all_platforms_inner(
             inner_path: "".into(),
             use_direct_platform_links: is_crate_root,
             current_target: "".into(),
-            csp_nonce: String::new(),
         }
         .into_response());
     }
@@ -803,7 +797,6 @@ pub(crate) async fn get_all_platforms_inner(
         inner_path,
         use_direct_platform_links: is_crate_root,
         current_target,
-        csp_nonce: String::new(),
     }
     .into_response())
 }

--- a/src/web/error.rs
+++ b/src/web/error.rs
@@ -148,7 +148,6 @@ impl IntoResponse for AxumNope {
                     title,
                     message,
                     status,
-                    csp_nonce: String::new(),
                 }
                 .into_response()
             }

--- a/src/web/features.rs
+++ b/src/web/features.rs
@@ -89,7 +89,6 @@ struct FeaturesPage {
     default_features: HashSet<String>,
     canonical_url: CanonicalUrl,
     is_latest_url: bool,
-    csp_nonce: String,
 }
 
 impl FeaturesPage {
@@ -167,7 +166,6 @@ pub(crate) async fn build_features_handler(
         default_features,
         is_latest_url: req_version.is_latest(),
         canonical_url: CanonicalUrl::from_path(format!("/crate/{}/latest/features", &name)),
-        csp_nonce: String::new(),
     }
     .into_response())
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -758,7 +758,6 @@ pub(crate) struct AxumErrorPage {
     /// The error message, displayed as a description
     pub message: Cow<'static, str>,
     pub status: StatusCode,
-    pub csp_nonce: String,
 }
 
 impl_axum_webpage! {

--- a/src/web/page/web_page.rs
+++ b/src/web/page/web_page.rs
@@ -26,8 +26,8 @@ macro_rules! impl_axum_webpage {
     ) => {
         impl $crate::web::page::web_page::AddCspNonce for $page {
             fn render_with_csp_nonce(&mut self, csp_nonce: String) -> askama::Result<String> {
-                self.csp_nonce = csp_nonce;
-                self.render()
+                let values: [(&str, &dyn std::any::Any); 1] = [("csp_nonce", &csp_nonce)];
+                self.render_with_values(&values)
             }
         }
 

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -238,7 +238,6 @@ async fn get_search_results(
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct HomePage {
     recent_releases: Vec<Release>,
-    csp_nonce: String,
 }
 
 impl_axum_webpage! {
@@ -250,10 +249,7 @@ pub(crate) async fn home_page(mut conn: DbConnection) -> AxumResult<impl IntoRes
     let recent_releases =
         get_releases(&mut conn, 1, RELEASES_IN_HOME, Order::ReleaseTime, true).await?;
 
-    Ok(HomePage {
-        recent_releases,
-        csp_nonce: String::new(),
-    })
+    Ok(HomePage { recent_releases })
 }
 
 #[derive(Template)]
@@ -261,7 +257,6 @@ pub(crate) async fn home_page(mut conn: DbConnection) -> AxumResult<impl IntoRes
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ReleaseFeed {
     recent_releases: Vec<Release>,
-    csp_nonce: String,
 }
 
 impl_axum_webpage! {
@@ -272,10 +267,7 @@ impl_axum_webpage! {
 pub(crate) async fn releases_feed_handler(mut conn: DbConnection) -> AxumResult<impl IntoResponse> {
     let recent_releases =
         get_releases(&mut conn, 1, RELEASES_IN_FEED, Order::ReleaseTime, true).await?;
-    Ok(ReleaseFeed {
-        recent_releases,
-        csp_nonce: String::new(),
-    })
+    Ok(ReleaseFeed { recent_releases })
 }
 
 #[derive(Template)]
@@ -289,7 +281,6 @@ struct ViewReleases {
     show_previous_page: bool,
     page_number: i64,
     owner: Option<String>,
-    csp_nonce: String,
 }
 
 impl_axum_webpage! { ViewReleases }
@@ -378,7 +369,6 @@ pub(crate) async fn releases_handler(
         show_previous_page,
         page_number,
         owner: None,
-        csp_nonce: String::new(),
     })
 }
 
@@ -431,7 +421,6 @@ pub(super) struct Search {
     /// This should always be `ReleaseType::Search`
     pub(super) release_type: ReleaseType,
     pub(super) status: http::StatusCode,
-    pub(super) csp_nonce: String,
 }
 
 impl Default for Search {
@@ -445,7 +434,6 @@ impl Default for Search {
             search_sort_by: None,
             release_type: ReleaseType::Search,
             status: http::StatusCode::OK,
-            csp_nonce: String::new(),
         }
     }
 }
@@ -644,7 +632,6 @@ struct ReleaseActivity {
     dates: Vec<String>,
     counts: Vec<i64>,
     failures: Vec<i64>,
-    csp_nonce: String,
 }
 
 impl_axum_webpage! { ReleaseActivity }
@@ -700,7 +687,6 @@ pub(crate) async fn activity_handler(mut conn: DbConnection) -> AxumResult<impl 
             .collect(),
         counts: rows.iter().map(|rows| rows.counts).collect(),
         failures: rows.iter().map(|rows| rows.failures).collect(),
-        csp_nonce: String::new(),
     })
 }
 
@@ -713,7 +699,6 @@ struct BuildQueuePage {
     rebuild_queue: Vec<QueuedCrate>,
     active_cdn_deployments: Vec<String>,
     in_progress_builds: Vec<(String, String)>,
-    csp_nonce: String,
     expand_rebuild_queue: bool,
 }
 
@@ -791,7 +776,6 @@ pub(crate) async fn build_queue_handler(
         rebuild_queue,
         active_cdn_deployments,
         in_progress_builds,
-        csp_nonce: String::new(),
         expand_rebuild_queue: params.expand.is_some(),
     })
 }

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -293,16 +293,12 @@ pub(super) fn build_axum_routes() -> AxumRouter {
                 #[derive(Template)]
                 #[template(path = "storage-change-detection.html")]
                 #[derive(Debug, Clone)]
-                struct StorageChangeDetection {
-                    csp_nonce: String,
-                }
+                struct StorageChangeDetection;
                 crate::impl_axum_webpage!(
                     StorageChangeDetection,
                     cache_policy = |_| CachePolicy::ForeverInCdnAndBrowser,
                 );
-                StorageChangeDetection {
-                    csp_nonce: String::new(),
-                }
+                StorageChangeDetection
             }),
         )
         .route_with_tsr(

--- a/src/web/sitemap.rs
+++ b/src/web/sitemap.rs
@@ -22,7 +22,6 @@ use std::sync::Arc;
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SitemapIndexXml {
     sitemaps: Vec<char>,
-    csp_nonce: String,
 }
 
 impl_axum_webpage! {
@@ -33,10 +32,7 @@ impl_axum_webpage! {
 pub(crate) async fn sitemapindex_handler() -> impl IntoResponse {
     let sitemaps: Vec<char> = ('a'..='z').collect();
 
-    SitemapIndexXml {
-        sitemaps,
-        csp_nonce: String::new(),
-    }
+    SitemapIndexXml { sitemaps }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -52,7 +48,6 @@ struct SitemapRow {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SitemapXml {
     releases: Vec<SitemapRow>,
-    csp_nonce: String,
 }
 
 impl_axum_webpage! {
@@ -102,10 +97,7 @@ pub(crate) async fn sitemap_handler(
     .try_collect()
     .await?;
 
-    Ok(SitemapXml {
-        releases,
-        csp_nonce: String::new(),
-    })
+    Ok(SitemapXml { releases })
 }
 
 #[derive(Template)]
@@ -118,7 +110,6 @@ struct AboutBuilds {
     limits: Limits,
     /// Just for the template, since this isn't shared with AboutPage
     active_tab: &'static str,
-    csp_nonce: String,
 }
 
 impl_axum_webpage!(AboutBuilds);
@@ -131,7 +122,6 @@ pub(crate) async fn about_builds_handler(
         rustc_version: get_config::<String>(&mut conn, ConfigName::RustcVersion).await?,
         limits: Limits::new(&config),
         active_tab: "builds",
-        csp_nonce: String::new(),
     })
 }
 
@@ -141,7 +131,6 @@ macro_rules! about_page {
         #[template(path = $template)]
         struct $ty {
             active_tab: &'static str,
-            csp_nonce: String,
         }
 
         impl_axum_webpage! { $ty }
@@ -163,27 +152,22 @@ pub(crate) async fn about_handler(subpage: Option<Path<String>>) -> AxumResult<i
     let response = match &subpage[..] {
         "about" | "index" => AboutPage {
             active_tab: "index",
-            csp_nonce: String::new(),
         }
         .into_response(),
         "badges" => AboutPageBadges {
             active_tab: "badges",
-            csp_nonce: String::new(),
         }
         .into_response(),
         "metadata" => AboutPageMetadata {
             active_tab: "metadata",
-            csp_nonce: String::new(),
         }
         .into_response(),
         "redirections" => AboutPageRedirection {
             active_tab: "redirections",
-            csp_nonce: String::new(),
         }
         .into_response(),
         "download" => AboutPageDownload {
             active_tab: "download",
-            csp_nonce: String::new(),
         }
         .into_response(),
         _ => {
@@ -193,7 +177,6 @@ pub(crate) async fn about_handler(subpage: Option<Path<String>>) -> AxumResult<i
                 title: "The requested page does not exist",
                 message: msg.into(),
                 status: StatusCode::NOT_FOUND,
-                csp_nonce: String::new(),
             };
             page.into_response()
         }

--- a/src/web/source.rs
+++ b/src/web/source.rs
@@ -163,7 +163,6 @@ struct SourcePage {
     canonical_url: CanonicalUrl,
     is_file_too_large: bool,
     is_latest_url: bool,
-    csp_nonce: String,
 }
 
 impl_axum_webpage! {
@@ -338,7 +337,6 @@ pub(crate) async fn source_browser_handler(
         canonical_url,
         is_file_too_large,
         is_latest_url: params.version.is_latest(),
-        csp_nonce: String::new(),
     }
     .into_response())
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,6 +17,8 @@
 
         <title>{%- block title -%} Docs.rs {%- endblock title -%}</title>
 
+        {%- let csp_nonce = askama::get_value::<String>("csp_nonce").unwrap() -%}
+
         <script nonce="{{ csp_nonce }}">{%- include "theme.js" -%}</script>
         {%- block css -%}{%- endblock css -%}
 

--- a/templates/storage-change-detection.html
+++ b/templates/storage-change-detection.html
@@ -8,7 +8,7 @@
             ../templates/theme.js when rustdoc in the current window changes the
             theme
         -->
-        <script nonce="{{ csp_nonce }}" type="text/javascript">
+        <script nonce="{{ askama::get_value::<String>("csp_nonce").unwrap() }}" type="text/javascript">
             onstorage = function(ev) {
                 parent.postMessage({
                     storage: {


### PR DESCRIPTION
With the new version of `askama` came the runtime values, which allows to remove a loooot of fields. :D