### PR TITLE
fix: Automatically install nightly toolchain when missing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -119,6 +119,7 @@ pub struct Config {
     pub(crate) build_cpu_limit: Option<u32>,
     pub(crate) build_default_memory_limit: Option<usize>,
     pub(crate) include_default_targets: bool,
+    #[allow(dead_code)]
     pub(crate) disable_memory_limit: bool,
 
     // automatic rebuild configuration


### PR DESCRIPTION
This change ensures that the required Rust toolchain is installed automatically if it is missing.

Fixes: #2051 