### PR TITLE
replace build-time gix dependency with git call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2036,7 +2036,6 @@ dependencies = [
  "font-awesome-as-a-crate",
  "futures-util",
  "getrandom 0.3.4",
- "gix 0.75.0",
  "grass",
  "hex",
  "hostname",
@@ -2594,13 +2593,13 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01237e8d3d78581f71642be8b0c2ae8c0b2b5c251c9c5d9ebbea3c1ea280dce8"
 dependencies = [
- "gix-actor 0.35.6",
+ "gix-actor",
  "gix-attributes 0.26.1",
  "gix-command",
  "gix-commitgraph 0.28.0",
  "gix-config 0.45.1",
  "gix-credentials 0.29.0",
- "gix-date 0.10.7",
+ "gix-date",
  "gix-diff 0.52.1",
  "gix-discover 0.40.1",
  "gix-features 0.42.1",
@@ -2646,13 +2645,13 @@ version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514c29cc879bdc0286b0cbc205585a49b252809eb86c69df4ce4f855ee75f635"
 dependencies = [
- "gix-actor 0.35.6",
+ "gix-actor",
  "gix-attributes 0.27.0",
  "gix-command",
  "gix-commitgraph 0.29.0",
  "gix-config 0.46.0",
  "gix-credentials 0.30.0",
- "gix-date 0.10.7",
+ "gix-date",
  "gix-diff 0.53.0",
  "gix-discover 0.41.0",
  "gix-features 0.43.1",
@@ -2693,66 +2692,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix"
-version = "0.75.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60beff35667fb0ac935c4c45941868d9cf5025e4b85c58deb3c5a65113e22ce4"
-dependencies = [
- "gix-actor 0.36.0",
- "gix-commitgraph 0.30.1",
- "gix-config 0.48.0",
- "gix-date 0.11.0",
- "gix-diff 0.55.0",
- "gix-discover 0.43.0",
- "gix-features 0.44.1",
- "gix-fs 0.17.0",
- "gix-glob 0.22.1",
- "gix-hash 0.20.1",
- "gix-hashtable 0.10.0",
- "gix-lock 19.0.0",
- "gix-object 0.52.0",
- "gix-odb 0.72.0",
- "gix-pack 0.62.0",
- "gix-path",
- "gix-protocol 0.53.0",
- "gix-ref 0.55.0",
- "gix-refspec 0.33.0",
- "gix-revision 0.37.0",
- "gix-revwalk 0.23.0",
- "gix-sec 0.12.2",
- "gix-shallow 0.6.0",
- "gix-tempfile 19.0.1",
- "gix-trace",
- "gix-traverse 0.49.0",
- "gix-url 0.33.2",
- "gix-utils",
- "gix-validate",
- "smallvec",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "gix-actor"
 version = "0.35.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "987a51a7e66db6ef4dc030418eb2a42af6b913a79edd8670766122d8af3ba59e"
 dependencies = [
  "bstr",
- "gix-date 0.10.7",
- "gix-utils",
- "itoa 1.0.15",
- "thiserror 2.0.17",
- "winnow",
-]
-
-[[package]]
-name = "gix-actor"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "694f6c16eb88b16b00b1d811e4e4bda6f79e9eb467a1b04fd5b848da677baa81"
-dependencies = [
- "bstr",
- "gix-date 0.11.0",
+ "gix-date",
  "gix-utils",
  "itoa 1.0.15",
  "thiserror 2.0.17",
@@ -2851,19 +2797,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-commitgraph"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826994ff6c01f1ff00d6a1844d7506717810a91ffed143da71e3bf39369751ef"
-dependencies = [
- "bstr",
- "gix-chunk",
- "gix-hash 0.20.1",
- "memmap2",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "gix-config"
 version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2899,26 +2832,6 @@ dependencies = [
  "gix-sec 0.12.2",
  "memchr",
  "once_cell",
- "smallvec",
- "thiserror 2.0.17",
- "unicode-bom",
- "winnow",
-]
-
-[[package]]
-name = "gix-config"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9419284839421488b5ab9b9b88386bdc1e159a986c08e17ffa3e9a5cd2b139f5"
-dependencies = [
- "bstr",
- "gix-config-value",
- "gix-features 0.44.1",
- "gix-glob 0.22.1",
- "gix-path",
- "gix-ref 0.55.0",
- "gix-sec 0.12.2",
- "memchr",
  "smallvec",
  "thiserror 2.0.17",
  "unicode-bom",
@@ -2964,7 +2877,7 @@ dependencies = [
  "bstr",
  "gix-command",
  "gix-config-value",
- "gix-date 0.10.7",
+ "gix-date",
  "gix-path",
  "gix-prompt",
  "gix-sec 0.12.2",
@@ -2978,19 +2891,6 @@ name = "gix-date"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "661245d045aa7c16ba4244daaabd823c562c3e45f1f25b816be2c57ee09f2171"
-dependencies = [
- "bstr",
- "itoa 1.0.15",
- "jiff",
- "smallvec",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-date"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f94626a5bc591a57025361a3a890092469e47c7667e59fc143439cd6eaf47fe"
 dependencies = [
  "bstr",
  "itoa 1.0.15",
@@ -3033,18 +2933,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-diff"
-version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc7735ca267da78c37e916e9b32d67b0b0e3fc9401378920e9469b5d497dccf"
-dependencies = [
- "bstr",
- "gix-hash 0.20.1",
- "gix-object 0.52.0",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "gix-discover"
 version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3072,22 +2960,6 @@ dependencies = [
  "gix-hash 0.19.0",
  "gix-path",
  "gix-ref 0.53.1",
- "gix-sec 0.12.2",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-discover"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809f8dba9fbd7a054894ec222815742b96def1ca08e18c38b1dbc1f737dd213d"
-dependencies = [
- "bstr",
- "dunce",
- "gix-fs 0.17.0",
- "gix-hash 0.20.1",
- "gix-path",
- "gix-ref 0.55.0",
  "gix-sec 0.12.2",
  "thiserror 2.0.17",
 ]
@@ -3129,24 +3001,6 @@ dependencies = [
  "libc",
  "once_cell",
  "parking_lot",
- "prodash 30.0.1",
- "thiserror 2.0.17",
- "walkdir",
-]
-
-[[package]]
-name = "gix-features"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa64593d1586135102307fb57fb3a9d3868b6b1f45a4da1352cce5070f8916a"
-dependencies = [
- "crc32fast",
- "gix-path",
- "gix-trace",
- "gix-utils",
- "libc",
- "libz-rs-sys",
- "once_cell",
  "prodash 30.0.1",
  "thiserror 2.0.17",
  "walkdir",
@@ -3223,20 +3077,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-fs"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1ecd896258cdc5ccd94d18386d17906b8de265ad2ecf68e3bea6b007f6a28f"
-dependencies = [
- "bstr",
- "fastrand",
- "gix-features 0.44.1",
- "gix-path",
- "gix-utils",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "gix-glob"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3257,18 +3097,6 @@ dependencies = [
  "bitflags 2.10.0",
  "bstr",
  "gix-features 0.43.1",
- "gix-path",
-]
-
-[[package]]
-name = "gix-glob"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74254992150b0a88fdb3ad47635ab649512dff2cbbefca7916bb459894fc9d56"
-dependencies = [
- "bitflags 2.10.0",
- "bstr",
- "gix-features 0.44.1",
  "gix-path",
 ]
 
@@ -3297,18 +3125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-hash"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826036a9bee95945b0be1e2394c64cd4289916c34a639818f8fd5153906985c1"
-dependencies = [
- "faster-hex",
- "gix-features 0.44.1",
- "sha1-checked",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "gix-hashtable"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3327,17 +3143,6 @@ checksum = "c35300b54896153e55d53f4180460931ccd69b7e8d2f6b9d6401122cdedc4f07"
 dependencies = [
  "gix-hash 0.19.0",
  "hashbrown 0.15.5",
- "parking_lot",
-]
-
-[[package]]
-name = "gix-hashtable"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27d4a3ea9640da504a2657fef3419c517fd71f1767ad8935298bcc805edd195"
-dependencies = [
- "gix-hash 0.20.1",
- "hashbrown 0.16.1",
  "parking_lot",
 ]
 
@@ -3446,17 +3251,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-lock"
-version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729d7857429a66023bc0c29d60fa21d0d6ae8862f33c1937ba89e0f74dd5c67f"
-dependencies = [
- "gix-tempfile 19.0.1",
- "gix-utils",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "gix-negotiate"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3464,7 +3258,7 @@ checksum = "2e1ea901acc4d5b44553132a29e8697210cb0e739b2d9752d713072e9391e3c9"
 dependencies = [
  "bitflags 2.10.0",
  "gix-commitgraph 0.28.0",
- "gix-date 0.10.7",
+ "gix-date",
  "gix-hash 0.18.0",
  "gix-object 0.49.1",
  "gix-revwalk 0.20.1",
@@ -3480,7 +3274,7 @@ checksum = "1d58d4c9118885233be971e0d7a589f5cfb1a8bd6cb6e2ecfb0fc6b1b293c83b"
 dependencies = [
  "bitflags 2.10.0",
  "gix-commitgraph 0.29.0",
- "gix-date 0.10.7",
+ "gix-date",
  "gix-hash 0.19.0",
  "gix-object 0.50.2",
  "gix-revwalk 0.21.0",
@@ -3495,8 +3289,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d957ca3640c555d48bb27f8278c67169fa1380ed94f6452c5590742524c40fbb"
 dependencies = [
  "bstr",
- "gix-actor 0.35.6",
- "gix-date 0.10.7",
+ "gix-actor",
+ "gix-date",
  "gix-features 0.42.1",
  "gix-hash 0.18.0",
  "gix-hashtable 0.8.1",
@@ -3516,32 +3310,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69ce108ab67b65fbd4fb7e1331502429d78baeb2eee10008bdef55765397c07"
 dependencies = [
  "bstr",
- "gix-actor 0.35.6",
- "gix-date 0.10.7",
+ "gix-actor",
+ "gix-date",
  "gix-features 0.43.1",
  "gix-hash 0.19.0",
  "gix-hashtable 0.9.0",
- "gix-path",
- "gix-utils",
- "gix-validate",
- "itoa 1.0.15",
- "smallvec",
- "thiserror 2.0.17",
- "winnow",
-]
-
-[[package]]
-name = "gix-object"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84743d1091c501a56f00d7f4c595cb30f20fcef6503b32ac0a1ff3817efd7b5d"
-dependencies = [
- "bstr",
- "gix-actor 0.36.0",
- "gix-date 0.11.0",
- "gix-features 0.44.1",
- "gix-hash 0.20.1",
- "gix-hashtable 0.10.0",
  "gix-path",
  "gix-utils",
  "gix-validate",
@@ -3558,7 +3331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "868f703905fdbcfc1bd750942f82419903ecb7039f5288adb5206d6de405e0c9"
 dependencies = [
  "arc-swap",
- "gix-date 0.10.7",
+ "gix-date",
  "gix-features 0.42.1",
  "gix-fs 0.15.0",
  "gix-hash 0.18.0",
@@ -3579,34 +3352,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9d7af10fda9df0bb4f7f9bd507963560b3c66cb15a5b825caf752e0eb109ac"
 dependencies = [
  "arc-swap",
- "gix-date 0.10.7",
+ "gix-date",
  "gix-features 0.43.1",
  "gix-fs 0.16.1",
  "gix-hash 0.19.0",
  "gix-hashtable 0.9.0",
  "gix-object 0.50.2",
  "gix-pack 0.60.0",
- "gix-path",
- "gix-quote",
- "parking_lot",
- "tempfile",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-odb"
-version = "0.72.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f81b480252f3a4d55f87e6e358c4c6f7615f98b1742e1e70118c57282a92e82"
-dependencies = [
- "arc-swap",
- "gix-date 0.11.0",
- "gix-features 0.44.1",
- "gix-fs 0.17.0",
- "gix-hash 0.20.1",
- "gix-hashtable 0.10.0",
- "gix-object 0.52.0",
- "gix-pack 0.62.0",
  "gix-path",
  "gix-quote",
  "parking_lot",
@@ -3657,40 +3409,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-pack"
-version = "0.62.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e868463538731a0fd99f3950637957413bbfbe69143520c0b5c1e163303577"
-dependencies = [
- "clru",
- "gix-chunk",
- "gix-features 0.44.1",
- "gix-hash 0.20.1",
- "gix-hashtable 0.10.0",
- "gix-object 0.52.0",
- "gix-path",
- "memmap2",
- "smallvec",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "gix-packetline"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64286a8b5148e76ab80932e72762dd27ccf6169dd7a134b027c8a262a8262fcf"
-dependencies = [
- "bstr",
- "faster-hex",
- "gix-trace",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-packetline"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad0ffb982a289888087a165d3e849cbac724f2aa5431236b050dd2cb9c7de31"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -3773,7 +3495,7 @@ checksum = "f5c17d78bb0414f8d60b5f952196dc2e47ec320dca885de9128ecdb4a0e38401"
 dependencies = [
  "bstr",
  "gix-credentials 0.29.0",
- "gix-date 0.10.7",
+ "gix-date",
  "gix-features 0.42.1",
  "gix-hash 0.18.0",
  "gix-lock 17.1.0",
@@ -3799,7 +3521,7 @@ checksum = "12b4b807c47ffcf7c1e5b8119585368a56449f3493da93b931e1d4239364e922"
 dependencies = [
  "bstr",
  "gix-credentials 0.30.0",
- "gix-date 0.10.7",
+ "gix-date",
  "gix-features 0.43.1",
  "gix-hash 0.19.0",
  "gix-lock 18.0.0",
@@ -3811,25 +3533,6 @@ dependencies = [
  "gix-shallow 0.5.0",
  "gix-trace",
  "gix-transport 0.48.0",
- "gix-utils",
- "maybe-async",
- "thiserror 2.0.17",
- "winnow",
-]
-
-[[package]]
-name = "gix-protocol"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6947d3b919ec8d10738f4251905a8485366ffdd24942cdbe9c6b69376bf57d64"
-dependencies = [
- "bstr",
- "gix-date 0.11.0",
- "gix-features 0.44.1",
- "gix-hash 0.20.1",
- "gix-ref 0.55.0",
- "gix-shallow 0.6.0",
- "gix-transport 0.50.0",
  "gix-utils",
  "maybe-async",
  "thiserror 2.0.17",
@@ -3853,7 +3556,7 @@ version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1b7985657029684d759f656b09abc3e2c73085596d5cdb494428823970a7762"
 dependencies = [
- "gix-actor 0.35.6",
+ "gix-actor",
  "gix-features 0.42.1",
  "gix-fs 0.15.0",
  "gix-hash 0.18.0",
@@ -3874,7 +3577,7 @@ version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b966f578079a42f4a51413b17bce476544cca1cf605753466669082f94721758"
 dependencies = [
- "gix-actor 0.35.6",
+ "gix-actor",
  "gix-features 0.43.1",
  "gix-fs 0.16.1",
  "gix-hash 0.19.0",
@@ -3882,27 +3585,6 @@ dependencies = [
  "gix-object 0.50.2",
  "gix-path",
  "gix-tempfile 18.0.0",
- "gix-utils",
- "gix-validate",
- "memmap2",
- "thiserror 2.0.17",
- "winnow",
-]
-
-[[package]]
-name = "gix-ref"
-version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51330a32f173c8e831731dfef8e93a748c23c057f4b028841f222564cad84cb"
-dependencies = [
- "gix-actor 0.36.0",
- "gix-features 0.44.1",
- "gix-fs 0.17.0",
- "gix-hash 0.20.1",
- "gix-lock 19.0.0",
- "gix-object 0.52.0",
- "gix-path",
- "gix-tempfile 19.0.1",
  "gix-utils",
  "gix-validate",
  "memmap2",
@@ -3939,21 +3621,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-refspec"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f88233214a302d61e60bb9d1387043c1759b761dba4a8704b341fecbf6b1266"
-dependencies = [
- "bstr",
- "gix-glob 0.22.1",
- "gix-hash 0.20.1",
- "gix-revision 0.37.0",
- "gix-validate",
- "smallvec",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "gix-revision"
 version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3962,7 +3629,7 @@ dependencies = [
  "bitflags 2.10.0",
  "bstr",
  "gix-commitgraph 0.28.0",
- "gix-date 0.10.7",
+ "gix-date",
  "gix-hash 0.18.0",
  "gix-hashtable 0.8.1",
  "gix-object 0.49.1",
@@ -3980,27 +3647,12 @@ dependencies = [
  "bitflags 2.10.0",
  "bstr",
  "gix-commitgraph 0.29.0",
- "gix-date 0.10.7",
+ "gix-date",
  "gix-hash 0.19.0",
  "gix-hashtable 0.9.0",
  "gix-object 0.50.2",
  "gix-revwalk 0.21.0",
  "gix-trace",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-revision"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe7f489bd27e7e388885210bc189088012db6062ccc75d713d1cef8eff56883"
-dependencies = [
- "bstr",
- "gix-commitgraph 0.30.1",
- "gix-date 0.11.0",
- "gix-hash 0.20.1",
- "gix-object 0.52.0",
- "gix-revwalk 0.23.0",
  "thiserror 2.0.17",
 ]
 
@@ -4011,7 +3663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc756b73225bf005ddeb871d1ca7b3c33e2417d0d53e56effa5a36765b52b28"
 dependencies = [
  "gix-commitgraph 0.28.0",
- "gix-date 0.10.7",
+ "gix-date",
  "gix-hash 0.18.0",
  "gix-hashtable 0.8.1",
  "gix-object 0.49.1",
@@ -4026,25 +3678,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06e74f91709729e099af6721bd0fa7d62f243f2005085152301ca5cdd86ec02c"
 dependencies = [
  "gix-commitgraph 0.29.0",
- "gix-date 0.10.7",
+ "gix-date",
  "gix-hash 0.19.0",
  "gix-hashtable 0.9.0",
  "gix-object 0.50.2",
- "smallvec",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-revwalk"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2fae8449d97fb92078c46cb63544e0024955f43738a610d24277a3b01d5a00"
-dependencies = [
- "gix-commitgraph 0.30.1",
- "gix-date 0.11.0",
- "gix-hash 0.20.1",
- "gix-hashtable 0.10.0",
- "gix-object 0.52.0",
  "smallvec",
  "thiserror 2.0.17",
 ]
@@ -4094,18 +3731,6 @@ dependencies = [
  "bstr",
  "gix-hash 0.19.0",
  "gix-lock 18.0.0",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-shallow"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2374692db1ee1ffa0eddcb9e86ec218f7c4cdceda800ebc5a9fdf73a8c08223"
-dependencies = [
- "bstr",
- "gix-hash 0.20.1",
- "gix-lock 19.0.0",
  "thiserror 2.0.17",
 ]
 
@@ -4167,18 +3792,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-tempfile"
-version = "19.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e265fc6b54e57693232a79d84038381ebfda7b1a3b1b8a9320d4d5fe6e820086"
-dependencies = [
- "gix-fs 0.17.0",
- "libc",
- "parking_lot",
- "tempfile",
-]
-
-[[package]]
 name = "gix-trace"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4196,7 +3809,7 @@ dependencies = [
  "gix-command",
  "gix-credentials 0.29.0",
  "gix-features 0.42.1",
- "gix-packetline 0.19.3",
+ "gix-packetline",
  "gix-quote",
  "gix-sec 0.11.0",
  "gix-url 0.31.0",
@@ -4215,26 +3828,10 @@ dependencies = [
  "gix-command",
  "gix-credentials 0.30.0",
  "gix-features 0.43.1",
- "gix-packetline 0.19.3",
+ "gix-packetline",
  "gix-quote",
  "gix-sec 0.12.2",
  "gix-url 0.32.0",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-transport"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e058d6667165dba7642b3c293d7c355e2a964acef9bc9408604547d952943a8f"
-dependencies = [
- "bstr",
- "gix-command",
- "gix-features 0.44.1",
- "gix-packetline 0.20.0",
- "gix-quote",
- "gix-sec 0.12.2",
- "gix-url 0.33.2",
  "thiserror 2.0.17",
 ]
 
@@ -4246,7 +3843,7 @@ checksum = "b8648172f85aca3d6e919c06504b7ac26baef54e04c55eb0100fa588c102cc33"
 dependencies = [
  "bitflags 2.10.0",
  "gix-commitgraph 0.28.0",
- "gix-date 0.10.7",
+ "gix-date",
  "gix-hash 0.18.0",
  "gix-hashtable 0.8.1",
  "gix-object 0.49.1",
@@ -4263,28 +3860,11 @@ checksum = "c7cdc82509d792ba0ad815f86f6b469c7afe10f94362e96c4494525a6601bdd5"
 dependencies = [
  "bitflags 2.10.0",
  "gix-commitgraph 0.29.0",
- "gix-date 0.10.7",
+ "gix-date",
  "gix-hash 0.19.0",
  "gix-hashtable 0.9.0",
  "gix-object 0.50.2",
  "gix-revwalk 0.21.0",
- "smallvec",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "gix-traverse"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054c79f4c3f87e794ff7dc1fec8306a2bb563cfb38f6be2dc0e4c0fa82f74d59"
-dependencies = [
- "bitflags 2.10.0",
- "gix-commitgraph 0.30.1",
- "gix-date 0.11.0",
- "gix-hash 0.20.1",
- "gix-hashtable 0.10.0",
- "gix-object 0.52.0",
- "gix-revwalk 0.23.0",
  "smallvec",
  "thiserror 2.0.17",
 ]
@@ -4315,19 +3895,6 @@ dependencies = [
  "percent-encoding",
  "thiserror 2.0.17",
  "url",
-]
-
-[[package]]
-name = "gix-url"
-version = "0.33.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d995249a1cf1ad79ba10af6499d4bf37cb78035c0983eaa09ec5910da694957c"
-dependencies = [
- "bstr",
- "gix-features 0.44.1",
- "gix-path",
- "percent-encoding",
- "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,6 @@ debug = "line-tables-only"
 [build-dependencies]
 time = "0.3"
 md5 = "0.8.0"
-gix = { version = "0.75.0", default-features = false }
 string_cache_codegen = "0.6.1"
 phf_codegen = "0.13"
 walkdir = "2"


### PR DESCRIPTION
previously: 
```
$ cargo tree -p gix@0.75.0 | wc -l
     309
```