### PR TITLE
fix rustdoc-json & coverage for proc-macro crates with custom rustc_args

### DIFF
--- a/.sqlx/query-aad790aa7ef85357e7f57c83b21621d5a82ef6a5333a617b1d2fb8631ebe9b42.json
+++ b/.sqlx/query-aad790aa7ef85357e7f57c83b21621d5a82ef6a5333a617b1d2fb8631ebe9b42.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT cov.total_items\n                    FROM\n                        crates as c\n                        INNER JOIN releases AS r ON c.id = r.crate_id\n                        LEFT OUTER JOIN doc_coverage AS cov ON r.id = cov.release_id\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "total_items",
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "doc_coverage",
+            "name": "total_items"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "aad790aa7ef85357e7f57c83b21621d5a82ef6a5333a617b1d2fb8631ebe9b42"
+}

--- a/crates/bin/docs_rs_builder/.sqlx/query-aad790aa7ef85357e7f57c83b21621d5a82ef6a5333a617b1d2fb8631ebe9b42.json
+++ b/crates/bin/docs_rs_builder/.sqlx/query-aad790aa7ef85357e7f57c83b21621d5a82ef6a5333a617b1d2fb8631ebe9b42.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT cov.total_items\n                    FROM\n                        crates as c\n                        INNER JOIN releases AS r ON c.id = r.crate_id\n                        LEFT OUTER JOIN doc_coverage AS cov ON r.id = cov.release_id\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "total_items",
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "doc_coverage",
+            "name": "total_items"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "aad790aa7ef85357e7f57c83b21621d5a82ef6a5333a617b1d2fb8631ebe9b42"
+}

--- a/crates/bin/docs_rs_builder/src/docbuilder/rustwide_builder.rs
+++ b/crates/bin/docs_rs_builder/src/docbuilder/rustwide_builder.rs
@@ -1891,6 +1891,7 @@ mod tests {
     #[test_case("scsys-macros", Version::new(0, 2, 6))]
     #[test_case("scsys-derive", Version::new(0, 2, 6))]
     #[test_case("thiserror-impl", Version::new(1, 0, 26))]
+    #[test_case("contained-macros", Version::new(0, 2, 5))]
     #[ignore]
     fn test_proc_macro(crate_: &'static str, version: Version) -> Result<()> {
         let env = TestEnvironment::new()?;
@@ -1905,6 +1906,23 @@ mod tests {
                 .successful
         );
 
+        // check coverage
+        let row = block_on_async_with_conn!(env, |mut conn| async {
+            sqlx::query!(
+                r#"SELECT cov.total_items
+                    FROM
+                        crates as c
+                        INNER JOIN releases AS r ON c.id = r.crate_id
+                        LEFT OUTER JOIN doc_coverage AS cov ON r.id = cov.release_id
+                "#
+            )
+            .fetch_one(&mut *conn)
+            .await
+            .map_err(Into::into)
+        })?;
+
+        assert!(row.total_items.unwrap() > 0);
+
         let storage = env.blocking_storage()?;
 
         // doc archive exists
@@ -1914,6 +1932,23 @@ mod tests {
         // source archive exists
         let source_archive = source_archive_path(&crate_, &version);
         assert!(storage.exists(&source_archive)?);
+
+        // test if rustdoc json was created
+        assert!(
+            storage
+                .list_prefix(&format!(
+                    "rustdoc-json/{}/{}/x86_64-unknown-linux-gnu/",
+                    crate_, version
+                ))
+                .filter_map(|res| res.ok())
+                .find(|path| {
+                    path.ends_with(&format!(
+                        "{}_{}_x86_64-unknown-linux-gnu_latest.json.zst",
+                        crate_, version
+                    ))
+                })
+                .is_some()
+        );
 
         Ok(())
     }

--- a/crates/lib/metadata/lib.rs
+++ b/crates/lib/metadata/lib.rs
@@ -300,10 +300,16 @@ impl Metadata {
                 .expect("serializing a string should never fail")
                 .to_string();
             cargo_args.push(format!("build.rustflags={rustflags}"));
-            cargo_args.push("-Zhost-config".into());
-            cargo_args.push("-Ztarget-applies-to-host".into());
-            cargo_args.push("--config".into());
-            cargo_args.push(format!("host.rustflags={rustflags}"));
+            if !self.proc_macro {
+                // Proc-macro crates are built only for the host and we deliberately omits
+                // --target for them, so Cargo already applies build.rustflags to their build.
+                // Enabling host config instead suppresses build.rustdocflags for that host build,
+                // dropping custom rustdoc flags and JSON output.
+                cargo_args.push("-Zhost-config".into());
+                cargo_args.push("-Ztarget-applies-to-host".into());
+                cargo_args.push("--config".into());
+                cargo_args.push(format!("host.rustflags={rustflags}"));
+            }
         }
 
         cargo_args.push("--config".into());


### PR DESCRIPTION
Weird corner-case. I was digging into [cases where we still don't get rustdoc-json for some crates](https://rust-lang.sentry.io/issues/7178942819/?query=is%3Aunresolved&referrer=issue-stream). 

In https://github.com/rust-lang/docs.rs/commit/3f92a79e12a98c77a15c003a810bdba3e9cdf3ca we added `-Zhost-config`, `-Ztarget-applies-to-host`, and `--config host.rustflags={}` to also pass custom `rustc_args` to build scripts. This works because we always pass `--target` to doc builds. 

In case of proc-macro builds it's different: we don't pass `--target`, so the args above lead to our custom `build.rustdocflags` config being ignored, including custom `rustdocflags` from the metadata, or `--output-format json` from us. 

This removes `target-applies-to-host` for proc-macro crates. 

*for now I wouldn't try to rebuild rustdoc-json, since it's super tricky to find the affected crates. This could be a part of a general backfill*. 