### PR TITLE
support streaming content from S3, start using it in the webserver

### DIFF
--- a/.sqlx/query-2fd2aad681960b30ca5149dfc7050c477667d5f022349661385026c757df88cc.json
+++ b/.sqlx/query-2fd2aad681960b30ca5149dfc7050c477667d5f022349661385026c757df88cc.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT\n                     path, mime, date_updated, compression,\n                     (CASE WHEN LENGTH(content) <= $2 THEN content ELSE NULL END) AS content,\n                     (LENGTH(content) > $2) AS \"is_too_big!\"\n                 FROM files\n                 WHERE path = $1;",
+  "query": "SELECT\n                     path, mime, date_updated, compression,\n                     substring(content from $2 for $3) as content\n                 FROM files\n                 WHERE path = $1;",
   "describe": {
     "columns": [
       {
@@ -27,16 +27,12 @@
         "ordinal": 4,
         "name": "content",
         "type_info": "Bytea"
-      },
-      {
-        "ordinal": 5,
-        "name": "is_too_big!",
-        "type_info": "Bool"
       }
     ],
     "parameters": {
       "Left": [
         "Text",
+        "Int4",
         "Int4"
       ]
     },
@@ -45,9 +41,8 @@
       false,
       false,
       true,
-      null,
       null
     ]
   },
-  "hash": "f0239a895d0ef72aff8d99f77a35656d2642564a6a3c40d742fc1b62d1c80d59"
+  "hash": "2fd2aad681960b30ca5149dfc7050c477667d5f022349661385026c757df88cc"
 }

--- a/.sqlx/query-ce9cf294c964be76b19585a35c37f4b3643b09cfea98ed8ba13e4dadb5b5e48c.json
+++ b/.sqlx/query-ce9cf294c964be76b19585a35c37f4b3643b09cfea98ed8ba13e4dadb5b5e48c.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT\n                     path, mime, date_updated, compression,\n                     substring(content from $2 for $3) as content,\n                     FALSE as \"is_too_big!\"\n                 FROM files\n                 WHERE path = $1;",
+  "query": "SELECT\n                     path,\n                     mime,\n                     date_updated,\n                     compression,\n                     content\n                 FROM files\n                 WHERE path = $1;",
   "describe": {
     "columns": [
       {
@@ -27,18 +27,11 @@
         "ordinal": 4,
         "name": "content",
         "type_info": "Bytea"
-      },
-      {
-        "ordinal": 5,
-        "name": "is_too_big!",
-        "type_info": "Bool"
       }
     ],
     "parameters": {
       "Left": [
-        "Text",
-        "Int4",
-        "Int4"
+        "Text"
       ]
     },
     "nullable": [
@@ -46,9 +39,8 @@
       false,
       false,
       true,
-      null,
-      null
+      true
     ]
   },
-  "hash": "3bdc47a7b7457e290e2c63f9c22742d17a52940631caa0688d3c8b5e2c3765c8"
+  "hash": "ce9cf294c964be76b19585a35c37f4b3643b09cfea98ed8ba13e4dadb5b5e48c"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,15 +370,18 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d615619615a650c571269c00dca41db04b9210037fa76ed8239f70404ab56985"
+checksum = "40f6024f3f856663b45fd0c9b6f2024034a702f453549449e0d84a305900dad4"
 dependencies = [
+ "bzip2 0.6.0",
  "flate2",
  "futures-core",
  "memchr",
  "pin-project-lite",
  "tokio",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -1214,6 +1217,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea8dcd42434048e4f7a304411d9273a411f647446c1234a65ce0554923f4cff"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,6 +1956,7 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "askama",
+ "async-compression",
  "async-stream",
  "async-trait",
  "aws-config",
@@ -1957,7 +1970,7 @@ dependencies = [
  "axum-extra",
  "backtrace",
  "base64 0.22.1",
- "bzip2",
+ "bzip2 0.5.2",
  "chrono",
  "clap",
  "comrak",
@@ -2018,6 +2031,7 @@ dependencies = [
  "thread_local",
  "time",
  "tokio",
+ "tokio-util",
  "toml",
  "tower",
  "tower-http",
@@ -4087,6 +4101,12 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775bf80d5878ab7c2b1080b5351a48b2f737d9f6f8b383574eebcc22be0dfccb"
 
 [[package]]
 name = "libc"
@@ -7930,7 +7950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "153a6fff49d264c4babdcfa6b4d534747f520e56e8f0f384f3b808c4b64cc1fd"
 dependencies = [
  "arbitrary",
- "bzip2",
+ "bzip2 0.5.2",
  "crc32fast",
  "indexmap 2.9.0",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,10 @@ derive_more = { version = "2.0.0", features = ["display"] }
 
 # Async
 tokio = { version = "1.0", features = ["rt-multi-thread", "signal", "macros"] }
+tokio-util = { version = "0.7.15", default-features = false, features = ["io"] }
 futures-util = "0.3.5"
 async-stream = "0.3.5"
+async-compression = { version = "0.4.25", features = ["tokio", "bzip2", "zstd", "gzip"] }
 aws-config = "1.0.0"
 aws-sdk-s3 = "1.3.0"
 aws-sdk-cloudfront = "1.3.0"

--- a/src/utils/html.rs
+++ b/src/utils/html.rs
@@ -1,8 +1,9 @@
-use crate::web::page::templates::{Body, Head, Vendored};
-use crate::web::rustdoc::RustdocPage;
+use crate::web::{
+    page::templates::{Body, Head, Vendored},
+    rustdoc::RustdocPage,
+};
 use askama::Template;
-use lol_html::element;
-use lol_html::errors::RewritingError;
+use lol_html::{element, errors::RewritingError};
 
 /// Rewrite a rustdoc page to have the docs.rs topbar
 ///


### PR DESCRIPTION
First step of streaming support for content. Adds streaming support to our storage backends (only for testing in the db backend, so no real streaming there). Then uses axum's streaming response feature to stream the responses to the client. 

Idea is also to give up size limits since we don't have memory issues any more. 


Next steps after this: 
- also support rustdoc html content by using the streaming functionality of lol-html. This needs some wrapping since lol-html doesn't do async yet. Probably using the rendering background thread & some channels. 
- start with streaming uploads too. 

My guess is that all content rendered via askama can't really be streamed, perhaps I switch to a manual streaming impl for bigger streamable things like the sitemap endpoints. 