### PR TITLE
reduce compression level inside zip files

### DIFF
--- a/crates/lib/docs_rs_storage/src/archive_index.rs
+++ b/crates/lib/docs_rs_storage/src/archive_index.rs
@@ -850,7 +850,9 @@ mod tests {
             for i in 0..file_count {
                 archive.start_file(
                     format!("testfile{i}"),
-                    SimpleFileOptions::default().compression_method(zip::CompressionMethod::Bzip2),
+                    SimpleFileOptions::default()
+                        .compression_method(zip::CompressionMethod::Bzip2)
+                        .compression_level(Some(1)),
                 )?;
                 archive.write_all(&objectcontent)?;
             }

--- a/crates/lib/docs_rs_storage/src/storage/non_blocking.rs
+++ b/crates/lib/docs_rs_storage/src/storage/non_blocking.rs
@@ -321,7 +321,8 @@ impl AsyncStorage {
                             info_span!("create_zip_archive", %archive_path, root_dir=%root_dir.display()).entered();
 
                         let options = zip::write::SimpleFileOptions::default()
-                            .compression_method(zip::CompressionMethod::Bzip2);
+                            .compression_method(zip::CompressionMethod::Bzip2)
+                            .compression_level(Some(3));
 
                         let mut zip = zip::ZipWriter::new(io::Cursor::new(Vec::new()));
                         for file_path in get_file_list(&root_dir) {


### PR DESCRIPTION
I did some tests. 

going from level 6 (the default) to level 3 gives us **25% performance improvement for 10% bigger zip files**. 

