### PR TITLE
chore: update deployment workflows and add ECS action

### DIFF
--- a/.github/actions/deploy-ecs/action.yml
+++ b/.github/actions/deploy-ecs/action.yml
@@ -1,0 +1,50 @@
+name: Deploy to ECS
+description: Build Docker image, push to ECR, and deploy to ECS
+
+inputs:
+  aws-iam:
+    description: Ending part of the ARN of the IAM role to assume for AWS credentials
+    required: true
+  cluster:
+    description: Name of the ECS cluster to deploy to
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: arn:aws:iam::${{ inputs.aws-iam }}
+        aws-region: us-east-1
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build and tag the Docker image
+      env:
+        REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        tags: ${{ env.REGISTRY }}/docs-rs-web:latest
+        target: web-server
+        file: dockerfiles/Dockerfile
+        push: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        build-args: GIT_VERSION=${{ github.sha }}
+
+    - name: Kick ECS to deploy new version
+      shell: bash
+      env:
+        CLUSTER: ${{ inputs.cluster }}
+        SERVICE: docs-rs-web
+      run: |
+        aws ecs update-service --service ${SERVICE} --cluster ${CLUSTER} --force-new-deployment
+        # Poll every 15 seconds until a successful state has been reached. Fail after 40 failed checks.
+        aws ecs wait services-stable --services ${SERVICE} --cluster ${CLUSTER}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -9,19 +9,20 @@ jobs:
   docker:
     name: Build and upload docker image
     runs-on: ubuntu-latest
+    environment: staging
+    concurrency: staging
+    if: github.repository_owner == 'rust-lang'
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Build the Docker image
-        run: docker build -t docs-rs-web -f dockerfiles/Dockerfile --target web-server .
-
-      - name: Upload the Docker image to ECR (dev)
-        uses: rust-lang/simpleinfra/github-actions/upload-docker-image@master
+      - name: Checkout repository
+        uses: actions/checkout@v6
         with:
-          image: docs-rs-web
-          repository: docs-rs-web
-          region: us-east-1
-          aws_access_key_id: "${{ secrets.staging_aws_access_key_id }}"
-          aws_secret_access_key: "${{ secrets.staging_aws_secret_access_key }}"
-          redeploy_ecs_cluster: docs-rs-staging
-          redeploy_ecs_service: docs-rs-web
+          persist-credentials: false
+
+      - name: Deploy to ECS
+        uses: ./.github/actions/deploy-ecs
+        with:
+          aws-iam: "519825364412:role/ci--rust-lang--docs.rs--staging"
+          cluster: docs-rs-staging

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,19 +8,19 @@ jobs:
   prod:
     name: Production
     runs-on: ubuntu-latest
+    environment: production
+    concurrency: production
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Build the Docker image
-        run: docker build -t docs-rs-web -f dockerfiles/Dockerfile --target web-server .
-
-      - name: Upload the Docker image to ECR (production)
-        uses: rust-lang/simpleinfra/github-actions/upload-docker-image@master
+      - name: Checkout repository
+        uses: actions/checkout@v6
         with:
-          image: docs-rs-web
-          repository: docs-rs-web
-          region: us-west-1
-          aws_access_key_id: "${{ secrets.aws_access_key_id }}"
-          aws_secret_access_key: "${{ secrets.aws_secret_access_key }}"
-          redeploy_ecs_cluster: rust-ecs-prod
-          redeploy_ecs_service: docs-rs-web
+          persist-credentials: false
+
+      - name: Deploy to ECS
+        uses: ./.github/actions/deploy-ecs
+        with:
+          aws-iam: "760062276060:role/ci--rust-lang--docs.rs--production"
+          cluster: docs-rs-prod


### PR DESCRIPTION
Update the deployment workflows by using latest best practices:
- Use GitHub OIDC vs `aws_secret_access_key` (after this PR is merged, we can delete the AWS secrets from the GitHub Actions secrets)
- Use official docker github actions, which we noticed are more robust in github actions wrt just running `docker build`
- Introduce caching to take advantage of cargo chef in CI

Based on https://github.com/rust-lang/bors/blob/main/.github/actions/deploy-ecs/action.yml

GitHub OIDC support was added in https://github.com/rust-lang/simpleinfra/pull/1006

Since the docker containers are not used yet, it is safe to merge this PR and experiment with it 👍

## Note on the github action
In the previous approach you were using a github action managed by the infra team, while now you don't anymore.

If there's a preference from various teams that the infra team creates a new shared github action (or update the existing one) we'll do it. But for now I would prefer to start with a local github action, so that we can iterate faster.

## Other Docker images

Do we need to upload other images to ECR? If yes, we can do it in another PR.