### PR TITLE
More `let` bindings to ensure no field is forgotten in `bincode::Encode` impls

### DIFF
--- a/src/db/types/version.rs
+++ b/src/db/types/version.rs
@@ -45,9 +45,16 @@ mod version_impl {
             &self,
             encoder: &mut E,
         ) -> Result<(), bincode::error::EncodeError> {
-            self.0.major.encode(encoder)?;
-            self.0.minor.encode(encoder)?;
-            self.0.patch.encode(encoder)?;
+            let Self(semver::Version {
+                major,
+                minor,
+                patch,
+                pre: _,
+                build: _,
+            }) = self;
+            major.encode(encoder)?;
+            minor.encode(encoder)?;
+            patch.encode(encoder)?;
             bincode::Encode::encode(self.0.pre.as_str(), encoder)?;
             bincode::Encode::encode(self.0.build.as_str(), encoder)?;
             Ok(())

--- a/src/utils/cargo_metadata.rs
+++ b/src/utils/cargo_metadata.rs
@@ -140,13 +140,20 @@ impl bincode::Encode for Dependency {
         &self,
         encoder: &mut E,
     ) -> Result<(), bincode::error::EncodeError> {
-        self.name.encode(encoder)?;
+        let Self {
+            name,
+            req,
+            kind,
+            rename,
+            optional,
+        } = self;
+        name.encode(encoder)?;
         // FIXME: VersionReq does not implement Encode, so we serialize it to string
         // Could be fixable by wrapping VersionReq in a newtype
-        self.req.to_string().encode(encoder)?;
-        self.kind.encode(encoder)?;
-        self.rename.encode(encoder)?;
-        self.optional.encode(encoder)?;
+        req.to_string().encode(encoder)?;
+        kind.encode(encoder)?;
+        rename.encode(encoder)?;
+        optional.encode(encoder)?;
         Ok(())
     }
 }


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/docs.rs/pull/3035.