### PR TITLE
fix: readme format

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ The recommended way to develop docs.rs is a combination of `cargo run` for
 the main binary and [docker-compose](https://docs.docker.com/compose/) for the external services.
 This gives you reasonable incremental build times without having to add new users and packages to your host machine.
 
-```
-
 ### Dependencies
 
 Docs.rs requires at least the following native C dependencies.


### PR DESCRIPTION
removed three stray backticks causing formatting issues

*Before*

<img width="980" height="1083" alt="readme-before" src="https://github.com/user-attachments/assets/70213457-cc2f-4e6e-a9c4-1a5b3a730d63" />

*After*

<img width="981" height="1092" alt="readme-after" src="https://github.com/user-attachments/assets/473c7ace-0704-43d7-aa9a-48cc59c5169a" />
