### PR TITLE
don't compress json twice

### DIFF
--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -3155,7 +3155,7 @@ mod test {
             web.assert_redirect_cached_unchecked(
                 &format!("/crate/dummy/{request_path_suffix}"),
                 &format!("https://static.docs.rs/rustdoc-json/dummy/{redirect_version}/{redirect_target}/\
-                    dummy_{redirect_version}_{redirect_target}_{redirect_format_version}.json.zst"),
+                    dummy_{redirect_version}_{redirect_target}_{redirect_format_version}.json"),
                 CachePolicy::ForeverInCdn,
                 &env.config(),
             )


### PR DESCRIPTION
fixes #2833 

we don't need to compress twice. 

I was wondering which compression I want to keep, and decided it should be the content-encoding. 

This means browsers would be able to live-decode, which would enable easier building of browser apps using this json. 

