### PR TITLE
Generate svg in the doc for `font-awesome-as-a-crate`

### DIFF
--- a/crates/lib/font-awesome-as-a-crate/build.rs
+++ b/crates/lib/font-awesome-as-a-crate/build.rs
@@ -71,10 +71,12 @@ fn write_fontawesome_sprite() {
             let _ = writeln!(acc, "impl {k} for {type_name} {{}}");
             acc
         });
+        let data_html = data.replace("<svg", "<svg style=\"height:1em;\"");
         dest_file
             .write_all(
                 format!(
-                    "\n#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+                    "\n#[doc = r#\"{data_html}\"#]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct {type_name};
 impl IconStr for {type_name} {{
     fn icon_name(&self) -> &'static str {{ r#\"{icon}\"# }}


### PR DESCRIPTION
Quite useful to actually see what the icon is:

<img width="392" height="710" alt="Screenshot From 2026-05-18 01-01-05" src="https://github.com/user-attachments/assets/87043918-264a-42c3-bdad-3eb7b227e9d2" />
