### PR TITLE
Update `browser-ui-test` version to `0.21.0`

### DIFF
--- a/dockerfiles/Dockerfile-gui-tests
+++ b/dockerfiles/Dockerfile-gui-tests
@@ -74,7 +74,7 @@ RUN mkdir out
 # https://github.com/puppeteer/puppeteer/issues/375
 #
 # We also specify the version in case we need to update it to go around cache limitations.
-RUN npm install -g browser-ui-test@0.20.5 --unsafe-perm=true
+RUN npm install -g browser-ui-test@0.21.0 --unsafe-perm=true
 
 EXPOSE 3000
 


### PR DESCRIPTION
New version of `browser-ui-test` fail if a JS error is encountered at any point. Would likely have helped detect https://github.com/rust-lang/docs.rs/pull/2846 much sooner. :)