### PR TITLE
Fix release description hover jitter

### DIFF
--- a/crates/bin/docs_rs_web/src/handlers/releases.rs
+++ b/crates/bin/docs_rs_web/src/handlers/releases.rs
@@ -827,6 +827,7 @@ pub(crate) async fn build_queue_handler(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::page::web_page::AddCspNonce;
     use crate::testing::{
         AxumResponseTestExt, AxumRouterTestExt, TestEnvironment, TestEnvironmentExt as _,
         async_wrapper,
@@ -2024,6 +2025,34 @@ mod tests {
 
             Ok(())
         });
+    }
+
+    #[test]
+    fn home_page_description_title_escapes_quotes() {
+        let description = r#"A "quoted" crate description"#;
+        let mut page = HomePage {
+            recent_releases: vec![Release {
+                name: FOO,
+                version: V1,
+                description: Some(description.into()),
+                target_name: None,
+                rustdoc_status: true,
+                build_time: None,
+                stars: 0,
+                has_unyanked_releases: Some(true),
+            }],
+        };
+
+        let html =
+            kuchikiki::parse_html().one(page.render_with_csp_nonce("test-nonce".into()).unwrap());
+        let description_element = html
+            .select_first(".recent-releases-container .description")
+            .expect("missing release description");
+
+        assert_eq!(
+            description_element.attributes.borrow().get("title"),
+            Some(description),
+        );
     }
 
     #[test]

--- a/crates/bin/docs_rs_web/templates/core/home.html
+++ b/crates/bin/docs_rs_web/templates/core/home.html
@@ -58,7 +58,7 @@ centered
                                     {{- release.name }}-{{ release.version -}}
                                 </div>
                                 <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description"
-                                    title="{{ release.description.as_deref().unwrap_or_default() }}">
+                                    title="{{ release.description.as_deref().unwrap_or_default()|escape }}">
                                     {{- release.description.as_deref().unwrap_or_default() -}}
                                 </div>
 

--- a/crates/bin/docs_rs_web/templates/core/home.html
+++ b/crates/bin/docs_rs_web/templates/core/home.html
@@ -57,7 +57,8 @@ centered
                                 <div class="pure-u-1 pure-u-sm-6-24 pure-u-md-5-24 name">
                                     {{- release.name }}-{{ release.version -}}
                                 </div>
-                                <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description">
+                                <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description"
+                                    title="{{ release.description.as_deref().unwrap_or_default() }}">
                                     {{- release.description.as_deref().unwrap_or_default() -}}
                                 </div>
 

--- a/crates/bin/docs_rs_web/templates/releases/releases.html
+++ b/crates/bin/docs_rs_web/templates/releases/releases.html
@@ -48,7 +48,7 @@ centered
                                     </div>
 
                                     <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description"
-                                        title="{{ release.description }}">
+                                        title="{{ release.description|escape }}">
                                         {{- release.description -}}
                                     </div>
 
@@ -84,7 +84,7 @@ centered
                                     </div> {#- -#}
 
                                     <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description"
-                                        title="{{ release.description.as_deref().unwrap_or_default() }}">
+                                        title="{{ release.description.as_deref().unwrap_or_default()|escape }}">
                                         {{- release.description.as_deref().unwrap_or_default() -}}
                                     </div>
 

--- a/crates/bin/docs_rs_web/templates/releases/releases.html
+++ b/crates/bin/docs_rs_web/templates/releases/releases.html
@@ -36,7 +36,8 @@ centered
                             <div class="release">
                                 <div class="pure-g">
                                     <div class="pure-u-1 pure-u-sm-6-24 pure-u-md-5-24 name not-available">{{ name }}</div>
-                                    <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description">Documentation not available on docs.rs</div>
+                                    <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description"
+                                        title="Documentation not available on docs.rs">Documentation not available on docs.rs</div>
                                 </div>
                             </div>
                         {%- when ReleaseStatus::External(release) -%}
@@ -46,7 +47,8 @@ centered
                                         {{- release.name -}}
                                     </div>
 
-                                    <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description">
+                                    <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description"
+                                        title="{{ release.description }}">
                                         {{- release.description -}}
                                     </div>
 
@@ -81,7 +83,8 @@ centered
                                         {%- endif -%}
                                     </div> {#- -#}
 
-                                    <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description">
+                                    <div class="pure-u-1 pure-u-sm-14-24 pure-u-md-16-24 description"
+                                        title="{{ release.description.as_deref().unwrap_or_default() }}">
                                         {{- release.description.as_deref().unwrap_or_default() -}}
                                     </div>
 

--- a/crates/bin/docs_rs_web/templates/style/style.scss
+++ b/crates/bin/docs_rs_web/templates/style/style.scss
@@ -389,13 +389,6 @@ div.recent-releases-container {
         }
     }
 
-    .description:hover {
-        @media #{$media-sm} {
-            overflow: visible;
-            white-space: normal;
-        }
-    }
-
     .date,
     .duration,
     .memory {

--- a/gui-tests/long-crate-description.goml
+++ b/gui-tests/long-crate-description.goml
@@ -16,3 +16,15 @@ store-property: (|description_selector|, {"scrollWidth": description_width})
 // It should be smaller due to padding, but if it overflows it'll be wider than the screen anyway.
 assert-false: |description_width| > |screen_width|
 
+// Desktop release descriptions are truncated, but hovering them should not change
+// the row height and make the release list jump around.
+set-window-size: (1200, 800)
+store-value: (release_selector, "div.recent-releases-container a.release")
+set-text: (|description_selector|, "A very long crate description that should remain on one line when hovered instead of expanding and moving nearby release rows")
+
+store-property: (|release_selector|, {"clientHeight": release_height})
+move-cursor-to: |description_selector|
+store-property: (|release_selector|, {"clientHeight": release_height_after_hover})
+
+assert: |release_height_after_hover| == |release_height|
+


### PR DESCRIPTION
## Summary
- keep release descriptions truncated on hover so release rows do not change height
- add `title` text so full descriptions remain available without layout shifts
- extend the long description GUI test to cover hover row height

Fixes #173

## Validation
- cargo check -p docs_rs_web
- cargo fmt --all --check
- git diff --check