### PR TITLE
storage: split BlobUpload from Blob

### DIFF
--- a/src/storage/database.rs
+++ b/src/storage/database.rs
@@ -1,4 +1,4 @@
-use super::{Blob, FileRange, StorageMetrics, StreamingBlob};
+use super::{BlobUpload, FileRange, StorageMetrics, StreamingBlob};
 use crate::{InstanceMetrics, db::Pool, error::Result};
 use chrono::{DateTime, Utc};
 use futures_util::stream::{Stream, TryStreamExt};
@@ -136,7 +136,7 @@ impl DatabaseBackend {
         })
     }
 
-    pub(super) async fn store_batch(&self, batch: Vec<Blob>) -> Result<()> {
+    pub(super) async fn store_batch(&self, batch: Vec<BlobUpload>) -> Result<()> {
         let mut conn = self.pool.get_async().await?;
         let mut trans = conn.begin().await?;
         for blob in batch {

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -1,4 +1,4 @@
-use super::{Blob, FileRange, StorageMetrics, StreamingBlob};
+use super::{BlobUpload, FileRange, StorageMetrics, StreamingBlob};
 use crate::{Config, InstanceMetrics};
 use anyhow::{Context as _, Error};
 use async_stream::try_stream;
@@ -222,7 +222,7 @@ impl S3Backend {
         })
     }
 
-    pub(super) async fn store_batch(&self, mut batch: Vec<Blob>) -> Result<(), Error> {
+    pub(super) async fn store_batch(&self, mut batch: Vec<BlobUpload>) -> Result<(), Error> {
         // Attempt to upload the batch 3 times
         for _ in 0..3 {
             let mut futures = FuturesUnordered::new();


### PR DESCRIPTION
prep for #3006 

instead of: 
```
 // this field is ignored by the backend
date_updated: Utc::now(),
```

( which would get more with the etag) 

this should be a separate type. 