### PR TITLE
run cargo update, upgrade rustwide, string_cache & zip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8697,9 +8697,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "4.6.1"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+checksum = "2f852905151ac8d4d06fdca66520a661c09730a74c6d4e2b0f27b436b382e532"
 dependencies = [
  "arbitrary",
  "bzip2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ lol_html = "2.0.0"
 font-awesome-as-a-crate = { path = "crates/font-awesome-as-a-crate" }
 dashmap = "6.0.0"
 string_cache = "0.9.0"
-zip = {version = "4.0.0", default-features = false, features = ["bzip2"]}
+zip = {version = "5.1.1", default-features = false, features = ["bzip2"]}
 bzip2 = "0.6.0"
 getrandom = "0.3.1"
 itertools = { version = "0.14.0" }


### PR DESCRIPTION
* https://github.com/rust-lang/rustwide/blob/master/CHANGELOG.md#0200---2025-08-22
* https://github.com/servo/string-cache/compare/v0.8.9...v0.9.0 (update is just the breaking upgrade of `phf_shared`) 
* https://github.com/servo/string-cache/compare/codegen-v0.5.4...string_cache_codegen-v0.6.0
* zip: reason for the breaking release: https://github.com/zip-rs/zip2/pull/415


### `cargo update`
```
Updating actix-http v3.11.0 -> v3.11.1
    Updating actix-rt v2.10.0 -> v2.11.0
    Removing android-tzdata v0.1.1
    Updating async-compression v0.4.27 -> v0.4.30
    Updating aws-config v1.8.5 -> v1.8.6
    Updating aws-credential-types v1.2.5 -> v1.2.6
    Updating aws-lc-rs v1.13.3 -> v1.14.0
    Updating aws-lc-sys v0.30.0 -> v0.31.0
    Updating aws-sdk-cloudfront v1.92.0 -> v1.94.0
    Updating aws-sdk-s3 v1.103.0 -> v1.105.0
    Updating aws-sdk-sso v1.81.0 -> v1.83.0
    Updating aws-sdk-ssooidc v1.82.0 -> v1.84.0
    Updating aws-sdk-sts v1.84.0 -> v1.85.0
    Updating aws-smithy-checksums v0.63.7 -> v0.63.8
    Updating aws-smithy-http-client v1.1.0 -> v1.1.1
    Updating aws-smithy-json v0.61.4 -> v0.61.5
    Updating aws-smithy-runtime v1.9.0 -> v1.9.2
    Updating bindgen v0.69.5 -> v0.72.1
    Updating bitflags v2.9.2 -> v2.9.4
    Updating cc v1.2.33 -> v1.2.36
    Updating chrono v0.4.41 -> v0.4.42
    Updating clap v4.5.45 -> v4.5.47
    Updating clap_builder v4.5.44 -> v4.5.47
    Updating clap_derive v4.5.45 -> v4.5.47
      Adding compression-codecs v0.4.30
      Adding compression-core v0.4.29
    Updating deranged v0.4.0 -> v0.5.3
    Updating errno v0.3.13 -> v0.3.14
      Adding find-msvc-tools v0.1.1
    Updating indexmap v2.10.0 -> v2.11.1
    Updating io-uring v0.7.9 -> v0.7.10
    Removing itertools v0.12.1
    Updating jobserver v0.1.33 -> v0.1.34
    Updating js-sys v0.3.77 -> v0.3.78
    Removing lazycell v1.3.0
    Updating libz-rs-sys v0.5.1 -> v0.5.2
    Removing linux-raw-sys v0.4.15
    Removing linux-raw-sys v0.9.4
      Adding linux-raw-sys v0.11.0
    Updating log v0.4.27 -> v0.4.28
    Updating memmap2 v0.9.7 -> v0.9.8
    Updating normpath v1.3.0 -> v1.4.0
    Updating potential_utf v0.1.2 -> v0.1.3
    Updating quick-xml v0.38.2 -> v0.38.3
    Updating regex v1.11.1 -> v1.11.2
    Updating regex-automata v0.4.9 -> v0.4.10
    Updating regex-lite v0.1.6 -> v0.1.7
    Updating regex-syntax v0.8.5 -> v0.8.6
    Removing rustc-hash v1.1.0
    Removing rustix v0.38.44
    Removing rustix v1.0.8
      Adding rustix v1.1.2
    Updating rustls-webpki v0.103.4 -> v0.103.5
    Updating schannel v0.1.27 -> v0.1.28
    Updating security-framework v3.3.0 -> v3.4.0
    Updating security-framework-sys v2.14.0 -> v2.15.0
    Updating tempfile v3.21.0 -> v3.22.0
    Updating time v0.3.41 -> v0.3.43
    Updating time-core v0.1.4 -> v0.1.6
    Updating time-macros v0.2.22 -> v0.2.24
    Updating unicode-ident v1.0.18 -> v1.0.19
    Updating ureq v3.1.0 -> v3.1.2
    Updating ureq-proto v0.5.0 -> v0.5.2
    Updating url v2.5.6 -> v2.5.7
    Updating uuid v1.18.0 -> v1.18.1
    Updating wasi v0.14.2+wasi-0.2.4 -> v0.14.5+wasi-0.2.4
      Adding wasip2 v1.0.0+wasi-0.2.4
    Updating wasm-bindgen v0.2.100 -> v0.2.101
    Updating wasm-bindgen-backend v0.2.100 -> v0.2.101
    Updating wasm-bindgen-futures v0.4.50 -> v0.4.51
    Updating wasm-bindgen-macro v0.2.100 -> v0.2.101
    Updating wasm-bindgen-macro-support v0.2.100 -> v0.2.101
    Updating wasm-bindgen-shared v0.2.100 -> v0.2.101
    Updating web-sys v0.3.77 -> v0.3.78
    Removing which v4.4.2
    Updating winapi-util v0.1.10 -> v0.1.11
      Adding windows-link v0.2.0
      Adding windows-sys v0.61.0
    Updating winnow v0.7.12 -> v0.7.13
      Adding wit-bindgen v0.45.1
    Removing wit-bindgen-rt v0.39.0
    Updating zerocopy v0.8.26 -> v0.8.27
    Updating zerocopy-derive v0.8.26 -> v0.8.27
    Updating zip v4.4.0 -> v4.6.1 (available: v5.1.1)
    Updating zlib-rs v0.5.1 -> v0.5.2
    Updating zstd-sys v2.0.15+zstd.1.5.7 -> v2.0.16+zstd.1.5.7
```