### PR TITLE
Make infobox about limited feature metadata clearer

### DIFF
--- a/crates/bin/docs_rs_web/templates/crate/features.html
+++ b/crates/bin/docs_rs_web/templates/crate/features.html
@@ -53,12 +53,17 @@
             <div class="pure-u-1 pure-u-sm-17-24 pure-u-md-19-24 package-details" id="main">
                 <h1>{{ metadata.name }}</h1>
                 <div class="info">
-                    There is very little structured metadata to build this page
-                    from currently. You should check the
-                    <a href="{{ params.rustdoc_url() }}">main library docs</a>,
-                    <a href="{{ params.crate_details_url() }}">readme</a>, or
+                    There is currently very little information to present on
+                    this page because Docs.rs has only limited support for
+                    extracting structured feature metadata from Cargo crates.
+                    This issue is tracked in
+                    <a href="https://rust-lang.github.io/rfcs/3416-feature-metadata.html">Rust RFC #3416</a>.
+                    Check this library's
+                    <a href="{{ params.rustdoc_url() }}">main docs</a>,
+                    <a href="{{ params.crate_details_url() }}">readme</a>, and
                     <a href="{{ params.clone().with_inner_path("Cargo.toml.orig").with_page_kind(PageKind::Source).source_url() }}">Cargo.toml</a>
-                    in case the author documented the features in them.
+                    in case its authors have documentation for features
+                    available there instead.
                 </div>
                 {%- if let Some(features) = sorted_features -%}
                     {%- if features.is_empty() -%}


### PR DESCRIPTION
I have clarified the message that tells the user about feature metadata support being limited and linked to the relevant Rust RFC.

I saw this message for the first time when I was looking for the best way to document feature flags in my published crate. It made me mistakenly doubt that I have misconfigured my crate by failing to supply proper metadata for display on this page. I realized that this is not the case only after a Web search that brought me to this Rust users forum thread:

https://users.rust-lang.org/t/what-does-there-is-very-little-structured-metadata-to-build-this-page-from-currently-on-the-crate-features-page-mean/137618

Turns out, I wasn't the only person who had difficulty understanding this message.

I believe this improved version will remove the ambiguity. I have tested its appearance on my local machine and I'm satisfied with it.