### PR TITLE
set & handle etags/if-none-match for first rustdoc assets 

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -14,3 +14,8 @@ reason = """
 [[disallowed-types]]
 path = "semver::Version"
 reason = "use our own custom db::types::version::Version so you can use it with sqlx"
+
+[[disallowed-types]]
+path = "axum_extra::headers::IfNoneMatch"
+reason = "use our own custom web::headers::IfNoneMatch for sane behaviour with missing headers"
+

--- a/src/web/file.rs
+++ b/src/web/file.rs
@@ -1,6 +1,6 @@
 //! Database based file handler
 
-use super::cache::CachePolicy;
+use super::{cache::CachePolicy, headers::IfNoneMatch};
 use crate::{
     Config,
     error::Result,
@@ -9,12 +9,14 @@ use crate::{
 use axum::{
     body::Body,
     extract::Extension,
-    http::{
-        StatusCode,
-        header::{CONTENT_TYPE, LAST_MODIFIED},
-    },
+    http::StatusCode,
     response::{IntoResponse, Response as AxumResponse},
 };
+use axum_extra::{
+    TypedHeader,
+    headers::{ContentType, LastModified},
+};
+use std::time::SystemTime;
 use tokio_util::io::ReaderStream;
 
 #[derive(Debug)]
@@ -37,21 +39,11 @@ impl File {
     }
 }
 
-impl IntoResponse for File {
-    fn into_response(self) -> AxumResponse {
-        (
-            StatusCode::OK,
-            [
-                (CONTENT_TYPE, self.0.mime.as_ref()),
-                (
-                    LAST_MODIFIED,
-                    &self.0.date_updated.format("%a, %d %b %Y %T %Z").to_string(),
-                ),
-            ],
-            Extension(CachePolicy::ForeverInCdnAndBrowser),
-            self.0.content,
-        )
-            .into_response()
+#[cfg(test)]
+impl File {
+    pub fn into_response(self, if_none_match: Option<&IfNoneMatch>) -> AxumResponse {
+        let streaming_blob: StreamingBlob = self.0.into();
+        StreamingFile(streaming_blob).into_response(if_none_match)
     }
 }
 
@@ -63,36 +55,105 @@ impl StreamingFile {
     pub(super) async fn from_path(storage: &AsyncStorage, path: &str) -> Result<StreamingFile> {
         Ok(StreamingFile(storage.get_stream(path).await?))
     }
-}
 
-impl IntoResponse for StreamingFile {
-    fn into_response(self) -> AxumResponse {
-        // Convert the AsyncBufRead into a Stream of Bytes
-        let stream = ReaderStream::new(self.0.content);
-        let body = Body::from_stream(stream);
-        (
-            StatusCode::OK,
-            [
-                (CONTENT_TYPE, self.0.mime.as_ref()),
-                (
-                    LAST_MODIFIED,
-                    &self.0.date_updated.format("%a, %d %b %Y %T %Z").to_string(),
-                ),
-            ],
-            Extension(CachePolicy::ForeverInCdnAndBrowser),
-            body,
-        )
-            .into_response()
+    pub fn into_response(self, if_none_match: Option<&IfNoneMatch>) -> AxumResponse {
+        const CACHE_POLICY: CachePolicy = CachePolicy::ForeverInCdnAndBrowser;
+        let last_modified = LastModified::from(SystemTime::from(self.0.date_updated));
+
+        if let Some(if_none_match) = if_none_match
+            && let Some(ref etag) = self.0.etag
+            && !if_none_match.precondition_passes(etag)
+        {
+            (
+                StatusCode::NOT_MODIFIED,
+                // it's generally recommended to repeat caching headers on 304 responses
+                TypedHeader(etag.clone()),
+                TypedHeader(last_modified),
+                Extension(CACHE_POLICY),
+            )
+                .into_response()
+        } else {
+            // Convert the AsyncBufRead into a Stream of Bytes
+            let stream = ReaderStream::new(self.0.content);
+
+            (
+                StatusCode::OK,
+                TypedHeader(ContentType::from(self.0.mime)),
+                TypedHeader(last_modified),
+                self.0.etag.map(TypedHeader),
+                Extension(CACHE_POLICY),
+                Body::from_stream(stream),
+            )
+                .into_response()
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::TestEnvironment;
+    use crate::{storage::CompressionAlgorithm, test::TestEnvironment, web::headers::compute_etag};
+    use axum_extra::headers::{ETag, HeaderMapExt as _};
     use chrono::Utc;
-    use http::header::CACHE_CONTROL;
-    use std::rc::Rc;
+    use http::header::{CACHE_CONTROL, ETAG, LAST_MODIFIED};
+    use std::{io, rc::Rc};
+
+    fn streaming_blob(
+        content: impl Into<Vec<u8>>,
+        alg: Option<CompressionAlgorithm>,
+    ) -> StreamingBlob {
+        let content = content.into();
+        StreamingBlob {
+            path: "some_path.db".into(),
+            mime: mime::APPLICATION_OCTET_STREAM,
+            date_updated: Utc::now(),
+            compression: alg,
+            etag: Some(compute_etag(&content)),
+            content_length: content.len(),
+            content: Box::new(io::Cursor::new(content)),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stream_into_response() -> Result<()> {
+        const CONTENT: &[u8] = b"Hello, world!";
+        let etag: ETag = {
+            // first request normal
+            let stream = StreamingFile(streaming_blob(CONTENT, None));
+            let resp = stream.into_response(None);
+            assert!(resp.status().is_success());
+            assert!(resp.headers().get(CACHE_CONTROL).is_none());
+            let cache = resp
+                .extensions()
+                .get::<CachePolicy>()
+                .expect("missing cache response extension");
+            assert!(matches!(cache, CachePolicy::ForeverInCdnAndBrowser));
+            assert!(resp.headers().get(LAST_MODIFIED).is_some());
+
+            resp.headers().typed_get().unwrap()
+        };
+
+        let if_none_match = IfNoneMatch::from(etag);
+
+        {
+            // cached request
+            let stream = StreamingFile(streaming_blob(CONTENT, None));
+            let resp = stream.into_response(Some(&if_none_match));
+            assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+
+            // cache related headers are repeated on the not-modified response
+            assert!(resp.headers().get(CACHE_CONTROL).is_none());
+            let cache = resp
+                .extensions()
+                .get::<CachePolicy>()
+                .expect("missing cache response extension");
+            assert!(matches!(cache, CachePolicy::ForeverInCdnAndBrowser));
+            assert!(resp.headers().get(LAST_MODIFIED).is_some());
+            assert!(resp.headers().get(ETAG).is_some());
+        }
+
+        Ok(())
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn file_roundtrip_axum() -> Result<()> {
@@ -111,7 +172,8 @@ mod tests {
 
         file.0.date_updated = now;
 
-        let resp = file.into_response();
+        let resp = file.into_response(None);
+        assert!(resp.status().is_success());
         assert!(resp.headers().get(CACHE_CONTROL).is_none());
         let cache = resp
             .extensions()
@@ -120,7 +182,7 @@ mod tests {
         assert!(matches!(cache, CachePolicy::ForeverInCdnAndBrowser));
         assert_eq!(
             resp.headers().get(LAST_MODIFIED).unwrap(),
-            &now.format("%a, %d %b %Y %T UTC").to_string(),
+            &now.format("%a, %d %b %Y %T GMT").to_string(),
         );
 
         Ok(())

--- a/src/web/headers/mod.rs
+++ b/src/web/headers/mod.rs
@@ -2,6 +2,7 @@ mod canonical_url;
 mod if_none_match;
 mod surrogate_key;
 
+use axum_extra::headers::ETag;
 pub use canonical_url::CanonicalUrl;
 use http::HeaderName;
 pub(crate) use if_none_match::IfNoneMatch;
@@ -14,8 +15,7 @@ pub static SURROGATE_CONTROL: HeaderName = HeaderName::from_static("surrogate-co
 /// compute our etag header value from some content
 ///
 /// Has to match the implementation in our build-script.
-#[cfg(test)]
-pub fn compute_etag<T: AsRef<[u8]>>(content: T) -> axum_extra::headers::ETag {
+pub fn compute_etag<T: AsRef<[u8]>>(content: T) -> ETag {
     let digest = md5::compute(&content);
     format!("\"{:x}\"", digest).parse().unwrap()
 }


### PR DESCRIPTION
Next step towards #1560. 

Idea is: 
- when we just proxy the asset from S3 directly, we can use the etag we get from the S3 API
- when the asset is fetched out of an archive, we can generate a valid etag based on the full archive etag + the range.

The next step after is trying to figure out an etag for rustdoc pages, which finally could give us the gains laid out in #1560 . 

I feel like there is also some duplication around conditional-get handling, but I want to see the rustdoc part first before I start reducing the duplication. 

I changed the format of the `Last-Modified` header too, it looks like using `UTC` is against RFC, and `GMT` would be correct. 