### PR TITLE
gracefully handle 404 errors from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,9 +2245,13 @@ dependencies = [
  "docs_rs_env_vars",
  "docs_rs_types",
  "docs_rs_utils",
+ "mime",
+ "mockito",
  "reqwest 0.13.2",
  "serde",
+ "serde_json",
  "sqlx",
+ "tokio",
  "tracing",
  "url",
 ]

--- a/crates/bin/docs_rs_builder/src/docbuilder/rustwide_builder.rs
+++ b/crates/bin/docs_rs_builder/src/docbuilder/rustwide_builder.rs
@@ -786,7 +786,7 @@ impl RustwideBuilder {
                         .runtime
                         .block_on(self.registry_api.get_release_data(name, version))
                         {
-                        Ok(data) => Some(data),
+                        Ok(data) => data,
                         Err(err) => {
                             error!(%name, %version, ?err, "could not fetch releases-data");
                             None

--- a/crates/bin/docs_rs_import_release/src/import.rs
+++ b/crates/bin/docs_rs_import_release/src/import.rs
@@ -4,6 +4,7 @@ use crate::{
     rustdoc::{download_static_files, find_static_paths, find_successful_build_targets},
     rustdoc_status::fetch_rustdoc_status,
 };
+use anyhow::anyhow;
 use anyhow::{Result, bail};
 use docs_rs_cargo_metadata::CargoMetadata;
 use docs_rs_database::releases::{
@@ -117,7 +118,10 @@ async fn import_test_release_inner(
         (files_list, source_size)
     };
 
-    let registry_data = registry_api.get_release_data(name, version).await?;
+    let registry_data = registry_api
+        .get_release_data(name, version)
+        .await?
+        .ok_or_else(|| anyhow!("registry data not found"))?;
 
     let rustdoc_dir = {
         info!("download & extract rustdoc archive...");

--- a/crates/lib/docs_rs_registry_api/Cargo.toml
+++ b/crates/lib/docs_rs_registry_api/Cargo.toml
@@ -18,3 +18,10 @@ serde = { workspace = true }
 sqlx = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
+
+[dev-dependencies]
+docs_rs_types = { path = "../docs_rs_types", features = ["testing"] }
+mime = { workspace = true }
+mockito = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }

--- a/crates/lib/docs_rs_registry_api/src/models.rs
+++ b/crates/lib/docs_rs_registry_api/src/models.rs
@@ -7,7 +7,7 @@ pub struct CrateData {
     pub owners: Vec<CrateOwner>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct ReleaseData {
     pub release_time: DateTime<Utc>,
     pub yanked: bool,


### PR DESCRIPTION
otherwise we are getting sentry reports. 