### PR TITLE
override build priorities for some workspaces

### DIFF
--- a/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
+++ b/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    UPDATE queue\n                    SET priority = $2\n                    WHERE name = $1\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e"
+}

--- a/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
+++ b/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            c.name as \"name: KrateName\",\n            repo.override_build_priority as \"priority!\"\n\n        FROM\n            crates AS c\n            INNER JOIN releases AS r ON c.latest_version_id = r.id\n            INNER JOIN repositories AS repo ON r.repository_id = repo.id\n\n        WHERE\n            c.name = ANY($1) AND\n            repo.override_build_priority IS NOT NULL\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name: KrateName",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a"
+}

--- a/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
+++ b/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = $2 WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085"
+}

--- a/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
+++ b/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT name, override_build_priority as \"priority!\"\n        FROM repositories\n        WHERE override_build_priority IS NOT NULL\n        ORDER BY name\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d"
+}

--- a/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
+++ b/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT override_build_priority FROM repositories WHERE name = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "override_build_priority",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed"
+}

--- a/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
+++ b/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = NULL WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033"
+}

--- a/README.md
+++ b/README.md
@@ -316,6 +316,27 @@ If you want to revert to a precise migration, you can run:
 cargo run --bin docs_rs_admin -- database migrate <migration number>
 ```
 
+#### `queue` subcommand
+
+```sh
+# Queue a specific crate release for building.
+# The optional `--priority` defaults to 5. Lower numbers run first.
+cargo run --bin docs_rs_admin -- queue add <CRATE_NAME> <CRATE_VERSION>
+cargo run --bin docs_rs_admin -- queue add <CRATE_NAME> <CRATE_VERSION> --priority -10
+
+# Inspect or manage default priorities for crates matching a Postgres pattern.
+cargo run --bin docs_rs_admin -- queue default-priority list
+cargo run --bin docs_rs_admin -- queue default-priority get <CRATE_NAME>
+cargo run --bin docs_rs_admin -- queue default-priority set 'tokio-%' -5
+cargo run --bin docs_rs_admin -- queue default-priority remove 'tokio-%'
+
+# Inspect or manage repository-specific build priority overrides using repositories.name.
+cargo run --bin docs_rs_admin -- queue repository-priority list
+cargo run --bin docs_rs_admin -- queue repository-priority get <owner/repo>
+cargo run --bin docs_rs_admin -- queue repository-priority set <owner/repo> -10
+cargo run --bin docs_rs_admin -- queue repository-priority remove <owner/repo>
+```
+
 
 ### Updating vendored sources
 

--- a/crates/bin/cratesfyi/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
+++ b/crates/bin/cratesfyi/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    UPDATE queue\n                    SET priority = $2\n                    WHERE name = $1\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e"
+}

--- a/crates/bin/cratesfyi/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
+++ b/crates/bin/cratesfyi/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            c.name as \"name: KrateName\",\n            repo.override_build_priority as \"priority!\"\n\n        FROM\n            crates AS c\n            INNER JOIN releases AS r ON c.latest_version_id = r.id\n            INNER JOIN repositories AS repo ON r.repository_id = repo.id\n\n        WHERE\n            c.name = ANY($1) AND\n            repo.override_build_priority IS NOT NULL\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name: KrateName",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a"
+}

--- a/crates/bin/cratesfyi/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
+++ b/crates/bin/cratesfyi/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = $2 WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085"
+}

--- a/crates/bin/cratesfyi/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
+++ b/crates/bin/cratesfyi/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT name, override_build_priority as \"priority!\"\n        FROM repositories\n        WHERE override_build_priority IS NOT NULL\n        ORDER BY name\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d"
+}

--- a/crates/bin/cratesfyi/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
+++ b/crates/bin/cratesfyi/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT override_build_priority FROM repositories WHERE name = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "override_build_priority",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed"
+}

--- a/crates/bin/cratesfyi/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
+++ b/crates/bin/cratesfyi/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = NULL WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033"
+}

--- a/crates/bin/docs_rs_admin/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
+++ b/crates/bin/docs_rs_admin/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    UPDATE queue\n                    SET priority = $2\n                    WHERE name = $1\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e"
+}

--- a/crates/bin/docs_rs_admin/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
+++ b/crates/bin/docs_rs_admin/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            c.name as \"name: KrateName\",\n            repo.override_build_priority as \"priority!\"\n\n        FROM\n            crates AS c\n            INNER JOIN releases AS r ON c.latest_version_id = r.id\n            INNER JOIN repositories AS repo ON r.repository_id = repo.id\n\n        WHERE\n            c.name = ANY($1) AND\n            repo.override_build_priority IS NOT NULL\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name: KrateName",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a"
+}

--- a/crates/bin/docs_rs_admin/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
+++ b/crates/bin/docs_rs_admin/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = $2 WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085"
+}

--- a/crates/bin/docs_rs_admin/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
+++ b/crates/bin/docs_rs_admin/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT name, override_build_priority as \"priority!\"\n        FROM repositories\n        WHERE override_build_priority IS NOT NULL\n        ORDER BY name\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d"
+}

--- a/crates/bin/docs_rs_admin/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
+++ b/crates/bin/docs_rs_admin/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT override_build_priority FROM repositories WHERE name = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "override_build_priority",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed"
+}

--- a/crates/bin/docs_rs_admin/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
+++ b/crates/bin/docs_rs_admin/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = NULL WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033"
+}

--- a/crates/bin/docs_rs_admin/src/main.rs
+++ b/crates/bin/docs_rs_admin/src/main.rs
@@ -121,6 +121,12 @@ enum QueueSubcommand {
         subcommand: PrioritySubcommand,
     },
 
+    /// Interactions with repository-specific build priorities
+    RepositoryPriority {
+        #[command(subcommand)]
+        subcommand: RepositoryPrioritySubcommand,
+    },
+
     /// Queue rebuilds for broken nightly versions of rustdoc, either for a single date (start) or a range (start inclusive, end exclusive)
     RebuildBrokenNightly {
         /// Start date of nightly builds to rebuild (inclusive)
@@ -148,6 +154,8 @@ impl QueueSubcommand {
 
             Self::DefaultPriority { subcommand } => subcommand.handle_args(ctx).await?,
 
+            Self::RepositoryPriority { subcommand } => subcommand.handle_args(ctx).await?,
+
             Self::RebuildBrokenNightly {
                 start_nightly_date,
                 end_nightly_date,
@@ -163,6 +171,70 @@ impl QueueSubcommand {
                 println!(
                     "Queued {queued_rebuilds_amount} rebuilds for broken nightly versions of rustdoc"
                 );
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
+enum RepositoryPrioritySubcommand {
+    /// Get build priority override for a repository
+    Get {
+        #[arg(name = "REPOSITORY")]
+        repository_name: String,
+    },
+
+    /// List build priority overrides for all repositories
+    List,
+
+    /// Set build priority override for a repository
+    Set {
+        #[arg(name = "REPOSITORY")]
+        repository_name: String,
+        #[arg(allow_negative_numbers = true)]
+        priority: i32,
+    },
+
+    /// Remove build priority override for a repository
+    Remove {
+        #[arg(name = "REPOSITORY")]
+        repository_name: String,
+    },
+}
+
+impl RepositoryPrioritySubcommand {
+    async fn handle_args(self, ctx: Context) -> Result<()> {
+        let mut conn = ctx.pool()?.get_async().await?;
+        match self {
+            Self::Get { repository_name } => {
+                let priority =
+                    workspaces::get_repository_build_priority(&mut conn, &repository_name).await?;
+
+                match priority {
+                    Some(priority) => println!("{repository_name} : {priority}"),
+                    None => println!("No priority override found for {repository_name}"),
+                }
+            }
+
+            Self::List => {
+                for (name, prio) in workspaces::list_repository_build_priorities(&mut conn).await? {
+                    println!("{:>20} : {:>3}", name, prio);
+                }
+            }
+
+            Self::Set {
+                repository_name,
+                priority,
+            } => {
+                workspaces::set_repository_build_priority(&mut conn, &repository_name, priority)
+                    .await?;
+
+                println!("Set repository '{repository_name}' to priority {priority}");
+            }
+
+            Self::Remove { repository_name } => {
+                workspaces::remove_repository_build_priority(&mut conn, &repository_name).await?;
             }
         }
         Ok(())

--- a/crates/bin/docs_rs_builder/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
+++ b/crates/bin/docs_rs_builder/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    UPDATE queue\n                    SET priority = $2\n                    WHERE name = $1\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e"
+}

--- a/crates/bin/docs_rs_builder/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
+++ b/crates/bin/docs_rs_builder/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            c.name as \"name: KrateName\",\n            repo.override_build_priority as \"priority!\"\n\n        FROM\n            crates AS c\n            INNER JOIN releases AS r ON c.latest_version_id = r.id\n            INNER JOIN repositories AS repo ON r.repository_id = repo.id\n\n        WHERE\n            c.name = ANY($1) AND\n            repo.override_build_priority IS NOT NULL\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name: KrateName",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a"
+}

--- a/crates/bin/docs_rs_builder/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
+++ b/crates/bin/docs_rs_builder/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = $2 WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085"
+}

--- a/crates/bin/docs_rs_builder/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
+++ b/crates/bin/docs_rs_builder/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT name, override_build_priority as \"priority!\"\n        FROM repositories\n        WHERE override_build_priority IS NOT NULL\n        ORDER BY name\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d"
+}

--- a/crates/bin/docs_rs_builder/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
+++ b/crates/bin/docs_rs_builder/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT override_build_priority FROM repositories WHERE name = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "override_build_priority",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed"
+}

--- a/crates/bin/docs_rs_builder/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
+++ b/crates/bin/docs_rs_builder/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = NULL WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033"
+}

--- a/crates/bin/docs_rs_import_release/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
+++ b/crates/bin/docs_rs_import_release/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    UPDATE queue\n                    SET priority = $2\n                    WHERE name = $1\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e"
+}

--- a/crates/bin/docs_rs_import_release/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
+++ b/crates/bin/docs_rs_import_release/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            c.name as \"name: KrateName\",\n            repo.override_build_priority as \"priority!\"\n\n        FROM\n            crates AS c\n            INNER JOIN releases AS r ON c.latest_version_id = r.id\n            INNER JOIN repositories AS repo ON r.repository_id = repo.id\n\n        WHERE\n            c.name = ANY($1) AND\n            repo.override_build_priority IS NOT NULL\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name: KrateName",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a"
+}

--- a/crates/bin/docs_rs_import_release/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
+++ b/crates/bin/docs_rs_import_release/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = $2 WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085"
+}

--- a/crates/bin/docs_rs_import_release/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
+++ b/crates/bin/docs_rs_import_release/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT name, override_build_priority as \"priority!\"\n        FROM repositories\n        WHERE override_build_priority IS NOT NULL\n        ORDER BY name\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d"
+}

--- a/crates/bin/docs_rs_import_release/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
+++ b/crates/bin/docs_rs_import_release/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT override_build_priority FROM repositories WHERE name = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "override_build_priority",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed"
+}

--- a/crates/bin/docs_rs_import_release/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
+++ b/crates/bin/docs_rs_import_release/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = NULL WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033"
+}

--- a/crates/bin/docs_rs_watcher/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
+++ b/crates/bin/docs_rs_watcher/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    UPDATE queue\n                    SET priority = $2\n                    WHERE name = $1\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e"
+}

--- a/crates/bin/docs_rs_watcher/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
+++ b/crates/bin/docs_rs_watcher/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            c.name as \"name: KrateName\",\n            repo.override_build_priority as \"priority!\"\n\n        FROM\n            crates AS c\n            INNER JOIN releases AS r ON c.latest_version_id = r.id\n            INNER JOIN repositories AS repo ON r.repository_id = repo.id\n\n        WHERE\n            c.name = ANY($1) AND\n            repo.override_build_priority IS NOT NULL\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name: KrateName",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a"
+}

--- a/crates/bin/docs_rs_watcher/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
+++ b/crates/bin/docs_rs_watcher/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = $2 WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085"
+}

--- a/crates/bin/docs_rs_watcher/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
+++ b/crates/bin/docs_rs_watcher/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT name, override_build_priority as \"priority!\"\n        FROM repositories\n        WHERE override_build_priority IS NOT NULL\n        ORDER BY name\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d"
+}

--- a/crates/bin/docs_rs_watcher/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
+++ b/crates/bin/docs_rs_watcher/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT override_build_priority FROM repositories WHERE name = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "override_build_priority",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed"
+}

--- a/crates/bin/docs_rs_watcher/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
+++ b/crates/bin/docs_rs_watcher/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = NULL WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033"
+}

--- a/crates/bin/docs_rs_web/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
+++ b/crates/bin/docs_rs_web/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    UPDATE queue\n                    SET priority = $2\n                    WHERE name = $1\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e"
+}

--- a/crates/bin/docs_rs_web/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
+++ b/crates/bin/docs_rs_web/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            c.name as \"name: KrateName\",\n            repo.override_build_priority as \"priority!\"\n\n        FROM\n            crates AS c\n            INNER JOIN releases AS r ON c.latest_version_id = r.id\n            INNER JOIN repositories AS repo ON r.repository_id = repo.id\n\n        WHERE\n            c.name = ANY($1) AND\n            repo.override_build_priority IS NOT NULL\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name: KrateName",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a"
+}

--- a/crates/bin/docs_rs_web/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
+++ b/crates/bin/docs_rs_web/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = $2 WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085"
+}

--- a/crates/bin/docs_rs_web/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
+++ b/crates/bin/docs_rs_web/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT name, override_build_priority as \"priority!\"\n        FROM repositories\n        WHERE override_build_priority IS NOT NULL\n        ORDER BY name\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d"
+}

--- a/crates/bin/docs_rs_web/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
+++ b/crates/bin/docs_rs_web/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT override_build_priority FROM repositories WHERE name = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "override_build_priority",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed"
+}

--- a/crates/bin/docs_rs_web/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
+++ b/crates/bin/docs_rs_web/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = NULL WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033"
+}

--- a/crates/lib/docs_rs_build_queue/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
+++ b/crates/lib/docs_rs_build_queue/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    UPDATE queue\n                    SET priority = $2\n                    WHERE name = $1\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e"
+}

--- a/crates/lib/docs_rs_build_queue/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
+++ b/crates/lib/docs_rs_build_queue/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            c.name as \"name: KrateName\",\n            repo.override_build_priority as \"priority!\"\n\n        FROM\n            crates AS c\n            INNER JOIN releases AS r ON c.latest_version_id = r.id\n            INNER JOIN repositories AS repo ON r.repository_id = repo.id\n\n        WHERE\n            c.name = ANY($1) AND\n            repo.override_build_priority IS NOT NULL\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name: KrateName",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a"
+}

--- a/crates/lib/docs_rs_build_queue/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
+++ b/crates/lib/docs_rs_build_queue/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = $2 WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085"
+}

--- a/crates/lib/docs_rs_build_queue/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
+++ b/crates/lib/docs_rs_build_queue/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT name, override_build_priority as \"priority!\"\n        FROM repositories\n        WHERE override_build_priority IS NOT NULL\n        ORDER BY name\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d"
+}

--- a/crates/lib/docs_rs_build_queue/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
+++ b/crates/lib/docs_rs_build_queue/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT override_build_priority FROM repositories WHERE name = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "override_build_priority",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed"
+}

--- a/crates/lib/docs_rs_build_queue/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
+++ b/crates/lib/docs_rs_build_queue/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = NULL WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033"
+}

--- a/crates/lib/docs_rs_build_queue/src/queue/non_blocking.rs
+++ b/crates/lib/docs_rs_build_queue/src/queue/non_blocking.rs
@@ -8,7 +8,10 @@ use docs_rs_opentelemetry::AnyMeterProvider;
 use docs_rs_repository_stats::workspaces;
 use docs_rs_types::{KrateName, Version};
 use futures_util::TryStreamExt as _;
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 #[derive(Debug)]
 pub struct AsyncBuildQueue {
@@ -171,7 +174,7 @@ impl AsyncBuildQueue {
     pub async fn deprioritize_workspaces(&self) -> Result<()> {
         let mut conn = self.db.get_async().await?;
 
-        let high_priority_names: Vec<_> = sqlx::query!(
+        let mut high_priority_names: HashSet<_> = sqlx::query!(
             r#"
              SELECT DISTINCT name AS "name: KrateName"
              FROM queue
@@ -184,13 +187,36 @@ impl AsyncBuildQueue {
         .map(|row| row.name)
         .collect();
 
-        let to_deprioritize: Vec<_> = workspaces::get_crate_counts(&mut conn, high_priority_names)
-            .await?
-            .into_iter()
-            .filter_map(|(name, count)| {
-                (count > self.config.deprioritize_workspace_size.into()).then(|| name.to_string())
-            })
-            .collect();
+        for (name, prio) in
+            workspaces::get_overriden_build_priorities(&mut conn, high_priority_names.iter())
+                .await?
+        {
+            if prio != PRIORITY_DEFAULT {
+                sqlx::query!(
+                    r#"
+                    UPDATE queue
+                    SET priority = $2
+                    WHERE name = $1
+                    "#,
+                    name as _,
+                    prio
+                )
+                .execute(&mut *conn)
+                .await?;
+            }
+
+            high_priority_names.remove(&name);
+        }
+
+        let to_deprioritize: Vec<_> =
+            workspaces::get_crate_counts(&mut conn, high_priority_names.iter())
+                .await?
+                .into_iter()
+                .filter_map(|(name, count)| {
+                    (count > self.config.deprioritize_workspace_size.into())
+                        .then(|| name.to_string())
+                })
+                .collect();
 
         sqlx::query!(
             r#"
@@ -485,7 +511,7 @@ mod tests {
         workspaces::rewrite_repository_stats(&mut conn).await?;
 
         assert_eq!(
-            workspaces::get_crate_counts(&mut conn, vec![FOO, BAR, BAZ]).await?,
+            workspaces::get_crate_counts(&mut conn, [FOO, BAR, BAZ].iter()).await?,
             HashMap::from_iter([(FOO, 2), (BAR, 2)])
         );
 
@@ -500,6 +526,58 @@ mod tests {
                 .map(|q| (q.name, q.priority))
                 .collect::<Vec<_>>(),
             vec![(BAZ, 0), (FOO, 1), (BAR, 1)]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_deprio_workspace_respects_repository_override_priority() -> Result<()> {
+        let mut config = Config::from_environment()?;
+        config.deprioritize_workspace_size = 1;
+        let env = test_queue_with_config(config).await?;
+
+        let mut conn = env.db.async_conn().await?;
+
+        let repo_id = FakeGithubStats {
+            repo: "owner1/repo1".into(),
+            stars: 0,
+            forks: 0,
+            issues: 0,
+        }
+        .create(&mut conn)
+        .await?;
+
+        for name in [FOO, BAR] {
+            env.fake_release()
+                .await
+                .name(&name)
+                .version(V1)
+                .create()
+                .await?;
+        }
+
+        sqlx::query!("UPDATE releases SET repository_id = $1", repo_id)
+            .execute(&mut *conn)
+            .await?;
+        workspaces::set_repository_build_priority(&mut conn, "owner1/repo1", -10).await?;
+
+        let queue = env.queue;
+        for krate in &[FOO, BAR, BAZ] {
+            queue.add_crate(krate, &V1, PRIORITY_DEFAULT, None).await?;
+        }
+
+        workspaces::rewrite_repository_stats(&mut conn).await?;
+        queue.deprioritize_workspaces().await?;
+
+        assert_eq!(
+            queue
+                .queued_crates()
+                .await?
+                .into_iter()
+                .map(|q| (q.name, q.priority))
+                .collect::<Vec<_>>(),
+            vec![(FOO, -10), (BAR, -10), (BAZ, PRIORITY_DEFAULT)]
         );
 
         Ok(())

--- a/crates/lib/docs_rs_context/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
+++ b/crates/lib/docs_rs_context/.sqlx/query-1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    UPDATE queue\n                    SET priority = $2\n                    WHERE name = $1\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1fcb4371909a27b059e3dba7c0791b40f873618036c55c679e5854dbd4cbf91e"
+}

--- a/crates/lib/docs_rs_context/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
+++ b/crates/lib/docs_rs_context/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            c.name as \"name: KrateName\",\n            repo.override_build_priority as \"priority!\"\n\n        FROM\n            crates AS c\n            INNER JOIN releases AS r ON c.latest_version_id = r.id\n            INNER JOIN repositories AS repo ON r.repository_id = repo.id\n\n        WHERE\n            c.name = ANY($1) AND\n            repo.override_build_priority IS NOT NULL\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name: KrateName",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a"
+}

--- a/crates/lib/docs_rs_context/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
+++ b/crates/lib/docs_rs_context/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = $2 WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085"
+}

--- a/crates/lib/docs_rs_context/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
+++ b/crates/lib/docs_rs_context/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT name, override_build_priority as \"priority!\"\n        FROM repositories\n        WHERE override_build_priority IS NOT NULL\n        ORDER BY name\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d"
+}

--- a/crates/lib/docs_rs_context/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
+++ b/crates/lib/docs_rs_context/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT override_build_priority FROM repositories WHERE name = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "override_build_priority",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed"
+}

--- a/crates/lib/docs_rs_context/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
+++ b/crates/lib/docs_rs_context/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = NULL WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033"
+}

--- a/crates/lib/docs_rs_database/migrations/20260407163134_repositories-override-priority.down.sql
+++ b/crates/lib/docs_rs_database/migrations/20260407163134_repositories-override-priority.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE repositories DROP COLUMN override_build_priority;

--- a/crates/lib/docs_rs_database/migrations/20260407163134_repositories-override-priority.up.sql
+++ b/crates/lib/docs_rs_database/migrations/20260407163134_repositories-override-priority.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE repositories ADD COLUMN override_build_priority INTEGER;

--- a/crates/lib/docs_rs_repository_stats/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
+++ b/crates/lib/docs_rs_repository_stats/.sqlx/query-53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            c.name as \"name: KrateName\",\n            repo.override_build_priority as \"priority!\"\n\n        FROM\n            crates AS c\n            INNER JOIN releases AS r ON c.latest_version_id = r.id\n            INNER JOIN repositories AS repo ON r.repository_id = repo.id\n\n        WHERE\n            c.name = ANY($1) AND\n            repo.override_build_priority IS NOT NULL\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name: KrateName",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "53eeab98d127a1ab001d09cc2288b8c185248d428b73c6519f7ea17557c8f02a"
+}

--- a/crates/lib/docs_rs_repository_stats/.sqlx/query-7bea41567a747d6043891a7934cfdf9c313f54cd346e509c9d131c705c216b0e.json
+++ b/crates/lib/docs_rs_repository_stats/.sqlx/query-7bea41567a747d6043891a7934cfdf9c313f54cd346e509c9d131c705c216b0e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE releases SET repository_id = $1 WHERE crate_id = (SELECT id FROM crates WHERE name = $2)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7bea41567a747d6043891a7934cfdf9c313f54cd346e509c9d131c705c216b0e"
+}

--- a/crates/lib/docs_rs_repository_stats/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
+++ b/crates/lib/docs_rs_repository_stats/.sqlx/query-bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = $2 WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bd593101e831d4eaa0cf68d6d73c58324b634e8afd5d16996a4dff5bfc88f085"
+}

--- a/crates/lib/docs_rs_repository_stats/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
+++ b/crates/lib/docs_rs_repository_stats/.sqlx/query-d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT name, override_build_priority as \"priority!\"\n        FROM repositories\n        WHERE override_build_priority IS NOT NULL\n        ORDER BY name\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "priority!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "d814d5028d9746c9b4e7f0dea309ec9b8c327a186d45089cfeec9a4bbfd31e9d"
+}

--- a/crates/lib/docs_rs_repository_stats/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
+++ b/crates/lib/docs_rs_repository_stats/.sqlx/query-f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT override_build_priority FROM repositories WHERE name = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "override_build_priority",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "f625fd73215b3a8b6868c2ac54aed281d3f167434871497dfea16378be3b81ed"
+}

--- a/crates/lib/docs_rs_repository_stats/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
+++ b/crates/lib/docs_rs_repository_stats/.sqlx/query-fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET override_build_priority = NULL WHERE name = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fa8f0319c0e27736bc02d53d743c44fd503c3cd4599ba36042053a9cd05aa033"
+}

--- a/crates/lib/docs_rs_repository_stats/src/workspaces.rs
+++ b/crates/lib/docs_rs_repository_stats/src/workspaces.rs
@@ -1,8 +1,7 @@
-use std::collections::HashMap;
-
-use anyhow::Result;
+use anyhow::{Result, anyhow, bail};
 use docs_rs_types::KrateName;
 use sqlx::Acquire as _;
+use std::collections::HashMap;
 
 /// update the crate-count on each repository.
 ///
@@ -69,12 +68,9 @@ pub async fn rewrite_repository_stats(conn: &mut sqlx::PgConnection) -> Result<(
 /// get the crate-count for the related workspace for a crate.
 pub async fn get_crate_counts(
     conn: &mut sqlx::PgConnection,
-    names: impl IntoIterator<Item = KrateName>,
+    names: impl Iterator<Item = &KrateName>,
 ) -> Result<HashMap<KrateName, i32>> {
-    let names: Vec<_> = names
-        .into_iter()
-        .map(|k: KrateName| k.to_string())
-        .collect();
+    let names: Vec<_> = names.map(|k: &KrateName| k.to_string()).collect();
 
     Ok(sqlx::query!(
         r#"
@@ -98,6 +94,108 @@ pub async fn get_crate_counts(
     .collect())
 }
 
+/// get the override-priorities for the given crate names
+pub async fn get_overriden_build_priorities(
+    conn: &mut sqlx::PgConnection,
+    names: impl Iterator<Item = &KrateName>,
+) -> Result<HashMap<KrateName, i32>> {
+    let names: Vec<_> = names.map(|k: &KrateName| k.to_string()).collect();
+
+    Ok(sqlx::query!(
+        r#"
+        SELECT
+            c.name as "name: KrateName",
+            repo.override_build_priority as "priority!"
+
+        FROM
+            crates AS c
+            INNER JOIN releases AS r ON c.latest_version_id = r.id
+            INNER JOIN repositories AS repo ON r.repository_id = repo.id
+
+        WHERE
+            c.name = ANY($1) AND
+            repo.override_build_priority IS NOT NULL
+        "#,
+        &names[..],
+    )
+    .fetch_all(&mut *conn)
+    .await?
+    .into_iter()
+    .map(|row| (row.name, row.priority))
+    .collect())
+}
+
+pub async fn get_repository_build_priority(
+    conn: &mut sqlx::PgConnection,
+    repository_name: &str,
+) -> Result<Option<i32>> {
+    sqlx::query_scalar!(
+        "SELECT override_build_priority FROM repositories WHERE name = $1",
+        repository_name
+    )
+    .fetch_optional(&mut *conn)
+    .await?
+    .ok_or_else(|| anyhow!("repository '{repository_name}' not found"))
+}
+
+pub async fn list_repository_build_priorities(
+    conn: &mut sqlx::PgConnection,
+) -> Result<HashMap<String, i32>> {
+    Ok(sqlx::query!(
+        r#"
+        SELECT name, override_build_priority as "priority!"
+        FROM repositories
+        WHERE override_build_priority IS NOT NULL
+        ORDER BY name
+        "#
+    )
+    .fetch_all(&mut *conn)
+    .await?
+    .into_iter()
+    .map(|row| (row.name, row.priority))
+    .collect())
+}
+
+pub async fn set_repository_build_priority(
+    conn: &mut sqlx::PgConnection,
+    repository_name: &str,
+    priority: i32,
+) -> Result<()> {
+    let updated = sqlx::query!(
+        "UPDATE repositories SET override_build_priority = $2 WHERE name = $1",
+        repository_name,
+        priority
+    )
+    .execute(&mut *conn)
+    .await?
+    .rows_affected();
+
+    if updated == 0 {
+        bail!("repository '{repository_name}' not found");
+    }
+
+    Ok(())
+}
+
+pub async fn remove_repository_build_priority(
+    conn: &mut sqlx::PgConnection,
+    repository_name: &str,
+) -> Result<()> {
+    let updated = sqlx::query!(
+        "UPDATE repositories SET override_build_priority = NULL WHERE name = $1",
+        repository_name
+    )
+    .execute(&mut *conn)
+    .await?
+    .rows_affected();
+
+    if updated == 0 {
+        bail!("repository '{repository_name}' not found");
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -108,6 +206,10 @@ mod tests {
     use docs_rs_test_fakes::{FakeGithubStats, FakeRelease};
     use docs_rs_types::testing::{BAR, BAZ, FOO};
     use pretty_assertions::assert_eq;
+
+    const REPO: &str = "owner1/repo1";
+    const REPO2: &str = "owner2/repo2";
+    const REPO3: &str = "owner3/repo3";
 
     struct TestEnv {
         db: TestDatabase,
@@ -163,14 +265,14 @@ mod tests {
         env.fake_release()
             .await
             .name(&FOO)
-            .github_stats("owner1/repo1", 0, 0, 0)
+            .github_stats(REPO, 0, 0, 0)
             .create()
             .await?;
 
         env.fake_release()
             .await
             .name(&BAR)
-            .github_stats("owner2/repo2", 0, 0, 0)
+            .github_stats(REPO2, 0, 0, 0)
             .create()
             .await?;
 
@@ -180,7 +282,7 @@ mod tests {
         // update was called
         assert_eq!(
             fetch_stats(&mut conn).await?,
-            vec![("owner1/repo1".into(), 0), ("owner2/repo2".into(), 0)]
+            vec![(REPO.into(), 0), (REPO2.into(), 0)]
         );
 
         rewrite_repository_stats(&mut conn).await?;
@@ -188,13 +290,13 @@ mod tests {
         // after the full rewrite, the count is correct
         assert_eq!(
             fetch_stats(&mut conn).await?,
-            vec![("owner1/repo1".into(), 1), ("owner2/repo2".into(), 1)]
+            vec![(REPO.into(), 1), (REPO2.into(), 1)]
         );
 
         env.fake_release()
             .await
             .name(&BAZ)
-            .github_stats("owner3/repo3", 0, 0, 0)
+            .github_stats(REPO3, 0, 0, 0)
             .create()
             .await?;
 
@@ -202,14 +304,10 @@ mod tests {
         // because neither the full rewrite or the single-repo update was called
         assert_eq!(
             fetch_stats(&mut conn).await?,
-            vec![
-                ("owner1/repo1".into(), 1),
-                ("owner2/repo2".into(), 1),
-                ("owner3/repo3".into(), 0),
-            ]
+            vec![(REPO.into(), 1), (REPO2.into(), 1), (REPO3.into(), 0),]
         );
 
-        let repo3_id = fetch_repo_id(&mut conn, "owner3/repo3").await?;
+        let repo3_id = fetch_repo_id(&mut conn, REPO3).await?;
 
         update_repository_stats(&mut conn, repo3_id).await?;
 
@@ -217,11 +315,7 @@ mod tests {
         // and the old repos are unchanged
         assert_eq!(
             fetch_stats(&mut conn).await?,
-            vec![
-                ("owner1/repo1".into(), 1),
-                ("owner2/repo2".into(), 1),
-                ("owner3/repo3".into(), 1),
-            ]
+            vec![(REPO.into(), 1), (REPO2.into(), 1), (REPO3.into(), 1),]
         );
 
         Ok(())
@@ -282,6 +376,153 @@ mod tests {
         assert_eq!(
             fetch_stats(&mut conn).await?,
             vec![("owner/repo".into(), 3),]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_get_overriden_build_priorities() -> Result<()> {
+        let env = test_env().await?;
+        let mut conn = env.db.async_conn().await?;
+
+        let prioritized_repo_id = FakeGithubStats {
+            repo: REPO.into(),
+            stars: 0,
+            forks: 0,
+            issues: 0,
+        }
+        .create(&mut conn)
+        .await?;
+
+        let default_repo_id = FakeGithubStats {
+            repo: REPO2.into(),
+            stars: 0,
+            forks: 0,
+            issues: 0,
+        }
+        .create(&mut conn)
+        .await?;
+
+        env.fake_release().await.name(&FOO).create().await?;
+        env.fake_release().await.name(&BAR).create().await?;
+
+        sqlx::query!("UPDATE releases SET repository_id = $1 WHERE crate_id = (SELECT id FROM crates WHERE name = $2)", prioritized_repo_id, FOO as _)
+            .execute(&mut *conn)
+            .await?;
+        sqlx::query!("UPDATE releases SET repository_id = $1 WHERE crate_id = (SELECT id FROM crates WHERE name = $2)", default_repo_id, BAR as _)
+            .execute(&mut *conn)
+            .await?;
+        set_repository_build_priority(&mut conn, REPO, -5).await?;
+
+        assert_eq!(
+            get_overriden_build_priorities(&mut conn, [FOO, BAR, BAZ].iter()).await?,
+            HashMap::from_iter([(FOO, -5)])
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_repository_build_priority_lifecycle() -> Result<()> {
+        let env = test_env().await?;
+        let mut conn = env.db.async_conn().await?;
+
+        FakeGithubStats {
+            repo: REPO.into(),
+            stars: 0,
+            forks: 0,
+            issues: 0,
+        }
+        .create(&mut conn)
+        .await?;
+
+        assert_eq!(get_repository_build_priority(&mut conn, REPO).await?, None);
+
+        set_repository_build_priority(&mut conn, REPO, -7).await?;
+
+        assert_eq!(
+            get_repository_build_priority(&mut conn, REPO).await?,
+            Some(-7)
+        );
+
+        remove_repository_build_priority(&mut conn, REPO).await?;
+
+        assert_eq!(get_repository_build_priority(&mut conn, REPO).await?, None);
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_repository_build_priority_get_missing() -> Result<()> {
+        let env = test_env().await?;
+        let mut conn = env.db.async_conn().await?;
+
+        let get_err = get_repository_build_priority(&mut conn, "missing/repo")
+            .await
+            .unwrap_err();
+        assert_eq!(get_err.to_string(), "repository 'missing/repo' not found");
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_repository_build_priority_set_missing() -> Result<()> {
+        let env = test_env().await?;
+        let mut conn = env.db.async_conn().await?;
+
+        let set_err = set_repository_build_priority(&mut conn, "missing/repo", -3)
+            .await
+            .unwrap_err();
+        assert_eq!(set_err.to_string(), "repository 'missing/repo' not found");
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_repository_build_priority_remove_missing() -> Result<()> {
+        let env = test_env().await?;
+        let mut conn = env.db.async_conn().await?;
+
+        let remove_err = remove_repository_build_priority(&mut conn, "missing/repo")
+            .await
+            .unwrap_err();
+        assert_eq!(
+            remove_err.to_string(),
+            "repository 'missing/repo' not found"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_list_repository_build_priorities() -> Result<()> {
+        let env = test_env().await?;
+        let mut conn = env.db.async_conn().await?;
+
+        FakeGithubStats {
+            repo: REPO.into(),
+            stars: 0,
+            forks: 0,
+            issues: 0,
+        }
+        .create(&mut conn)
+        .await?;
+
+        FakeGithubStats {
+            repo: REPO2.into(),
+            stars: 0,
+            forks: 0,
+            issues: 0,
+        }
+        .create(&mut conn)
+        .await?;
+
+        set_repository_build_priority(&mut conn, REPO, -5).await?;
+
+        assert_eq!(
+            list_repository_build_priorities(&mut conn).await?,
+            HashMap::from_iter([(REPO.into(), -5)])
         );
 
         Ok(())


### PR DESCRIPTION
Fixes #3276 

the current automatic workspace deprio groups crates by repository, counts the crates, and will trigger deprioritization when there are more than 20 crates in that repo. 

This is what we want for (I assume) most workspaces, which are released together most of the time. These clog the queue and we want them on prio -1. 

But there are exceptions we learned about in the recent "full queue" event: [`tokio`](https://github.com/tokio-rs/tokio), or [`rustcrypto/utils`](https://github.com/RustCrypto/utils), where we have many crates in one repo, but they aren't released together, but only separately. So these we don't need to deprioritize, and in the situations where the queue is full, this is rather annoying for the maintainers. 

So this PR will enable us to override the priority for a repository / workspace, for the current cases just to "revert it back" to high priority. I can also use that feature to deprioritize workspaces _further down_. We're doing this for `swc_%` at the moment, I think it was because it's a huge workspace and wasn't even in production, or self-hosts their docs. I could imagine we can even drop the old build-priorities thing and instead just use this. 

