### PR TITLE
add retries to fastly api requests, use same retry logic for registry api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,6 +2169,8 @@ dependencies = [
  "mockito",
  "opentelemetry",
  "reqwest",
+ "reqwest-middleware",
+ "reqwest-retry",
  "tokio",
  "tracing",
  "url",
@@ -2288,6 +2290,8 @@ dependencies = [
  "mime",
  "mockito",
  "reqwest",
+ "reqwest-middleware",
+ "reqwest-retry",
  "serde",
  "serde_json",
  "sqlx",
@@ -6663,6 +6667,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-middleware"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.5.0",
+ "reqwest",
+ "thiserror",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.17",
+ "http 1.5.0",
+ "hyper",
+ "reqwest",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "wasmtimer",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47"
+dependencies = [
+ "rand 0.10.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8610,6 +8658,20 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ pretty_assertions = "1.4.0"
 rand = "0.10"
 regex = "1"
 reqwest = { version = "0.13", features = ["gzip", "json", "stream"] }
+reqwest-middleware = "0.5"
+reqwest-retry = "0.9"
 sentry = { version = "0.49.0", features = ["backtrace", "panic", "tower-http", "tracing"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/bin/docs_rs_web/Cargo.toml
+++ b/crates/bin/docs_rs_web/Cargo.toml
@@ -54,7 +54,6 @@ opentelemetry = { workspace = true }
 postcard = { workspace = true }
 rayon-core = "1.13.0"
 regex = { workspace = true }
-reqwest = { workspace = true }
 sentry = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -92,6 +91,7 @@ kuchikiki = "0.8"
 mockito = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 pretty_assertions = { workspace = true }
+reqwest = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/lib/docs_rs_fastly/Cargo.toml
+++ b/crates/lib/docs_rs_fastly/Cargo.toml
@@ -20,6 +20,8 @@ http = { workspace = true }
 itertools = { workspace = true }
 opentelemetry = { workspace = true }
 reqwest = { workspace = true }
+reqwest-middleware = { workspace = true }
+reqwest-retry = { workspace = true }
 tokio = { workspace = true, optional = true }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/lib/docs_rs_fastly/src/cdn/real.rs
+++ b/crates/lib/docs_rs_fastly/src/cdn/real.rs
@@ -10,6 +10,8 @@ use http::{
 };
 use itertools::Itertools as _;
 use opentelemetry::KeyValue;
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
 use tracing::{error, instrument};
 use url::Url;
 
@@ -21,9 +23,11 @@ const FASTLY_KEY: HeaderName = HeaderName::from_static("fastly-key");
 // see https://www.fastly.com/documentation/reference/api/purging/
 const MAX_SURROGATE_KEYS_IN_BATCH_PURGE: usize = 256;
 
+const RETRIES: u32 = 3;
+
 #[derive(Debug)]
 pub struct RealCdn {
-    client: reqwest::Client,
+    client: ClientWithMiddleware,
     api_host: Url,
     service_sid: String,
     metrics: CdnMetrics,
@@ -46,9 +50,15 @@ impl RealCdn {
         headers.insert(FASTLY_KEY, HeaderValue::from_str(api_token)?);
 
         Ok(Self {
-            client: reqwest::Client::builder()
-                .default_headers(headers)
-                .build()?,
+            client: ClientBuilder::new(
+                reqwest::Client::builder()
+                    .default_headers(headers)
+                    .build()?,
+            )
+            .with(RetryTransientMiddleware::new_with_policy(
+                ExponentialBackoff::builder().build_with_max_retries(RETRIES),
+            ))
+            .build(),
             service_sid: service_sid.clone(),
             api_host: config.api_host.clone(),
             metrics: CdnMetrics::new(meter_provider),
@@ -220,6 +230,10 @@ mod tests {
             .match_header(FASTLY_KEY, "test-token")
             .match_header(&SURROGATE_KEY, "crate-bar crate-foo")
             .with_status(500)
+            .expect(
+                // initial call + retries
+                (1 + RETRIES) as usize,
+            )
             .create_async()
             .await;
 

--- a/crates/lib/docs_rs_registry_api/Cargo.toml
+++ b/crates/lib/docs_rs_registry_api/Cargo.toml
@@ -14,6 +14,8 @@ docs_rs_env_vars = { path = "../docs_rs_env_vars" }
 docs_rs_types = { path = "../docs_rs_types" }
 docs_rs_utils = { path = "../docs_rs_utils" }
 reqwest = { workspace = true }
+reqwest-middleware = { workspace = true }
+reqwest-retry = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }

--- a/crates/lib/docs_rs_registry_api/src/api.rs
+++ b/crates/lib/docs_rs_registry_api/src/api.rs
@@ -5,11 +5,13 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 use docs_rs_types::{KrateName, Version};
-use docs_rs_utils::{APP_USER_AGENT, retry_async};
+use docs_rs_utils::APP_USER_AGENT;
 use reqwest::{
     StatusCode,
     header::{ACCEPT, HeaderValue, USER_AGENT},
 };
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
 use serde::{Deserialize, de::DeserializeOwned};
 use tracing::instrument;
 use url::Url;
@@ -17,8 +19,7 @@ use url::Url;
 #[derive(Debug)]
 pub struct RegistryApi {
     api_base: Url,
-    max_retries: u32,
-    client: reqwest::Client,
+    client: ClientWithMiddleware,
 }
 
 impl RegistryApi {
@@ -30,22 +31,25 @@ impl RegistryApi {
     }
 
     pub fn new(api_base: Url, max_retries: u32) -> Result<Self> {
-        let headers = vec![
+        let headers = [
             (USER_AGENT, HeaderValue::from_static(APP_USER_AGENT)),
             (ACCEPT, HeaderValue::from_static("application/json")),
         ]
         .into_iter()
         .collect();
 
-        let client = reqwest::Client::builder()
-            .default_headers(headers)
-            .build()?;
+        let client = ClientBuilder::new(
+            reqwest::Client::builder()
+                .default_headers(headers)
+                .build()
+                .map_err(reqwest_middleware::Error::Reqwest)?,
+        )
+        .with(RetryTransientMiddleware::new_with_policy(
+            ExponentialBackoff::builder().build_with_max_retries(max_retries),
+        ))
+        .build();
 
-        Ok(Self {
-            api_base,
-            client,
-            max_retries,
-        })
+        Ok(Self { api_base, client })
     }
 
     /// Make a request to crates.io, parse the response as JSON.
@@ -65,31 +69,19 @@ impl RegistryApi {
     where
         T: DeserializeOwned,
     {
-        let response = retry_async(
-            || async {
-                // Make the request.
-                // This would error on connection errors etc.
-                let response = self.client.get(url.clone()).send().await?;
-
-                if response.status().is_server_error() {
-                    // this just to let reqwest generate us its "standard" error
-                    let err = response.error_for_status_ref().unwrap_err();
-                    let text = response.text().await.unwrap_or_default();
-                    // we only want to retry on 5xx errors.
-                    // for client errors we assume that trying again is not worth it.
-                    Err(Error::HttpError(err, text))
-                } else {
-                    Ok::<_, Error>(response)
-                }
-            },
-            self.max_retries,
-        )
-        .await?;
-
+        let response = self.client.get(url.clone()).send().await?;
         let status = response.status();
 
         if status.is_success() {
-            Ok(response.json().await?)
+            Ok(response
+                .json()
+                .await
+                .map_err(reqwest_middleware::Error::Reqwest)?)
+        } else if status.is_server_error() {
+            // this just to let reqwest generate us its "standard" error
+            let err = response.error_for_status_ref().unwrap_err();
+            let text = response.text().await.unwrap_or_default();
+            Err(Error::HttpError(err.into(), text))
         } else {
             let text = response.text().await.unwrap_or_default();
 
@@ -303,7 +295,8 @@ mod tests {
             .await;
 
         let err = reqwest::get(&srv.url())
-            .await?
+            .await
+            .map_err(reqwest_middleware::Error::Reqwest)?
             .error_for_status()
             .unwrap_err();
 

--- a/crates/lib/docs_rs_registry_api/src/error.rs
+++ b/crates/lib/docs_rs_registry_api/src/error.rs
@@ -16,7 +16,7 @@ pub enum Error {
     #[error("missing metadata in crates.io response")]
     MissingMetadata,
     #[error("HTTP error: {0}\n{1}")]
-    HttpError(reqwest::Error, String),
+    HttpError(reqwest_middleware::Error, String),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -32,8 +32,8 @@ impl Error {
     }
 }
 
-impl From<reqwest::Error> for Error {
-    fn from(err: reqwest::Error) -> Self {
+impl From<reqwest_middleware::Error> for Error {
+    fn from(err: reqwest_middleware::Error) -> Self {
         Self::HttpError(err, String::new())
     }
 }
@@ -43,6 +43,7 @@ mod tests {
     use super::*;
     use anyhow::anyhow;
     use reqwest::StatusCode;
+    use std::result::Result;
 
     #[test]
     fn test_error_without_status() {
@@ -65,7 +66,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_error_reqwest_error_status() -> Result<()> {
+    async fn test_error_reqwest_error_status() -> Result<(), reqwest::Error> {
         let status = StatusCode::INTERNAL_SERVER_ERROR;
 
         let mut srv = mockito::Server::new_async().await;


### PR DESCRIPTION
to fix errors like [this sentry error](https://rust-lang.sentry.io/issues/7478288604/?project=5499376&query=is%3Aunresolved&referrer=issue-stream) 

- fastly api requests weren't retried before, we have some sentry errors where content was outdated because of that. 
- registry api retries where just retried for all possible errors. the reqwest-retry logic only retries transient errors, which would reduce load on crates.io. 

With this middleware we get retries just for "transient" errors, and niceties like jittering. 

When the repackage & https://github.com/rust-lang/docs.rs/pull/3414 is done we then can remove our custom `retry_async` method. 

the default retry strategy is explained here: 
- https://docs.rs/reqwest-retry/latest/reqwest_retry/fn.default_on_request_success.html 
- https://docs.rs/reqwest-retry/latest/reqwest_retry/fn.default_on_request_failure.html 