### PR TITLE
temporary command to recompress broken index files in storage

### DIFF
--- a/.sqlx/query-29e5ac519965abe821ae15c21014d9943a38c16ca49ba014d8227df1b605bad9.json
+++ b/.sqlx/query-29e5ac519965abe821ae15c21014d9943a38c16ca49ba014d8227df1b605bad9.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                r.id,\n                c.name,\n                r.version as \"version: Version\",\n                r.release_time\n            FROM\n                crates AS c\n                INNER JOIN releases AS r ON r.crate_id = c.id\n            WHERE\n                r.archive_storage IS TRUE AND\n                r.id >= $1 AND\n                r.id <= $2\n            ORDER BY\n                r.id DESC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "version: Version",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "release_time",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "29e5ac519965abe821ae15c21014d9943a38c16ca49ba014d8227df1b605bad9"
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ bzip2 = "0.6.0"
 getrandom = "0.3.1"
 itertools = { version = "0.14.0" }
 hex = "0.4.3"
-derive_more = { version = "2.0.0", features = ["display", "deref", "from", "into"] }
+derive_more = { version = "2.0.0", features = ["display", "deref", "from", "into", "from_str"] }
 sysinfo = { version = "0.37.2", default-features = false, features = ["system"] }
 derive_builder = "0.20.2"
 

--- a/Justfile
+++ b/Justfile
@@ -11,8 +11,11 @@ sqlx-prepare ADDITIONAL_ARGS="":
 sqlx-check:
   just sqlx-prepare "--check"
 
-lint: 
-  cargo clippy --all-features --all-targets --workspace --locked -- -D warnings
+lint *args: 
+  cargo clippy --all-features --all-targets --workspace --locked {{ args }} -- -D warnings
+
+lint-fix:
+  just lint --fix --allow-dirty --allow-staged
 
 lint-js *args:
   deno run -A npm:eslint@9 static templates gui-tests eslint.config.js {{ args }}

--- a/src/db/types/mod.rs
+++ b/src/db/types/mod.rs
@@ -1,4 +1,4 @@
-use derive_more::Display;
+use derive_more::{Display, FromStr};
 use serde::{Deserialize, Serialize};
 
 pub mod dependencies;
@@ -8,7 +8,7 @@ pub mod version;
 #[sqlx(transparent)]
 pub struct CrateId(pub i32);
 
-#[derive(Debug, Clone, Copy, Display, PartialEq, Eq, Hash, Serialize, sqlx::Type)]
+#[derive(Debug, Clone, Copy, Display, PartialEq, Eq, Hash, FromStr, Serialize, sqlx::Type)]
 #[sqlx(transparent)]
 pub struct ReleaseId(pub i32);
 

--- a/src/storage/archive_index.rs
+++ b/src/storage/archive_index.rs
@@ -1,5 +1,7 @@
-use crate::error::Result;
-use crate::storage::{FileRange, compression::CompressionAlgorithm};
+use crate::{
+    error::Result,
+    storage::{FileRange, compression::CompressionAlgorithm},
+};
 use anyhow::{Context as _, bail};
 use itertools::Itertools as _;
 use sqlx::{Acquire as _, QueryBuilder, Row as _, Sqlite};


### PR DESCRIPTION
To fix the files broken in https://github.com/Nullus157/async-compression/issues/420, see https://github.com/rust-lang/docs.rs/pull/2988. 

min/max release ids are for me to control how far it has to go. I'll probably limit the process to a subset first, and then extend the process to longer, at most to the point when I reployed https://github.com/rust-lang/docs.rs/pull/2920. 

