### PR TITLE
Improve display of build information icons

### DIFF
--- a/crates/bin/docs_rs_web/templates/crate/build_details.html
+++ b/crates/bin/docs_rs_web/templates/crate/build_details.html
@@ -41,7 +41,7 @@
                                         {{ crate::icons::IconCheck.render_solid(false, false, "") }}
                                     {%- else %}
                                         {{ crate::icons::IconXmark.render_solid(false, false, "") }}
-                                    {%- endif %}&nbsp;
+                                    {%- endif %}&nbsp;&nbsp;
                                 {%- endif -%}
                                     {{ crate::icons::IconFileLines.render_solid(false, false, "") }}
                                 </div>


### PR DESCRIPTION
Currently:

<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/99355109-3d29-488d-9fe8-9e705dbe1dfc" />

With this change:

<img width="480" height="270" alt="Screenshot From 2026-05-23 10-49-12" src="https://github.com/user-attachments/assets/aeec7e5c-cf84-4e4f-9fd8-af874595dc65" />

