### PR TITLE
Fix JS error when menu is closed and alt key is pressed

### DIFF
--- a/static/menu.js
+++ b/static/menu.js
@@ -281,7 +281,10 @@
                 e.preventDefault();
                 e.stopPropagation();
             }
-        } else if (e.target.parentNode.classList.contains("pure-menu-has-children")) {
+        } else if (e.target.parentNode &&
+            e.target.parentNode.classList &&
+            e.target.parentNode.classList.contains("pure-menu-has-children")
+        ) {
             switch (e.key.toLowerCase()) {
                 case "arrowdown":
                 case "down":


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/972f8e27-518a-4b0d-a934-d6259f880b7e)

Here's how I trigger the bug:

1. Open a topbar menu.
2. Close it by clicking on text in the document
3. Press the `alt` key.

Now the fun part: it doesn't happen all the time so can't really write a GUI test for it. ^^'