### PR TITLE
storage: convert some blocking i/o to non-blocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2356,6 +2356,7 @@ dependencies = [
  "test-case",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "walkdir",
  "zip",

--- a/crates/lib/docs_rs_storage/Cargo.toml
+++ b/crates/lib/docs_rs_storage/Cargo.toml
@@ -45,6 +45,7 @@ strum = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { version = "0.7.15", default-features = false, features = ["io-util"] }
 tracing = { workspace = true }
 walkdir = { workspace = true }
 zip = { workspace = true }

--- a/crates/lib/docs_rs_storage/src/archive_index.rs
+++ b/crates/lib/docs_rs_storage/src/archive_index.rs
@@ -1,9 +1,15 @@
 use crate::types::FileRange;
 use anyhow::{Context as _, Result, anyhow, bail};
 use docs_rs_types::CompressionAlgorithm;
-use itertools::Itertools as _;
+use docs_rs_utils::spawn_blocking;
 use sqlx::{Acquire as _, ConnectOptions as _, QueryBuilder, Row as _, Sqlite};
-use std::{fs, io, path::Path};
+use std::path::Path;
+use tokio::{
+    fs,
+    io::{AsyncRead, AsyncSeek},
+    sync::mpsc,
+};
+use tokio_util::io::SyncIoBridge;
 use tracing::instrument;
 
 pub(crate) const ARCHIVE_INDEX_FILE_EXTENSION: &str = "index";
@@ -29,7 +35,7 @@ impl FileInfo {
 async fn sqlite_create<P: AsRef<Path>>(path: P) -> Result<sqlx::SqliteConnection> {
     let path = path.as_ref();
     if path.exists() {
-        fs::remove_file(path)?;
+        fs::remove_file(path).await?;
     }
 
     sqlx::sqlite::SqliteConnectOptions::new()
@@ -61,10 +67,13 @@ async fn sqlite_open<P: AsRef<Path>>(path: P) -> Result<sqlx::SqliteConnection> 
 ///
 /// Will delete the destination file if it already exists.
 #[instrument(skip(zipfile))]
-pub(crate) async fn create<R: io::Read + io::Seek, P: AsRef<Path> + std::fmt::Debug>(
-    zipfile: &mut R,
+pub(crate) async fn create<
+    R: AsyncRead + AsyncSeek + Unpin + Send + 'static,
+    P: AsRef<Path> + std::fmt::Debug,
+>(
+    zipfile: R,
     destination: P,
-) -> Result<()> {
+) -> Result<R> {
     let mut conn = sqlite_create(destination).await?;
     let mut tx = conn.begin().await?;
 
@@ -82,40 +91,58 @@ pub(crate) async fn create<R: io::Read + io::Seek, P: AsRef<Path> + std::fmt::De
     .execute(&mut *tx)
     .await?;
 
-    let mut archive = zip::ZipArchive::new(zipfile)?;
     let compression_bzip = CompressionAlgorithm::Bzip2 as i32;
+    let (tx_entries, mut rx_entries) = mpsc::channel::<(String, u64, u64, i32)>(1000);
 
-    const CHUNKS: usize = 1000;
-    for chunk in &(0..archive.len()).chunks(CHUNKS) {
-        for i in chunk {
-            let mut insert_stmt =
-                QueryBuilder::<Sqlite>::new("INSERT INTO files (path, start, end, compression) ");
-
+    let zip_task = spawn_blocking(move || {
+        let mut bridge = SyncIoBridge::new(zipfile);
+        let mut archive = zip::ZipArchive::new(&mut bridge)?;
+        for i in 0..archive.len() {
             let entry = archive.by_index(i)?;
 
             let start = entry
                 .data_start()
                 .ok_or_else(|| anyhow!("missing data_start in zip derectory"))?;
-
             let end = start + entry.compressed_size() - 1;
             let compression_raw = match entry.compression() {
                 zip::CompressionMethod::Bzip2 => compression_bzip,
                 c => bail!("unsupported compression algorithm {} in zip-file", c),
             };
 
-            insert_stmt.push_values([()], |mut b, _| {
-                b.push_bind(entry.name())
+            tx_entries
+                .blocking_send((entry.name().to_string(), start, end, compression_raw))
+                .map_err(|_| anyhow!("archive index receiver dropped"))?;
+        }
+        drop(archive);
+        Ok(bridge.into_inner())
+    });
+
+    const CHUNKS: usize = 1000;
+    let mut chunk = Vec::with_capacity(CHUNKS);
+    loop {
+        let received = rx_entries.recv_many(&mut chunk, CHUNKS).await;
+        if received == 0 {
+            break;
+        }
+        let mut insert_stmt =
+            QueryBuilder::<Sqlite>::new("INSERT INTO files (path, start, end, compression) ");
+        insert_stmt.push_values(
+            chunk.drain(..),
+            |mut b, (path, start, end, compression_raw)| {
+                b.push_bind(path)
                     .push_bind(start as i64)
                     .push_bind(end as i64)
                     .push_bind(compression_raw);
-            });
-            insert_stmt
-                .build()
-                .persistent(false)
-                .execute(&mut *tx)
-                .await?;
-        }
+            },
+        );
+        insert_stmt
+            .build()
+            .persistent(false)
+            .execute(&mut *tx)
+            .await?;
     }
+
+    let zipfile = zip_task.await?;
 
     sqlx::query("CREATE INDEX idx_files_path ON files (path);")
         .execute(&mut *tx)
@@ -127,7 +154,7 @@ pub(crate) async fn create<R: io::Read + io::Seek, P: AsRef<Path> + std::fmt::De
     // VACUUM outside the transaction
     sqlx::query("VACUUM").execute(&mut conn).await?;
 
-    Ok(())
+    Ok(zipfile)
 }
 
 async fn find_in_sqlite_index<'e, E>(executor: E, search_for: &str) -> Result<Option<FileInfo>>
@@ -180,31 +207,32 @@ mod tests {
     use std::io::Write;
     use zip::write::SimpleFileOptions;
 
-    fn create_test_archive(file_count: u32) -> fs::File {
-        let mut tf = tempfile::tempfile().unwrap();
+    async fn create_test_archive(file_count: u32) -> Result<fs::File> {
+        spawn_blocking(move || {
+            let tf = tempfile::tempfile()?;
 
-        let objectcontent: Vec<u8> = (0..255).collect();
+            let objectcontent: Vec<u8> = (0..255).collect();
 
-        let mut archive = zip::ZipWriter::new(tf);
-        for i in 0..file_count {
-            archive
-                .start_file(
+            let mut archive = zip::ZipWriter::new(tf);
+            for i in 0..file_count {
+                archive.start_file(
                     format!("testfile{i}"),
                     SimpleFileOptions::default().compression_method(zip::CompressionMethod::Bzip2),
-                )
-                .unwrap();
-            archive.write_all(&objectcontent).unwrap();
-        }
-        tf = archive.finish().unwrap();
-        tf
+                )?;
+                archive.write_all(&objectcontent)?;
+            }
+            Ok(archive.finish()?)
+        })
+        .await
+        .map(fs::File::from_std)
     }
 
     #[tokio::test]
     async fn index_create_save_load_sqlite() -> Result<()> {
-        let mut tf = create_test_archive(1);
+        let tf = create_test_archive(1).await?;
 
-        let tempfile = tempfile::NamedTempFile::new().unwrap().into_temp_path();
-        create(&mut tf, &tempfile).await?;
+        let tempfile = tempfile::NamedTempFile::new()?.into_temp_path();
+        create(tf, &tempfile).await?;
 
         let fi = find_in_file(&tempfile, "testfile0").await?.unwrap();
 
@@ -216,11 +244,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn archive_with_more_than_65k_files() -> Result<()> {
-        let mut tf = create_test_archive(100_000);
+    async fn empty_archive() -> Result<()> {
+        let tf = create_test_archive(0).await?;
 
         let tempfile = tempfile::NamedTempFile::new()?.into_temp_path();
-        create(&mut tf, &tempfile).await?;
+        create(tf, &tempfile).await?;
+
+        let mut conn = sqlite_open(&tempfile).await?;
+
+        let row = sqlx::query("SELECT count(*) FROM files")
+            .fetch_one(&mut conn)
+            .await?;
+
+        assert_eq!(row.get::<i64, _>(0), 0);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn archive_with_more_than_65k_files() -> Result<()> {
+        let tf = create_test_archive(100_000).await?;
+
+        let tempfile = tempfile::NamedTempFile::new()?.into_temp_path();
+        create(tf, &tempfile).await?;
 
         let mut conn = sqlite_open(&tempfile).await?;
 

--- a/crates/lib/docs_rs_storage/src/config.rs
+++ b/crates/lib/docs_rs_storage/src/config.rs
@@ -57,6 +57,12 @@ pub struct Config {
     // and we already know in advance we need these 50k entries.
     // So we can preallocate the DashMap with this number to avoid resizes.
     pub local_archive_cache_expected_count: usize,
+
+    // How much we want to parallelize local filesystem logic.
+    // For pure I/O this could be quite high (32/64), but
+    // we often also add compression on top of it, which is CPU-bound,
+    // even when just light / simpler compression.
+    pub local_filesystem_parallelism: usize,
 }
 
 impl AppConfig for Config {
@@ -82,6 +88,10 @@ impl AppConfig for Config {
             max_file_size_html: env("DOCSRS_MAX_FILE_SIZE_HTML", 50 * 1024 * 1024)?,
             #[cfg(any(test, feature = "testing"))]
             s3_bucket_is_temporary: false,
+            local_filesystem_parallelism: env(
+                "DOCSRS_LOCAL_FILESYSTEM_PARALLELISM",
+                std::thread::available_parallelism()?.get(),
+            )?,
         })
     }
 

--- a/crates/lib/docs_rs_storage/src/storage/non_blocking.rs
+++ b/crates/lib/docs_rs_storage/src/storage/non_blocking.rs
@@ -11,7 +11,7 @@ use crate::{
     metrics::StorageMetrics,
     types::{FileRange, StorageKind},
     utils::{
-        file_list::get_file_list,
+        file_list::{get_file_list, walk_dir_recursive},
         storage_path::{rustdoc_archive_path, source_archive_path},
     },
 };
@@ -21,15 +21,13 @@ use docs_rs_mimes::{self as mimes, detect_mime};
 use docs_rs_opentelemetry::AnyMeterProvider;
 use docs_rs_types::{BuildId, CompressionAlgorithm, KrateName, Version};
 use docs_rs_utils::spawn_blocking;
-use futures_util::stream::BoxStream;
+use futures_util::{TryStreamExt as _, future, stream::BoxStream};
 use std::{
     fmt,
-    fs::{self, File},
-    io::{self, BufReader},
     path::{Path, PathBuf},
     sync::Arc,
 };
-use tokio::sync::Mutex;
+use tokio::{fs, io, sync::Mutex};
 use tracing::{debug, info_span, instrument, trace, warn};
 
 pub struct AsyncStorage {
@@ -254,8 +252,8 @@ impl AsyncStorage {
 
         let _write_guard = rwlock.lock().await;
 
-        if tokio::fs::try_exists(&local_index_path).await? {
-            tokio::fs::remove_file(&local_index_path).await?;
+        if fs::try_exists(&local_index_path).await? {
+            fs::remove_file(&local_index_path).await?;
         }
 
         Ok(())
@@ -271,7 +269,7 @@ impl AsyncStorage {
             .parent()
             .ok_or_else(|| anyhow::anyhow!("index path without parent"))?
             .to_path_buf();
-        tokio::fs::create_dir_all(&parent).await?;
+        fs::create_dir_all(&parent).await?;
 
         // Create a unique temp file in the cache folder.
         let (temp_file, mut temp_path) = spawn_blocking({
@@ -282,16 +280,16 @@ impl AsyncStorage {
         .into_parts();
 
         // Download into temp file.
-        let mut temp_file = tokio::fs::File::from_std(temp_file);
+        let mut temp_file = fs::File::from_std(temp_file);
         let mut stream = self.get_stream(remote_index_path).await?.content;
-        tokio::io::copy(&mut stream, &mut temp_file).await?;
+        io::copy(&mut stream, &mut temp_file).await?;
         temp_file.sync_all().await?;
 
         temp_path.disable_cleanup(true);
 
         // Publish atomically.
         // Will replace any existing file.
-        tokio::fs::rename(&temp_path, local_index_path).await?;
+        fs::rename(&temp_path, local_index_path).await?;
 
         // fsync parent dir to make rename durable
         spawn_blocking(move || {
@@ -431,8 +429,9 @@ impl AsyncStorage {
         root_dir: impl AsRef<Path> + fmt::Debug,
     ) -> Result<(Vec<FileEntry>, CompressionAlgorithm)> {
         let root_dir = root_dir.as_ref();
-        let (mut zip_content,    file_paths) =
+        let (zip_content, file_paths) =
             spawn_blocking({
+                use std::{io, fs};
                 let archive_path = archive_path.to_owned();
                 let root_dir = root_dir.to_owned();
 
@@ -480,24 +479,25 @@ impl AsyncStorage {
 
         let alg = CompressionAlgorithm::default();
         let remote_index_path = format!("{}.{ARCHIVE_INDEX_FILE_EXTENSION}", &archive_path);
-        let compressed_index_content = {
+        let (zip_content, compressed_index_content) = {
             let _span = info_span!("create_archive_index", %remote_index_path).entered();
 
-            tokio::fs::create_dir_all(&self.config.temp_dir).await?;
+            fs::create_dir_all(&self.config.temp_dir).await?;
             let local_index_path =
                 tempfile::NamedTempFile::new_in(&self.config.temp_dir)?.into_temp_path();
 
-            archive_index::create(&mut io::Cursor::new(&mut zip_content), &local_index_path)
-                .await?;
+            let zip_cursor =
+                archive_index::create(std::io::Cursor::new(zip_content), &local_index_path).await?;
+            let zip_content = zip_cursor.into_inner();
 
             let mut buf: Vec<u8> = Vec::new();
             compress_async(
-                &mut tokio::io::BufReader::new(tokio::fs::File::open(&local_index_path).await?),
+                &mut io::BufReader::new(fs::File::open(&local_index_path).await?),
                 &mut buf,
                 alg,
             )
             .await?;
-            buf
+            (zip_content, buf)
         };
 
         self.backend
@@ -531,45 +531,53 @@ impl AsyncStorage {
         let root_dir = root_dir.as_ref();
         let alg = CompressionAlgorithm::default();
 
-        let (blobs, file_paths_and_mimes) = spawn_blocking({
-            let prefix = prefix.to_owned();
-            let root_dir = root_dir.to_owned();
-            move || {
-                let mut file_paths = Vec::new();
-                let mut blobs: Vec<BlobUpload> = Vec::new();
-                for file_path in get_file_list(&root_dir) {
-                    let file_path = file_path?;
+        let (file_paths_and_mimes, blobs): (Vec<_>, Vec<_>) = walk_dir_recursive(&root_dir)
+            .err_into::<anyhow::Error>()
+            .map_ok(|item| async move {
+                // Some files have insufficient permissions
+                // (like .lock file created by cargo in documentation directory).
+                // Skip these files.
+                let Ok(file) = fs::File::open(&item).await else {
+                    return Ok(None);
+                };
 
-                    // Some files have insufficient permissions
-                    // (like .lock file created by cargo in documentation directory).
-                    // Skip these files.
-                    let Ok(file) = fs::File::open(root_dir.join(&file_path)) else {
-                        continue;
-                    };
+                let content = {
+                    let mut buf: Vec<u8> = Vec::new();
+                    compress_async(io::BufReader::new(file), &mut buf, alg).await?;
+                    buf
+                };
 
-                    let file_size = file.metadata()?.len();
+                let bucket_path = prefix.join(&item.relative).to_string_lossy().to_string();
 
-                    let content = compress(file, alg)?;
-                    let bucket_path = prefix.join(&file_path).to_string_lossy().to_string();
+                let file_size = item.metadata.len();
 
-                    let file_info = FileEntry {
-                        path: file_path,
-                        size: file_size,
-                    };
-                    let mime = file_info.mime();
-                    file_paths.push(file_info);
+                let file_info = FileEntry {
+                    path: item.relative.clone(),
+                    size: file_size,
+                };
+                let mime = file_info.mime();
 
-                    blobs.push(BlobUpload {
+                Ok(Some((
+                    file_info,
+                    BlobUpload {
                         path: bucket_path,
                         mime,
                         content,
                         compression: Some(alg),
-                    });
-                }
-                Ok((blobs, file_paths))
-            }
-        })
-        .await?;
+                    },
+                )))
+            })
+            .try_buffer_unordered(self.config.local_filesystem_parallelism)
+            .try_filter_map(|item| future::ready(Ok(item)))
+            .try_fold(
+                (Vec::new(), Vec::new()),
+                |(mut file_paths_and_mimes, mut blobs), (file_info, blob)| async move {
+                    file_paths_and_mimes.push(file_info);
+                    blobs.push(blob);
+                    Ok((file_paths_and_mimes, blobs))
+                },
+            )
+            .await?;
 
         self.backend.store_batch(blobs).await?;
         Ok((file_paths_and_mimes, alg))
@@ -640,7 +648,17 @@ impl AsyncStorage {
         let source_path = source_path.as_ref();
 
         let alg = CompressionAlgorithm::default();
-        let content = compress(BufReader::new(File::open(source_path)?), alg)?;
+
+        let content = {
+            let mut buf: Vec<u8> = Vec::new();
+            compress_async(
+                io::BufReader::new(fs::File::open(source_path).await?),
+                &mut buf,
+                alg,
+            )
+            .await?;
+            buf
+        };
 
         let mime = detect_mime(&target_path).to_owned();
 
@@ -691,7 +709,6 @@ impl std::fmt::Debug for AsyncStorage {
 mod test {
     use super::*;
     use crate::testing::TestStorage;
-    use tokio::fs;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_outdated_local_archive_index_gets_redownloaded() -> Result<()> {
@@ -833,7 +850,6 @@ mod backend_tests {
     use crate::{PathNotFoundError, errors::SizeLimitReached};
     use docs_rs_headers::compute_etag;
     use docs_rs_opentelemetry::testing::TestMetrics;
-    use futures_util::TryStreamExt as _;
 
     fn get_file_info(files: &[FileEntry], path: impl AsRef<Path>) -> Option<&FileEntry> {
         let path = path.as_ref();
@@ -1084,9 +1100,9 @@ mod backend_tests {
         for &file in &files {
             let path = dir.path().join(file);
             if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent)?;
+                fs::create_dir_all(parent).await?;
             }
-            fs::write(path, "data")?;
+            fs::write(path, "data").await?;
         }
 
         let local_index_location = storage
@@ -1120,7 +1136,7 @@ mod backend_tests {
 
         // delete the existing index to test the download of it
         if local_index_location.exists() {
-            fs::remove_file(&local_index_location)?;
+            fs::remove_file(&local_index_location).await?;
         }
 
         // the first exists-query will download and store the index
@@ -1174,9 +1190,9 @@ mod backend_tests {
         for &file in &files {
             let path = dir.path().join(file);
             if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent)?;
+                fs::create_dir_all(parent).await?;
             }
-            fs::write(path, "data")?;
+            fs::write(path, "data").await?;
         }
 
         let (stored_files, algs) = storage.store_all(Path::new("prefix"), dir.path()).await?;

--- a/crates/lib/docs_rs_storage/src/utils/file_list.rs
+++ b/crates/lib/docs_rs_storage/src/utils/file_list.rs
@@ -1,6 +1,9 @@
 use anyhow::Result;
+use async_stream::try_stream;
+use futures_util::Stream;
 use std::{
-    iter,
+    fs::Metadata,
+    io, iter,
     path::{Path, PathBuf},
 };
 use walkdir::WalkDir;
@@ -41,20 +44,102 @@ pub fn get_file_list<P: AsRef<Path>>(path: P) -> Box<dyn Iterator<Item = Result<
     }
 }
 
+#[derive(Debug)]
+pub(crate) struct FileItem {
+    pub(crate) absolute: PathBuf,
+    pub(crate) relative: PathBuf,
+    pub(crate) metadata: Metadata,
+}
+
+impl AsRef<Path> for FileItem {
+    fn as_ref(&self) -> &Path {
+        &self.absolute
+    }
+}
+
+/// Recursively walks a directory and yields all files (not directories) found within it.
+///
+/// Roughly an async version of `get_file_list`.
+pub(crate) fn walk_dir_recursive(
+    root: impl AsRef<Path>,
+) -> impl Stream<Item = Result<FileItem, io::Error>> {
+    let root = root.as_ref().to_path_buf();
+    try_stream! {
+        let mut dirs = vec![root.clone()];
+
+        while let Some(dir) = dirs.pop() {
+            let mut entries = tokio::fs::read_dir(&dir).await?;
+            while let Some(entry) = entries.next_entry().await? {
+                let path = entry.path();
+                let meta = entry.metadata().await?;
+                if meta.is_dir() {
+                    dirs.push(path.clone());
+                } else {
+                    let relative =  path.strip_prefix(&root).unwrap().to_path_buf();
+
+                    yield FileItem { absolute: path, relative, metadata: meta };
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::env;
+    use futures_util::TryStreamExt;
 
     #[test]
     fn test_get_file_list() -> Result<()> {
-        let dir = env::current_dir().unwrap();
+        use std::fs;
 
-        let files: Vec<_> = get_file_list(&dir).collect::<Result<Vec<_>>>()?;
-        assert!(!files.is_empty());
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
 
-        let files: Vec<_> = get_file_list(dir.join("Cargo.toml")).collect::<Result<Vec<_>>>()?;
-        assert_eq!(files[0], std::path::Path::new("Cargo.toml"));
+        fs::create_dir_all(root.join("nested"))?;
+        fs::write(root.join("root.txt"), b"root")?;
+        fs::write(root.join("nested").join("child.txt"), b"child")?;
+
+        let mut files: Vec<_> = get_file_list(root).collect::<Result<Vec<_>>>()?;
+        files.sort();
+        assert_eq!(
+            files,
+            vec![PathBuf::from("nested/child.txt"), PathBuf::from("root.txt"),]
+        );
+
+        let files: Vec<_> = get_file_list(root.join("root.txt")).collect::<Result<Vec<_>>>()?;
+        assert_eq!(files, vec![PathBuf::from("root.txt")]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_walk_dir_recursive() -> Result<()> {
+        use tokio::fs;
+
+        let dir = tempfile::tempdir()?;
+        let root = dir.path();
+
+        let nested = root.join("a/b");
+        fs::create_dir_all(&nested).await?;
+        fs::write(root.join("root.txt"), b"root").await?;
+        fs::write(root.join("a").join("child.txt"), b"child").await?;
+        fs::write(nested.join("leaf.txt"), b"leaf").await?;
+
+        let mut files: Vec<_> = walk_dir_recursive(root)
+            .map_ok(|item| item.relative)
+            .try_collect()
+            .await?;
+        files.sort();
+
+        assert_eq!(
+            files,
+            vec![
+                PathBuf::from("a/b/leaf.txt"),
+                PathBuf::from("a/child.txt"),
+                PathBuf::from("root.txt"),
+            ]
+        );
 
         Ok(())
     }

--- a/crates/lib/docs_rs_utils/src/lib.rs
+++ b/crates/lib/docs_rs_utils/src/lib.rs
@@ -7,6 +7,8 @@ pub use runtime_ext::Handle;
 
 use anyhow::{Context as _, Result};
 use std::fmt;
+use std::pin::Pin;
+use std::task::{Context, Poll, ready};
 use std::{panic, thread, time::Duration};
 use tokio::runtime;
 use tracing::{Span, error, warn};
@@ -66,23 +68,53 @@ pub const RUSTDOC_STATIC_PATH: &str = "/-/rustdoc.static/";
 /// })
 /// .await?
 /// ```
-pub async fn spawn_blocking<F, R>(f: F) -> Result<R>
+pub fn spawn_blocking<F, R>(f: F) -> SpawnBlockingHandle<R>
 where
     F: FnOnce() -> Result<R> + Send + 'static,
     R: Send + 'static,
 {
     let span = Span::current();
 
-    let result = tokio::task::spawn_blocking(move || {
+    let inner = tokio::task::spawn_blocking(move || {
         let _guard = span.enter();
         f()
-    })
-    .await;
+    });
 
-    match result {
-        Ok(result) => result,
-        Err(err) if err.is_panic() => panic::resume_unwind(err.into_panic()),
-        Err(err) => Err(err.into()),
+    SpawnBlockingHandle { inner }
+}
+
+pub struct SpawnBlockingHandle<R> {
+    inner: tokio::task::JoinHandle<Result<R>>,
+}
+
+impl<R> SpawnBlockingHandle<R> {
+    pub fn abort(&self) {
+        self.inner.abort();
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.inner.is_finished()
+    }
+
+    pub fn id(&self) -> tokio::task::Id {
+        self.inner.id()
+    }
+
+    pub fn into_inner(self) -> tokio::task::JoinHandle<Result<R>> {
+        self.inner
+    }
+}
+
+impl<R> Future for SpawnBlockingHandle<R> {
+    type Output = Result<R>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let result = ready!(Pin::new(&mut self.inner).poll(cx));
+        match result {
+            Ok(result) => Poll::Ready(result),
+            Err(err) if err.is_panic() => panic::resume_unwind(err.into_panic()),
+            Err(err) => Poll::Ready(Err(err.into())),
+        }
     }
 }
 


### PR DESCRIPTION
When working on something else I discovered that there were places where I used blocking i/o functionality inside async functions. 

It wasn't too big of an issue, since this is only used on the build-servers, so blocking the tokio runtime threads is not a huge problem, but for other things I'm planning it would be good to fix ( streaming / parallel uploads). 

I now validated that all remaining sync i/o is inside `spawn_blocking`. 

For one function (upload a whole local folder) I also now introduced paralellism. 

The change to our own `spawn_blocking` was necessary so we can use it in the same way as the original tokio `spawn_blocking` ( = use the function to spawn a task, that then start running, and join it later). 