### PR TITLE
add fallback logic when we discover the local index cache is outdated

### DIFF
--- a/src/storage/compression.rs
+++ b/src/storage/compression.rs
@@ -7,7 +7,7 @@ use std::{
     io::{self, Read},
 };
 use strum::{Display, EnumIter, EnumString, FromRepr};
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite};
 
 pub type CompressionAlgorithms = HashSet<CompressionAlgorithm>;
 
@@ -129,19 +129,19 @@ where
 /// You provide an AsyncRead that gives us the compressed data. With the
 /// wrapper we return you can then read decompressed data from the wrapper.
 pub fn wrap_reader_for_decompression<'a>(
-    input: impl AsyncRead + Unpin + Send + 'a,
+    input: impl AsyncBufRead + Unpin + Send + 'a,
     algorithm: CompressionAlgorithm,
-) -> Box<dyn AsyncRead + Unpin + Send + 'a> {
+) -> Box<dyn AsyncBufRead + Unpin + Send + 'a> {
     use async_compression::tokio::bufread;
     use tokio::io;
 
     match algorithm {
         CompressionAlgorithm::Zstd => {
-            Box::new(bufread::ZstdDecoder::new(io::BufReader::new(input)))
+            Box::new(io::BufReader::new(bufread::ZstdDecoder::new(input)))
         }
-        CompressionAlgorithm::Bzip2 => Box::new(bufread::BzDecoder::new(io::BufReader::new(input))),
+        CompressionAlgorithm::Bzip2 => Box::new(io::BufReader::new(bufread::BzDecoder::new(input))),
         CompressionAlgorithm::Gzip => {
-            Box::new(bufread::GzipDecoder::new(io::BufReader::new(input)))
+            Box::new(io::BufReader::new(bufread::GzipDecoder::new(input)))
         }
     }
 }


### PR DESCRIPTION
Multiple parts: 
1. we do a first decompression test by buffering some first bytes from the decompressed stream directly 
2. In case of errors when fetching files from archives, we'll just delete the local cache and try again 

This is only a last resort. Generally I want to find all race conditions with the caching, prioritized by how often they happen. The other cases are hopefully caught by this logic. 

Errors where this will help: 
- [in the source views](https://rust-lang.sentry.io/issues/6997669894/?query=is%3Aunresolved&referrer=issue-stream). That's the biggest other bug, which I'll fix separately. 
- [in the rustdoc html views](https://rust-lang.sentry.io/issues/6984159109/?query=is%3Aunresolved&referrer=issue-stream), not sure what the race is here. 


I also have an idea how to restructure the whole archive index thing so people don't have to think about locking. 