### PR TITLE
archive-index-caches: just flush instead of sync_all, retry on corrupted files

### DIFF
--- a/crates/bin/docs_rs_web/src/lib.rs
+++ b/crates/bin/docs_rs_web/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #![allow(
     // clippy::cognitive_complexity,
     // TODO: `AxumNope::Redirect(EscapedURI, CachePolicy)` is too big.

--- a/crates/lib/docs_rs_registry_api/src/api.rs
+++ b/crates/lib/docs_rs_registry_api/src/api.rs
@@ -401,7 +401,7 @@ mod tests {
 
         assert!(matches!(
             test_search(status, response.clone()).await.unwrap_err(),
-            Error::CrateIoApiError(status, errors) if errors == response
+            Error::CrateIoApiError(_status, errors) if errors == response
         ));
 
         Ok(())

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.94.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Thinking about the cache / boot problem, this is the next thing I want to try. it looks like we gain up t

Perhaps I was too pessimistic/conservative about the corrupted files we saw. 

From what I see: 
- the flush will flush into disc caches
- because of the rename, the download is atomic 
- so the server will either see the full download, or nothing. 

This will also hold true in case of the server process crashes. 

Of course it won't in case of kernel crashes, but IMO that's fine for this use-case (locally cached files, the source of truth is on S3)


I added the rust-toolchain change because it lead to CI errors, somehow I think CI isn't using rust-toolchain.toml, need to check that separately. 