### PR TITLE
Cargo update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8694,9 +8694,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "5.1.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f852905151ac8d4d06fdca66520a661c09730a74c6d4e2b0f27b436b382e532"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
 dependencies = [
  "arbitrary",
  "bzip2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ lol_html = "2.0.0"
 font-awesome-as-a-crate = { path = "crates/font-awesome-as-a-crate" }
 dashmap = "6.0.0"
 string_cache = "0.9.0"
-zip = {version = "5.1.1", default-features = false, features = ["bzip2"]}
+zip = {version = "6.0.0", default-features = false, features = ["bzip2"]}
 bzip2 = "0.6.0"
 getrandom = "0.3.1"
 itertools = { version = "0.14.0" }


### PR DESCRIPTION
- https://github.com/zip-rs/zip2/blob/master/CHANGELOG.md#600---2025-10-09
- https://github.com/kivikakk/comrak/releases/tag/v0.44.0


### `cargo update` 

```
  Updating aws-lc-sys v0.32.2 -> v0.32.3
    Updating aws-sdk-cloudfront v1.97.0 -> v1.98.0
    Updating cc v1.2.40 -> v1.2.41
    Updating cfg-if v1.0.3 -> v1.0.4
    Updating clap v4.5.48 -> v4.5.49
    Updating clap_builder v4.5.48 -> v4.5.49
    Updating clap_derive v4.5.47 -> v4.5.49
    Updating clap_lex v0.7.5 -> v0.7.6
    Updating find-msvc-tools v0.1.3 -> v0.1.4
    Updating generic-array v0.14.7 -> v0.14.9
    Updating getrandom v0.3.3 -> v0.3.4
    Updating half v2.6.0 -> v2.7.1
    Removing io-uring v0.7.10
    Updating libc v0.2.176 -> v0.2.177
    Updating libloading v0.8.8 -> v0.8.9
    Updating nu-ansi-term v0.50.1 -> v0.50.3
    Updating openssl v0.10.73 -> v0.10.74
    Updating openssl-sys v0.9.109 -> v0.9.110
    Updating regex v1.11.3 -> v1.12.2
    Updating regex-automata v0.4.11 -> v0.4.13
    Updating regex-lite v0.1.7 -> v0.1.8
    Updating regex-syntax v0.8.6 -> v0.8.8
    Updating reqwest v0.12.23 -> v0.12.24
    Updating rustls-native-certs v0.8.1 -> v0.8.2
    Updating serde_spanned v1.0.2 -> v1.0.3
    Updating socket2 v0.6.0 -> v0.6.1
    Updating stable_deref_trait v1.2.0 -> v1.2.1
    Updating tokio v1.47.1 -> v1.48.0
    Updating tokio-macros v2.5.0 -> v2.6.0
    Updating toml v0.9.7 -> v0.9.8
    Updating toml_datetime v0.7.2 -> v0.7.3
    Updating toml_parser v1.0.3 -> v1.0.4
    Updating toml_writer v1.0.3 -> v1.0.4
    Removing wasi v0.14.7+wasi-0.2.4
```