### PR TITLE
move shared crate-details functions into database crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2003,8 +2003,10 @@ name = "docs_rs_database"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "docs_rs_env_vars",
  "docs_rs_opentelemetry",
+ "docs_rs_types",
  "futures-util",
  "hex",
  "opentelemetry",

--- a/crates/lib/docs_rs_database/.sqlx/query-1e660947261dfa1a5d1745d1732df59e0cf67ef1906da818086d063e6a0e21c6.json
+++ b/crates/lib/docs_rs_database/.sqlx/query-1e660947261dfa1a5d1745d1732df59e0cf67ef1906da818086d063e6a0e21c6.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE crates\n         SET latest_version_id = $2\n         WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1e660947261dfa1a5d1745d1732df59e0cf67ef1906da818086d063e6a0e21c6"
+}

--- a/crates/lib/docs_rs_database/.sqlx/query-4894c7d8c4e354dca1d952362b2e0cb25441e8e65b273e01ed86d2d3ecebfe84.json
+++ b/crates/lib/docs_rs_database/.sqlx/query-4894c7d8c4e354dca1d952362b2e0cb25441e8e65b273e01ed86d2d3ecebfe84.json
@@ -1,0 +1,87 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n             releases.id as \"id: ReleaseId\",\n             releases.version as \"version: Version\",\n             release_build_status.build_status as \"build_status!: BuildStatus\",\n             releases.yanked,\n             releases.is_library,\n             releases.rustdoc_status,\n             releases.release_time,\n             releases.target_name,\n             releases.default_target,\n             releases.doc_targets\n         FROM releases\n         INNER JOIN release_build_status ON releases.id = release_build_status.rid\n         WHERE\n             releases.crate_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id: ReleaseId",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "version: Version",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "build_status!: BuildStatus",
+        "type_info": {
+          "Custom": {
+            "name": "build_status",
+            "kind": {
+              "Enum": [
+                "in_progress",
+                "success",
+                "failure"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "yanked",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "is_library",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "rustdoc_status",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "release_time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "target_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "default_target",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "doc_targets",
+        "type_info": "Json"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "4894c7d8c4e354dca1d952362b2e0cb25441e8e65b273e01ed86d2d3ecebfe84"
+}

--- a/crates/lib/docs_rs_database/Cargo.toml
+++ b/crates/lib/docs_rs_database/Cargo.toml
@@ -6,8 +6,10 @@ build = "build.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+chrono = { workspace = true }
 docs_rs_env_vars = { path = "../docs_rs_env_vars" }
 docs_rs_opentelemetry = { path = "../docs_rs_opentelemetry" }
+docs_rs_types = { path = "../docs_rs_types" }
 futures-util = { workspace = true }
 hex = "0.4.3"
 opentelemetry = { workspace = true }

--- a/crates/lib/docs_rs_database/src/crate_details.rs
+++ b/crates/lib/docs_rs_database/src/crate_details.rs
@@ -1,0 +1,116 @@
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use docs_rs_types::{BuildStatus, CrateId, ReleaseId, Version};
+use futures_util::TryStreamExt as _;
+use serde_json::Value;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Release {
+    pub id: ReleaseId,
+    pub version: Version,
+    #[allow(clippy::doc_overindented_list_items)]
+    /// Aggregated build status of the release.
+    /// * no builds -> build In progress
+    /// * any build is successful -> Success
+    ///   -> even with failed or in-progress builds we have docs to show
+    /// * any build is failed -> Failure
+    ///   -> we can only have Failure or InProgress here, so the Failure is the
+    ///      important part on this aggregation level.
+    /// * the rest is all builds are in-progress -> InProgress
+    ///   -> if we have any builds, and the previous conditions don't match, we end
+    ///      up here, but we still check.
+    ///
+    /// calculated in a database view : `release_build_status`
+    pub build_status: BuildStatus,
+    pub yanked: Option<bool>,
+    pub is_library: Option<bool>,
+    pub rustdoc_status: Option<bool>,
+    pub target_name: Option<String>,
+    pub default_target: Option<String>,
+    pub doc_targets: Option<Vec<String>>,
+    pub release_time: Option<DateTime<Utc>>,
+}
+
+pub fn parse_doc_targets(targets: Value) -> Vec<String> {
+    let mut targets: Vec<String> = serde_json::from_value(targets).unwrap_or_default();
+    targets.sort_unstable();
+    targets
+}
+
+/// Return all releases for a crate, sorted in descending order by semver
+pub async fn releases_for_crate(
+    conn: &mut sqlx::PgConnection,
+    crate_id: CrateId,
+) -> Result<Vec<Release>, anyhow::Error> {
+    let mut releases: Vec<Release> = sqlx::query!(
+        r#"SELECT
+             releases.id as "id: ReleaseId",
+             releases.version as "version: Version",
+             release_build_status.build_status as "build_status!: BuildStatus",
+             releases.yanked,
+             releases.is_library,
+             releases.rustdoc_status,
+             releases.release_time,
+             releases.target_name,
+             releases.default_target,
+             releases.doc_targets
+         FROM releases
+         INNER JOIN release_build_status ON releases.id = release_build_status.rid
+         WHERE
+             releases.crate_id = $1"#,
+        crate_id.0,
+    )
+    .fetch(&mut *conn)
+    .try_filter_map(|row| async move {
+        Ok(Some(Release {
+            id: row.id,
+            version: row.version,
+            build_status: row.build_status,
+            yanked: row.yanked,
+            is_library: row.is_library,
+            rustdoc_status: row.rustdoc_status,
+            target_name: row.target_name,
+            default_target: row.default_target,
+            doc_targets: row.doc_targets.map(parse_doc_targets),
+            release_time: row.release_time,
+        }))
+    })
+    .try_collect()
+    .await?;
+
+    releases.sort_by(|a, b| b.version.cmp(&a.version));
+    Ok(releases)
+}
+
+pub fn latest_release(releases: &[Release]) -> Option<&Release> {
+    if let Some(release) = releases.iter().find(|release| {
+        release.version.pre.is_empty()
+            && release.yanked == Some(false)
+            && release.build_status != BuildStatus::InProgress
+    }) {
+        Some(release)
+    } else {
+        releases
+            .iter()
+            .find(|release| release.build_status != BuildStatus::InProgress)
+    }
+}
+
+pub async fn update_latest_version_id(
+    conn: &mut sqlx::PgConnection,
+    crate_id: CrateId,
+) -> Result<()> {
+    let releases = releases_for_crate(conn, crate_id).await?;
+
+    sqlx::query!(
+        "UPDATE crates
+         SET latest_version_id = $2
+         WHERE id = $1",
+        crate_id.0,
+        latest_release(&releases).map(|release| release.id.0),
+    )
+    .execute(&mut *conn)
+    .await?;
+
+    Ok(())
+}

--- a/crates/lib/docs_rs_database/src/lib.rs
+++ b/crates/lib/docs_rs_database/src/lib.rs
@@ -1,4 +1,5 @@
 mod config;
+pub mod crate_details;
 mod errors;
 mod metrics;
 mod migrations;

--- a/crates/lib/docs_rs_repository_stats/.sqlx/query-1e660947261dfa1a5d1745d1732df59e0cf67ef1906da818086d063e6a0e21c6.json
+++ b/crates/lib/docs_rs_repository_stats/.sqlx/query-1e660947261dfa1a5d1745d1732df59e0cf67ef1906da818086d063e6a0e21c6.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE crates\n         SET latest_version_id = $2\n         WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1e660947261dfa1a5d1745d1732df59e0cf67ef1906da818086d063e6a0e21c6"
+}

--- a/crates/lib/docs_rs_repository_stats/.sqlx/query-4894c7d8c4e354dca1d952362b2e0cb25441e8e65b273e01ed86d2d3ecebfe84.json
+++ b/crates/lib/docs_rs_repository_stats/.sqlx/query-4894c7d8c4e354dca1d952362b2e0cb25441e8e65b273e01ed86d2d3ecebfe84.json
@@ -1,0 +1,87 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n             releases.id as \"id: ReleaseId\",\n             releases.version as \"version: Version\",\n             release_build_status.build_status as \"build_status!: BuildStatus\",\n             releases.yanked,\n             releases.is_library,\n             releases.rustdoc_status,\n             releases.release_time,\n             releases.target_name,\n             releases.default_target,\n             releases.doc_targets\n         FROM releases\n         INNER JOIN release_build_status ON releases.id = release_build_status.rid\n         WHERE\n             releases.crate_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id: ReleaseId",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "version: Version",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "build_status!: BuildStatus",
+        "type_info": {
+          "Custom": {
+            "name": "build_status",
+            "kind": {
+              "Enum": [
+                "in_progress",
+                "success",
+                "failure"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "yanked",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "is_library",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "rustdoc_status",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "release_time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "target_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "default_target",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "doc_targets",
+        "type_info": "Json"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "4894c7d8c4e354dca1d952362b2e0cb25441e8e65b273e01ed86d2d3ecebfe84"
+}

--- a/src/bin/cratesfyi.rs
+++ b/src/bin/cratesfyi.rs
@@ -10,7 +10,10 @@ use docs_rs::{
         list_crate_priorities, queue_builder, remove_crate_priority, set_crate_priority,
     },
 };
-use docs_rs_database::service_config::{ConfigName, get_config, set_config};
+use docs_rs_database::{
+    crate_details,
+    service_config::{ConfigName, get_config, set_config},
+};
 use docs_rs_storage::add_path_into_database;
 use docs_rs_types::{CrateId, Version};
 use futures_util::StreamExt;
@@ -533,7 +536,7 @@ impl DatabaseSubcommand {
 
                         println!("handling crate {}", row.name);
 
-                        db::update_latest_version_id(&mut update_conn, row.id).await?;
+                        crate_details::update_latest_version_id(&mut update_conn, row.id).await?;
                     }
 
                     Ok::<(), anyhow::Error>(())

--- a/src/build_queue.rs
+++ b/src/build_queue.rs
@@ -1,6 +1,6 @@
 use crate::{
     BuildPackageSummary, Config, Context, Index, RustwideBuilder,
-    db::{delete_crate, delete_version, update_latest_version_id},
+    db::{delete_crate, delete_version},
     docbuilder::{BuilderMetrics, PackageKind},
     error::Result,
     utils::{get_crate_priority, report_error},
@@ -10,6 +10,7 @@ use chrono::NaiveDate;
 use crates_index_diff::{Change, CrateVersion};
 use docs_rs_database::{
     AsyncPoolClient, Pool,
+    crate_details::update_latest_version_id,
     service_config::{ConfigName, get_config, set_config},
 };
 use docs_rs_fastly::{Cdn, CdnBehaviour as _};

--- a/src/db/delete.rs
+++ b/src/db/delete.rs
@@ -1,11 +1,10 @@
 use crate::{Config, error::Result};
 use anyhow::Context as _;
+use docs_rs_database::crate_details::update_latest_version_id;
 use docs_rs_storage::{AsyncStorage, rustdoc_archive_path, source_archive_path};
 use docs_rs_types::{CrateId, Version};
 use fn_error_context::context;
 use sqlx::Connection;
-
-use super::update_latest_version_id;
 
 /// List of directories in docs.rs's underlying storage (either the database or S3) containing a
 /// subdirectory named after the crate. Those subdirectories will be deleted.

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,5 +1,4 @@
 //! Database operations
-pub use self::add_package::update_latest_version_id;
 pub(crate) use self::add_package::{
     add_doc_coverage, finish_build, finish_release, initialize_build, initialize_crate,
     initialize_release, update_build_with_error,

--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -20,6 +20,7 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use docs_rs_cargo_metadata::{Dependency, ReleaseDependencyList};
+use docs_rs_database::crate_details::{Release, latest_release, parse_doc_targets};
 use docs_rs_headers::CanonicalUrl;
 use docs_rs_registry_api::OwnerKind;
 use docs_rs_storage::{AsyncStorage, PathNotFoundError};
@@ -75,33 +76,6 @@ struct RepositoryMetadata {
     forks: i32,
     issues: i32,
     name: Option<String>,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub(crate) struct Release {
-    pub id: ReleaseId,
-    pub version: Version,
-    #[allow(clippy::doc_overindented_list_items)]
-    /// Aggregated build status of the release.
-    /// * no builds -> build In progress
-    /// * any build is successful -> Success
-    ///   -> even with failed or in-progress builds we have docs to show
-    /// * any build is failed -> Failure
-    ///   -> we can only have Failure or InProgress here, so the Failure is the
-    ///      important part on this aggregation level.
-    /// * the rest is all builds are in-progress -> InProgress
-    ///   -> if we have any builds, and the previous conditions don't match, we end
-    ///      up here, but we still check.
-    ///
-    /// calculated in a database view : `release_build_status`
-    pub build_status: BuildStatus,
-    pub yanked: Option<bool>,
-    pub is_library: Option<bool>,
-    pub rustdoc_status: Option<bool>,
-    pub target_name: Option<String>,
-    pub default_target: Option<String>,
-    pub doc_targets: Option<Vec<String>>,
-    pub release_time: Option<DateTime<Utc>>,
 }
 
 impl CrateDetails {
@@ -211,7 +185,7 @@ impl CrateDetails {
             rustdoc_status: krate.rustdoc_status,
             target_name: krate.target_name.clone(),
             default_target: krate.default_target,
-            doc_targets: krate.doc_targets.map(MetaData::parse_doc_targets),
+            doc_targets: krate.doc_targets.map(parse_doc_targets),
             yanked: krate.yanked,
             rustdoc_css_file: krate
                 .rustc_version
@@ -368,65 +342,6 @@ impl CrateDetails {
     pub fn latest_release(&self) -> Result<&Release> {
         latest_release(&self.releases).ok_or_else(|| anyhow!("crate without releases"))
     }
-}
-
-pub(crate) fn latest_release(releases: &[Release]) -> Option<&Release> {
-    if let Some(release) = releases.iter().find(|release| {
-        release.version.pre.is_empty()
-            && release.yanked == Some(false)
-            && release.build_status != BuildStatus::InProgress
-    }) {
-        Some(release)
-    } else {
-        releases
-            .iter()
-            .find(|release| release.build_status != BuildStatus::InProgress)
-    }
-}
-
-/// Return all releases for a crate, sorted in descending order by semver
-pub(crate) async fn releases_for_crate(
-    conn: &mut sqlx::PgConnection,
-    crate_id: CrateId,
-) -> Result<Vec<Release>, anyhow::Error> {
-    let mut releases: Vec<Release> = sqlx::query!(
-        r#"SELECT
-             releases.id as "id: ReleaseId",
-             releases.version as "version: Version",
-             release_build_status.build_status as "build_status!: BuildStatus",
-             releases.yanked,
-             releases.is_library,
-             releases.rustdoc_status,
-             releases.release_time,
-             releases.target_name,
-             releases.default_target,
-             releases.doc_targets
-         FROM releases
-         INNER JOIN release_build_status ON releases.id = release_build_status.rid
-         WHERE
-             releases.crate_id = $1"#,
-        crate_id.0,
-    )
-    .fetch(&mut *conn)
-    .try_filter_map(|row| async move {
-        Ok(Some(Release {
-            id: row.id,
-            version: row.version,
-            build_status: row.build_status,
-            yanked: row.yanked,
-            is_library: row.is_library,
-            rustdoc_status: row.rustdoc_status,
-            target_name: row.target_name,
-            default_target: row.default_target,
-            doc_targets: row.doc_targets.map(MetaData::parse_doc_targets),
-            release_time: row.release_time,
-        }))
-    })
-    .try_collect()
-    .await?;
-
-    releases.sort_by(|a, b| b.version.cmp(&a.version));
-    Ok(releases)
 }
 
 #[derive(Debug, Clone, Template)]
@@ -727,7 +642,7 @@ mod tests {
         fake_release_that_failed_before_build,
     };
     use anyhow::Error;
-    use docs_rs_database::testing::TestDatabase;
+    use docs_rs_database::{crate_details::releases_for_crate, testing::TestDatabase};
     use docs_rs_registry_api::CrateOwner;
     use docs_rs_types::KrateName;
     use http::StatusCode;


### PR DESCRIPTION
will be needed by the watcher & the builder binaries. 