### PR TITLE
release `font-awesome-as-a-crate` 0.3.1 for better docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,7 +2763,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-awesome-as-a-crate"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "foreign-types"

--- a/crates/lib/font-awesome-as-a-crate/Cargo.toml
+++ b/crates/lib/font-awesome-as-a-crate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-awesome-as-a-crate"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "CC-BY-4.0 AND MIT"
 description = "Font Awesome Free, packaged as a crate"


### PR DESCRIPTION
no automation yet, afterwards we can run `cargo publish` to publish. 

includes
- https://github.com/rust-lang/docs.rs/pull/3339