### PR TITLE
Remove ambiguity from feature flag with no dependencies.

### DIFF
--- a/crates/bin/docs_rs_web/templates/crate/features.html
+++ b/crates/bin/docs_rs_web/templates/crate/features.html
@@ -108,7 +108,7 @@
                                     {%- endfor -%}
                                 </ul>
                             {%- else -%}
-                                <p>This feature flag does not enable additional features.</p>
+                                <p>This feature flag does not enable additional feature flags.</p>
                             {%- endif -%}
                         {%- endfor -%}
                     {% endif -%}


### PR DESCRIPTION
For the longest time I thought that it meant that the feature flag was defined but unused, not enabling any features. I just realized that it was actually talking about dependencies. So I figured it was good to make this more clear to avoid other people being confused like I was.