### PR TITLE
Add base for alert support

### DIFF
--- a/crates/bin/docs_rs_web/src/lib.rs
+++ b/crates/bin/docs_rs_web/src/lib.rs
@@ -41,3 +41,11 @@ pub(crate) static GLOBAL_ALERT: Option<GlobalAlert> = Some(GlobalAlert {
     fa_icon: "exclamation-triangle",
 });
 */
+
+pub(crate) fn get_alert() -> Option<(&'static str, usize)> {
+    Some((
+        "We are changing which targets are built by default on May 1st.<br>\
+        <a href=\"https://blog.rust-lang.org/2026/04/04/docsrs-only-default-targets/\">Learn more</a>",
+        1,
+    ))
+}

--- a/crates/bin/docs_rs_web/templates/alert.js
+++ b/crates/bin/docs_rs_web/templates/alert.js
@@ -1,0 +1,16 @@
+(function() {
+    const alertCheckbox = document.getElementById("docsrs-alert-input");
+    alertCheckbox.onchange = () => {
+        // If the user clicks on the "close button", we save this info in their local storage.
+        window.localStorage.setItem("hide-alert-id", alertCheckbox.getAttribute("data-id"));
+    };
+
+    const info = window.localStorage.getItem("hide-alert-id");
+    if (info !== null) {
+        const alertId = alertCheckbox.getAttribute("data-id");
+        // If the user already "closed" the alert, we don't show it anymore.
+        if (alertId === info) {
+            alertCheckbox.checked = true;
+        }
+    }
+})();

--- a/crates/bin/docs_rs_web/templates/header/topbar_end.html
+++ b/crates/bin/docs_rs_web/templates/header/topbar_end.html
@@ -123,3 +123,15 @@
         </div>
     </div>
 </div>
+
+{%- if let Some((alert, alert_id)) = crate::get_alert() -%}
+    <input type="checkbox" id="docsrs-alert-input" data-id={{alert_id|safe}}>
+    <label id="docsrs-alert-hide" for="docsrs-alert-input" title="Close alert message">
+        {{- crate::icons::IconXmark.render_solid(false, false, "") -}}
+    </label>
+    <div id="docsrs-alert">
+        {{- crate::icons::IconCircleInfo.render_solid(false, false, "") -}}
+        <span class="alert-text">{{- alert|safe -}}</span>
+    </div>
+    <script type="text/javascript">{%- include "alert.js" -%}</script>
+{%- endif -%}

--- a/crates/bin/docs_rs_web/templates/style/_navbar.scss
+++ b/crates/bin/docs_rs_web/templates/style/_navbar.scss
@@ -407,3 +407,53 @@ i.dependencies.normal {
     visibility: hidden;
     display: none;
 }
+
+#docsrs-alert-input {
+    display: none;
+}
+#docsrs-alert-hide {
+    z-index: 100001; // Must be one more than `#docsrs-alert`'s z-index.
+    right: 16px;
+    top: calc(#{$top-navbar-height} + 11px);
+    position: fixed;
+    cursor: pointer;
+    font-size: 1.3rem;
+    color: #ddd;
+}
+#docsrs-alert-hide:hover {
+    color: #fff;
+}
+#docsrs-alert {
+    position: fixed;
+    z-index: 100000;
+    right: 10px;
+    top: calc(#{$top-navbar-height} + 10px);
+    width: 40ch;
+    background: #3ea2ff;
+    border-radius: 6px;
+    font-family: $font-family-sans;
+    color: #fff;
+    display: flex;
+
+    > .fa {
+        padding: 0 10px;
+        align-content: center;
+        background: #64b4ff;
+        border-top-left-radius: 6px;
+        border-bottom-left-radius: 6px;
+    }
+
+    > .alert-text {
+        padding: 8px;
+        padding-right: 4ch;
+
+        a {
+            color: #fff;
+            text-decoration: underline;
+        }
+    }
+}
+#docsrs-alert-input:checked + label + #docsrs-alert,
+#docsrs-alert-input:checked + label {
+    display: none;
+}


### PR DESCRIPTION
This is a POC to add support for alerts. For now, it always generates an alert so you can give it a try. Even without JS, you can hide the alert. If JS is enabled when closing the alert, it will store the information and not show this alert again from this point.