### PR TITLE
Build & upload rustdoc json output next to other docs 

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -815,6 +815,25 @@ pub(crate) fn rustdoc_archive_path(name: &str, version: &str) -> String {
     format!("rustdoc/{name}/{version}.zip")
 }
 
+#[derive(strum::Display, Debug, PartialEq, Eq)]
+#[strum(serialize_all = "snake_case")]
+pub(crate) enum RustdocJsonFormatVersion {
+    #[strum(serialize = "{0}")]
+    Version(u16),
+    Latest,
+}
+
+pub(crate) fn rustdoc_json_path(
+    name: &str,
+    version: &str,
+    target: &str,
+    format_version: RustdocJsonFormatVersion,
+) -> String {
+    format!(
+        "rustdoc-json/{name}/{version}/{target}/{name}_{version}_{target}_{format_version}.json.zst"
+    )
+}
+
 pub(crate) fn source_archive_path(name: &str, version: &str) -> String {
     format!("sources/{name}/{version}.zip")
 }


### PR DESCRIPTION
First part of #1285 

This first will just start building the json & put the files into the bucket & the logs into our log-storage. 

The handlers to access the JSON will follow in another PR. 


I think the whole builder needs a refactor so we don't need these huge methods any more, but I want to do that separately. 