### PR TITLE
extend response time histogram buckets to be able to see longer requests

### DIFF
--- a/crates/bin/docs_rs_web/src/metrics.rs
+++ b/crates/bin/docs_rs_web/src/metrics.rs
@@ -20,7 +20,8 @@ use std::{borrow::Cow, sync::Arc, time::Instant};
 ///
 /// Otel default buckets are not suited for that.
 pub const RESPONSE_TIME_HISTOGRAM_BUCKETS: &[f64] = &[
-    0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+    0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.5, 3.5, 5.0, 7.5, 10.0,
+    15.0, 20.0, 30.0, 45.0, 60.0, 90.0, 120.0,
 ];
 
 #[derive(Debug)]


### PR DESCRIPTION
<img width="748" height="293" alt="image" src="https://github.com/user-attachments/assets/0f96fb0e-a5b7-4c5b-93ac-b700e8fdc226" />

The metrics looked like this, but I knew there weren't any timeouts (60s) because we would report these to sentry. 

Reason for this is that there is no histogram bucket for response times >10s right now. 

I also realized that fastly is cutting the connection even earlier (15s is the default), which is fixed here: https://github.com/rust-lang/simpleinfra/pull/1014