### PR TITLE
styling: fix inconsistency in license padding on smaller screens

### DIFF
--- a/crates/bin/docs_rs_web/templates/style/_navbar.scss
+++ b/crates/bin/docs_rs_web/templates/style/_navbar.scss
@@ -142,7 +142,7 @@ div.nav-container {
             outline: unset;
         }
 
-        .pure-menu-item a.pure-menu-link {
+        .pure-menu-item .pure-menu-link {
             padding: 6.4px 5px 6.4px 5px;
             align-content: center;
 
@@ -157,7 +157,7 @@ div.nav-container {
         }
 
         @media #{$media-md} {
-            .docsrs-logo, .pure-menu-item .pure-menu-text, .pure-menu-item a.pure-menu-link {
+            .docsrs-logo, .pure-menu-item .pure-menu-text, .pure-menu-item .pure-menu-link {
                 padding: 6.4px 16px 6.4px 16px;
             }
         }


### PR DESCRIPTION
The License row in the dropdown menu of the navbar is inconsistent with the permalink and crate page rows on smaller screens. This change just makes them consistent.

Current: 
<img width="414" height="542" alt="image" src="https://github.com/user-attachments/assets/822f03fd-e325-400b-a0c0-a647223865ef" />

Fixed:
<img width="396" height="463" alt="Screenshot 2026-06-11 at 10 21 08 PM" src="https://github.com/user-attachments/assets/0585dd94-b44c-4c84-95da-d7f0fbfc3f2b" />
