### PR TITLE
Revert "update to rust 1.89.0"

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.88.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This reverts commit b1cd544010562f07acbd4d2fe7f0c9cc0dbff05e.