### PR TITLE
also retry index download on exists-in-archive, change locking

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -581,7 +581,7 @@ impl AsyncStorage {
         drop(write_guard);
 
         // Final attempt: if this still fails, bubble the error.
-        return archive_index::find_in_file(local_index_path, path_in_archive).await;
+        archive_index::find_in_file(local_index_path, path_in_archive).await
     }
 
     #[instrument]


### PR DESCRIPTION
I'm sorry for the whole back and forth here. 

With the time I have difficulties reproducing the load-issue locally, so it's testing in production :) 
( hopefully with little impact). 

[This sentry error](https://rust-lang.sentry.io/organizations/rust-lang/issues/7090056011/distributions/url/?environment=production&project=5499376&query=is%3Aunresolved&referrer=issue-stream) pointed me to 

1. I didn't add the ["fallback" that protects against some index edge cases](https://github.com/rust-lang/docs.rs/pull/2997) to all places where we work with the index. Thats in this PR. 
2. I went back to a simpler solution for the download-or-fetch problem, between the old and the new way. 


With a warm local cache all should be fine, I have to find a good time when I just test the cold cache. 

**the whole "cold cache" issue will bite us when we migrate our webserver to ecs, I assume there we'll have a fresh filesystem for every deploy**