### PR TITLE
Remove `once_cell` whenever possible

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,15 +2,14 @@ use anyhow::{Context as _, Error, Result};
 use std::{env, path::Path};
 
 mod tracked {
-    use once_cell::sync::Lazy;
     use std::{
         collections::HashSet,
         io::{Error, Result},
         path::{Path, PathBuf},
-        sync::Mutex,
+        sync::{LazyLock, Mutex},
     };
 
-    static SEEN: Lazy<Mutex<HashSet<PathBuf>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+    static SEEN: LazyLock<Mutex<HashSet<PathBuf>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
 
     pub(crate) fn track(path: impl AsRef<Path>) -> Result<()> {
         let path = path.as_ref();

--- a/src/db/mimes.rs
+++ b/src/db/mimes.rs
@@ -1,9 +1,9 @@
 use mime::Mime;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 macro_rules! mime {
     ($id:ident, $mime:expr) => {
-        pub(crate) static $id: Lazy<Mime> = Lazy::new(|| $mime.parse().unwrap());
+        pub(crate) static $id: LazyLock<Mime> = LazyLock::new(|| $mime.parse().unwrap());
     };
 }
 

--- a/src/repositories/updater.rs
+++ b/src/repositories/updater.rs
@@ -5,10 +5,10 @@ use crate::{Config, db::Pool};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures_util::stream::TryStreamExt;
-use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::sync::LazyLock;
 use tracing::{debug, info, trace, warn};
 
 #[async_trait]
@@ -309,7 +309,7 @@ impl RepositoryStatsUpdater {
 }
 
 pub(crate) fn repository_name(url: &str) -> Option<RepositoryName> {
-    static RE: Lazy<Regex> = Lazy::new(|| {
+    static RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"https?://(?P<host>[^/]+)/(?P<owner>[\w\._/-]+)/(?P<repo>[\w\._-]+)").unwrap()
     });
 

--- a/src/utils/rustc_version.rs
+++ b/src/utils/rustc_version.rs
@@ -1,8 +1,8 @@
 use crate::error::Result;
 use anyhow::{Context, anyhow};
 use chrono::prelude::*;
-use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::LazyLock;
 
 /// Parses rustc commit hash from rustc version string
 pub fn parse_rustc_version<S: AsRef<str>>(version: S) -> Result<String> {
@@ -22,7 +22,7 @@ pub fn parse_rustc_version<S: AsRef<str>>(version: S) -> Result<String> {
 }
 
 pub(crate) fn parse_rustc_date<S: AsRef<str>>(version: S) -> Result<NaiveDate> {
-    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r" (\d+)-(\d+)-(\d+)\)$").unwrap());
+    static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r" (\d+)-(\d+)-(\d+)\)$").unwrap());
 
     let cap = RE
         .captures(version.as_ref())

--- a/src/web/highlight.rs
+++ b/src/web/highlight.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use syntect::{
     html::{ClassStyle, ClassedHTMLGenerator},
     parsing::{SyntaxReference, SyntaxSet},
@@ -13,7 +13,7 @@ const PER_LINE_BYTE_LENGTH_LIMIT: usize = 512;
 #[error("the code exceeded a highlighting limit")]
 pub struct LimitsExceeded;
 
-static SYNTAXES: Lazy<SyntaxSet> = Lazy::new(|| {
+static SYNTAXES: LazyLock<SyntaxSet> = LazyLock::new(|| {
     static SYNTAX_DATA: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/syntect.packdump"));
 
     let syntaxes: SyntaxSet = syntect::dumps::from_uncompressed_data(SYNTAX_DATA).unwrap();

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -33,12 +33,11 @@ use axum::{
     response::{IntoResponse, Response as AxumResponse},
 };
 use http::{HeaderValue, header};
-use once_cell::sync::Lazy;
 use semver::Version;
 use serde::Deserialize;
 use std::{
     collections::{BTreeMap, HashMap},
-    sync::Arc,
+    sync::{Arc, LazyLock},
 };
 use tracing::{Instrument, debug, error, info_span, instrument, trace};
 
@@ -50,8 +49,8 @@ pub(crate) struct OfficialCrateDescription {
     pub(crate) description: &'static str,
 }
 
-pub(crate) static DOC_RUST_LANG_ORG_REDIRECTS: Lazy<HashMap<&str, OfficialCrateDescription>> =
-    Lazy::new(|| {
+pub(crate) static DOC_RUST_LANG_ORG_REDIRECTS: LazyLock<HashMap<&str, OfficialCrateDescription>> =
+    LazyLock::new(|| {
         HashMap::from([
             (
                 "alloc",


### PR DESCRIPTION
The only thing remaining to completely get rid of it is for `get_or_try_init` feature to be stabilized. So for now, it remains used in `cratesfyi` and in the tests.