### PR TITLE
ignore "unmaintained" warning for bincode, it's used by syntect

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -16,6 +16,9 @@ ignore = [
 
     "RUSTSEC-2025-0134", # rustls-pemfile is unmaintained 
     # https://github.com/rust-lang/docs.rs/issues/3070
+
+    "RUSTSEC-2025-0141", # Bincode is unmaintained 
+    # https://github.com/rust-lang/docs.rs/issues/3122
 ]
 informational_warnings = ["unmaintained"] # warn for categories of informational advisories
 severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "critical")


### PR DESCRIPTION
https://github.com/rust-lang/docs.rs/issues/3122

https://github.com/trishume/syntect/issues/606