### PR TITLE
Link queued crates to exact versions

### DIFF
--- a/crates/bin/docs_rs_web/src/handlers/releases.rs
+++ b/crates/bin/docs_rs_web/src/handlers/releases.rs
@@ -1849,6 +1849,12 @@ mod tests {
                 let a = li.as_node().select_first("a").expect("missing link");
                 assert!(a.text_contents().contains(expected.0));
                 assert!(a.text_contents().contains(&expected.1.to_string()));
+                assert_eq!(
+                    a.attributes.borrow().get("href"),
+                    Some(
+                        format!("https://crates.io/crates/{}/{}", expected.0, expected.1).as_str()
+                    )
+                );
 
                 if let Some(priority) = expected.2 {
                     assert!(
@@ -2001,6 +2007,17 @@ mod tests {
 
             assert_eq!(build_queue_list.len(), 1);
             assert_eq!(rebuild_queue_list.len(), 2);
+            for li in build_queue_list.iter().chain(&rebuild_queue_list) {
+                let a = li.as_node().select_first("a").expect("missing link");
+                let text = a.text_contents();
+                let mut parts = text.split_whitespace();
+                let name = parts.next().expect("missing crate name");
+                let version = parts.next().expect("missing crate version");
+                assert_eq!(
+                    a.attributes.borrow().get("href"),
+                    Some(format!("https://crates.io/crates/{name}/{version}").as_str())
+                );
+            }
             assert!(
                 rebuild_queue_list
                     .iter()

--- a/crates/bin/docs_rs_web/templates/releases/build_queue.html
+++ b/crates/bin/docs_rs_web/templates/releases/build_queue.html
@@ -81,7 +81,7 @@ centered
                 {%- if !queue.is_empty() -%}
                     {% for crate_item in queue -%}
                         <li>
-                            <a href="https://crates.io/crates/{{ crate_item.name }}">
+                            <a href="https://crates.io/crates/{{ crate_item.name }}/{{ crate_item.version }}">
                                 {{- crate_item.name }} {{ crate_item.version -}}
                             </a>
 
@@ -116,7 +116,7 @@ centered
                     {%- if !rebuild_queue.is_empty() -%}
                         {% for crate_item in rebuild_queue -%}
                             <li>
-                                <a href="https://crates.io/crates/{{ crate_item.name }}">
+                                <a href="https://crates.io/crates/{{ crate_item.name }}/{{ crate_item.version }}">
                                     {{- crate_item.name }} {{ crate_item.version -}}
                                 </a>
                             </li>


### PR DESCRIPTION
Queued releases now link to their exact crates.io version pages instead of the crate-level page, which always resolves to the latest release.

This applies consistently to the normal build queue and the expandable automated rebuild queue. The existing render tests now assert the full version-specific `href` for every queued item.

Fixes #1009.

Validation:

- `cargo test -p docs_rs_web --no-run`
- `cargo clippy -p docs_rs_web --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The targeted queue tests compile locally but require the repository's PostgreSQL test service (`DOCSRS_DATABASE_URL`) to execute. Docker Desktop is not running on this Windows host, so local execution stops during shared `TestEnvironment` setup before reaching any assertions; upstream CI has the required service.
