### PR TITLE
clean up audit.toml

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -5,17 +5,11 @@ ignore = [
     "RUSTSEC-2024-0320", # yaml-rust is unmaintained. 
     # https://github.com/rust-lang/docs.rs/issues/2469
 
-    "RUSTSEC-2024-0370", # proc-macro-error is unmaintained
-    # https://github.com/rust-lang/docs.rs/issues/2595
-
     "RUSTSEC-2025-0007", # `ring` is unmaintained. Not much we can do about it.
     # https://github.com/rust-lang/docs.rs/issues/2741
 
     "RUSTSEC-2025-0057", # fxhash - no longer maintained. Not much we can do about it.
     # https://github.com/rust-lang/docs.rs/issues/2914
-
-    "RUSTSEC-2025-0134", # rustls-pemfile is unmaintained 
-    # https://github.com/rust-lang/docs.rs/issues/3070
 
     "RUSTSEC-2025-0141", # Bincode is unmaintained 
     # https://github.com/rust-lang/docs.rs/issues/3122


### PR DESCRIPTION
Fixes #3070, Fixes #2595 

these are gone from the dependency tree now.