### PR TITLE
gui-tests: explicitly install chrome in docker image, fix lint-js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.7.14
 
       - uses: taiki-e/install-action@v2
         with:

--- a/dockerfiles/Dockerfile-gui-tests
+++ b/dockerfiles/Dockerfile-gui-tests
@@ -26,6 +26,7 @@ RUN apt-get install -y --no-install-recommends \
   libasound2 \
   libatk1.0-0 \
   libatk-bridge2.0-0 \
+  chromium \
   libc6 \
   libcairo2 \
   libcups2 \
@@ -67,6 +68,8 @@ WORKDIR /build
 RUN mkdir out
 
 COPY ../package.json /build/package.json
+
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
 # For now, we need to use `--unsafe-perm=true` to go around an issue when npm tries
 # to create a new folder. For reference:


### PR DESCRIPTION
- gui tests randomly started failing, probably because of an update of a non-locked version of something. I couldn't quickly figure out the exact problem (because , JS), so I just `apt install chromium`, which works. 
- `lint-js` also started randomly failing. This is likely because there is a new `deno` version (2.8). We freeze the deno version now in CI. 

I'm aware that there is probably ( likely ) a nicer / more future proof way of fixing these issues, but I want to unblock open PRs (https://github.com/rust-lang/docs.rs/pull/3274, https://github.com/rust-lang/docs.rs/pull/3348 ), so I can publish / merge / deploy. 