### PR TITLE
drop http 0.2 dependency, let AWS SDKs use http/hyper 1

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,7 +13,4 @@
     extends: ["schedule:weekly"],
     groupName: "lockfile maintenance",
   },
-    "ignoreDeps": [
-        "http02" // AWS SDK needs an old http version for testing
-    ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,7 +2045,6 @@ dependencies = [
  "grass",
  "hex",
  "hostname",
- "http 0.2.12",
  "http 1.3.1",
  "http-body-util",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,6 @@ constant_time_eq = "0.4.2"
 [dev-dependencies]
 criterion = "0.7.0"
 kuchikiki = "0.8"
-http02 = { version = "0.2.11", package = "http"} # AWS SDKs need http 0.2 for testing
 http-body-util = "0.1.0"
 rand = "0.9"
 mockito = "1.0.2"

--- a/src/cdn.rs
+++ b/src/cdn.rs
@@ -1202,16 +1202,16 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn invalidate_path() {
         let conn = StaticReplayClient::new(vec![ReplayEvent::new(
-            http02::Request::builder()
+            http::Request::builder()
                 .header("content-type", "application/xml")
-                .uri(http02::uri::Uri::from_static(
+                .uri(http::uri::Uri::from_static(
                     "https://cloudfront.amazonaws.com/2020-05-31/distribution/some_distribution/invalidation",
                 ))
                 .body(SdkBody::from(
                     r#"<InvalidationBatch xmlns="http://cloudfront.amazonaws.com/doc/2020-05-31/"><Paths><Quantity>2</Quantity><Items><Path>/some/path*</Path><Path>/another/path/*</Path></Items></Paths><CallerReference>some_reference</CallerReference></InvalidationBatch>"#,
                 ))
                 .unwrap(),
-            http02::Response::builder()
+            http::Response::builder()
                 .status(200)
                 .body(SdkBody::from(
                     r#"
@@ -1252,14 +1252,14 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn get_invalidation_info_doesnt_exist() {
         let conn = StaticReplayClient::new(vec![ReplayEvent::new(
-            http02::Request::builder()
+            http::Request::builder()
                 .header("content-type", "application/xml")
-                .uri(http02::uri::Uri::from_static(
+                .uri(http::uri::Uri::from_static(
                    "https://cloudfront.amazonaws.com/2020-05-31/distribution/some_distribution/invalidation/some_reference"
                 ))
                 .body(SdkBody::empty())
                 .unwrap(),
-            http02::Response::builder()
+            http::Response::builder()
                 .status(404)
                 .body(SdkBody::empty())
                 .unwrap(),
@@ -1281,14 +1281,14 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn get_invalidation_info_completed() {
         let conn = StaticReplayClient::new(vec![ReplayEvent::new(
-            http02::Request::builder()
+            http::Request::builder()
                 .header("content-type", "application/xml")
-                .uri(http02::uri::Uri::from_static(
+                .uri(http::uri::Uri::from_static(
                    "https://cloudfront.amazonaws.com/2020-05-31/distribution/some_distribution/invalidation/some_reference"
                 ))
                 .body(SdkBody::empty())
                 .unwrap(),
-            http02::Response::builder()
+            http::Response::builder()
                 .status(200)
                 .body(SdkBody::from(
                    r#"<Invalidation xmlns="http://cloudfront.amazonaws.com/doc/2020-05-31/">


### PR DESCRIPTION
I wanted to check progress on this topic with the AWS SDK, because I was kind of waiting for a breaking release. 

But that didn't come. 

Their tracking issue: https://github.com/awslabs/aws-sdk-rust/issues/977 
says the external API is migrated. 

So I dropped the dependency and it just worked :) 