### PR TITLE
skip crate-delete when there is no crate, also remove it from the build queue

### DIFF
--- a/.sqlx/query-4b13fe2c8df2b8b8bf019344313b2bc6442482a604cf90fb6106154f8e69a1c2.json
+++ b/.sqlx/query-4b13fe2c8df2b8b8bf019344313b2bc6442482a604cf90fb6106154f8e69a1c2.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE\n             FROM queue\n             WHERE\n                name = $1 AND\n                version = $2\n             ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4b13fe2c8df2b8b8bf019344313b2bc6442482a604cf90fb6106154f8e69a1c2"
+}

--- a/.sqlx/query-f8b389df3451e4b5e6539e9260ba6340edf69c7dba22e667aedd510e868b0f00.json
+++ b/.sqlx/query-f8b389df3451e4b5e6539e9260ba6340edf69c7dba22e667aedd510e868b0f00.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE\n             FROM queue\n             WHERE name = $1\n             ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f8b389df3451e4b5e6539e9260ba6340edf69c7dba22e667aedd510e868b0f00"
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -41,6 +41,8 @@ use tokio::{runtime, task::block_in_place};
 use tower::ServiceExt;
 use tracing::error;
 
+// testing krate name constants
+pub(crate) const KRATE: &str = "krate";
 // some versions as constants for tests
 pub(crate) const V0_1: Version = Version::new(0, 1, 0);
 pub(crate) const V1: Version = Version::new(1, 0, 0);


### PR DESCRIPTION
With crate authors being able to delete releases / crates themselves, we have to handle some new cases, for example that we get a crate-delete request and the crate is still just queued. 

Mainly coming from [this sentry error](https://rust-lang.sentry.io/issues/6998677655/events/837a51e52e6c489883f02d4d18074363/?query=&referrer=previous-event). 

Examples: 
- https://github.com/search?q=repo%3Arust-lang%2Fcrates.io-index+vulnera-advisors&type=commits&s=committer-date&o=asc
- https://github.com/search?q=repo%3Arust-lang%2Fcrates.io-index+celerrate-lsp&type=commits&s=committer-date&o=asc

This PR does two things: 
1. just skip crate/version delete when we don't find the crate
2. also remove the crate or version from the build queue