### PR TITLE
extend releases.license column length

### DIFF
--- a/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
+++ b/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
@@ -12,7 +12,7 @@
         "Bool",
         "Bool",
         "Bool",
-        "Varchar",
+        "Text",
         "Varchar",
         "Varchar",
         "Varchar",

--- a/.sqlx/query-cf5426dc0b94b07b8aea1fde144bbbb3caa1e6ebfb5d9348f5d27a134b82a55c.json
+++ b/.sqlx/query-cf5426dc0b94b07b8aea1fde144bbbb3caa1e6ebfb5d9348f5d27a134b82a55c.json
@@ -147,7 +147,7 @@
       {
         "ordinal": 26,
         "name": "license",
-        "type_info": "Varchar"
+        "type_info": "Text"
       },
       {
         "ordinal": 27,

--- a/crates/bin/cratesfyi/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
+++ b/crates/bin/cratesfyi/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
@@ -12,7 +12,7 @@
         "Bool",
         "Bool",
         "Bool",
-        "Varchar",
+        "Text",
         "Varchar",
         "Varchar",
         "Varchar",

--- a/crates/bin/cratesfyi/.sqlx/query-cf5426dc0b94b07b8aea1fde144bbbb3caa1e6ebfb5d9348f5d27a134b82a55c.json
+++ b/crates/bin/cratesfyi/.sqlx/query-cf5426dc0b94b07b8aea1fde144bbbb3caa1e6ebfb5d9348f5d27a134b82a55c.json
@@ -147,7 +147,7 @@
       {
         "ordinal": 26,
         "name": "license",
-        "type_info": "Varchar"
+        "type_info": "Text"
       },
       {
         "ordinal": 27,

--- a/crates/bin/docs_rs_admin/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
+++ b/crates/bin/docs_rs_admin/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
@@ -12,7 +12,7 @@
         "Bool",
         "Bool",
         "Bool",
-        "Varchar",
+        "Text",
         "Varchar",
         "Varchar",
         "Varchar",

--- a/crates/bin/docs_rs_builder/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
+++ b/crates/bin/docs_rs_builder/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
@@ -12,7 +12,7 @@
         "Bool",
         "Bool",
         "Bool",
-        "Varchar",
+        "Text",
         "Varchar",
         "Varchar",
         "Varchar",

--- a/crates/bin/docs_rs_import_release/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
+++ b/crates/bin/docs_rs_import_release/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
@@ -12,7 +12,7 @@
         "Bool",
         "Bool",
         "Bool",
-        "Varchar",
+        "Text",
         "Varchar",
         "Varchar",
         "Varchar",

--- a/crates/bin/docs_rs_watcher/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
+++ b/crates/bin/docs_rs_watcher/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
@@ -12,7 +12,7 @@
         "Bool",
         "Bool",
         "Bool",
-        "Varchar",
+        "Text",
         "Varchar",
         "Varchar",
         "Varchar",

--- a/crates/bin/docs_rs_web/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
+++ b/crates/bin/docs_rs_web/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
@@ -12,7 +12,7 @@
         "Bool",
         "Bool",
         "Bool",
-        "Varchar",
+        "Text",
         "Varchar",
         "Varchar",
         "Varchar",

--- a/crates/bin/docs_rs_web/.sqlx/query-cf5426dc0b94b07b8aea1fde144bbbb3caa1e6ebfb5d9348f5d27a134b82a55c.json
+++ b/crates/bin/docs_rs_web/.sqlx/query-cf5426dc0b94b07b8aea1fde144bbbb3caa1e6ebfb5d9348f5d27a134b82a55c.json
@@ -147,7 +147,7 @@
       {
         "ordinal": 26,
         "name": "license",
-        "type_info": "Varchar"
+        "type_info": "Text"
       },
       {
         "ordinal": 27,

--- a/crates/lib/docs_rs_build_limits/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
+++ b/crates/lib/docs_rs_build_limits/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
@@ -12,7 +12,7 @@
         "Bool",
         "Bool",
         "Bool",
-        "Varchar",
+        "Text",
         "Varchar",
         "Varchar",
         "Varchar",

--- a/crates/lib/docs_rs_build_queue/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
+++ b/crates/lib/docs_rs_build_queue/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
@@ -12,7 +12,7 @@
         "Bool",
         "Bool",
         "Bool",
-        "Varchar",
+        "Text",
         "Varchar",
         "Varchar",
         "Varchar",

--- a/crates/lib/docs_rs_context/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
+++ b/crates/lib/docs_rs_context/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
@@ -12,7 +12,7 @@
         "Bool",
         "Bool",
         "Bool",
-        "Varchar",
+        "Text",
         "Varchar",
         "Varchar",
         "Varchar",

--- a/crates/lib/docs_rs_database/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
+++ b/crates/lib/docs_rs_database/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
@@ -12,7 +12,7 @@
         "Bool",
         "Bool",
         "Bool",
-        "Varchar",
+        "Text",
         "Varchar",
         "Varchar",
         "Varchar",

--- a/crates/lib/docs_rs_database/.sqlx/query-5fb3aafe01df37fb6dbd3a25702c7d5472acb49c1646311e078fdb548d366e5f.json
+++ b/crates/lib/docs_rs_database/.sqlx/query-5fb3aafe01df37fb6dbd3a25702c7d5472acb49c1646311e078fdb548d366e5f.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT license FROM releases WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "license",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "5fb3aafe01df37fb6dbd3a25702c7d5472acb49c1646311e078fdb548d366e5f"
+}

--- a/crates/lib/docs_rs_database/migrations/20260419071012_release-license-longer.down.sql
+++ b/crates/lib/docs_rs_database/migrations/20260419071012_release-license-longer.down.sql
@@ -1,0 +1,7 @@
+-- this reverse migration might fail when we have other records
+-- referencing releases with longer license strings.
+--
+-- If this has to be reverted we probably would have to manually run
+-- db::delete::delete_version for the releases.
+DELETE FROM releases WHERE LENGTH(license) > 100;
+ALTER TABLE releases ALTER COLUMN license TYPE VARCHAR(100);

--- a/crates/lib/docs_rs_database/migrations/20260419071012_release-license-longer.up.sql
+++ b/crates/lib/docs_rs_database/migrations/20260419071012_release-license-longer.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE releases ALTER COLUMN license TYPE TEXT;

--- a/crates/lib/docs_rs_database/src/releases.rs
+++ b/crates/lib/docs_rs_database/src/releases.rs
@@ -1406,4 +1406,68 @@ mod test {
 
         Ok(())
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_long_license() -> Result<()> {
+        let test_metrics = TestMetrics::new();
+        let db = TestDatabase::new(&Config::test_config()?, test_metrics.provider()).await?;
+
+        let mut conn = db.async_conn().await?;
+
+        let crate_id = initialize_crate(&mut conn, &KRATE).await?;
+        let release_id = initialize_release(&mut conn, crate_id, &V0_1).await?;
+
+        // Create a license string longer than 100 characters to test the migration
+        // from VARCHAR(100) to TEXT
+        let long_license = "MIT OR Apache-2.0 ".repeat(15); // ~270 characters
+        assert!(
+            long_license.len() > 100,
+            "License should be longer than old VARCHAR(100) limit"
+        );
+
+        let tempdir = tempfile::tempdir()?;
+        finish_release(
+            &mut conn,
+            crate_id,
+            release_id,
+            &MetadataPackage {
+                id: "42".to_string(),
+                name: KRATE.to_string(),
+                version: V0_1.clone(),
+                license: Some(long_license.clone()),
+                repository: None,
+                homepage: None,
+                description: None,
+                documentation: None,
+                dependencies: Vec::new(),
+                targets: Vec::new(),
+                readme: None,
+                keywords: Vec::new(),
+                features: BTreeMap::new(),
+            },
+            tempdir.path(),
+            DEFAULT_TARGET,
+            Value::Array(vec![]),
+            vec![DEFAULT_TARGET.to_string()],
+            &ReleaseData::default(),
+            true,
+            false,
+            iter::empty(),
+            None,
+            true,
+            24,
+        )
+        .await?;
+
+        let db_license = sqlx::query_scalar!(
+            "SELECT license FROM releases WHERE id = $1",
+            release_id as _
+        )
+        .fetch_one(&mut *conn)
+        .await?;
+
+        assert_eq!(db_license, Some(long_license));
+
+        Ok(())
+    }
 }

--- a/crates/lib/docs_rs_repository_stats/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
+++ b/crates/lib/docs_rs_repository_stats/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
@@ -12,7 +12,7 @@
         "Bool",
         "Bool",
         "Bool",
-        "Varchar",
+        "Text",
         "Varchar",
         "Varchar",
         "Varchar",

--- a/crates/lib/docs_rs_test_fakes/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
+++ b/crates/lib/docs_rs_test_fakes/.sqlx/query-5cf9b185b54dde447b6ba1458178c4fad4c75e72c6a7b7735d17835b9b746ac3.json
@@ -12,7 +12,7 @@
         "Bool",
         "Bool",
         "Bool",
-        "Varchar",
+        "Text",
         "Varchar",
         "Varchar",
         "Varchar",


### PR DESCRIPTION
Fixes #3301

postgres performance characteristics are the same with `VARCHAR(xxx)` or `TEXT` columns, other than with different databases