### PR TITLE
Improve display of build logs title

### DIFF
--- a/crates/bin/docs_rs_web/templates/crate/build_details.html
+++ b/crates/bin/docs_rs_web/templates/crate/build_details.html
@@ -20,9 +20,11 @@
 {%- block body -%}
     <div class="container">
         <div class="recent-releases-container">
-            <div class="release">
-                <strong>Build #{{ build_details.id }} {%- if let Some(build_time) = build_details.build_time %} {{ build_time.format("%F %T") }}{% endif %}</strong>
-            </div>
+            <h4>Build #{{ build_details.id }}
+                {%- if let Some(build_time) = build_details.build_time %}
+                    {{~ build_time.format("%F %T") }}
+                {%- endif -%}
+            </h4>
 
             {%- if build_details.build_status  == "failure" -%}
                 <p class="build-info">{{ crate::icons::IconTriangleExclamation.render_solid(false, false, "") }} Build failed. If you want to re-trigger a documentation build, you can do it <a href="https://crates.io/crates/{{metadata.name}}/{{metadata.version}}/rebuild-docs">here</a>. You can find more information on <b>docs.rs</b> builds documentation on the <a href="/about/builds">builds page</a>.</p>


### PR DESCRIPTION
Currently:

<img width="409" height="558" alt="Screenshot From 2026-05-08 01-00-07" src="https://github.com/user-attachments/assets/d3a7e4a1-f8b5-452d-8566-37adbe36670e" />

With this PR:

<img width="456" height="569" alt="Screenshot From 2026-05-08 00-52-24" src="https://github.com/user-attachments/assets/2e05cdb5-dffe-4760-b239-a1689bb10a66" />

Also, when you hover the "Build ..." title, the background doesn't change colour anymore.