### PR TITLE
Categorize crates.io API errors

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -119,6 +119,8 @@ pub struct Config {
     pub(crate) build_cpu_limit: Option<u32>,
     pub(crate) build_default_memory_limit: Option<usize>,
     pub(crate) include_default_targets: bool,
+
+    #[allow(dead_code)]
     pub(crate) disable_memory_limit: bool,
 
     // automatic rebuild configuration

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,7 +120,7 @@ pub struct Config {
     pub(crate) build_default_memory_limit: Option<usize>,
     pub(crate) include_default_targets: bool,
 
-    #[allow(dead_code)]
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub(crate) disable_memory_limit: bool,
 
     // automatic rebuild configuration

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -260,8 +260,7 @@ fn handle_registry_error(err: anyhow::Error) -> Result<SearchResult, SearchError
         if let Some(status) = registry_request_error.status() {
             if status.is_client_error() || status.is_server_error() {
                 return Err(SearchError::CratesIo(format!(
-                    "crates.io returned {}: {}",
-                    status, registry_request_error
+                    "crates.io returned {status}: {registry_request_error}"
                 )));
             }
         }
@@ -273,10 +272,7 @@ fn handle_registry_error(err: anyhow::Error) -> Result<SearchResult, SearchError
 //Error message to gracefully display
 fn create_search_error_response(query: String, sort_by: String, error_message: String) -> Search {
     Search {
-        title: format!(
-            "Search service is not currently available: {}",
-            error_message
-        ),
+        title: format!("Search service is not currently available: {error_message}"),
         releases: vec![],
         search_query: Some(query),
         search_sort_by: Some(sort_by),

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -256,14 +256,13 @@ async fn get_search_results(
 // Categorize  errors from registry
 fn handle_registry_error(err: anyhow::Error) -> Result<SearchResult, SearchError> {
     // Capture crates.io API error
-    if let Some(registry_request_error) = err.downcast_ref::<reqwest::Error>() {
-        if let Some(status) = registry_request_error.status() {
-            if status.is_client_error() || status.is_server_error() {
-                return Err(SearchError::CratesIo(format!(
-                    "crates.io returned {status}: {registry_request_error}"
-                )));
-            }
-        }
+    if let Some(registry_request_error) = err.downcast_ref::<reqwest::Error>()
+        && let Some(status) = registry_request_error.status()
+        && (status.is_client_error() || status.is_server_error())
+    {
+        return Err(SearchError::CratesIo(format!(
+            "crates.io returned {status}: {registry_request_error}"
+        )));
     }
     // Move all other error types to this wrapper
     Err(SearchError::Other(err))

--- a/src/web/releases.rs
+++ b/src/web/releases.rs
@@ -2376,6 +2376,11 @@ mod tests {
                     .text_contents()
                     .contains("We're having issues communicating with crates.io")
             );
+            assert!(
+                parse_html.text_contents().contains("501")
+                    || parse_html.text_contents().contains("500")
+            );
+            assert!(parse_html.text_contents().contains("crates.io returned"));
             Ok(())
         })
     }


### PR DESCRIPTION
This PR improves error handling for queries to the `crates.io` API by categorizing error responses and updating how they are surfaced to users. Instead of logging 4xx or 5xx errors and reporting them to sentry, now we simply show them directly to the user.

Previously, all errors from the crates.io API were logged and reported to Sentry. By surfacing these errors to users, we get to reduce noise in the tracking system and provide more descriptive responses.

Closes #2480 