### PR TITLE
registry-api: gracefully handle releases not found

### DIFF
--- a/crates/bin/docs_rs_builder/src/docbuilder/rustwide_builder.rs
+++ b/crates/bin/docs_rs_builder/src/docbuilder/rustwide_builder.rs
@@ -786,7 +786,7 @@ impl RustwideBuilder {
                         .runtime
                         .block_on(self.registry_api.get_release_data(name, version))
                         {
-                        Ok(data) => Some(data),
+                        Ok(data) => data,
                         Err(err) => {
                             error!(%name, %version, ?err, "could not fetch releases-data");
                             None

--- a/crates/bin/docs_rs_import_release/src/import.rs
+++ b/crates/bin/docs_rs_import_release/src/import.rs
@@ -4,7 +4,7 @@ use crate::{
     rustdoc::{download_static_files, find_static_paths, find_successful_build_targets},
     rustdoc_status::fetch_rustdoc_status,
 };
-use anyhow::{Result, bail};
+use anyhow::{Result, anyhow, bail};
 use docs_rs_cargo_metadata::CargoMetadata;
 use docs_rs_database::releases::{
     finish_build, finish_release, initialize_build, initialize_crate, initialize_release,
@@ -117,7 +117,10 @@ async fn import_test_release_inner(
         (files_list, source_size)
     };
 
-    let registry_data = registry_api.get_release_data(name, version).await?;
+    let registry_data = registry_api
+        .get_release_data(name, version)
+        .await?
+        .ok_or_else(|| anyhow!("release not found in registry"))?;
 
     let rustdoc_dir = {
         info!("download & extract rustdoc archive...");

--- a/crates/lib/docs_rs_registry_api/Cargo.toml
+++ b/crates/lib/docs_rs_registry_api/Cargo.toml
@@ -22,6 +22,7 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+docs_rs_types = { path = "../docs_rs_types", features = ["testing"] }
 mime = { workspace = true }
 mockito = { workspace = true }
 test-case = { workspace = true }

--- a/crates/lib/docs_rs_registry_api/src/error.rs
+++ b/crates/lib/docs_rs_registry_api/src/error.rs
@@ -61,7 +61,6 @@ mod tests {
         let status = StatusCode::INTERNAL_SERVER_ERROR;
 
         assert!(Error::CrateIoApiError(status, ApiErrors::default()).status() == Some(status));
-
         assert!(Error::CrateIoError(status, "".into()).status() == Some(status));
     }
 

--- a/crates/lib/docs_rs_registry_api/src/models.rs
+++ b/crates/lib/docs_rs_registry_api/src/models.rs
@@ -8,6 +8,7 @@ pub struct CrateData {
 }
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct ReleaseData {
     pub release_time: DateTime<Utc>,
     pub yanked: bool,


### PR DESCRIPTION
I remember some edge cases when this can happen, one of them is definitely when the release was deleted after it was queued, but before it was built. 


