### PR TITLE
revert onig_sys patch, update onig & onig-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4596,11 +4596,11 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "onig"
-version = "6.4.0"
+version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.1",
  "libc",
  "once_cell",
  "onig_sys",
@@ -4608,8 +4608,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.8.1"
-source = "git+https://github.com/rust-onig/rust-onig?rev=c4378abcbf30d58cf5f230c0d2e6375f2be05a47#c4378abcbf30d58cf5f230c0d2e6375f2be05a47"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,8 +141,3 @@ harness = false
 name = "cratesfyi"
 test = false
 doc = false
-
-[patch.crates-io.onig_sys]
-# Once new version (> 69.8.1) is released, we can remove this patch.
-git = "https://github.com/rust-onig/rust-onig"
-rev = "c4378abcbf30d58cf5f230c0d2e6375f2be05a47"


### PR DESCRIPTION
reverts `onig_sys` patch from a1a3d06804682dad0eac6c6318472f4b0991690c . 

updates `onig` and `onig_sys`: 

```
$ cargo update -p onig
    Updating crates.io index
     Locking 2 packages to latest Rust 1.87.0 compatible versions
    Updating onig v6.4.0 -> v6.5.1
      Adding onig_sys v69.9.1
    Removing onig_sys v69.8.1 (https://github.com/rust-onig/rust-onig?rev=c4378abcbf30d58cf5f230c0d2e6375f2be05a47#c4378abc)
```