### PR TITLE
Rename sub menu label containing docs.rs information "docs.rs"

### DIFF
--- a/dockerfiles/run-gui-tests.sh
+++ b/dockerfiles/run-gui-tests.sh
@@ -38,4 +38,5 @@ SERVER_PID=$!
 # status="docker run . -v `pwd`:/build/out:ro gui_tests"
 docker compose run gui_tests
 status=$?
+kill $SERVER_PID
 exit $status

--- a/templates/header/topbar_end.html
+++ b/templates/header/topbar_end.html
@@ -6,9 +6,9 @@
 
                 <ul class="pure-menu-list">
                     {#
-                    The Rust dropdown menu
+                    The docs.rs dropdown menu
                     #}<li class="pure-menu-item pure-menu-has-children">
-                        <a href="#" class="pure-menu-link" aria-label="Rust">Rust</a>
+                        <a href="#" class="pure-menu-link" aria-label="docs.rs">docs.rs</a>
                         <ul class="pure-menu-children">
                             {% call macros::menu_link(
                                 href="/about",
@@ -20,6 +20,14 @@
                                 text="Privacy policy",
                                 target="_blank"
                             ) %}
+                        </ul>
+                    </li>
+                </ul>
+                <ul class="pure-menu-list">{#
+                    The Rust dropdown menu
+                    #}<li class="pure-menu-item pure-menu-has-children">
+                        <a href="#" class="pure-menu-link" aria-label="Rust">Rust</a>
+                        <ul class="pure-menu-children">
                             {% call macros::menu_link(
                                 href="https://www.rust-lang.org/",
                                 text="Rust website",

--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -138,8 +138,22 @@ div.nav-container {
             outline: unset;
         }
 
-        .docsrs-logo, .pure-menu-item a.pure-menu-link, .pure-menu-item .pure-menu-text {
-            padding: 6.4px 16px 6.4px 16px;
+        .pure-menu-item a.pure-menu-link {
+            padding: 6.4px 5px 6.4px 5px;
+
+            @media #{$media-sm} {
+                padding: 6.4px 10px 6.4px 10px;
+            }
+        }
+
+        .docsrs-logo, .pure-menu-item .pure-menu-text {
+            padding: 6.4px 10px 6.4px 10px;
+        }
+
+        @media #{$media-md} {
+            .docsrs-logo, .pure-menu-item .pure-menu-text, .pure-menu-item a.pure-menu-link {
+                padding: 6.4px 16px 6.4px 16px;
+            }
         }
 
         .pure-menu-link, .pure-menu-text {


### PR DESCRIPTION
The naming of this sub-menu is kinda unclear and definitely doesn't help finding information about docs.rs. So instead, let's rename it "docs.rs" directly to make it more obvious what it actually contains.