### PR TITLE
Fix lifetime warning by explicitly inferring from context

### DIFF
--- a/src/repositories/updater.rs
+++ b/src/repositories/updater.rs
@@ -308,7 +308,7 @@ impl RepositoryStatsUpdater {
     }
 }
 
-pub(crate) fn repository_name(url: &str) -> Option<RepositoryName> {
+pub(crate) fn repository_name(url: &str) -> Option<RepositoryName<'_>> {
     static RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"https?://(?P<host>[^/]+)/(?P<owner>[\w\._/-]+)/(?P<repo>[\w\._-]+)").unwrap()
     });


### PR DESCRIPTION
Look below for context:
```
--> src/repositories/updater.rs:311:36
     |
     | pub(crate) fn repository_name(url: &str) -> Option<RepositoryName> {
     |                                    ^^^^            -------------- the same lifetime is hidden here
     |                                    |
     |                                    the lifetime is elided here
     |
     = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
````