### PR TITLE
add renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,16 @@
+{
+  extends: [
+    "config:recommended",
+    "schedule:weekly",
+    ":prConcurrentLimitNone",
+    ":prHourlyLimitNone",
+  ],
+  semanticCommits: "enabled",
+  rangeStrategy: "replace",
+  rebaseWhen: "conflicted",
+  lockFileMaintenance: {
+    enabled: true,
+    extends: ["schedule:weekly"],
+    groupName: "lockfile maintenance",
+  },
+}


### PR DESCRIPTION
This config works in other apps I maintain seamlessly. 

One weekly `cargo update` PR, and then separate PRs for semver-breaking updates. 

related: https://github.com/rust-lang/team/pull/2023