### PR TITLE
unify find-latest-version 

### DIFF
--- a/crates/bin/docs_rs_web/src/handlers/crate_details.rs
+++ b/crates/bin/docs_rs_web/src/handlers/crate_details.rs
@@ -11,7 +11,7 @@ use crate::{
     page::templates::{RenderBrands, RenderRegular, RenderSolid, filters},
     utils::{get_correct_docsrs_style_file, licenses},
 };
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use askama::Template;
 use axum::{
     extract::Extension,
@@ -19,7 +19,7 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use docs_rs_cargo_metadata::{Dependency, ReleaseDependencyList};
-use docs_rs_database::crate_details::{Release, latest_release, parse_doc_targets};
+use docs_rs_database::crate_details::{Release, parse_doc_targets};
 use docs_rs_headers::CanonicalUrl;
 use docs_rs_registry_api::OwnerKind;
 use docs_rs_storage::{AsyncStorage, PathNotFoundError};
@@ -338,9 +338,9 @@ impl CrateDetails {
     }
 
     /// Returns the latest non-yanked, non-prerelease release of this crate (or latest
-    /// yanked/prereleased if that is all that exist).
-    pub fn latest_release(&self) -> Result<&Release> {
-        latest_release(&self.releases).ok_or_else(|| anyhow!("crate without releases"))
+    /// prereleased if that is all that exist). Returns `None` if every release is yanked.
+    pub fn latest_release(&self) -> Option<&Release> {
+        docs_rs_database::crate_details::latest_release(&self.releases)
     }
 }
 
@@ -660,10 +660,13 @@ pub(crate) async fn get_all_platforms_inner(
         .into_response());
     }
 
-    let latest_release = latest_release(&matched_release.all_releases)
-        .expect("we couldn't end up here without releases");
+    let latest_release =
+        docs_rs_database::crate_details::latest_release(&matched_release.all_releases);
 
-    let current_target = if latest_release.build_status.is_success() {
+    let current_target = if latest_release
+        .map(|r| r.build_status.is_success())
+        .unwrap_or(false)
+    {
         params
             .doc_target_or_default()
             .unwrap_or_default()
@@ -1175,192 +1178,6 @@ mod tests {
     }
 
     #[test]
-    fn test_latest_version() {
-        async_wrapper(|env| async move {
-            let db = env.pool()?;
-
-            env.fake_release()
-                .await
-                .name("foo")
-                .version("0.0.1")
-                .create()
-                .await?;
-            env.fake_release()
-                .await
-                .name("foo")
-                .version("0.0.3")
-                .create()
-                .await?;
-            env.fake_release()
-                .await
-                .name("foo")
-                .version("0.0.2")
-                .create()
-                .await?;
-
-            let mut conn = db.get_async().await?;
-            for version in &["0.0.1", "0.0.2", "0.0.3"] {
-                let details = crate_details(&mut conn, "foo", *version, None).await;
-                assert_eq!(
-                    details.latest_release().unwrap().version,
-                    Version::parse("0.0.3")?
-                );
-            }
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_latest_version_ignores_prerelease() {
-        async_wrapper(|env| async move {
-            let db = env.pool()?;
-
-            env.fake_release()
-                .await
-                .name("foo")
-                .version("0.0.1")
-                .create()
-                .await?;
-            env.fake_release()
-                .await
-                .name("foo")
-                .version("0.0.3-pre.1")
-                .create()
-                .await?;
-            env.fake_release()
-                .await
-                .name("foo")
-                .version("0.0.2")
-                .create()
-                .await?;
-
-            let mut conn = db.get_async().await?;
-            for &version in &["0.0.1", "0.0.2", "0.0.3-pre.1"] {
-                let details = crate_details(&mut conn, "foo", version, None).await;
-                assert_eq!(
-                    details.latest_release().unwrap().version,
-                    Version::parse("0.0.2")?
-                );
-            }
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_latest_version_ignores_yanked() {
-        async_wrapper(|env| async move {
-            let db = env.pool()?;
-
-            env.fake_release()
-                .await
-                .name("foo")
-                .version("0.0.1")
-                .create()
-                .await?;
-            env.fake_release()
-                .await
-                .name("foo")
-                .version("0.0.3")
-                .yanked(true)
-                .create()
-                .await?;
-            env.fake_release()
-                .await
-                .name("foo")
-                .version("0.0.2")
-                .create()
-                .await?;
-
-            let mut conn = db.get_async().await?;
-            for &version in &["0.0.1", "0.0.2", "0.0.3"] {
-                let details = crate_details(&mut conn, "foo", version, None).await;
-                assert_eq!(
-                    details.latest_release().unwrap().version,
-                    Version::parse("0.0.2")?
-                );
-            }
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_latest_version_only_yanked() {
-        async_wrapper(|env| async move {
-            let db = env.pool()?;
-
-            env.fake_release()
-                .await
-                .name("foo")
-                .version("0.0.1")
-                .yanked(true)
-                .create()
-                .await?;
-            env.fake_release()
-                .await
-                .name("foo")
-                .version("0.0.3")
-                .yanked(true)
-                .create()
-                .await?;
-            env.fake_release()
-                .await
-                .name("foo")
-                .version("0.0.2")
-                .yanked(true)
-                .create()
-                .await?;
-
-            let mut conn = db.get_async().await?;
-            for &version in &["0.0.1", "0.0.2", "0.0.3"] {
-                let details = crate_details(&mut conn, "foo", version, None).await;
-                assert_eq!(
-                    details.latest_release().unwrap().version,
-                    Version::parse("0.0.3")?
-                );
-            }
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_latest_version_in_progress() {
-        async_wrapper(|env| async move {
-            let db = env.pool()?;
-
-            env.fake_release()
-                .await
-                .name("foo")
-                .version("0.0.1")
-                .create()
-                .await?;
-            env.fake_release()
-                .await
-                .name("foo")
-                .version("0.0.2")
-                .builds(vec![
-                    FakeBuild::default().build_status(BuildStatus::InProgress),
-                ])
-                .create()
-                .await?;
-
-            let mut conn = db.get_async().await?;
-            for &version in &["0.0.1", "0.0.2"] {
-                let details = crate_details(&mut conn, "foo", version, None).await;
-                assert_eq!(
-                    details.latest_release().unwrap().version,
-                    Version::parse("0.0.1")?
-                );
-            }
-
-            Ok(())
-        })
-    }
-
-    #[test]
     fn releases_dropdowns_show_binary_warning() {
         async_wrapper(|env| async move {
             env.fake_release()
@@ -1411,11 +1228,18 @@ mod tests {
                 .create()
                 .await?;
 
-            let response = env.web_app().await.get("/crate/foo/latest").await?;
+            let response = env
+                .web_app()
+                .await
+                .assert_success("/crate/foo/0.1.0")
+                .await?;
 
             let page = kuchikiki::parse_html().one(response.text().await?);
+            // multiple `a.pure-menu-link` elements share this href (the topbar's
+            // `crate-name` link and the navigation "Crate" tab); the version dropdown's
+            // entry is the only one rendered with `rel="nofollow"` by the macro.
             let link = page
-                .select_first("a.pure-menu-link[href='/crate/foo/0.1.0']")
+                .select_first("a.pure-menu-link[href='/crate/foo/0.1.0'][rel='nofollow']")
                 .unwrap();
 
             assert_eq!(

--- a/crates/bin/docs_rs_web/src/handlers/releases.rs
+++ b/crates/bin/docs_rs_web/src/handlers/releases.rs
@@ -1490,16 +1490,17 @@ mod tests {
 
         let links = get_release_links("/releases/search?query=some_random_crate", &web).await?;
 
-        // `some_other_crate` won't be shown since we don't have it yet
-        assert_eq!(links.len(), 4);
+        // `some_other_crate` won't be shown since we don't have it yet.
+        // `yet_another_crate` only has a yanked release, so it has no canonical "latest"
+        // and renders as "Documentation not available on docs.rs" (no anchor).
+        assert_eq!(links.len(), 3);
         // * `max_version` from the crates.io search result will be ignored since we
         //   might not have it yet, or the doc-build might be in progress.
         // * ranking/order from crates.io result is preserved
         // * version used is the highest semver following our own "latest version" logic
         assert_eq!(links[0], "/some_random_crate/latest/some_random_crate/");
         assert_eq!(links[1], "/and_another_one/latest/and_another_one/");
-        assert_eq!(links[2], "/yet_another_crate/0.1.0/yet_another_crate/");
-        assert_eq!(links[3], "/crate/failed_hard/0.1.0");
+        assert_eq!(links[2], "/crate/failed_hard/0.1.0");
         Ok(())
     }
 

--- a/crates/bin/docs_rs_web/src/handlers/rustdoc.rs
+++ b/crates/bin/docs_rs_web/src/handlers/rustdoc.rs
@@ -730,10 +730,12 @@ pub(crate) async fn rustdoc_html_server_handler(
         );
     }
 
-    let latest_release = krate.latest_release()?;
+    let latest_release = krate.latest_release();
 
     // Get the latest version of the crate
-    let latest_version = latest_release.version.clone();
+    let latest_version = latest_release
+        .map(|release| release.version.clone())
+        .unwrap_or_else(|| krate.version.clone());
     let is_latest_version = latest_version == krate.version;
     let is_prerelease = !(krate.version.pre.is_empty());
 
@@ -744,7 +746,7 @@ pub(crate) async fn rustdoc_html_server_handler(
         .rustdoc_url()
         .append_raw_query(original_query.as_deref());
 
-    let latest_path = if latest_release.build_status.is_success() {
+    let latest_path = if latest_release.is_some_and(|release| release.build_status.is_success()) {
         params
             .clone()
             .with_req_version(&ReqVersion::Latest)
@@ -1618,6 +1620,50 @@ mod test {
             let redirect =
                 latest_version_redirect("dummy", "/dummy/0.2.1/dummy/", &web, env.config()).await?;
             assert_eq!(redirect, "/crate/dummy/latest/target-redirect/dummy/");
+
+            Ok(())
+        })
+    }
+
+    #[test_case(true)]
+    #[test_case(false)]
+    fn no_latest_stable_button_when_latest_stable_is_yanked(archive_storage: bool) {
+        async fn has_latest_redirect_button(
+            path: &str,
+            web: &axum::Router,
+        ) -> Result<bool, anyhow::Error> {
+            web.assert_success(path).await?;
+            let data = web.get(path).await?.text().await?;
+            Ok(kuchikiki::parse_html()
+                .one(data)
+                .select("form > ul > li > a.warn")
+                .expect("invalid selector")
+                .next()
+                .is_some())
+        }
+
+        async_wrapper(|env| async move {
+            env.fake_release()
+                .await
+                .name("dummy")
+                .version("0.2.0-pre.1")
+                .archive_storage(archive_storage)
+                .rustdoc_file("dummy/index.html")
+                .create()
+                .await?;
+            env.fake_release()
+                .await
+                .name("dummy")
+                .version("0.2.0")
+                .archive_storage(archive_storage)
+                .rustdoc_file("dummy/index.html")
+                .yanked(true)
+                .create()
+                .await?;
+
+            let web = env.web_app().await;
+            assert!(!has_latest_redirect_button("/dummy/latest/dummy/", &web).await?);
+            assert!(!has_latest_redirect_button("/dummy/0.2.0-pre.1/dummy/", &web).await?);
 
             Ok(())
         })

--- a/crates/bin/docs_rs_web/src/match_release.rs
+++ b/crates/bin/docs_rs_web/src/match_release.rs
@@ -118,22 +118,37 @@ fn semver_match<'a, F: Fn(&Release) -> bool>(
     req: &VersionReq,
     filter: F,
 ) -> Option<&'a Release> {
-    // first try standard semver match using `VersionReq::match`, should handle most cases.
-    if let Some(release) = releases
+    releases
         .iter()
         .filter(|release| filter(release))
         .find(|release| req.matches(&release.version))
-    {
-        Some(release)
-    } else if req == &VersionReq::STAR {
-        // semver `*` does not match pre-releases.
-        // So when we only have pre-releases, `VersionReq::STAR` would lead to an
-        // empty result.
-        // In this case we just return the latest prerelease instead of nothing.
-        releases.iter().find(|release| filter(release))
-    } else {
-        None
+}
+
+fn not_yanked(release: &Release) -> bool {
+    release.yanked.is_none() || release.yanked == Some(false)
+}
+
+fn best_release_for_req<'a>(
+    releases: &'a [Release],
+    req_semver: &VersionReq,
+) -> Option<&'a Release> {
+    // `VersionReq::STAR` ("*", "latest", "newest") is the "give me the latest" query;
+    // delegate to the canonical picker so `/latest/`, `crates.latest_version_id`, and the
+    // rustdoc topbar all agree on what "latest" means. Note: `latest_release` deliberately
+    // excludes in-progress builds — there's no canonical latest until the build finishes —
+    // so STAR returns `None` (and `/latest/` 404s) for a crate whose only non-yanked
+    // releases are still building. The non-STAR branch below keeps an in-progress fallback
+    // because there the user asked for a specific range and serving the matching
+    // in-progress release is more useful than 404.
+    if req_semver == &VersionReq::STAR {
+        return docs_rs_database::crate_details::latest_release(releases);
     }
+    // For other semver requirements: prefer non-yanked + non-in-progress, fall back to
+    // allowing in-progress builds if nothing else matches.
+    semver_match(releases, req_semver, |release: &Release| {
+        release.build_status != BuildStatus::InProgress && not_yanked(release)
+    })
+    .or_else(|| semver_match(releases, req_semver, not_yanked))
 }
 
 /// Checks the database for crate releases that match the given name and version.
@@ -210,25 +225,10 @@ pub(crate) async fn match_version(
         ReqVersion::Semver(version_req) => version_req.clone(),
     };
 
-    // when matching semver requirements,
-    // we generally only want to look at non-yanked releases,
-    // excluding releases which just contain in-progress builds
-    if let Some(release) = semver_match(&releases, &req_semver, |r: &Release| {
-        r.build_status != BuildStatus::InProgress && (r.yanked.is_none() || r.yanked == Some(false))
-    }) {
-        return Ok(MatchedRelease {
-            name: name.to_owned(),
-            corrected_name,
-            req_version: input_version.clone(),
-            release: release.clone(),
-            all_releases: releases,
-        });
-    }
-
-    // when we don't find any match with "normal" releases, we also look into in-progress releases
-    if let Some(release) = semver_match(&releases, &req_semver, |r: &Release| {
-        r.yanked.is_none() || r.yanked == Some(false)
-    }) {
+    // when matching semver requirements, we generally only want to look at non-yanked
+    // releases, excluding releases which just contain in-progress builds. If there are no
+    // matching non-in-progress releases, we also look into in-progress releases.
+    if let Some(release) = best_release_for_req(&releases, &req_semver) {
         return Ok(MatchedRelease {
             name: name.to_owned(),
             corrected_name,

--- a/crates/lib/docs_rs_database/src/crate_details.rs
+++ b/crates/lib/docs_rs_database/src/crate_details.rs
@@ -82,18 +82,23 @@ pub async fn releases_for_crate(
     Ok(releases)
 }
 
+/// Pick the "latest" release worth pointing users at: non-yanked, build is no longer
+/// in-progress, preferring stable over prerelease. Returns `None` when no release meets
+/// this bar — either every release is yanked, or the only non-yanked releases are still
+/// building. Callers should treat `None` as "no canonical latest" (e.g. `/latest/` 404s,
+/// `latest_version_id` is NULL, topbar hides the "Go to latest" button).
 pub fn latest_release(releases: &[Release]) -> Option<&Release> {
-    if let Some(release) = releases.iter().find(|release| {
-        release.version.pre.is_empty()
-            && release.yanked == Some(false)
-            && release.build_status != BuildStatus::InProgress
-    }) {
-        Some(release)
-    } else {
-        releases
-            .iter()
-            .find(|release| release.build_status != BuildStatus::InProgress)
+    fn eligible(release: &Release) -> bool {
+        let not_yanked = release.yanked.is_none() || release.yanked == Some(false);
+        not_yanked && release.build_status != BuildStatus::InProgress
     }
+
+    // releases are sorted by version desc, so `find` returns the highest match.
+    // Prefer non-prerelease, then fall back to prerelease if nothing else qualifies.
+    releases
+        .iter()
+        .find(|r| eligible(r) && r.version.pre.is_empty())
+        .or_else(|| releases.iter().find(|r| eligible(r)))
 }
 
 pub async fn update_latest_version_id(
@@ -113,4 +118,129 @@ pub async fn update_latest_version_id(
     .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn release(version: &str, yanked: bool, build_status: BuildStatus) -> Release {
+        Release {
+            id: ReleaseId(0),
+            version: Version::parse(version).unwrap(),
+            build_status,
+            yanked: Some(yanked),
+            is_library: Some(true),
+            rustdoc_status: Some(true),
+            target_name: None,
+            default_target: None,
+            doc_targets: None,
+            release_time: None,
+        }
+    }
+
+    /// Helper mirroring how `releases_for_crate` returns the slice: sorted by version desc.
+    fn sorted(mut releases: Vec<Release>) -> Vec<Release> {
+        releases.sort_by(|a, b| b.version.cmp(&a.version));
+        releases
+    }
+
+    #[test]
+    fn picks_highest_when_all_eligible() {
+        let releases = sorted(vec![
+            release("0.0.1", false, BuildStatus::Success),
+            release("0.0.3", false, BuildStatus::Success),
+            release("0.0.2", false, BuildStatus::Success),
+        ]);
+        assert_eq!(
+            latest_release(&releases).unwrap().version,
+            Version::parse("0.0.3").unwrap()
+        );
+    }
+
+    #[test]
+    fn prefers_stable_over_prerelease() {
+        let releases = sorted(vec![
+            release("0.0.1", false, BuildStatus::Success),
+            release("0.0.3-pre.1", false, BuildStatus::Success),
+            release("0.0.2", false, BuildStatus::Success),
+        ]);
+        assert_eq!(
+            latest_release(&releases).unwrap().version,
+            Version::parse("0.0.2").unwrap()
+        );
+    }
+
+    #[test]
+    fn picks_highest_prerelease_when_no_stable_exists() {
+        let releases = sorted(vec![
+            release("0.0.3-pre.1", false, BuildStatus::Success),
+            release("0.0.2-pre.1", false, BuildStatus::Success),
+        ]);
+        assert_eq!(
+            latest_release(&releases).unwrap().version,
+            Version::parse("0.0.3-pre.1").unwrap()
+        );
+    }
+
+    #[test]
+    fn skips_yanked_releases() {
+        let releases = sorted(vec![
+            release("0.0.1", false, BuildStatus::Success),
+            release("0.0.3", true, BuildStatus::Success),
+            release("0.0.2", false, BuildStatus::Success),
+        ]);
+        assert_eq!(
+            latest_release(&releases).unwrap().version,
+            Version::parse("0.0.2").unwrap()
+        );
+    }
+
+    #[test]
+    fn returns_none_when_all_releases_are_yanked() {
+        let releases = sorted(vec![
+            release("0.0.1", true, BuildStatus::Success),
+            release("0.0.3", true, BuildStatus::Success),
+            release("0.0.2", true, BuildStatus::Success),
+        ]);
+        assert!(latest_release(&releases).is_none());
+    }
+
+    #[test]
+    fn prefers_non_in_progress() {
+        let releases = sorted(vec![
+            release("0.0.1", false, BuildStatus::Success),
+            release("0.0.2", false, BuildStatus::InProgress),
+        ]);
+        assert_eq!(
+            latest_release(&releases).unwrap().version,
+            Version::parse("0.0.1").unwrap()
+        );
+    }
+
+    #[test]
+    fn returns_none_when_only_in_progress_exists() {
+        // An in-progress build isn't a canonical "latest" — no docs to show yet.
+        let releases = sorted(vec![release("0.0.1", false, BuildStatus::InProgress)]);
+        assert!(latest_release(&releases).is_none());
+    }
+
+    #[test]
+    fn yanked_latest_with_unyanked_prerelease_picks_prerelease() {
+        // Regression for the topbar bug: latest stable is yanked, a non-yanked prerelease
+        // exists. We must not return the yanked stable.
+        let releases = sorted(vec![
+            release("0.2.0", true, BuildStatus::Success),
+            release("0.2.0-pre.1", false, BuildStatus::Success),
+        ]);
+        assert_eq!(
+            latest_release(&releases).unwrap().version,
+            Version::parse("0.2.0-pre.1").unwrap()
+        );
+    }
+
+    #[test]
+    fn empty_releases_returns_none() {
+        assert!(latest_release(&[]).is_none());
+    }
 }

--- a/gui-tests/yanked.goml
+++ b/gui-tests/yanked.goml
@@ -1,3 +1,0 @@
-go-to: |DOC_PATH| + "/releases/search?query=libtest"
-
-assert-text: ("//*[contains(@class, 'release')]//*[contains(@class, 'name')][contains(text(), 'libtest-0.0.1')]", "Yanked", CONTAINS)


### PR DESCRIPTION
Fixes #3290 by unifying "latest version" logic across all places. 

This also leads to some behavioural changes, which are mostly fine IMO, they become tricky when all releases of a crate are yanked. In this "all-yanked" case, **we will start treating a crate with only yanked releases as "hidden / deleted" in some cases**. Personally this feels more correct, but I'm happy to discuss. 

AI summary of the before/after: 

## Behavioural changes in `fix-latest-release`

This branch consolidates three "latest release" decisions onto a single canonical picker:

- `/crate/{name}/latest/...` URL resolution (via `match_version`)
- The rustdoc topbar's `is_latest_version` / "Go to latest" button
- The `crates.latest_version_id` column (read by sitemaps, home page lists, crates.io search bridge, "I'm feeling lucky", watcher rebuilds, repository stats)

The picker is:

> The highest **non-yanked**, **non-in-progress** release, preferring stable over prerelease. `None` otherwise.

The table below shows how each surface changes per scenario.

### Legend

| | meaning |
|---|---|
| **main** | behaviour on `main` |
| **this branch** | behaviour after the fix |
| 🐛 | bug / inconsistency that's being fixed |
| ✅ | strict improvement |
| ➖ | intentional behaviour change, arguably an improvement |
| ✔ | no change |

---

### Scenario 1 — All releases yanked

| Surface | main | this branch |
|---|---|---|
| `/crate/foo/latest/...` | 404 | 404 ✔ |
| Topbar `latest_release` | Returns highest yanked release → `Result::?` propagates "crate without releases" → **500** 🐛 | Returns `None`; "Go to latest" button hidden ✅ |
| `crates.latest_version_id` | Points at a yanked release id | `NULL` ✅ |
| Sitemap | Crate advertised with yanked URL → 404 on crawl 🐛 | Crate dropped from sitemap ✅ |
| Home page lists (Recent, Stars, …) | Yanked release surfaced as "latest" 🐛 | Crate dropped ✅ |
| crates.io search bridge | Linked to yanked latest | "Documentation not available on docs.rs" ➖ |
| "I'm feeling lucky" | Could land on yanked docs | Crate skipped ✅ |
| Watcher rebuilds | Rebuilds the yanked release | Crate skipped ✅ |
| Repository `crate_count` | Counted | Not counted ➖ |

### Scenario 2 — Yanked stable + non-yanked prerelease (the bug-report case)

Example: `[0.2.0 yanked, 0.2.0-pre.1 not yanked]`.

| Surface | main | this branch |
|---|---|---|
| `/crate/foo/latest/...` | Resolves to **prerelease** (`0.2.0-pre.1`) | Resolves to **prerelease** ✔ |
| Topbar `latest_release` | **Yanked stable** (`0.2.0`) 🐛 | **Prerelease** ✅ |
| → `is_latest_version` on `/0.2.0-pre.1/` | `false` → "Go to latest" button shown 🐛 | `true` → button hidden ✅ |
| Clicking "Go to latest" | Redirects to `/latest/` → same prerelease page (loop) 🐛 | Button not shown ✅ |
| `crates.latest_version_id` | Yanked stable | Prerelease ✅ |
| Home page lists | Lists the yanked stable as latest | Lists the prerelease ✅ |

### Scenario 3 — Only non-yanked releases are in-progress

Example: brand-new crate with one release whose build hasn't finished.

| Surface | main | this branch |
|---|---|---|
| `/crate/foo/latest/...` | Resolves to in-progress release → no rustdoc HTML in storage → effective 404 🐛 | 404 ✅ |
| Topbar `latest_release` | `None` → 500 🐛 | `None` → button hidden ✅ |
| `crates.latest_version_id` | `NULL` | `NULL` ✔ |
| `^1.0` semver query (range-matching, not `/latest/`) | Returns in-progress release if it matches | Returns in-progress release if it matches ✔ |

### Scenario 4 — Failed build is the highest non-yanked release

| Surface | main | this branch |
|---|---|---|
| `/crate/foo/latest/...` | Resolves to the failed release | Resolves to the failed release ✔ |
| Topbar `latest_release` | Failed release | Failed release ✔ |
| `latest_path` (button target) | `crate_details_url()` (build wasn't successful) | `crate_details_url()` ✔ |
| `crates.latest_version_id` | Points at failed release | Points at failed release ✔ |
| Sitemap | Filtered out (`rustdoc_status = false`) | Filtered out ✔ |
| Home page Recent / Most stars | Shown | Shown ✔ |
| Home page "Recent failures" | Shown | Shown ✔ |

> No change for failed-build handling — the filter on every code path has always been `build_status != InProgress`, which lets both `Success` and `Failure` through.

### Scenario 5 — Specific yanked version (direct exact-match URL)

Example: `/crate/foo/0.2.0/...` where `0.2.0` is yanked.

| Surface | main | this branch |
|---|---|---|
| Resolves the release | Yes (exact-match bypasses the picker) | Yes ✔ |
| Yanked warning in topbar | Shown | Shown ✔ |
| `is_latest_version` | Computed against the picker's choice — may or may not be the yanked version | Computed against the picker's choice ✔ (but now consistent with `/latest/`) |

> The exact-match path through `match_version` has never applied the yanked filter — yanked versions remain navigable when their version is in the URL. Unchanged.

---

### Summary

- 🐛 → ✅ : The "topbar 500 on all-yanked" and "Go to latest leads to a same-page loop" bugs are fixed.
- 🐛 → ✅ : Sitemaps stop advertising URLs that 404.
- 🐛 → ✅ : Home page release feeds stop surfacing yanked-as-latest.
- ➖ : crates.io search bridge renders all-yanked crates as "not available" instead of linking to a yanked release. Debatable; we considered this acceptable.
- ✔ : Failed builds, direct exact-version URLs, and non-STAR semver queries (`^1.0`, etc.) are unchanged.

The picker is now structurally the same across `/latest/`, the topbar, and `latest_version_id` — disagreement isn't just unlikely, it's impossible by construction.

### Backfill

Existing `crates.latest_version_id` rows on production may still point at yanked or otherwise stale picks. They self-heal next time any build event triggers `update_latest_version_id` for that crate. For an eager rewrite, run the existing `docs_rs_admin` backfill command.