### PR TITLE
 improve archive index locking

### DIFF
--- a/justfiles/testing.just
+++ b/justfiles/testing.just
@@ -1,6 +1,14 @@
 # just commands for CI & local development
 
 [group('testing')]
+bench-rustdoc-page host="http://127.0.0.1:8888":
+  rm -rf ignored/cratesfyi-prefix/archive_cache/*
+  ab \
+    -n 10000 \
+    -c 500 \
+    {{ host }}/rayon/1.11.0/rayon/
+
+[group('testing')]
 [group('sqlx')]
 sqlx-prepare *args: _ensure_db_and_s3_are_running
   cargo sqlx prepare \


### PR DESCRIPTION
Until there is an automation I regularly remove the local archive file cache. https://github.com/rust-lang/docs.rs/pull/2971 was a first step towards building that automated cleanup job. 

But this time this cleaning actually lead to docs.rs being down. 

I couldn't really reproduce it locally, but IMO the reason is likely my locking structure, most likely the `.write` locks queueing up when the local cache is empty. 

The optimization here is: **only use a lock to block for writes**. 
potential reads just wait until the file exists if there is already a writer downloading the index. 

Also we treat broken index as "missing index", so hopefully won't have any problems. 


Another optimization is that I pre-allocate the dashmap, since we know we'll add a bunch of entries. 