### PR TITLE
ensure current tracing span is passed into streaming html rewrite

### DIFF
--- a/src/utils/html.rs
+++ b/src/utils/html.rs
@@ -42,7 +42,11 @@ pub(crate) fn rewrite_rustdoc_html_stream<R>(
 where
     R: AsyncRead + Unpin + 'static,
 {
+    let span = tracing::info_span!("rewrite_rustdoc_html_stream");
+
     stream!({
+        let _guard = span.enter();
+
         let (input_sender, input_receiver) = std::sync::mpsc::channel::<Option<Vec<u8>>>();
         let (result_sender, mut result_receiver) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
 


### PR DESCRIPTION
I want to 
- see the parent spans from the request when logging errors while rewriting 
- have a separate span for performance tracing the rewriter. 

Coming from [these errors](https://rust-lang.sentry.io/issues/6775662340/?environment=production&project=5499376&query=is%3Aunresolved&referrer=issue-stream), where I want to see if they are flakes. 