### PR TITLE
Fix license display when it overflows parent menu width

### DIFF
--- a/crates/bin/docs_rs_web/templates/rustdoc/topbar.html
+++ b/crates/bin/docs_rs_web/templates/rustdoc/topbar.html
@@ -12,7 +12,7 @@
         }
     </script>
     {%- if krate is defined -%}
-        <li class="pure-menu-item pure-menu-has-children">
+        <li class="pure-menu-item pure-menu-has-children crate-dropdown">
             <a href="#" class="pure-menu-link crate-name" title="{{ metadata.description.as_deref().unwrap_or_default() }}">
                 {{ crate::icons::IconCube.render_solid(false, false, "") }}
                 <span class="title">{{ metadata.name }}-{{ metadata.version }}</span>
@@ -43,7 +43,7 @@
 
                     {%- if let Some(parsed_licenses) = krate.parsed_license -%}
                         <li class="pure-menu-item">
-                            <span class="pure-menu-link description">
+                            <span class="pure-menu-link description license">
                             {{- crate::icons::IconScaleUnbalancedFlip.render_solid(false, false, "") }}
                             {%+ for item in parsed_licenses -%}
                                 {%- match item -%}

--- a/crates/bin/docs_rs_web/templates/style/_navbar.scss
+++ b/crates/bin/docs_rs_web/templates/style/_navbar.scss
@@ -73,6 +73,10 @@ div.nav-container {
         &.description {
             font-size: 14.4px;
         }
+
+        &.description.license {
+            white-space: normal;
+        }
     }
     a.pure-menu-sublink {
         color: var(--color-navbar-standard);

--- a/gui-tests/long-license-text.goml
+++ b/gui-tests/long-license-text.goml
@@ -1,0 +1,28 @@
+// Checks that the links have the expected color.
+
+go-to: |DOC_PATH| + "/sysinfo"
+store-value: (menu_selector, '.crate-dropdown')
+store-value: (sub_menu_selector, |menu_selector| + ' .pure-menu-children')
+store-value: (license_selector, |sub_menu_selector| + ' .license')
+click: |menu_selector|
+wait-for-css: (|sub_menu_selector|, {"display": "block"})
+store-size: (
+    |license_selector|,
+    {"height": original_height, "width": original_width},
+)
+store-size: (|sub_menu_selector|, {"width": menu_width})
+// Menu has a border of 1px, so both sides makes it 2px total.
+assert: (|menu_width| - 2) == |original_width|
+
+// Now we change the content of the license to make it overflow the menu's width.
+store-property: (|license_selector|, {"innerHTML": html})
+set-property: (
+    |license_selector|,
+    {"innerHTML": |html| + "OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0 OR blablablablabla"},
+)
+// And now, the height should have increased while the width should remain the same.
+store-size: (
+    |license_selector|,
+    {"height": new_height, "width": new_width},
+)
+assert: |new_width| == |original_width| && |new_height| > |original_height|


### PR DESCRIPTION
Fixes https://github.com/rust-lang/docs.rs/issues/3275.