### PR TITLE
replace `i686-unknown-linux-gnu` in default target list with `aarch64-unknown-linux-gnu`

### DIFF
--- a/crates/metadata/lib.rs
+++ b/crates/metadata/lib.rs
@@ -58,7 +58,7 @@ pub const HOST_TARGET: &str = env!("DOCSRS_METADATA_HOST_TARGET");
 /// [tier one]: https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-1
 pub const DEFAULT_TARGETS: &[&str] = &[
     "i686-pc-windows-msvc",
-    "i686-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
     "aarch64-apple-darwin",
     "x86_64-pc-windows-msvc",
     "x86_64-unknown-linux-gnu",

--- a/src/docbuilder/rustwide_builder.rs
+++ b/src/docbuilder/rustwide_builder.rs
@@ -1473,8 +1473,8 @@ mod tests {
                     targets,
                     vec![
                         "aarch64-apple-darwin",
+                        "aarch64-unknown-linux-gnu",
                         "i686-pc-windows-msvc",
-                        "i686-unknown-linux-gnu",
                         "x86_64-pc-windows-msvc",
                         "x86_64-unknown-linux-gnu",
                     ]
@@ -1675,7 +1675,7 @@ mod tests {
                     serde_json::Value::Array(vec![]),
                     vec![
                         "i686-pc-windows-msvc".into(),
-                        "i686-unknown-linux-gnu".into(),
+                        "aarch64-unknown-linux-gnu".into(),
                         "aarch64-apple-darwin".into(),
                         "x86_64-pc-windows-msvc".into(),
                         "x86_64-unknown-linux-gnu".into(),

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -990,11 +990,11 @@ mod test {
             let web = env.web_app().await;
             web.assert_redirect("/bat/0.2.0", "/crate/bat/0.2.0")
                 .await?;
-            web.assert_redirect("/bat/0.2.0/i686-unknown-linux-gnu", "/crate/bat/0.2.0")
+            web.assert_redirect("/bat/0.2.0/aarch64-unknown-linux-gnu", "/crate/bat/0.2.0")
                 .await?;
             /* TODO: this should work (https://github.com/rust-lang/docs.rs/issues/603)
-            assert_redirect("/bat/0.2.0/i686-unknown-linux-gnu/bat", "/crate/bat/0.2.0", web)?;
-            assert_redirect("/bat/0.2.0/i686-unknown-linux-gnu/bat/", "/crate/bat/0.2.0/", web)?;
+            assert_redirect("/bat/0.2.0/aarch64-unknown-linux-gnu/bat", "/crate/bat/0.2.0", web)?;
+            assert_redirect("/bat/0.2.0/aarch64-unknown-linux-gnu/bat/", "/crate/bat/0.2.0/", web)?;
             */
             Ok(())
         })

--- a/templates/core/Cargo.toml.example
+++ b/templates/core/Cargo.toml.example
@@ -25,7 +25,7 @@ default-target = "x86_64-unknown-linux-gnu"
 # - x86_64-unknown-linux-gnu
 # - aarch64-apple-darwin
 # - x86_64-pc-windows-msvc
-# - i686-unknown-linux-gnu
+# - aarch64-unknown-linux-gnu
 # - i686-pc-windows-msvc
 #
 # Set this to `[]` to only build the default target.


### PR DESCRIPTION
Resolves #2940

changes should be similar to https://github.com/rust-lang/docs.rs/pull/2927 