### PR TITLE
fix wrong target-redifect links in topbar release list partial 

### DIFF
--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -270,19 +270,7 @@ pub(super) fn build_axum_routes() -> AxumRouter {
             get_internal(super::crate_details::get_all_platforms_root),
         )
         .route(
-            "/crate/{name}/{version}/menus/releases/{target}",
-            get_internal(super::crate_details::get_all_releases),
-        )
-        .route(
             "/crate/{name}/{version}/menus/releases/{target}/{*path}",
-            get_internal(super::crate_details::get_all_releases),
-        )
-        .route(
-            "/crate/{name}/{version}/menus/releases",
-            get_internal(super::crate_details::get_all_releases),
-        )
-        .route(
-            "/crate/{name}/{version}/menus/releases/{target}/",
             get_internal(super::crate_details::get_all_releases),
         )
         .route(

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -1105,6 +1105,7 @@ mod test {
     use anyhow::Context;
     use chrono::{NaiveDate, Utc};
     use kuchikiki::traits::TendrilSink;
+    use pretty_assertions::assert_eq;
     use reqwest::StatusCode;
     use std::collections::BTreeMap;
     use test_case::test_case;
@@ -2687,15 +2688,15 @@ mod test {
             let releases_response = env
                 .web_app()
                 .await
-                .get("/crate/hexponent/0.3.1/menus/releases")
+                .get("/crate/hexponent/0.3.1/menus/releases/x86_64-unknown-linux-gnu/hexponent/index.html")
                 .await?;
             assert!(releases_response.status().is_success());
             releases_response.assert_cache_control(CachePolicy::ForeverInCdn, &env.config());
             assert_eq!(
                 parse_release_links_from_menu(&releases_response.text().await?),
                 vec![
-                    "/crate/hexponent/0.3.1/target-redirect/hexponent/index.html".to_owned(),
-                    "/crate/hexponent/0.3.0/target-redirect/hexponent/index.html".to_owned(),
+                    "/crate/hexponent/0.3.1/target-redirect/x86_64-unknown-linux-gnu/hexponent/index.html".to_owned(),
+                    "/crate/hexponent/0.3.0/target-redirect/x86_64-unknown-linux-gnu/hexponent/index.html".to_owned(),
                 ]
             );
 


### PR DESCRIPTION
So, I think this is the fix for #2922. 

Initially thought this has to be an issue with our search-fallback logic (`web::rustdoc::path_for_version`). 

But then I found our that the version redirect links are generated wrong. 

We have this page in the issue: `https://docs.rs/toml/0.5.11/src/toml/de.rs.html`. The expected version-links in the topbar should be ` https://docs.rs/crate/toml/0.9.6/target-redirect/x86_64-unknown-linux-gnu/src/toml/de.rs.html`, but they are ` https://docs.rs/crate/toml/0.9.6/target-redirect/x86_64-unknown-linux-gnu/toml/toml/de.rs.html`. 

See the difference? 

Generally this seems to be a regression from one of #2355, #2113 or something else. 

Looking deeper I found an oddness, but not yet how that happened to me: 

There is only one place where the `/menus/releases/` partial is loaded, which is the topbar. And there it's only loaded when we have docs. So, if I'm not missing something, **there is no place where the partial is loaded without target or without inner-path**. So IMO quite a bit of the complexity in `get_all_releases` can be removed. 

The changed tests are for things I believe that also can't happen in prod. 

Or am I missing something? 