### PR TITLE
Add link to the build queue when crate is building/in the build queue

### DIFF
--- a/templates/crate/builds.html
+++ b/templates/crate/builds.html
@@ -31,51 +31,56 @@
                 </div>
 
                 <ul>
+                    <li>
                     {%- for build in builds -%}
-                        {% set close_tag %}
                         <li>
-                            {%- if build.build_status != "in_progress" %}
-                            <a href="/crate/{{ metadata.name }}/{{ metadata.version }}/builds/{{ build.id }}" class="release">
-                            {% set close_tag = "a" %}
+                            {%- if build.build_status != "in_progress" -%}
+                                <a href="/crate/{{ metadata.name }}/{{ metadata.version }}/builds/{{ build.id }}" class="release"> {#- -#}
+                                    <div class="pure-g"> {#- -#}
+                                        <div class="pure-u-1 pure-u-sm-1-24 build">
+                                            {%- if build.build_status == "success" -%}
+                                                {{ crate::icons::IconCheck.render_solid(false, false, "") }}
+                                            {%- elif build.build_status == "failure" -%}
+                                                {{ crate::icons::IconTriangleExclamation.render_solid(false, false, "") }}
+                                            {%- else -%}
+                                                {{ crate::icons::IconX.render_solid(false, false, "") }}
+                                            {%- endif -%}
+                                        </div> {#- -#}
+                                        <div class="pure-u-1 pure-u-sm-10-24">
+                                            {%- if let Some(rustc_version) = build.rustc_version -%}
+                                                {{ rustc_version }}
+                                            {%- else -%}
+                                                &mdash;
+                                            {%- endif -%}
+                                        </div> {#- -#}
+                                        <div class="pure-u-1 pure-u-sm-10-24">
+                                            {%- if let Some(docsrs_version) = build.docsrs_version -%}
+                                                {{ docsrs_version }}
+                                            {%- else -%}
+                                                &mdash;
+                                            {%- endif -%}
+                                        </div> {#- -#}
+                                        <div class="pure-u-1 pure-u-sm-3-24 date">
+                                            {%- if let Some(build_time) = build.build_time -%}
+                                                {{ build_time|timeformat }}
+                                            {%- else -%}
+                                                &mdash;
+                                            {%- endif -%}
+                                        </div> {#- -#}
+                                    </div> {#- -#}
+                                </a>
                             {%- else -%}
-                            <div class="build-in-progress">
-                            {% set close_tag = "div" %}
-                            {%- endif %}
-                                <div class="pure-g">
-                                    <div class="pure-u-1 pure-u-sm-1-24 build">
-                                        {%- if build.build_status == "success" -%}
-                                            {{ crate::icons::IconCheck.render_solid(false, false, "") }}
-                                        {%- elif build.build_status == "failure" -%}
-                                            {{ crate::icons::IconTriangleExclamation.render_solid(false, false, "") }}
-                                        {%- elif build.build_status == "in_progress" -%}
-                                            {{ crate::icons::IconGear.render_solid(false, true, "") }}
-                                        {%- else -%}
-                                            {{ crate::icons::IconX.render_solid(false, false, "") }}
-                                        {%- endif -%}
-                                    </div>
-                                    <div class="pure-u-1 pure-u-sm-10-24">
-                                        {%- if let Some(rustc_version) = build.rustc_version -%}
-                                            {{ rustc_version }}
-                                        {%- else -%}
-                                            &mdash;
-                                        {%- endif -%}
-                                    </div>
-                                    <div class="pure-u-1 pure-u-sm-10-24">
-                                        {%- if let Some(docsrs_version) = build.docsrs_version -%}
-                                            {{ docsrs_version }}
-                                        {%- else -%}
-                                            &mdash;
-                                        {%- endif -%}
-                                    </div>
-                                    <div class="pure-u-1 pure-u-sm-3-24 date">
-                                        {%- if let Some(build_time) = build.build_time -%}
-                                            {{ build_time|timeformat }}
-                                        {%- else -%}
-                                            &mdash;
-                                        {%- endif -%}
+                                <div class="build-in-progress">
+                                    <div class="pure-g"> {#- -#}
+                                        <div class="pure-u-1 pure-u-sm-1-24 build">
+                                            {{- crate::icons::IconGear.render_solid(false, true, "") -}}
+                                        </div> {#- -#}
+                                        <div class="pure-u-1 pure-u-sm-23-24 build"> {#- -#}
+                                            In the <a href="/releases/queue" class="normal">build queue</a> {#- -#}
+                                        </div>
                                     </div>
                                 </div>
-                            </{{ close_tag }}>
+                            {%- endif -%}
                         </li>
                     {%- endfor -%}
                 </ul>

--- a/templates/style/style.scss
+++ b/templates/style/style.scss
@@ -304,10 +304,6 @@ div.recent-releases-container {
         padding: 0.4em $search-result-right-left-padding;
         color: var(--color-standard);
 
-        a {
-            color: var(--color-standard);
-        }
-
         @media #{$media-lg} {
             padding: 0.4em 0;
             margin: 0 1em;


### PR DESCRIPTION
It now looks like this:

![image](https://github.com/user-attachments/assets/bbfd3bf4-d148-4349-978b-62b6891f6782)