### PR TITLE
fix json / coverage builds with custom -Z rustdoc-scrape-examples given

### DIFF
--- a/crates/bin/docs_rs_builder/src/docbuilder/rustwide_builder.rs
+++ b/crates/bin/docs_rs_builder/src/docbuilder/rustwide_builder.rs
@@ -2427,4 +2427,67 @@ mod tests {
 
         Ok(())
     }
+
+    #[test_case("ffizz-string", Version::new(0, 5, 0))]
+    #[test_case("ffizz-passby", Version::new(0, 5, 0))]
+    #[ignore]
+    fn test_with_examples_custom_scrape(crate_: &'static str, version: Version) -> Result<()> {
+        // some crates add `-Zrustdoc-scrape-examples` themselves in their `cargo-args`.
+        // In this case we just remove it.
+        let crate_: KrateName = crate_.parse().unwrap();
+
+        let mut config = Config::test_config()?;
+        config.include_default_targets = false;
+        let env = TestEnvironment::builder().config(config).build()?;
+
+        let mut builder = env.build_builder()?;
+        builder.update_toolchain()?;
+        assert!(
+            builder
+                .build_package(&crate_, &version, PackageKind::CratesIo, false)?
+                .successful
+        );
+
+        // check release record in the db
+        let row = block_on_async_with_conn!(env, |mut conn| async {
+            sqlx::query!(
+                r#"SELECT
+                        c.name,
+                        r.version,
+                        r.rustdoc_status,
+                        cov.total_items
+                    FROM
+                        crates as c
+                        INNER JOIN releases AS r ON c.id = r.crate_id
+                        LEFT OUTER JOIN doc_coverage AS cov ON r.id = cov.release_id
+                "#
+            )
+            .fetch_one(&mut *conn)
+            .await
+            .map_err(Into::into)
+        })?;
+
+        assert_eq!(row.name, crate_.as_str());
+        assert_eq!(row.version, version.to_string());
+        assert!(row.total_items.unwrap() > 0);
+
+        let storage = env.blocking_storage()?;
+        assert!(
+            storage
+                .list_prefix(&format!(
+                    "rustdoc-json/{}/{}/x86_64-unknown-linux-gnu/",
+                    row.name, row.version
+                ))
+                .filter_map(|res| res.ok())
+                .find(|path| {
+                    path.ends_with(&format!(
+                        "{}_{}_x86_64-unknown-linux-gnu_latest.json.zst",
+                        row.name, row.version
+                    ))
+                })
+                .is_some()
+        );
+
+        Ok(())
+    }
 }

--- a/crates/lib/metadata/Cargo.toml
+++ b/crates/lib/metadata/Cargo.toml
@@ -2,7 +2,7 @@
 name = "docsrs-metadata"
 version = "0.1.0"
 authors = ["Joshua Nelson <jyn514@gmail.com>", "The Rust Project Developers"]
-edition = "2021"
+edition = "2024"
 license = "MIT"
 repository = "https://github.com/rust-lang/docs.rs"
 description = "Document crates the same way docs.rs would"

--- a/crates/lib/metadata/lib.rs
+++ b/crates/lib/metadata/lib.rs
@@ -313,7 +313,24 @@ impl Metadata {
         cargo_args.push(format!("build.rustdocflags={rustdocflags}"));
 
         cargo_args.extend(additional_args.iter().map(|s| s.to_owned()));
-        cargo_args.extend_from_slice(&self.cargo_args);
+        cargo_args.reserve(cargo_args.len() + self.cargo_args.len());
+        let mut cargo_args_iter = self.cargo_args.iter().peekable();
+        while let Some(arg) = cargo_args_iter.next() {
+            // custom `-Z rustdoc-scrape-examples` is unnecessary since we add it ourselves,
+            // and it breaks rustdoc json & coverage builds.
+            if arg == "-Zrustdoc-scrape-examples" {
+                continue;
+            }
+            if arg == "-Z"
+                && let Some(next_arg) = cargo_args_iter.peek()
+                && next_arg.as_str() == "rustdoc-scrape-examples"
+            {
+                cargo_args_iter.next();
+                continue;
+            }
+
+            cargo_args.push(arg.to_owned());
+        }
         cargo_args
     }
 
@@ -851,5 +868,18 @@ mod test_calculations {
             "-Zbuild-std".into(),
         ];
         assert_eq!(metadata.cargo_args(&[], &[]), expected_args);
+
+        // We add `-Zrustdoc-scrape-examples` ourselves, so providing it in metadata will
+        // be ignored.
+        for cargo_args in [
+            vec!["-Zrustdoc-scrape-examples".into()],
+            vec!["-Z".into(), "rustdoc-scrape-examples".into()],
+        ] {
+            let metadata = Metadata {
+                cargo_args,
+                ..Metadata::default()
+            };
+            assert_eq!(metadata.cargo_args(&[], &[]), default_cargo_args(&[]));
+        }
     }
 }


### PR DESCRIPTION
Fix errors like [this](https://rust-lang.sentry.io/issues/7178942819/events/3ea4bc256f564e80a92520e37fea1933/?query=is%3Aunresolved&referrer=previous-event). 

Since https://github.com/rust-lang/docs.rs/pull/3438 we only pass `-Z rustdoc-scrape-examples` for HTML builds. But crates can use docs.rs metadata to add `-Z rustdoc-scrape-examples` themselves. This breaks the coverage & json builds for them. 

