### PR TITLE
break long words to prevent horizontal scroll

### DIFF
--- a/crates/bin/docs_rs_web/templates/style/style.scss
+++ b/crates/bin/docs_rs_web/templates/style/style.scss
@@ -378,12 +378,14 @@ div.recent-releases-container {
     .description {
         font-family: $font-family-serif;
         font-weight: normal;
+        overflow-wrap: break-word;
 
         @media #{$media-sm} {
             font-size: 1em;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
+            overflow-wrap: normal;
         }
     }
 

--- a/gui-tests/long-crate-description.goml
+++ b/gui-tests/long-crate-description.goml
@@ -7,8 +7,8 @@ store-value: (description_selector, "div.recent-releases-container .description"
 set-text: (|description_selector|, "SOME/VERYVERY/LONG/SEQUENCE/OF/TEXT/SEPARATED/BY/SLASHES\nAnotherveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongWord")
 
 // Set width to size smaller than media-sm as that's when we don't truncate the text
-store-value(screen_width, 567)
-set-window-size(|screen_width|, 800)
+store-value: (screen_width, 567)
+set-window-size: (|screen_width|, 800)
 
 store-property: (|description_selector|, {"scrollWidth": description_width})
 

--- a/gui-tests/long-crate-description.goml
+++ b/gui-tests/long-crate-description.goml
@@ -1,0 +1,18 @@
+// Checks that a crate description with a very long sequence of characters doesn't result in a horizontal scroll bar
+
+go-to: |DOC_PATH| + "/releases/search?query=sysinfo"
+
+store-value: (description_selector, "div.recent-releases-container .description")
+
+set-text: (|description_selector|, "SOME/VERYVERY/LONG/SEQUENCE/OF/TEXT/SEPARATED/BY/SLASHES\nAnotherveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongWord")
+
+// Set width to size smaller than media-sm as that's when we don't truncate the text
+store-value(screen_width, 567)
+set-window-size(|screen_width|, 800)
+
+store-property: (|description_selector|, {"scrollWidth": description_width})
+
+// Check that the description width isn't wider than the screen.
+// It should be smaller due to padding, but if it overflows it'll be wider than the screen anyway.
+assert-false: |description_width| > |screen_width|
+


### PR DESCRIPTION
Came across [this crate](https://docs.rs/releases/search?query=pgmold-sqlparser) with a description that was overflowing and breaking the layout:
<img width="392" height="542" alt="Screenshot 2026-06-22 at 11 15 39 AM" src="https://github.com/user-attachments/assets/6fc0a5a8-8cba-4bd3-8e52-1d7bd7f55dda" />

For this specific crate description, it only breaks the layout on Safari or Chrome related browsers as Firefox breaks long words on slashes as well. A long word would break the layout on any browser, but I think that kind of case would be rarer. This CSS change breaks the word if they get too long, so that the layout doesn't break.

<img width="451" height="514" alt="Screenshot 2026-06-22 at 11 20 31 AM" src="https://github.com/user-attachments/assets/8de47cf4-db46-44ee-bca3-e86b4c60fe1e" />

There's a few other CSS options that could resolve this as detailed in [css-tricks](https://css-tricks.com/where-lines-break-is-complicated-heres-all-the-related-css-and-html/), but I thought this one was the most effective and minimal change to resolve this.