### PR TITLE
re-encode original uri when extracting rustdoc params

### DIFF
--- a/src/web/escaped_uri.rs
+++ b/src/web/escaped_uri.rs
@@ -1,4 +1,4 @@
-use crate::web::encode_url_path;
+use crate::web::{encode_url_path, url_decode};
 use askama::filters::HtmlSafe;
 use http::{Uri, uri::PathAndQuery};
 use std::{borrow::Borrow, fmt::Display, iter, str::FromStr};
@@ -8,6 +8,8 @@ use url::form_urlencoded;
 ///
 /// Ensures that the path part is always properly percent-encoded, including some characters
 /// that http::Uri would allow, but we still want to encode, like umlauts.
+/// Also ensures that some characters are _not_ encoded that sometimes arrive percent-encoded
+/// from browsers, so we then can easily compare URIs, knowing they are encoded the same way.
 ///
 /// Also we support fragments, with http::Uri doesn't support yet.
 /// See https://github.com/hyperium/http/issues/775
@@ -20,7 +22,16 @@ pub struct EscapedURI {
 impl EscapedURI {
     pub fn from_uri(uri: Uri) -> Self {
         if uri.path_and_query().is_some() {
-            let encoded_path = encode_url_path(uri.path());
+            let encoded_path = encode_url_path(
+                // we re-encode the path so we know all EscapedURI instances are comparable and
+                // encoded the same way.
+                // Example: "^" is not escaped when axum generates an Uri, we also didn't do it
+                // for a long time so we have nicers URLs with caret, since it's supported by
+                // most browsers to be shown in the URL bar.
+                // But: the actual request will have it encoded, which means the `Uri`
+                // we get from axum when handling the request will have it encoded.
+                &url_decode(uri.path()).expect("was in Uri, so has to have been correct"),
+            );
             if uri.path() == encoded_path {
                 Self {
                     uri,
@@ -223,6 +234,22 @@ impl From<Uri> for EscapedURI {
     }
 }
 
+impl TryFrom<String> for EscapedURI {
+    type Error = http::uri::InvalidUri;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+impl TryFrom<&str> for EscapedURI {
+    type Error = http::uri::InvalidUri;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
 impl PartialEq<String> for &EscapedURI {
     fn eq(&self, other: &String) -> bool {
         *self == other
@@ -286,6 +313,7 @@ mod tests {
     }
 
     #[test_case("/something" => "/something"; "plain path")]
+    #[test_case("/semver/%5E1.2.3" => "/semver/^1.2.3"; "we encode less")]
     #[test_case("/somethingäöü" => "/something%C3%A4%C3%B6%C3%BC"; "path with umlauts")]
     fn test_escaped_uri_encodes_path_from_uri(path: &str) -> String {
         let uri: Uri = path.parse().unwrap();

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -80,6 +80,10 @@ pub(crate) fn encode_url_path(path: &str) -> String {
     utf8_percent_encode(path, PATH).to_string()
 }
 
+pub(crate) fn url_decode<'a>(input: &'a str) -> Result<Cow<'a, str>> {
+    Ok(percent_encoding::percent_decode(input.as_bytes()).decode_utf8()?)
+}
+
 const DEFAULT_BIND: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 3000);
 
 /// Represents a version identifier in a request in the original state.

--- a/src/web/routes.rs
+++ b/src/web/routes.rs
@@ -193,8 +193,12 @@ pub(super) fn build_axum_routes() -> AxumRouter {
             "/releases/failures/{page}",
             get_internal(super::releases::releases_failures_by_stars_handler),
         )
-        .route_with_tsr(
+        .route(
             "/crate/{name}",
+            get_internal(super::crate_details::crate_details_handler),
+        )
+        .route(
+            "/crate/{name}/",
             get_internal(super::crate_details::crate_details_handler),
         )
         .route_with_tsr(

--- a/src/web/rustdoc.rs
+++ b/src/web/rustdoc.rs
@@ -220,7 +220,7 @@ pub(crate) async fn rustdoc_redirector_handler(
     let params = params.with_page_kind(PageKind::Rustdoc);
 
     fn redirect_to_doc(
-        original_uri: Option<&Uri>,
+        original_uri: Option<&EscapedURI>,
         url: EscapedURI,
         cache_policy: CachePolicy,
         path_in_crate: Option<&str>,


### PR DESCRIPTION
Fixes #3026 

Reason for the bug was that we don't encode the `^` in our URLs, following what axum does internally. 

But when we compare that path with the one coming from the request, it doesn't match. 

For now I think we can solve it this way, by making our own `EscapedURI` always encode the same way. 