### PR TITLE
Fix dark theme table header text color

### DIFF
--- a/templates/style/_themes.scss
+++ b/templates/style/_themes.scss
@@ -62,7 +62,7 @@ html[data-docs-rs-theme="dark"] {
   --color-warn: #e57300;
   --color-background-input: #f0f0f0;
   --color-table-header-background: #545252;
-  --color-table-header: #000;
+  --color-table-header: #c0c0c0;
   --color-search-focus: #078dd8;
   --chart-title-color: #c0c0c0;
   --chart-grid: #4e4e4e;


### PR DESCRIPTION
Currently:

![Screenshot From 2025-07-02 11-37-03](https://github.com/user-attachments/assets/e0fa057e-cdd5-4154-9ead-ff1c47a3b723)

With this PR:

![image](https://github.com/user-attachments/assets/7d7fc9e7-4900-4c20-9c64-3a8aac943a49)
