### PR TITLE
reduce debug information in dev builds for better compile times

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,22 @@
-[profile.debug]
-# rustc spends an inordinate amount of time on LLVM
-rustflags = ["-C", "no-prepopulate-passes"]
+[profile.dev]
+# recommendation coming from 
+# https://doc.rust-lang.org/nightly/cargo/guide/build-performance.html#reduce-amount-of-generated-debug-information
+# for our normal dev work, line-tables are good enough to see line numbers in backtraces.
+debug = "line-tables-only"
+# mostly for mac os, splits debug info into separate files to speed up incremental builds
+# https://corrode.dev/blog/tips-for-faster-rust-compile-times/#macos-only-faster-incremental-debug-builds
+split-debuginfo = "unpacked"
+
+[profile.dev.build-override]
+# optimize proc macros & build scripts, make them execute faster 
+# https://corrode.dev/blog/tips-for-faster-rust-compile-times/#avoid-procedural-macro-crates
+opt-level = 3
+
+[profile.dev.package."*"]
+# no debug information for dependencies
+debug = false
+
+[profile.debugging]
+# big "debugging" profile, if you need to do real interactive debugging
+inherits = "dev"
+debug = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
 
 env:
   RUST_CACHE_KEY: rust-cache-20241114
+  # disable incremental builds in CI, it's not needed
+  CARGO_INCREMENTAL: 0
+
 
 jobs:
   sqlx:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,10 +128,6 @@ aws-smithy-http = "0.62.0"
 indoc = "2.0.0"
 pretty_assertions = "1.4.0"
 
-[profile.dev.package."*"]
-opt-level = 2
-debug = "line-tables-only"
-
 [build-dependencies]
 time = "0.3"
 md5 = "0.8.0"


### PR DESCRIPTION
mostly coming from : 
- https://doc.rust-lang.org/nightly/cargo/guide/build-performance.html
- https://corrode.dev/blog/tips-for-faster-rust-compile-times/

On my machine (clean dev build): 
- before: `8m 24s`
- after: `3m 42s`


I wonder if we should also put linker config into the config? Similar to us already using `mold` in our `Dockerfile`? Or is that something people should do on their machines? 


( separately I'll look if we can reduce dependencies / reduce proc macros ) 