### PR TITLE
fix endless loop when generating fastly invalidations

### DIFF
--- a/src/cdn/fastly.rs
+++ b/src/cdn/fastly.rs
@@ -46,9 +46,13 @@ where
         // SurrogateKeys::from_iter::until_full only consumes as many elements as will fit into
         // the header.
         // The rest is up to the next `batching` iteration.
-        Some(SurrogateKeys::from_iter_until_full(
-            it.take(MAX_SURROGATE_KEYS_IN_BATCH_PURGE),
-        ))
+        let keys = SurrogateKeys::from_iter_until_full(it.take(MAX_SURROGATE_KEYS_IN_BATCH_PURGE));
+
+        if keys.key_count() > 0 {
+            Some(keys)
+        } else {
+            None
+        }
     }) {
         for sid in config
             .fastly_service_sid_web


### PR DESCRIPTION
if we want a hotfix. 

I'm also working on dropping the fastly api lib for direct reqwests. 

we're getting an error, I think when shutting down the server: 

https://rust-lang.sentry.io/issues/7060459082/?query=is%3Aunresolved&referrer=issue-stream
> Reqwest(reqwest::Error { kind: Request, url: "https://api.fastly.com/service/PqekaQ4n2Cy4QOG85AjuAH/purge", source: hyper_util::client::legacy::Error(SendRequest, hyper::Error(User(DispatchGone), "runtime dropped the dispatch task")) })

My guess is that the fastly client tries to do some background work? 

So in parallel I'm working on dropping the library, which won't take much longer. 

**this PR is not needed when we review & merge #3034**