### PR TITLE
fix build performance tracing

### DIFF
--- a/crates/lib/docs_rs_logging/src/lib.rs
+++ b/crates/lib/docs_rs_logging/src/lib.rs
@@ -8,6 +8,15 @@ use sentry::{
 use std::{env, str::FromStr as _, sync::Arc};
 use tracing_subscriber::{EnvFilter, filter::Directive, prelude::*};
 
+/// defines the transaction name to be used for our rustwide builder.
+///
+/// We want to trace _all_ builds, while we want to apply a
+/// sampling ratio to web requests.
+///
+/// From what I see right now, the transaction name or op is the only way
+/// to distinguish build transactions from web requests.
+pub const BUILD_PACKAGE_TRANSACTION_NAME: &str = "docbuilder.build_package";
+
 pub struct Guard {
     #[allow(dead_code)]
     sentry_guard: Option<sentry::ClientInitGuard>,
@@ -54,8 +63,7 @@ pub fn init() -> anyhow::Result<Guard> {
                 return if sampled { 1.0 } else { 0.0 };
             }
 
-            let op = ctx.operation();
-            if op == "docbuilder.build_package" {
+            if ctx.name() == BUILD_PACKAGE_TRANSACTION_NAME {
                 // record all transactions for builds
                 1.
             } else {

--- a/crates/lib/docs_rs_utils/src/lib.rs
+++ b/crates/lib/docs_rs_utils/src/lib.rs
@@ -1,6 +1,9 @@
+mod runtime_ext;
 pub mod rustc_version;
 #[cfg(feature = "testing")]
 pub mod testing;
+
+pub use runtime_ext::Handle;
 
 use anyhow::{Context as _, Result};
 use std::fmt;

--- a/crates/lib/docs_rs_utils/src/runtime_ext.rs
+++ b/crates/lib/docs_rs_utils/src/runtime_ext.rs
@@ -1,0 +1,27 @@
+use std::ops::Deref;
+use tokio::runtime;
+use tracing::Instrument as _;
+
+/// Newtype around `tokio::runtime::Handle` that adds
+/// missing integration with tracing spans.
+pub struct Handle(runtime::Handle);
+
+impl Handle {
+    pub fn block_on<F: Future>(&self, future: F) -> F::Output {
+        runtime::Handle::block_on(self, future.in_current_span())
+    }
+}
+
+impl From<runtime::Handle> for Handle {
+    fn from(handle: runtime::Handle) -> Self {
+        Handle(handle)
+    }
+}
+
+impl Deref for Handle {
+    type Target = runtime::Handle;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}


### PR DESCRIPTION
I wanted to look into performance traces for builds, and discovered they are all over the place. 

Mainly: the main `docbuilder.build_package` trace is not connected to the child traces. 

I'm not 100% sure if these changes solve it completely, but I definitely discovered these issues, and they are fixed by the PR: 

- we had logic in place that would force _all_ builds to be traced, and only applies the sampling ratio to web requests. **This didn't work**, at least since the multi-crate migration. I validated what's in `ctx.operation()` and `ctx.name()` and fixed the filter. 
- we have our custom `spawn_blocking` function that takes care of passing on the parent span into the task because tokio doesn't. I realized that `block_on` has the same issue. For now I just used the new fixed handle for builds. If it solves the issues there, I'll move the `spawn_blocking` fn into the handler too, and update the whole codebase. 