### PR TITLE
gix: switch from http-curl/openssl to http-reqwest/rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,36 +1658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl"
-version = "0.4.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fc3b6dd0b87ba36e565715bf9a2ced221311db47bd18011676f24a6066edbc"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "schannel",
- "socket2 0.6.1",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.85+curl-8.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0efa6142b5ecc05f6d3eaa39e6af4888b9d3939273fb592c92b7088a8cf3fdb"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "cvt"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3603,7 +3573,6 @@ checksum = "a4d4ed02a2ebe771a26111896ecda0b98b58ed35e1d9c0ccf07251c1abb4918d"
 dependencies = [
  "base64",
  "bstr",
- "curl",
  "gix-command",
  "gix-credentials",
  "gix-features",
@@ -3611,6 +3580,7 @@ dependencies = [
  "gix-quote",
  "gix-sec",
  "gix-url",
+ "reqwest 0.13.1",
  "thiserror 2.0.18",
 ]
 

--- a/crates/bin/docs_rs_watcher/Cargo.toml
+++ b/crates/bin/docs_rs_watcher/Cargo.toml
@@ -9,8 +9,10 @@ edition = "2024"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-crates-index = { version = "3.0.0", default-features = false, features = ["git", "git-https", "git-performance", "parallel"] }
-crates-index-diff = { version = "29.0.0", features = [ "max-performance" ] }
+# NOTE: on the new infra, switch back from `git-https-reqwest` to `git-https` (curl) once the curl version is new enough
+crates-index = { version = "3.0.0", default-features = false, features = ["git", "git-https-reqwest", "git-performance", "parallel"] }
+# NOTE: on the new infra, switch back from `http-reqwest` to `http-curl` once the curl version is new enough
+crates-index-diff = { version = "29.0.0", default-features = false, features = [ "max-performance", "semver", "http-reqwest" ] }
 docs_rs_build_queue = { path = "../../lib/docs_rs_build_queue" }
 docs_rs_config = { path = "../../lib/docs_rs_config" }
 docs_rs_context = { path = "../../lib/docs_rs_context" }


### PR DESCRIPTION
the build on our server breaks because the ubuntu version we run (18.04) has a quite old openssl version (1.1.1), and libcurl needs 3.0. 

```
  cargo:warning=curl/lib/vtls/openssl.c:101:6: error: #error "OpenSSL 3.0.0 or later required"
  cargo:warning= #    error "OpenSSL 3.0.0 or later required"
  cargo:warning=      ^~~~~
```

I think temporarily switching to reqwest / rustls is better, until we run on the new infra. 