### PR TITLE
no security audits on forks

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   security_audit:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'rust-lang'
     steps:
       - uses: actions/checkout@v6
       - id: install


### PR DESCRIPTION
I got an email about security audit failing on my fork on docs-rs. This prevents the audit check to run on forks, so that contributors aren't annoyed by this.