### PR TITLE
add workspace lints, forbid dbg! usage, remove current usages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,10 @@ url = { version = "2.1.1", features = ["serde"] }
 walkdir = "2"
 zip = { version = "7.0.0", default-features = false, features = ["bzip2"] }
 
+[workspace.lints.clippy]
+dbg_macro = "warn"
+todo = "warn"
+
 [profile.dev]
 # recommendation coming from 
 # https://doc.rust-lang.org/nightly/cargo/guide/build-performance.html#reduce-amount-of-generated-debug-information

--- a/crates/bin/cratesfyi/Cargo.toml
+++ b/crates/bin/cratesfyi/Cargo.toml
@@ -18,3 +18,6 @@ docs_rs_watcher = { path = "../docs_rs_watcher" }
 docs_rs_web = { path = "../docs_rs_web" }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bin/docs_rs_admin/Cargo.toml
+++ b/crates/bin/docs_rs_admin/Cargo.toml
@@ -38,3 +38,6 @@ docs_rs_test_fakes = { path = "../../lib/docs_rs_test_fakes" }
 docs_rs_types = { path = "../../lib/docs_rs_types", features = ["testing"] }
 pretty_assertions = { workspace = true }
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bin/docs_rs_builder/Cargo.toml
+++ b/crates/bin/docs_rs_builder/Cargo.toml
@@ -52,3 +52,6 @@ docs_rs_types = { path = "../../lib/docs_rs_types", features = ["testing"] }
 docs_rs_utils = { path = "../../lib/docs_rs_utils", features = ["testing"] }
 pretty_assertions = { workspace = true }
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bin/docs_rs_builder/src/docbuilder/rustwide_builder.rs
+++ b/crates/bin/docs_rs_builder/src/docbuilder/rustwide_builder.rs
@@ -1587,7 +1587,6 @@ mod tests {
                         .collect();
                     json_files.retain(|f| f.ends_with(&format!(".json.{ext}")));
                     json_files.sort();
-                    dbg!(&json_files);
                     assert!(json_files[0].starts_with(&format!("empty-library_1.0.0_{target}_")));
                     assert!(json_files[0].ends_with(&format!(".json.{ext}")));
                     assert_eq!(

--- a/crates/bin/docs_rs_import_release/Cargo.toml
+++ b/crates/bin/docs_rs_import_release/Cargo.toml
@@ -32,3 +32,6 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }
 zip = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bin/docs_rs_watcher/Cargo.toml
+++ b/crates/bin/docs_rs_watcher/Cargo.toml
@@ -44,3 +44,6 @@ docs_rs_test_fakes = { path = "../../lib/docs_rs_test_fakes" }
 docs_rs_types = { path = "../../lib/docs_rs_types", features = ["testing"] }
 pretty_assertions = { workspace = true }
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bin/docs_rs_web/Cargo.toml
+++ b/crates/bin/docs_rs_web/Cargo.toml
@@ -94,3 +94,6 @@ pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 walkdir = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bin/docs_rs_web/src/extractors/rustdoc.rs
+++ b/crates/bin/docs_rs_web/src/extractors/rustdoc.rs
@@ -1369,14 +1369,11 @@ mod tests {
             .with_target_name("dummy")
             .with_doc_targets(TARGETS.iter().cloned());
 
-        dbg!(&params);
-
         assert!(params.doc_target().is_none());
         assert_eq!(params.inner_path(), "dummy/struct.Dummy.html");
         assert_eq!(params.storage_path(), "dummy/struct.Dummy.html");
 
         let params = params.with_doc_target(DEFAULT_TARGET);
-        dbg!(&params);
         assert_eq!(params.doc_target(), Some(DEFAULT_TARGET));
         assert_eq!(params.inner_path(), "dummy/struct.Dummy.html");
         assert_eq!(params.storage_path(), "dummy/struct.Dummy.html");
@@ -1438,8 +1435,6 @@ mod tests {
             .with_maybe_doc_target(target)
             .with_maybe_inner_path(path)
             .with_doc_targets(TARGETS.iter().cloned());
-
-        dbg!(&params);
 
         assert_eq!(params.doc_target(), expected_target);
         assert_eq!(params.inner_path(), expected_path);
@@ -1587,7 +1582,6 @@ mod tests {
 
         // with page-kind "Rustdoc", we get the full path with static suffix
         let params = params.with_page_kind(PageKind::Rustdoc);
-        dbg!(&params);
         assert_eq!(
             params.rustdoc_url(),
             format!("/krate/latest/{OTHER_TARGET}/path_add/static.html")
@@ -1632,8 +1626,6 @@ mod tests {
             .with_doc_target("dummy")
             .with_inner_path("struct.Dummy.html");
 
-        dbg!(&params);
-
         // initial params, doc-target is "dummy", not validated
         assert_eq!(params.doc_target(), Some("dummy"));
         assert_eq!(params.inner_path(), "struct.Dummy.html");
@@ -1645,8 +1637,6 @@ mod tests {
             .with_target_name(KRATE.to_string())
             .with_doc_targets(TARGETS.iter().cloned());
 
-        dbg!(&params);
-
         assert_eq!(params.doc_target(), None);
         assert_eq!(params.inner_path(), "dummy/struct.Dummy.html");
 
@@ -1655,7 +1645,6 @@ mod tests {
         // Then we expect the path to be intact still, and the target to be set, even
         // though the folder-part of the path was initially generated from the doc_target field.
         let params = params.with_doc_target(OTHER_TARGET);
-        dbg!(&params);
         assert_eq!(params.doc_target(), Some(OTHER_TARGET));
         assert_eq!(params.inner_path(), "dummy/struct.Dummy.html");
     }
@@ -1703,23 +1692,19 @@ mod tests {
     #[test]
     fn test_parse_something() {
         // test for https://github.com/rust-lang/docs.rs/issues/2989
-        let params = dbg!(
-            RustdocParams::new(KRATE)
-                .with_page_kind(PageKind::Rustdoc)
-                .try_with_original_uri(format!("/{KRATE}/latest/{KRATE}"))
-                .unwrap()
-                .with_req_version(ReqVersion::Latest)
-                .with_doc_target(KRATE.to_string())
-        );
+        let params = RustdocParams::new(KRATE)
+            .with_page_kind(PageKind::Rustdoc)
+            .try_with_original_uri(format!("/{KRATE}/latest/{KRATE}"))
+            .unwrap()
+            .with_req_version(ReqVersion::Latest)
+            .with_doc_target(KRATE.to_string());
 
         assert_eq!(params.rustdoc_url(), "/krate/latest/krate/");
 
-        let params = dbg!(
-            params
-                .with_target_name(KRATE.to_string())
-                .with_default_target(DEFAULT_TARGET)
-                .with_doc_targets(TARGETS.iter().cloned())
-        );
+        let params = params
+            .with_target_name(KRATE.to_string())
+            .with_default_target(DEFAULT_TARGET)
+            .with_doc_targets(TARGETS.iter().cloned());
 
         assert_eq!(params.rustdoc_url(), "/krate/latest/krate/");
     }
@@ -1742,8 +1727,6 @@ mod tests {
             .with_target_name(KRATE.to_string())
             .with_doc_targets(TARGETS.iter().cloned());
 
-        dbg!(&params);
-
         assert_eq!(params.rustdoc_url(), expected_url);
     }
 
@@ -1760,8 +1743,6 @@ mod tests {
             .with_req_version(ReqVersion::Exact(ver))
             .with_doc_target(KRATE.to_string())
             .with_inner_path("trait.Itertools.html");
-
-        dbg!(&params);
 
         assert_eq!(
             params.rustdoc_url(),

--- a/crates/bin/docs_rs_web/src/handlers/builds.rs
+++ b/crates/bin/docs_rs_web/src/handlers/builds.rs
@@ -550,14 +550,14 @@ mod tests {
             };
             Overrides::save(&mut conn, &FOO, limits).await?;
 
-            let page = kuchikiki::parse_html().one(dbg!(
+            let page = kuchikiki::parse_html().one(
                 env.web_app()
                     .await
                     .assert_success(&format!("/crate/foo/{V1}/builds"))
                     .await?
                     .text()
-                    .await?
-            ));
+                    .await?,
+            );
 
             let header = page.select(".about h4").unwrap().next().unwrap();
             assert_eq!(header.text_contents(), "foo's sandbox limits");

--- a/crates/bin/docs_rs_web/src/handlers/crate_details.rs
+++ b/crates/bin/docs_rs_web/src/handlers/crate_details.rs
@@ -1812,8 +1812,6 @@ mod tests {
                 })
                 .collect();
 
-            dbg!(&platform_links);
-
             assert_eq!(platform_links.len(), 2);
 
             for (_, url, rel) in &platform_links {
@@ -1836,7 +1834,7 @@ mod tests {
             url: &str,
             should_contain_redirect: bool,
         ) {
-            let response = env.web_app().await.get(dbg!(url)).await.unwrap();
+            let response = env.web_app().await.get(url).await.unwrap();
             let status = response.status();
             assert!(
                 status.is_success(),
@@ -1846,11 +1844,7 @@ mod tests {
                 response.redirect_target().unwrap_or_default(),
             );
             let text = response.text().await.unwrap();
-            let list1 = dbg!(check_links(
-                text.clone(),
-                false,
-                dbg!(should_contain_redirect)
-            ));
+            let list1 = check_links(text.clone(), false, should_contain_redirect);
 
             // Same test with AJAX endpoint.
             let platform_menu_url = kuchikiki::parse_html()
@@ -1862,12 +1856,7 @@ mod tests {
                 .get("data-url")
                 .expect("data-url")
                 .to_string();
-            let response = env
-                .web_app()
-                .await
-                .get(&dbg!(platform_menu_url))
-                .await
-                .unwrap();
+            let response = env.web_app().await.get(&platform_menu_url).await.unwrap();
             assert!(
                 response.status().is_success(),
                 "{}",
@@ -1877,11 +1866,11 @@ mod tests {
                 CachePolicy::ForeverInCdn(KrateName::from_str("dummy").unwrap().into()),
                 env.config(),
             );
-            let list2 = dbg!(check_links(
+            let list2 = check_links(
                 response.text().await.unwrap(),
                 true,
                 should_contain_redirect,
-            ));
+            );
             assert_eq!(list1, list2);
         }
 

--- a/crates/bin/docs_rs_web/src/handlers/rustdoc.rs
+++ b/crates/bin/docs_rs_web/src/handlers/rustdoc.rs
@@ -225,9 +225,6 @@ pub(crate) async fn rustdoc_redirector_handler(
         Ok(axum_cached_redirect(url, cache_policy)?)
     }
 
-    dbg!(&params);
-    dbg!(&original_uri);
-
     // edge case 1:
     // global static assets for older builds are served from the root, which ends up
     // in this handler as `params.name`.
@@ -358,8 +355,6 @@ pub(crate) async fn rustdoc_redirector_handler(
         .instrument(info_span!("serve asset for crate"))
         .await;
     }
-
-    dbg!(&params);
 
     if matched_release.rustdoc_status() {
         Ok(redirect_to_doc(
@@ -1871,7 +1866,7 @@ mod test {
         ) -> Result<(), anyhow::Error> {
             let mut links: BTreeMap<_, _> = links.iter().copied().collect();
 
-            for (platform, link, rel) in dbg!(get_platform_links(path, web).await?) {
+            for (platform, link, rel) in get_platform_links(path, web).await? {
                 assert_eq!(rel, "nofollow");
                 web.assert_redirect(&link, links.remove(platform.as_str()).unwrap())
                     .await?;
@@ -2887,15 +2882,15 @@ mod test {
                 .create()
                 .await?;
 
-            let dom = kuchikiki::parse_html().one(dbg!(
+            let dom = kuchikiki::parse_html().one(
                 env.web_app()
                     .await
                     .get("/testing/0.1.0/testing/")
                     .await?
                     .error_for_status()?
                     .text()
-                    .await?
-            ));
+                    .await?,
+            );
             assert!(
                 dom.select(
                     r#"a[href="/optional-dep/^1.2.3/"] > i[class="dependencies normal"] + i"#

--- a/crates/bin/docs_rs_web/src/metrics.rs
+++ b/crates/bin/docs_rs_web/src/metrics.rs
@@ -194,13 +194,11 @@ mod tests {
                 *entry += 2;
             }
 
-            let collected = dbg!(env.collected_metrics());
+            let collected = env.collected_metrics();
             let metric = collected.get_metric("web", "docsrs.web.routes_visited")?;
             let AggregatedMetrics::U64(MetricData::Sum(routes_visited)) = metric.data() else {
                 panic!("Expected Sum<U64> metric data");
             };
-
-            dbg!(&routes_visited);
 
             let routes_visited: HashMap<String, u64> = routes_visited
                 .data_points()
@@ -244,8 +242,6 @@ mod tests {
             else {
                 panic!("Expected Histogram<F64> metric data");
             };
-
-            dbg!(&response_time);
 
             let response_time_sample_counts: HashMap<String, u64> = response_time
                 .data_points()

--- a/crates/lib/crates_io_validation/Cargo.toml
+++ b/crates/lib/crates_io_validation/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2024"
 [dependencies]
 thiserror = "=2.0.18"
 unicode-xid = "=0.2.6"
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_build_limits/Cargo.toml
+++ b/crates/lib/docs_rs_build_limits/Cargo.toml
@@ -22,3 +22,5 @@ docs_rs_types = { path = "../docs_rs_types", features = ["testing"] }
 pretty_assertions = { workspace = true }
 tokio = { workspace = true }
 
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_build_queue/Cargo.toml
+++ b/crates/lib/docs_rs_build_queue/Cargo.toml
@@ -37,3 +37,6 @@ docs_rs_types = { path = "../docs_rs_types", features = ["testing"] }
 docs_rs_utils = { path = "../../lib/docs_rs_utils", features = ["testing"] }
 pretty_assertions = { workspace = true }
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_cargo_metadata/Cargo.toml
+++ b/crates/lib/docs_rs_cargo_metadata/Cargo.toml
@@ -15,3 +15,6 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_config/Cargo.toml
+++ b/crates/lib/docs_rs_config/Cargo.toml
@@ -10,3 +10,5 @@ testing = []
 [dependencies]
 anyhow = { workspace = true }
 
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_context/Cargo.toml
+++ b/crates/lib/docs_rs_context/Cargo.toml
@@ -29,3 +29,6 @@ docs_rs_repository_stats = { path = "../docs_rs_repository_stats" }
 docs_rs_storage = { path = "../docs_rs_storage" }
 docs_rs_test_fakes = { path = "../docs_rs_test_fakes", optional = true }
 tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_database/Cargo.toml
+++ b/crates/lib/docs_rs_database/Cargo.toml
@@ -44,3 +44,6 @@ docs_rs_types = { path = "../docs_rs_types", features = ["testing"] }
 rand = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_env_vars/Cargo.toml
+++ b/crates/lib/docs_rs_env_vars/Cargo.toml
@@ -7,3 +7,6 @@ edition.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_fastly/Cargo.toml
+++ b/crates/lib/docs_rs_fastly/Cargo.toml
@@ -30,3 +30,6 @@ docs_rs_headers = { path = "../docs_rs_headers", features = ["testing"] }
 docs_rs_opentelemetry = { path = "../docs_rs_opentelemetry", features = ["testing"] }
 mockito = { workspace = true }
 tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_headers/Cargo.toml
+++ b/crates/lib/docs_rs_headers/Cargo.toml
@@ -24,3 +24,6 @@ axum-extra = { workspace = true }
 serde_json = { workspace = true }
 test-case = { workspace = true }
 tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_logging/Cargo.toml
+++ b/crates/lib/docs_rs_logging/Cargo.toml
@@ -18,3 +18,6 @@ tracing-subscriber = { version = "0.3.20", default-features = false, features = 
 
 [dev-dependencies]
 docs_rs_config = { path = "../docs_rs_config", features = ["testing"] }
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_mimes/Cargo.toml
+++ b/crates/lib/docs_rs_mimes/Cargo.toml
@@ -11,3 +11,6 @@ mime_guess = "2"
 
 [dev-dependencies]
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_opentelemetry/Cargo.toml
+++ b/crates/lib/docs_rs_opentelemetry/Cargo.toml
@@ -22,3 +22,6 @@ url = { workspace = true }
 [dev-dependencies]
 docs_rs_config = { path = "../docs_rs_config", features = ["testing"] }
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_registry_api/Cargo.toml
+++ b/crates/lib/docs_rs_registry_api/Cargo.toml
@@ -27,3 +27,6 @@ mime = { workspace = true }
 mockito = { workspace = true }
 test-case = { workspace = true }
 tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_repository_stats/Cargo.toml
+++ b/crates/lib/docs_rs_repository_stats/Cargo.toml
@@ -32,3 +32,6 @@ docs_rs_types = { path = "../docs_rs_types", features = ["testing"] }
 mockito = { workspace = true }
 pretty_assertions = { workspace = true }
 tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_rustdoc_json/Cargo.toml
+++ b/crates/lib/docs_rs_rustdoc_json/Cargo.toml
@@ -13,3 +13,6 @@ strum = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_storage/Cargo.toml
+++ b/crates/lib/docs_rs_storage/Cargo.toml
@@ -61,3 +61,6 @@ test-case = { workspace = true }
 [[bench]]
 name = "compression"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_test_fakes/Cargo.toml
+++ b/crates/lib/docs_rs_test_fakes/Cargo.toml
@@ -19,3 +19,6 @@ serde_json = { workspace = true }
 sqlx = { workspace = true }
 tempfile = { workspace = true }
 tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_types/Cargo.toml
+++ b/crates/lib/docs_rs_types/Cargo.toml
@@ -25,3 +25,6 @@ thiserror = { workspace = true }
 pretty_assertions = { workspace = true }
 test-case = { workspace = true }
 tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_uri/Cargo.toml
+++ b/crates/lib/docs_rs_uri/Cargo.toml
@@ -15,3 +15,6 @@ url = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/lib/docs_rs_utils/Cargo.toml
+++ b/crates/lib/docs_rs_utils/Cargo.toml
@@ -20,3 +20,6 @@ anyhow = { workspace = true }
 chrono = { workspace = true }
 time = "0.3"
 tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/lib/font-awesome-as-a-crate/Cargo.toml
+++ b/crates/lib/font-awesome-as-a-crate/Cargo.toml
@@ -6,3 +6,5 @@ license = "CC-BY-4.0 AND MIT"
 description = "Font Awesome Free, packaged as a crate"
 repository = "https://github.com/rust-lang/docs.rs"
 
+[lints]
+workspace = true

--- a/crates/lib/metadata/Cargo.toml
+++ b/crates/lib/metadata/Cargo.toml
@@ -16,3 +16,6 @@ path = "lib.rs"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2"
 toml = "0.9"
+
+[lints]
+workspace = true

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -11,3 +11,6 @@ docs_rs_web = { path = "../crates/bin/docs_rs_web" }
 reqwest = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[lints]
+workspace = true


### PR DESCRIPTION
after not having the build-logs in the cratesfyi log stream I saw that I actually left a `dbg!` macro call in one of the main web handlers... 

Of course this contributes quite much to our currently high log usage. 

To be very save, this adds config for workspace lints, and sets `warn` for `dbg!` and `todo!` (we have `-D warnings` in `just lint`)

I also removed them in tests for now, [while there is `allow-dbg-in-tests`](https://doc.rust-lang.org/stable/clippy/lint_configuration.html#allow-dbg-in-tests), I couldn't quickly figure out how to best have a workspace-level `clippy.toml`. 

