### PR TITLE
update quinn-proto to fix security alert

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -13,6 +13,9 @@ ignore = [
 
     "RUSTSEC-2025-0141", # Bincode is unmaintained 
     # https://github.com/rust-lang/docs.rs/issues/3122
+
+    "RUSTSEC-2026-0173", # proc-macro-error2 is unmaintained
+    # https://github.com/rust-lang/docs.rs/issues/3386
 ]
 informational_warnings = ["unmaintained"] # warn for categories of informational advisories
 severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "critical")

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6322,9 +6322,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
Fixes #3385 

ignores the other warning. 