### PR TITLE
remove more unused dependencies, add cargo-machete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: install `just`
-        run: sudo snap install --edge --classic just
-
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just,sqlx-cli
 
       - name: restore build & cargo cache
         uses: Swatinem/rust-cache@v2
@@ -32,9 +31,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: install SQLX CLI
-        run: cargo binstall sqlx-cli
 
       - name: run sqlx migration up & down
         run: |
@@ -51,8 +47,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: install `just`
-        run: sudo snap install --edge --classic just
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
 
       - name: restore build & cargo cache
         uses: Swatinem/rust-cache@v2
@@ -77,8 +74,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: install `just`
-        run: sudo snap install --edge --classic just
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
 
       - name: Run GUI tests
         run: just run-gui-tests
@@ -94,18 +92,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: install `just`
-        run: sudo snap install --edge --classic just
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just,fd-find,cargo-machete
 
       - name: restore build & cargo cache
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: ${{ env.RUST_CACHE_KEY }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - run: just lint
+      - run: just lint lint-dependencies
 
   lint-js:
     name: js linters
@@ -115,8 +111,9 @@ jobs:
 
       - uses: denoland/setup-deno@v2
 
-      - name: install `just`
-        run: sudo snap install --edge --classic just
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
 
       - run: just lint-js
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,8 +2009,6 @@ dependencies = [
  "serde_with",
  "slug",
  "sqlx",
- "string_cache 0.9.0",
- "string_cache_codegen 0.6.1",
  "strum",
  "syntect",
  "sysinfo",
@@ -2028,7 +2026,6 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "url",
- "uuid",
  "walkdir",
  "zip",
  "zstd",
@@ -4857,8 +4854,8 @@ dependencies = [
  "log",
  "phf 0.10.1",
  "phf_codegen 0.10.0",
- "string_cache 0.8.9",
- "string_cache_codegen 0.5.4",
+ "string_cache",
+ "string_cache_codegen",
  "tendril",
 ]
 
@@ -7369,19 +7366,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "string_cache"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared 0.13.1",
- "precomputed-hash",
- "serde",
-]
-
-[[package]]
 name = "string_cache_codegen"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7389,18 +7373,6 @@ checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "string_cache_codegen"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
-dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -8249,7 +8221,6 @@ version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.3.4",
  "js-sys",
  "serde",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ strum = { version = "0.27.0", features = ["derive"] }
 lol_html = "2.0.0"
 font-awesome-as-a-crate = { path = "crates/font-awesome-as-a-crate" }
 dashmap = "6.0.0"
-string_cache = "0.9.0"
 zip = {version = "6.0.0", default-features = false, features = ["bzip2"]}
 bzip2 = "0.6.0"
 getrandom = "0.3.1"
@@ -75,8 +74,6 @@ aws-config = { version = "1.0.0", default-features = false, features = ["rt-toki
 aws-sdk-s3 = "1.3.0"
 aws-smithy-types-convert = { version = "0.60.0", features = ["convert-chrono"] }
 http = "1.0.0"
-uuid = { version = "1.1.2", features = ["v4"]}
-
 
 # Data serialization and deserialization
 serde = { version = "1.0", features = ["derive"] }
@@ -125,12 +122,14 @@ pretty_assertions = "1.4.0"
 [build-dependencies]
 time = "0.3"
 md5 = "0.8.0"
-string_cache_codegen = "0.6.1"
 phf_codegen = "0.13"
 walkdir = "2"
 anyhow = { version = "1.0.42", features = ["backtrace"] }
 grass = { version = "0.13.1", default-features = false }
 syntect = { version = "5.0.0", default-features = false, features = ["parsing", "dump-create", "yaml-load", "regex-onig"] }
+
+[package.metadata.cargo-machete]
+ignored = ["phf"]
 
 [[bench]]
 name = "compression"

--- a/build.rs
+++ b/build.rs
@@ -78,7 +78,6 @@ fn main() -> Result<()> {
     let mut etag_map: ETagMap = ETagMap::new();
 
     compile_sass(out_dir, &mut etag_map)?;
-    write_known_targets(out_dir)?;
     compile_syntax(out_dir).context("could not compile syntax files")?;
     calculate_static_etags(&mut etag_map)?;
 
@@ -222,24 +221,6 @@ fn calculate_static_etags(etag_map: &mut ETagMap) -> Result<()> {
             etag_map.entry(partial_path_str, etag_from_path(path)?);
         }
     }
-
-    Ok(())
-}
-
-fn write_known_targets(out_dir: &Path) -> Result<()> {
-    use std::io::BufRead;
-
-    let targets: Vec<String> = std::process::Command::new("rustc")
-        .args(["--print", "target-list"])
-        .output()?
-        .stdout
-        .lines()
-        .filter(|s| s.as_ref().map_or(true, |s| !s.is_empty()))
-        .collect::<std::io::Result<_>>()?;
-
-    string_cache_codegen::AtomType::new("target::TargetAtom", "target_atom!")
-        .atoms(&targets)
-        .write_to_file(&out_dir.join("target_atom.rs"))?;
 
     Ok(())
 }

--- a/justfiles/testing.just
+++ b/justfiles/testing.just
@@ -54,7 +54,7 @@ clippy-fix:
 
 # run all linters, for local development & CI
 [group('testing')]
-lint: format 
+lint: format lint-dependencies
   #!/usr/bin/env bash
   set -euo pipefail
 
@@ -64,6 +64,18 @@ lint: format
     just clippy-fix
   fi
 
+[group('testing')]
+lint-dependencies:
+  # check unused deps with cargo machete is fast, 
+  # but has many false positives. 
+  # While it can also recurse into subdirs, it would 
+  # also stumble onto our broken crates in `/tests/crates/*`, 
+  # where I also don't want to add machete-metadata.
+  @fd \
+    --glob 'Cargo.toml' \
+    --type file \
+    --exclude tests \
+    -X cargo machete {}
 
 [group('testing')]
 lint-js *args:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,13 +33,6 @@ mod test;
 pub mod utils;
 mod web;
 
-#[allow(dead_code)]
-mod target {
-    //! [`crate::target::TargetAtom`] is an interned string type for rustc targets, such as
-    //! `x86_64-unknown-linux-gnu`. See the [`string_cache`] docs for usage examples.
-    include!(concat!(env!("OUT_DIR"), "/target_atom.rs"));
-}
-
 use web::page::GlobalAlert;
 
 // Warning message shown in the navigation bar of every page. Set to `None` to hide it.


### PR DESCRIPTION
- `uuid` was used in the cloudfront logic (removed in #3059) 
- `string_cache` and its codegen was used for the "targets-visited" metric thing. so gone with #3053

another **11** dependencies gone from the tree ;)

Seeing how often I forget that, I added [`cargo machete`](https://github.com/bnjbvr/cargo-machete) to CI. While it has a couple of false positives, which lead to ignore-lists in our `Cargo.toml`, but it is fast and would have caught all my recent mistakes. Also it needed a workaround for our build-test crates. 

