### PR TITLE
ci: don't override rust toolchain, so rust-toolchain.toml is actually used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: update rust toolchain
-        run: |
-          rustup override set stable
-          rustup update stable
-
       - name: install `just`
         run: sudo snap install --edge --classic just
 
@@ -76,11 +71,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: update rust toolchain
-        run: |
-          rustup override set stable
-          rustup update stable
-
       - name: restore build & cargo cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -117,11 +107,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: update rust toolchain
-        run: |
-          rustup override set stable
-          rustup update stable
-
       - name: restore build & cargo cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -150,10 +135,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: update rust toolchain
-        run: |
-          rustup override set stable
-          rustup update stable
-          rustup component add rustfmt
+        run: rustup component add rustfmt
 
       - run: cargo fmt -- --check
 
@@ -165,10 +147,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: update rust toolchain
-        run: |
-          rustup override set stable
-          rustup update stable
-          rustup component add clippy
+        run: rustup component add clippy
 
       - name: install `just`
         run: sudo snap install --edge --classic just

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.88.0"


### PR DESCRIPTION
seeing https://github.com/rust-lang/docs.rs/pull/2852 I actually realized that our `rust-toolchain.toml` was actually never used in CI. 

This changes here. 