### PR TITLE
fix: archive index caching fast-path should also update moka

### DIFF
--- a/crates/lib/docs_rs_storage/src/archive_index.rs
+++ b/crates/lib/docs_rs_storage/src/archive_index.rs
@@ -444,7 +444,20 @@ impl Cache {
 
         // fast path: try to use whatever is there, no locking
         let force_redownload = match find_in_file(&local_index_path, path_in_archive).await {
-            Ok(res) => return Ok(res),
+            Ok(res) => {
+                // Keep moka's recency/frequency view in sync with successful fast-path
+                // file lookups so TTI and admission decisions reflect real usage.
+                if self.manager.get(&local_index_path).await.is_none() {
+                    let entry_path = local_index_path.clone();
+                    self.manager
+                        .entry(local_index_path.clone())
+                        .or_insert_with(
+                            async move { Arc::new(Entry::from_path(&entry_path).await) },
+                        )
+                        .await;
+                }
+                return Ok(res);
+            }
             Err(err) => {
                 let force_redownload = !err.is::<PathNotFoundError>();
                 debug!(?err, "archive index lookup failed, will try repair.");
@@ -1107,6 +1120,7 @@ mod tests {
             downloader.download_count(&format!("{ARCHIVE_NAME}.{ARCHIVE_INDEX_FILE_EXTENSION}")),
             0
         );
+        assert!(cache.manager.get(&cache_file).await.is_some());
 
         Ok(())
     }


### PR DESCRIPTION
the metrics and some digging made me realize there is a bug in the logic. 

Moka makes caching decisions based on how often the index is accessed. And the fast-path didn't touch moka at all. 