### PR TITLE
fix build-test after breaking nightly proc-macro change

### DIFF
--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -1548,7 +1548,7 @@ mod tests {
     fn test_rustflags_are_passed_to_build_script() {
         wrapper(|env| {
             let crate_ = "proc-macro2";
-            let version = "1.0.33";
+            let version = "1.0.95";
             let mut builder = RustwideBuilder::init(env).unwrap();
             builder.update_toolchain()?;
             assert!(


### PR DESCRIPTION
This fixes the build-test breaking on master. 

Reason is https://github.com/rust-lang/rust/pull/139671, fixed in https://github.com/dtolnay/proc-macro2/pull/497, released in `proc-macro2 1.0.95`. 

The thing I'm not 100% certain is: we added this test in https://github.com/rust-lang/docs.rs/pull/1800, and I don't know if the new `proc-macro2` version also covers what we wanted to test here. 

<details>
<summary>full extracted error from the CI logs </summary>

```
[stderr]  Documenting proc-macro2 v1.0.33 (/opt/rustwide/workdir)    
[stderr] error[E0412]: cannot find type `SourceFile` in crate `proc_macro`    
[stderr]    --> src/wrapper.rs:362:26    
[stderr]     |    
[stderr] 362 |     Compiler(proc_macro::SourceFile),    
[stderr]     |                          ^^^^^^^^^^ not found in `proc_macro`    
[stderr]     |    
[stderr] help: consider importing one of these structs    
[stderr]     |    
[stderr] 1   + use crate::SourceFile;    
[stderr]     |    
[stderr] 1   + use crate::fallback::SourceFile;    
[stderr]     |    
[stderr] help: if you import `SourceFile`, refer to it directly    
[stderr]     |    
[stderr] 362 -     Compiler(proc_macro::SourceFile),    
[stderr] 362 +     Compiler(SourceFile),    
[stderr]     |    
[stderr]     
[stderr] error[E0412]: cannot find type `SourceFile` in crate `proc_macro`    
[stderr]    --> src/wrapper.rs:368:32    
[stderr]     |    
[stderr] 368 |     fn nightly(sf: proc_macro::SourceFile) -> Self {    
[stderr]     |                                ^^^^^^^^^^ not found in `proc_macro`    
[stderr]     |    
[stderr] help: consider importing one of these structs    
[stderr]     |    
[stderr] 1   + use crate::SourceFile;    
[stderr]     |    
[stderr] 1   + use crate::fallback::SourceFile;    
[stderr]     |    
[stderr] help: if you import `SourceFile`, refer to it directly    
[stderr]     |    
[stderr] 368 -     fn nightly(sf: proc_macro::SourceFile) -> Self {    
[stderr] 368 +     fn nightly(sf: SourceFile) -> Self {    

```

</details>