### PR TITLE
Add a link in docs.rs menu to the build queue

### DIFF
--- a/templates/header/topbar_end.html
+++ b/templates/header/topbar_end.html
@@ -20,6 +20,11 @@
                                 text="Privacy policy",
                                 target="_blank"
                             ) %}
+                            {% call macros::menu_link(
+                                href="/releases/queue",
+                                text="Build queue",
+                                target="",
+                            ) %}
                         </ul>
                     </li>
                 </ul>


### PR DESCRIPTION
Since users can now retrigger crate docs build from crates.io, I think it'll become common enough for them to see where the doc build of their crate is at.