### PR TITLE
Unify all "/releases" pages to be "centered"

### DIFF
--- a/crates/bin/docs_rs_web/templates/releases/activity.html
+++ b/crates/bin/docs_rs_web/templates/releases/activity.html
@@ -12,6 +12,10 @@
     {%- include "header/topbar.html" -%}
 {%- endblock topbar -%}
 
+{%- block body_classes -%}
+centered
+{%- endblock body_classes -%}
+
 {%- block body -%}
     <div class="container">
         <canvas id="releases-activity-chart"></canvas>

--- a/crates/bin/docs_rs_web/templates/releases/build_queue.html
+++ b/crates/bin/docs_rs_web/templates/releases/build_queue.html
@@ -12,6 +12,10 @@
     {%- include "header/topbar.html" -%}
 {%- endblock topbar -%}
 
+{%- block body_classes -%}
+centered
+{%- endblock body_classes -%}
+
 {%- block body -%}
     <div class="container">
         <div class="recent-releases-container">


### PR DESCRIPTION
All "/releases" tabs except for the two last ones are "centered", this PR fixes that.

Not centered tab:
<img width="704" height="245" alt="Screenshot From 2026-01-12 17-56-46" src="https://github.com/user-attachments/assets/cf056647-c40b-4fec-8f5f-17b2a56df41f" />

Centered tab:
<img width="704" height="245" alt="image" src="https://github.com/user-attachments/assets/4c016b12-618f-4c2a-93bd-377ea7f5cccc" />
