### PR TITLE
fix static asset caching after workspace refactor

### DIFF
--- a/.github/actions/deploy-ecs/action.yml
+++ b/.github/actions/deploy-ecs/action.yml
@@ -37,7 +37,7 @@ runs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        build-args: GIT_VERSION=${{ github.sha }}
+        build-args: GIT_SHA=${{ github.sha }}
 
     - name: Kick ECS to deploy new version
       shell: bash

--- a/crates/lib/docs_rs_utils/build.rs
+++ b/crates/lib/docs_rs_utils/build.rs
@@ -1,18 +1,31 @@
-use anyhow::Result;
-use std::env;
+use anyhow::{Context as _, Result, anyhow};
+use std::{env, path::PathBuf, process::Command};
 
 fn main() -> Result<()> {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=GIT_SHA");
     read_git_version()?;
     Ok(())
 }
 
 fn read_git_version() -> Result<()> {
     if let Ok(v) = env::var("GIT_SHA") {
-        // first try to read an externally provided git SAH, e.g., from CI
+        // first try to read an externally provided git SHA, e.g., from CI
         println!("cargo:rustc-env=GIT_SHA={v}");
     } else {
+        if let Some(path) = git_head_ref_path().context("error trying to get git head ref path")? {
+            println!("cargo:rerun-if-changed={}", path.display());
+        }
+
         // then try to read the git repo.
-        let maybe_hash = get_git_hash()?;
+        let maybe_hash = match git_output(["rev-parse", "--short", "HEAD"]) {
+            Ok(hash) => Some(hash),
+            Err(err) => {
+                eprintln!("error trying to get git head ref path: {:?}", err);
+                None
+            }
+        };
+
         let git_hash = maybe_hash.as_deref().unwrap_or("???????");
         println!("cargo:rustc-env=GIT_SHA={git_hash}");
     }
@@ -25,27 +38,29 @@ fn read_git_version() -> Result<()> {
     Ok(())
 }
 
-fn get_git_hash() -> Result<Option<String>> {
-    use std::process::Command;
-
+fn git_head_ref_path() -> Result<Option<PathBuf>> {
+    let git_dir = git_output(["rev-parse", "--git-dir"])?;
     let output = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output();
+        .args(["symbolic-ref", "-q", "HEAD"])
+        .output()?;
 
-    match output {
-        Ok(output) if output.status.success() => {
-            let hash = String::from_utf8(output.stdout)?.trim().to_string();
+    if output.status.success() {
+        let head_ref = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        Ok(Some(PathBuf::from(git_dir).join(head_ref)))
+    } else {
+        Ok(None)
+    }
+}
 
-            Ok(Some(hash))
-        }
-        Ok(output) => {
-            let err = String::from_utf8_lossy(&output.stderr);
-            eprintln!("failed to get git repo: {}", err.trim());
-            Ok(None)
-        }
-        Err(err) => {
-            eprintln!("failed to execute git: {err}");
-            Ok(None)
-        }
+fn git_output<const N: usize>(args: [&str; N]) -> Result<String> {
+    let output = Command::new("git").args(args).output()?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(
+            anyhow!(String::from_utf8_lossy(&output.stderr).trim().to_string())
+                .context(format!("error running git command: {:?}", args)),
+        )
     }
 }


### PR DESCRIPTION
the design of the in-progress-builds table was broken after deploy (https://github.com/rust-lang/docs.rs/pull/3258) 

- the `BUILD_VERSION` and `APP_USER_AGENT` include the git sha as version identifier 
- it is used as cache-buster when serving static assets (`style.css` and such) 
- but the `docs_rs_utils` subcrate was only recompiled when it was changed itself 
- so the version wasn't updated, which means the filenames weren't updated, which means they were cached in the CDN & the browser while they changed in the codebase. 

Locally this would have compile time impact due to relinking. Alternatives would have been: 
- not use the git sha for cache-busting (probably doing that separately) 
- not caching static assets locally. 
