### PR TITLE
tell crates-index which http library to choose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,6 +2916,7 @@ version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd1543cd9b8abcbcebaa1a666a5c168ee2cda4dea50d3961ee0e6d1c42f81e5b"
 dependencies = [
+ "bytes",
  "crc32fast",
  "crossbeam-channel",
  "flate2",
@@ -3748,8 +3749,11 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f7cc0179fc89d53c54e1f9ce51229494864ab4bf136132d69db1b011741ca3"
 dependencies = [
+ "base64 0.22.1",
  "bstr",
+ "curl",
  "gix-command",
+ "gix-credentials 0.30.0",
  "gix-features 0.43.1",
  "gix-packetline",
  "gix-quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tracing-subscriber = { version = "0.3.20", default-features = false, features = 
 tracing-log = "0.2.0"
 regex = "1"
 clap = { version = "4.0.22", features = [ "derive" ] }
-crates-index = { version = "3.0.0", default-features = false, features = ["git", "git-performance", "parallel"] }
+crates-index = { version = "3.0.0", default-features = false, features = ["git", "git-https", "git-performance", "parallel"] }
 rayon = "1.6.1"
 num_cpus = "1.15.0"
 crates-index-diff = { version = "28.0.0", features = [ "max-performance" ]}


### PR DESCRIPTION
I tried to run the `database synchronize` command and got this error: 

```
$ cratesfyi database synchronize --dry-run
{"timestamp":"2025-09-11T17:22:00.225643Z","level":"INFO","fields":{"message":"Loading data from database..."},"target":"docs_rs::utils::consistency"}
{"timestamp":"2025-09-11T17:22:00.227775Z","level":"DEBUG","fields":{"message":"creating database pool (if this hangs, consider running `docker-compose up -d db s3`)"},"target":"docs_rs::db::pool"}
{"timestamp":"2025-09-11T17:22:20.109146Z","level":"INFO","fields":{"message":"Loading data from index..."},"target":"docs_rs::utils::consistency"}
{"timestamp":"2025-09-11T17:22:20.128522Z","level":"DEBUG","fields":{"message":"Opening with `crates_index`"},"target":"docs_rs::index"}
Error: Loading crate data from index for consistency check

Caused by:
    Loading crate data from index for consistency check

Caused by:
    "gix" crate failed. If problems persist, consider deleting `~/.cargo/registry/index/github.com-1ecc6299db9ec823/`

Caused by:
    'https' is not compiled in. Compile with the 'http-client-curl' or 'http-client-reqwest' cargo feature

Stack backtrace:
   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
   1: docs_rs::utils::consistency::index::load
   2: docs_rs::utils::spawn_blocking::{{closure}}::{{closure}}
   3: tokio::runtime::task::core::Core<T,S>::poll
   4: tokio::runtime::task::harness::Harness<T,S>::poll
   5: tokio::runtime::blocking::pool::Inner::run
   6: std::sys::backtrace::__rust_begin_short_backtrace
   7: core::ops::function::FnOnce::call_once{{vtable.shim}}
   8: std::sys::pal::unix::thread::Thread::new::thread_start
   9: start_thread
             at /build/glibc-uZu3wS/glibc-2.27/nptl/pthread_create.c:463:0
  10: __clone
             at /build/glibc-uZu3wS/glibc-2.27/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95:0
```

Related `crates-index` commits: 
- https://github.com/frewsxcv/rust-crates-index/commit/a8953e0939711940f2ef554155edcf3853030df3#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542
- https://github.com/frewsxcv/rust-crates-index/commit/d003e6986f6fbe6041790cdeefcd052eb360f2e8

previously the `curl` engine was the default, which is why I chose it. I checked if using the `reqwests` engine would add less dependencies, but it doesn't make a difference. 
