### PR TITLE
Add build date to dropdown

### DIFF
--- a/crates/bin/docs_rs_web/src/handlers/builds.rs
+++ b/crates/bin/docs_rs_web/src/handlers/builds.rs
@@ -28,10 +28,10 @@ use std::sync::Arc;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Build {
     id: BuildId,
-    rustc_version: Option<String>,
+    pub rustc_version: Option<String>,
     docsrs_version: Option<String>,
-    build_status: BuildStatus,
-    build_time: Option<DateTime<Utc>>,
+    pub build_status: BuildStatus,
+    pub build_time: Option<DateTime<Utc>>,
     build_duration: Option<Duration>,
     memory_peak: Option<i64>,
     errors: Option<String>,
@@ -179,7 +179,7 @@ pub(crate) async fn build_trigger_rebuild_handler(
     Ok((StatusCode::CREATED, Json(serde_json::json!({}))))
 }
 
-async fn get_builds(
+pub(super) async fn get_builds(
     conn: &mut sqlx::PgConnection,
     name: &KrateName,
     version: &Version,

--- a/crates/bin/docs_rs_web/src/handlers/crate_details.rs
+++ b/crates/bin/docs_rs_web/src/handlers/crate_details.rs
@@ -5,6 +5,7 @@ use crate::{
         DbConnection,
         rustdoc::{PageKind, RustdocParams},
     },
+    handlers::builds::{self, Build},
     impl_axum_webpage,
     match_release::{MatchedRelease, match_version},
     metadata::MetaData,
@@ -45,6 +46,7 @@ pub(crate) struct CrateDetails {
     build_status: BuildStatus,
     pub latest_build_id: Option<BuildId>,
     last_successful_build: Option<Version>,
+    pub latest_build: Option<Build>,
     pub rustdoc_status: Option<bool>,
     pub archive_storage: bool,
     pub repository_url: Option<String>,
@@ -218,6 +220,14 @@ impl CrateDetails {
             .map(Into::into)
             .collect();
 
+        let builds = builds::get_builds(conn, &krate.name, version).await?;
+        let latest_build = builds
+            .into_iter()
+            .filter(|build| {
+                build.build_status == BuildStatus::Success && build.build_time.is_some()
+            })
+            .max_by_key(|build| build.build_time);
+
         let mut crate_details = CrateDetails {
             name: krate.name,
             version: version.clone(),
@@ -230,6 +240,7 @@ impl CrateDetails {
             build_status: krate.build_status,
             latest_build_id: krate.latest_build_id,
             last_successful_build: None,
+            latest_build,
             rustdoc_status: krate.rustdoc_status,
             archive_storage: krate.archive_storage,
             repository_url: krate.repository_url,

--- a/crates/bin/docs_rs_web/src/handlers/rustdoc.rs
+++ b/crates/bin/docs_rs_web/src/handlers/rustdoc.rs
@@ -32,6 +32,7 @@ use axum_extra::{
     headers::{ContentType, ETag, Header as _, HeaderMapExt as _},
     typed_header::TypedHeader,
 };
+use chrono::{DateTime, Utc};
 use docs_rs_cargo_metadata::Dependency;
 use docs_rs_database::Pool;
 use docs_rs_headers::{ETagComputer, IfNoneMatch, X_ROBOTS_TAG};
@@ -397,6 +398,8 @@ pub struct LimitedCrateDetails {
     dependencies: Vec<Dependency>,
     total_items: Option<i32>,
     documented_items: Option<i32>,
+    latest_build_time: Option<DateTime<Utc>>,
+    latest_build_rustc_version: Option<String>,
 }
 
 impl From<CrateDetails> for LimitedCrateDetails {
@@ -410,8 +413,15 @@ impl From<CrateDetails> for LimitedCrateDetails {
             dependencies,
             total_items,
             documented_items,
+            latest_build,
             ..
         } = value;
+
+        let (latest_build_time, latest_build_rustc_version) = if let Some(b) = latest_build {
+            (b.build_time, b.rustc_version)
+        } else {
+            (None, None)
+        };
 
         Self {
             total_items,
@@ -422,6 +432,8 @@ impl From<CrateDetails> for LimitedCrateDetails {
             repository_url,
             owners,
             dependencies,
+            latest_build_time,
+            latest_build_rustc_version,
         }
     }
 }

--- a/crates/bin/docs_rs_web/templates/rustdoc/topbar.html
+++ b/crates/bin/docs_rs_web/templates/rustdoc/topbar.html
@@ -58,6 +58,13 @@
                             </span>
                         </li>
                     {%- endif -%}
+                    {%- if let Some(time) = krate.latest_build_time -%}
+                        <li class="pure-menu-item">
+                            <span class="pure-menu-link description" title="Built with {%- if let Some(version) = krate.latest_build_rustc_version -%} {{ version }} {%- else -%} Version unavailable {%- endif -%} ">
+                                {{ crate::icons::IconGears.render_solid(false, false, "") }} {{ time|timeformat }}
+                            </span>
+                        </li>
+                    {%- endif -%}
                 </ul>
 
                 <div class="pure-g menu-item-divided">

--- a/crates/bin/docs_rs_web/templates/rustdoc/topbar.html
+++ b/crates/bin/docs_rs_web/templates/rustdoc/topbar.html
@@ -60,7 +60,7 @@
                     {%- endif -%}
                     {%- if let Some(time) = krate.latest_build_time -%}
                         <li class="pure-menu-item">
-                            <span class="pure-menu-link description" title="Built with {%- if let Some(version) = krate.latest_build_rustc_version -%} {{ version }} {%- else -%} Version unavailable {%- endif -%} ">
+                            <span class="pure-menu-link description" title="Built with {% if let Some(version) = krate.latest_build_rustc_version -%} {{ version }} {%- else -%} Version unavailable {%- endif -%} ">
                                 {{ crate::icons::IconGears.render_solid(false, false, "") }} {{ time|timeformat }}
                             </span>
                         </li>

--- a/crates/bin/docs_rs_web/templates/rustdoc/topbar.html
+++ b/crates/bin/docs_rs_web/templates/rustdoc/topbar.html
@@ -61,7 +61,7 @@
                     {%- if let Some(time) = krate.latest_build_time -%}
                         <li class="pure-menu-item">
                             <span class="pure-menu-link description" title="{% if let Some(version) = krate.latest_build_rustc_version -%} Built with {{ version }} {%- else -%} Version unavailable {%- endif -%} ">
-                                {{ crate::icons::IconGears.render_solid(false, false, "") }} {{ time|timeformat }}
+                                {{ crate::icons::IconGears.render_solid(false, false, "") }} {{ time.format("%d %B %Y") }}
                             </span>
                         </li>
                     {%- endif -%}

--- a/crates/bin/docs_rs_web/templates/rustdoc/topbar.html
+++ b/crates/bin/docs_rs_web/templates/rustdoc/topbar.html
@@ -60,7 +60,7 @@
                     {%- endif -%}
                     {%- if let Some(time) = krate.latest_build_time -%}
                         <li class="pure-menu-item">
-                            <span class="pure-menu-link description" title="Built with {% if let Some(version) = krate.latest_build_rustc_version -%} {{ version }} {%- else -%} Version unavailable {%- endif -%} ">
+                            <span class="pure-menu-link description" title="{% if let Some(version) = krate.latest_build_rustc_version -%} Built with {{ version }} {%- else -%} Version unavailable {%- endif -%} ">
                                 {{ crate::icons::IconGears.render_solid(false, false, "") }} {{ time|timeformat }}
                             </span>
                         </li>

--- a/gui-tests/crate-topbar-dropdown-menu.goml
+++ b/gui-tests/crate-topbar-dropdown-menu.goml
@@ -28,8 +28,8 @@ click: "#nav-search-form .crate-dropdown"
 wait-for: |active_crate_dropdown_selector|
 
 store-value: (crate_main_info_items, ".package-details-menu > ul > .pure-menu-item")
-// There should be 3 items.
-assert-count: (|crate_main_info_items|, 3)
+// There should be 4 items.
+assert-count: (|crate_main_info_items|, 4)
 
 // Now we check the paddings with various widths.
 call-function: ("check-padding", {"width": 900})


### PR DESCRIPTION
Addresses #1740.

<img width="448" height="207" alt="Screenshot 2026-06-18 at 10 41 10 PM" src="https://github.com/user-attachments/assets/c9aac5b0-131c-4738-914a-0140b462bc36" />


Would adding a link to the builds page make sense? 
E.g. https://docs.rs/crate/jiff/0.2.28/builds