### PR TITLE
Revert "ensure current tracing span is passed into streaming html rewrite"

### DIFF
--- a/src/utils/html.rs
+++ b/src/utils/html.rs
@@ -42,11 +42,7 @@ pub(crate) fn rewrite_rustdoc_html_stream<R>(
 where
     R: AsyncRead + Unpin + 'static,
 {
-    let span = tracing::info_span!("rewrite_rustdoc_html_stream");
-
     stream!({
-        let _guard = span.enter();
-
         let (input_sender, input_receiver) = std::sync::mpsc::channel::<Option<Vec<u8>>>();
         let (result_sender, mut result_receiver) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
 


### PR DESCRIPTION
This reverts commit bfdb52219aa396de9e21cd3377b81fddfb1f39dd.

This leads to memory issues in production, likely some async-drop issue