### PR TITLE
Link directly to crates.io page to retrigger a documentation build

### DIFF
--- a/templates/crate/build_details.html
+++ b/templates/crate/build_details.html
@@ -26,7 +26,7 @@
             </div>
 
             {%- if build_details.build_status  == "failure" -%}
-                <p class="build-info">{{ crate::icons::IconTriangleExclamation.render_solid(false, false, "") }} Build failed. If you want to re-trigger a documentation build, you can do it on <a href="https://crates.io/crates/{{metadata.name}}/versions">crates.io</a>. You can find more information on <b>docs.rs</b> builds documentation on the <a href="/about/builds">builds page</a>.</p>
+                <p class="build-info">{{ crate::icons::IconTriangleExclamation.render_solid(false, false, "") }} Build failed. If you want to re-trigger a documentation build, you can do it <a href="https://crates.io/crates/{{metadata.name}}/{{metadata.version}}/rebuild-docs">here</a>. You can find more information on <b>docs.rs</b> builds documentation on the <a href="/about/builds">builds page</a>.</p>
             {%- endif -%}
 
             <ul>


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/crates.io/pull/11508.