### PR TITLE
block more encoded path traversals

### DIFF
--- a/crates/bin/docs_rs_web/src/middleware/security.rs
+++ b/crates/bin/docs_rs_web/src/middleware/security.rs
@@ -41,7 +41,11 @@ fn validate_path(initial_path: &str) -> Result<()> {
 }
 
 fn validate_decoded_path(path: &str) -> Result<()> {
-    if path.contains("/../") || path.ends_with("/..") {
+    if path.contains("/../")
+        || path.ends_with("/..")
+        || path.contains("//\\../")
+        || path.contains("\\..\\")
+    {
         bail!("path traversal attempt");
     }
 
@@ -61,6 +65,7 @@ mod tests {
         testing::{AxumResponseTestExt as _, AxumRouterTestExt as _},
     };
     use axum::{Router, middleware, routing::get};
+
     use test_case::test_case;
     use tower::ServiceBuilder;
 
@@ -77,6 +82,14 @@ mod tests {
     #[test_case("/minidumper/latest/%252523script"; "triple encoded hash")]
     #[test_case(
         "/crate/mika-cli/latest/source/..%25c1%259c..%25c1%259c..%25c1%259c..%25c1%259c..%25c1%259c..%25c1%259c..%25c1%259c..%25c1%259c/etc/passwd"
+    )]
+    #[test_case(
+        "/crate/aether/latest/source/compiler/node_modules/@richardanaya//%5c../%5c../%5c../%5c../%5c../%5c../%5c../etc/passwd";
+        "with backslash"
+    )]
+    #[test_case(
+        "/casual_logger/0.6.4/%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5cwindows/win.ini";
+        "double backslash"
     )]
     async fn test_invalid_path(path: &str) -> Result<()> {
         let app = Router::new()

--- a/crates/bin/docs_rs_web/src/middleware/security.rs
+++ b/crates/bin/docs_rs_web/src/middleware/security.rs
@@ -45,6 +45,7 @@ fn validate_decoded_path(path: &str) -> Result<()> {
         || path.ends_with("/..")
         || path.contains("//\\../")
         || path.contains("\\..\\")
+        || path.ends_with("\\..")
     {
         bail!("path traversal attempt");
     }
@@ -90,6 +91,10 @@ mod tests {
     #[test_case(
         "/casual_logger/0.6.4/%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5cwindows/win.ini";
         "double backslash"
+    )]
+    #[test_case(
+        "/casual_logger/0.6.4/%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e%5c%2e%2e";
+        "ends with backslash dot dot"
     )]
     async fn test_invalid_path(path: &str) -> Result<()> {
         let app = Router::new()


### PR DESCRIPTION
- https://rust-lang.sentry.io/issues/7195650500/?query=is%3Aunresolved&referrer=issue-stream
- https://rust-lang.sentry.io/issues/7318119675/?query=is%3Aunresolved&referrer=issue-stream

This fixes one of the cases, I'm not sure how to fix the others yet. 

<img width="983" height="255" alt="image" src="https://github.com/user-attachments/assets/cd29c6cd-8a00-474b-8ded-ea68628311f9" />

Notable: 
in the URL we don't have any encoded chars, but in the path we try to get from storage, we have them. 


Generally: 
when I finished the repackage, and all is in archive storage, these errors won't happen any more, sqlite will just return 404. 