### PR TITLE
mark in-progress builds as canceled when we restart

### DIFF
--- a/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
+++ b/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE builds\n           SET\n               build_status = 'failure',\n               errors = $1,\n               build_finished = NOW()\n           WHERE\n               rid = $2\n               AND build_status = 'in_progress'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65"
+}

--- a/crates/bin/cratesfyi/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
+++ b/crates/bin/cratesfyi/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE builds\n           SET\n               build_status = 'failure',\n               errors = $1,\n               build_finished = NOW()\n           WHERE\n               rid = $2\n               AND build_status = 'in_progress'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65"
+}

--- a/crates/bin/docs_rs_admin/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
+++ b/crates/bin/docs_rs_admin/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE builds\n           SET\n               build_status = 'failure',\n               errors = $1,\n               build_finished = NOW()\n           WHERE\n               rid = $2\n               AND build_status = 'in_progress'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65"
+}

--- a/crates/bin/docs_rs_builder/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
+++ b/crates/bin/docs_rs_builder/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE builds\n           SET\n               build_status = 'failure',\n               errors = $1,\n               build_finished = NOW()\n           WHERE\n               rid = $2\n               AND build_status = 'in_progress'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65"
+}

--- a/crates/bin/docs_rs_import_release/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
+++ b/crates/bin/docs_rs_import_release/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE builds\n           SET\n               build_status = 'failure',\n               errors = $1,\n               build_finished = NOW()\n           WHERE\n               rid = $2\n               AND build_status = 'in_progress'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65"
+}

--- a/crates/bin/docs_rs_watcher/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
+++ b/crates/bin/docs_rs_watcher/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE builds\n           SET\n               build_status = 'failure',\n               errors = $1,\n               build_finished = NOW()\n           WHERE\n               rid = $2\n               AND build_status = 'in_progress'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65"
+}

--- a/crates/bin/docs_rs_web/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
+++ b/crates/bin/docs_rs_web/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE builds\n           SET\n               build_status = 'failure',\n               errors = $1,\n               build_finished = NOW()\n           WHERE\n               rid = $2\n               AND build_status = 'in_progress'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65"
+}

--- a/crates/lib/docs_rs_build_limits/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
+++ b/crates/lib/docs_rs_build_limits/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE builds\n           SET\n               build_status = 'failure',\n               errors = $1,\n               build_finished = NOW()\n           WHERE\n               rid = $2\n               AND build_status = 'in_progress'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65"
+}

--- a/crates/lib/docs_rs_build_queue/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
+++ b/crates/lib/docs_rs_build_queue/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE builds\n           SET\n               build_status = 'failure',\n               errors = $1,\n               build_finished = NOW()\n           WHERE\n               rid = $2\n               AND build_status = 'in_progress'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65"
+}

--- a/crates/lib/docs_rs_context/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
+++ b/crates/lib/docs_rs_context/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE builds\n           SET\n               build_status = 'failure',\n               errors = $1,\n               build_finished = NOW()\n           WHERE\n               rid = $2\n               AND build_status = 'in_progress'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65"
+}

--- a/crates/lib/docs_rs_database/.sqlx/query-8f08f5d1c472cfb1de747e57f4e768ffb00096a0274a0888300fee74ce165a18.json
+++ b/crates/lib/docs_rs_database/.sqlx/query-8f08f5d1c472cfb1de747e57f4e768ffb00096a0274a0888300fee74ce165a18.json
@@ -1,0 +1,51 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n                id as \"id: BuildId\",\n                build_status as \"build_status: BuildStatus\",\n                errors,\n                build_finished\n               FROM builds\n               WHERE rid = $1\n               ORDER BY id ASC",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id: BuildId",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "build_status: BuildStatus",
+        "type_info": {
+          "Custom": {
+            "name": "build_status",
+            "kind": {
+              "Enum": [
+                "in_progress",
+                "success",
+                "failure"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "errors",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "build_finished",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "8f08f5d1c472cfb1de747e57f4e768ffb00096a0274a0888300fee74ce165a18"
+}

--- a/crates/lib/docs_rs_database/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
+++ b/crates/lib/docs_rs_database/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE builds\n           SET\n               build_status = 'failure',\n               errors = $1,\n               build_finished = NOW()\n           WHERE\n               rid = $2\n               AND build_status = 'in_progress'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65"
+}

--- a/crates/lib/docs_rs_database/src/releases.rs
+++ b/crates/lib/docs_rs_database/src/releases.rs
@@ -359,6 +359,21 @@ pub async fn initialize_build(
 ) -> Result<BuildId> {
     let hostname = hostname::get()?;
 
+    sqlx::query!(
+        r#"UPDATE builds
+           SET
+               build_status = 'failure',
+               errors = $1,
+               build_finished = NOW()
+           WHERE
+               rid = $2
+               AND build_status = 'in_progress'"#,
+        "build aborted: builder process restarted before completion",
+        release_id as _,
+    )
+    .execute(&mut *conn)
+    .await?;
+
     let build_id = sqlx::query_scalar!(
         r#"INSERT INTO builds(rid, build_status, build_server, build_started)
          VALUES ($1, $2, $3, NOW())
@@ -1293,6 +1308,51 @@ mod test {
 
         let another_build_id = initialize_build(&mut conn, release_id).await?;
         assert_ne!(build_id, another_build_id);
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_initialize_build_marks_previous_attempt_as_failure() -> Result<()> {
+        let test_metrics = TestMetrics::new();
+        let db = TestDatabase::new(&Config::test_config()?, test_metrics.provider()).await?;
+
+        let mut conn = db.async_conn().await?;
+        let crate_id = initialize_crate(&mut conn, &KRATE).await?;
+        let release_id = initialize_release(&mut conn, crate_id, &V1).await?;
+
+        let first_build_id = initialize_build(&mut conn, release_id).await?;
+        let second_build_id = initialize_build(&mut conn, release_id).await?;
+
+        assert_ne!(first_build_id, second_build_id);
+
+        let builds = sqlx::query!(
+            r#"SELECT
+                id as "id: BuildId",
+                build_status as "build_status: BuildStatus",
+                errors,
+                build_finished
+               FROM builds
+               WHERE rid = $1
+               ORDER BY id ASC"#,
+            release_id.0,
+        )
+        .fetch_all(&mut *conn)
+        .await?;
+
+        assert_eq!(builds.len(), 2);
+
+        assert_eq!(builds[0].id, first_build_id);
+        assert_eq!(builds[0].build_status, BuildStatus::Failure);
+        assert_eq!(
+            builds[0].errors,
+            Some("build aborted: builder process restarted before completion".into())
+        );
+        assert!(builds[0].build_finished.is_some());
+
+        assert_eq!(builds[1].id, second_build_id);
+        assert_eq!(builds[1].build_status, BuildStatus::InProgress);
+        assert!(builds[1].build_finished.is_none());
 
         Ok(())
     }

--- a/crates/lib/docs_rs_repository_stats/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
+++ b/crates/lib/docs_rs_repository_stats/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE builds\n           SET\n               build_status = 'failure',\n               errors = $1,\n               build_finished = NOW()\n           WHERE\n               rid = $2\n               AND build_status = 'in_progress'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65"
+}

--- a/crates/lib/docs_rs_test_fakes/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
+++ b/crates/lib/docs_rs_test_fakes/.sqlx/query-db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE builds\n           SET\n               build_status = 'failure',\n               errors = $1,\n               build_finished = NOW()\n           WHERE\n               rid = $2\n               AND build_status = 'in_progress'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "db263dde3b65426a1244e6e3f386cf75c37d3b3aa5c2883d1a1a916dec9a1b65"
+}


### PR DESCRIPTION
This solves an annoyance that existed since I added https://github.com/rust-lang/docs.rs/pull/2533. 

When I want to update the docs.rs binaries, and would just run `update-docs.rs`, then we have leftover `in-progress` records in the `builds` table. Our process would just exit. The build itself was fine, since postgres would just unlock the record, and another builder (or this one, restarted) would pick it up again. 

But: the in-progress record would stay in the database. 

This is a small workaround for this. The queue guarantees that these only can be one build for each release, so we can simply mark existing in-progress build records as error. 

[This doesn't solve the issue that we'll still have the old `docker run` process running in the background, but that's for a separate PR.](https://github.com/rust-lang/docs.rs/issues/3251)

Note: **this issue would have become a bigger one with more automatic deployments for the new infra**. 