### PR TITLE
switch docker build to cargo-chef

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,4 @@
 /target/
 /triagebot.toml
 archive_cache
+.git

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,19 +1,27 @@
 # syntax=docker/dockerfile:1
 
-# To produce a smaller image this Dockerfile contains two separate stages: in
-# the first one all the build dependencies are installed and docs.rs is built,
-# while in the second one just the runtime dependencies are installed, with the
-# binary built in the previous stage copied there.
-#
-# As of 2019-10-29 this reduces the image from 2.8GB to 500 MB.
+FROM rust:1.92-slim-trixie AS chef
 
+# We only pay the installation cost once, 
+# it will be cached from the second build onwards
+RUN cargo install cargo-chef 
+WORKDIR /build
+
+#################
+#  Plan stage  #
+#################
+
+FROM chef AS planner
+WORKDIR /build
+
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
 #################
 #  Build stage  #
 #################
 
-FROM rust:1.92-slim-trixie AS build
-
+FROM chef AS build
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install packaged dependencies
@@ -34,51 +42,33 @@ RUN apt-get update && \
     mold \
     clang
 
-ENV PATH=/root/.cargo/bin:$PATH
+WORKDIR /build
 
-# get the git SHA from the build args, for our generated version numbers
-ARG GIT_SHA=dev
-ENV GIT_SHA=$GIT_SHA
+COPY --from=planner /build/recipe.json recipe.json
 
 # Configure linking to use mold instead for speed (need to use clang because gcc
 # is too old on this image)
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang
 ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS=-Clink-arg=-fuse-ld=mold
 
-# Build the dependencies in a separate step to avoid rebuilding all of them
-# every time the source code changes. This takes advantage of Docker's layer
-# caching, and it works by copying the Cargo.{toml,lock} with dummy source code
-# and doing a full build with it.
-WORKDIR /build
-COPY benches benches
-COPY Cargo.lock Cargo.toml ./
-COPY crates crates
-COPY .sqlx .sqlx/
-RUN mkdir -p src/bin && \
-    echo "fn main() {}" > src/bin/cratesfyi.rs && \
-    echo "fn main() {}" > build.rs
 
 ARG PROFILE=release
+
+# Build dependencies - this is the caching Docker layer!
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry,sharing=locked \
     --mount=type=cache,target=/build/target,id=cargo-target,sharing=locked \
-    cargo build --profile=$PROFILE
+    cargo chef cook --profile=$PROFILE --recipe-path /build/recipe.json
 
-# Dependencies are now cached, copy the actual source code and do another full
-# build. The touch on all the .rs files is needed, otherwise cargo assumes the
-# source code didn't change thanks to mtime weirdness.
-RUN rm -rf src build.rs
+ENV PATH=/root/.cargo/bin:$PATH
 
-COPY build.rs build.rs
-RUN touch build.rs
-COPY src src/
-RUN find src -name "*.rs" -exec touch {} \;
-COPY templates templates/
-COPY vendor vendor/
-COPY static static/
-COPY assets assets/
-COPY .sqlx .sqlx/
-COPY migrations migrations/
+# get the git SHA from the build args, for our generated version numbers
+ARG GIT_SHA=dev
+ENV GIT_SHA=$GIT_SHA
 
+ENV SQLX_OFFLINE=true
+
+# Build application
+COPY . .
 ARG PROFILE_DIR=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry,sharing=locked \
     --mount=type=cache,target=/build/target,id=cargo-target,sharing=locked \


### PR DESCRIPTION
Our current approach would be super annoying to maintain with all the current & future subcrates. 

See https://github.com/LukeMathWalker/cargo-chef?tab=readme-ov-file#benefits-of-cargo-chef