### PR TITLE
fix: align header button text/icons vertically

### DIFF
--- a/templates/style/_navbar.scss
+++ b/templates/style/_navbar.scss
@@ -140,6 +140,7 @@ div.nav-container {
 
         .pure-menu-item a.pure-menu-link {
             padding: 6.4px 5px 6.4px 5px;
+            align-content: center;
 
             @media #{$media-sm} {
                 padding: 6.4px 10px 6.4px 10px;
@@ -148,6 +149,7 @@ div.nav-container {
 
         .docsrs-logo, .pure-menu-item .pure-menu-text {
             padding: 6.4px 10px 6.4px 10px;
+            align-content: center;
         }
 
         @media #{$media-md} {


### PR DESCRIPTION
Tweaks the CSS for the docs.rs header bar to align the text+icons vertically within the buttons/anchors. They are now aligned with the text in the search input.

Quite nitpicky and kinda hard to tell from these diffs below but 🤷

| before | after |
|--------|--------|
| <img width="1339" height="352" alt="wide_before" src="https://github.com/user-attachments/assets/c09f5e0e-10a0-4605-b710-67ffe054e03d" /> | <img width="1339" height="352" alt="wide_after" src="https://github.com/user-attachments/assets/44024266-995e-4d42-950b-26a95b565f3f" /> | 
| <img width="1339" height="352" alt="skinny_before" src="https://github.com/user-attachments/assets/26115b07-4798-4e89-a959-4d9d783e4f89" /> | <img width="1339" height="352" alt="skinny_after" src="https://github.com/user-attachments/assets/d58f67f5-997b-4bca-ad44-2e8d3e811a9e" /> |


p.s. nice work on the rust docs!
