### PR TITLE
Fix indent of docs.rs build page code example

### DIFF
--- a/crates/bin/docs_rs_web/templates/core/about/builds.html
+++ b/crates/bin/docs_rs_web/templates/core/about/builds.html
@@ -32,19 +32,19 @@
             <h4 id="detecting-docsrs"> <a href="#detecting-docsrs">Detecting Docs.rs</a> </h4>
             <p>
                 To recognize Docs.rs from your Rust code, you can test for the <code>docsrs</code> cfg, e.g.:
-                {% filter dedent(None)|highlight("rust") -%}
-                    #[cfg(docsrs)]
-                    mod documentation;
+                {% filter highlight("rust") -%}
+#[cfg(docsrs)]
+mod documentation;
                 {%- endfilter %}
                 The `docsrs` cfg only applies to the final rustdoc invocation (i.e. the crate currently
                 being documented). It does not apply to dependencies (including workspace ones).
             </p>
             <p>
                 To recognize Docs.rs from <code>build.rs</code> files, you can test for the environment variable <code>DOCS_RS</code>, e.g.:
-                {% filter dedent(3)|highlight("rust") -%}
-                    if std::env::var("DOCS_RS").is_ok() {
-                        // ... your code here ...
-                    }
+                {% filter highlight("rust") -%}
+if std::env::var("DOCS_RS").is_ok() {
+    // ... your code here ...
+}
                 {%- endfilter %}
                 This approach can be helpful if you need dependencies for building the library, but not for building the documentation.
             </p>
@@ -56,9 +56,9 @@
 
             <p>
                 You can configure how your crate is built by adding <a href="metadata">package metadata</a> to your <code>Cargo.toml</code>, e.g.:
-                {% filter dedent(None)|highlight("toml") -%}
-                    [package.metadata.docs.rs]
-                    rustc-args = ["--cfg", "my_cfg"]
+                {% filter highlight("toml") -%}
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "my_cfg"]
                 {%- endfilter %}
                 Here, the compiler arguments are set so that <code>#[cfg(my_cfg)]</code> (not to be confused with <code>#[cfg(doc)]</code>) can be used for conditional compilation.
                 This approach is also useful for setting <a href="https://doc.rust-lang.org/cargo/reference/features.html">cargo features</a>.


### PR DESCRIPTION
Fixes this bug (on https://docs.rs/about/builds):

<img width="379" height="116" alt="image" src="https://github.com/user-attachments/assets/1a5fe395-bfc5-40de-94c2-acdadb16ca10" />
