### PR TITLE
reopen crates-index every time we check

### DIFF
--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -206,11 +206,10 @@ impl CommandLine {
 
                 start_background_metrics_webserver(Some(metric_server_socket_addr), &ctx)?;
 
-                ctx.runtime.block_on(async move {
-                    let index = Index::from_config(&ctx.config).await?;
-                    docs_rs::utils::watch_registry(&ctx.async_build_queue, &ctx.config, &index)
-                        .await
-                })?;
+                ctx.runtime.block_on(docs_rs::utils::watch_registry(
+                    &ctx.async_build_queue,
+                    &ctx.config,
+                ))?;
             }
             Self::StartBuildServer {
                 metric_server_socket_addr,


### PR DESCRIPTION
Temporary fix for this sentry error: 
https://rust-lang.sentry.io/issues/7014063476/?environment=production&project=5499376&query=is%3Aunresolved&referrer=issue-stream

also related: 
https://github.com/GitoxideLabs/gitoxide/issues/1788#issuecomment-3568109598

I don't know why this started happening in the extent it does, somehow after I re-created the index clone locally. 