### PR TITLE
storage/s3: reduce unnecessary retries, add cleanup for legacy storage

### DIFF
--- a/.sqlx/query-aba5fee7730e45595659a8b653607eaac1d9bc07473c886de2a240a094db7778.json
+++ b/.sqlx/query-aba5fee7730e45595659a8b653607eaac1d9bc07473c886de2a240a094db7778.json
@@ -1,0 +1,38 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n             c.name as \"name: KrateName\",\n             r.version as \"version: Version\"\n          FROM\n             crates as c\n             INNER JOIN releases AS r ON c.id = r.crate_id\n          ORDER BY\n             c.name, r.version;\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name: KrateName",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "crates",
+            "name": "name"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "version: Version",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "releases",
+            "name": "version"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "aba5fee7730e45595659a8b653607eaac1d9bc07473c886de2a240a094db7778"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,6 +1998,7 @@ dependencies = [
  "docs_rs_logging",
  "docs_rs_opentelemetry",
  "docs_rs_repository_stats",
+ "docs_rs_storage",
  "docs_rs_test_fakes",
  "docs_rs_types",
  "docs_rs_uri",

--- a/crates/bin/docs_rs_admin/Cargo.toml
+++ b/crates/bin/docs_rs_admin/Cargo.toml
@@ -18,6 +18,7 @@ docs_rs_fastly = { path = "../../lib/docs_rs_fastly" }
 docs_rs_headers = { path = "../../lib/docs_rs_headers" }
 docs_rs_logging = { path = "../../lib/docs_rs_logging" }
 docs_rs_repository_stats = { path = "../../lib/docs_rs_repository_stats" }
+docs_rs_storage = { path = "../../lib/docs_rs_storage" }
 docs_rs_types = { path = "../../lib/docs_rs_types" }
 docs_rs_uri = { path = "../../lib/docs_rs_uri" }
 docs_rs_utils = { path = "../../lib/docs_rs_utils" }
@@ -32,6 +33,7 @@ docs_rs_config = { path = "../../lib/docs_rs_config", features = ["testing"] }
 docs_rs_context = { path = "../../lib/docs_rs_context", features = ["testing"] }
 docs_rs_database = { path = "../../lib/docs_rs_database", features = ["testing"] }
 docs_rs_opentelemetry = { path = "../../lib/docs_rs_opentelemetry", features = ["testing"] }
+docs_rs_storage = { path = "../../lib/docs_rs_storage", features = ["testing"] }
 docs_rs_test_fakes = { path = "../../lib/docs_rs_test_fakes" }
 docs_rs_types = { path = "../../lib/docs_rs_types", features = ["testing"] }
 pretty_assertions = { workspace = true }

--- a/crates/bin/docs_rs_admin/src/cleanup_s3.rs
+++ b/crates/bin/docs_rs_admin/src/cleanup_s3.rs
@@ -1,0 +1,197 @@
+use anyhow::{Result, bail};
+use docs_rs_storage::{AsyncStorage, rustdoc_archive_path, source_archive_path};
+use docs_rs_types::{KrateName, Version};
+use futures_util::TryStreamExt as _;
+use tracing::{info, instrument};
+
+async fn check_archive(storage: &AsyncStorage, path: impl AsRef<str>) -> Result<()> {
+    let path = path.as_ref();
+    if !storage.exists(path).await? {
+        bail!("archive {} missing", path);
+    }
+
+    let index_path = format!("{path}.index");
+    if !storage.exists(&index_path).await? {
+        bail!("archive index {} missing", index_path);
+    }
+
+    Ok(())
+}
+
+async fn clean_prefix(
+    storage: &AsyncStorage,
+    prefix: impl AsRef<str>,
+    dry_run: bool,
+) -> Result<()> {
+    let prefix = prefix.as_ref();
+
+    if dry_run {
+        let mut stream = storage.list_prefix(prefix).await;
+
+        while let Some(key) = stream.try_next().await? {
+            info!(%key, %prefix, "deleting legacy file");
+        }
+    } else {
+        storage.delete_prefix(prefix).await?;
+    }
+
+    Ok(())
+}
+
+#[instrument(skip_all)]
+pub(crate) async fn cleanup_s3_bucket(
+    conn: &mut sqlx::PgConnection,
+    storage: &AsyncStorage,
+    dry_run: bool,
+) -> Result<()> {
+    let mut result = sqlx::query!(
+        r#"SELECT
+             c.name as "name: KrateName",
+             r.version as "version: Version"
+          FROM
+             crates as c
+             INNER JOIN releases AS r ON c.id = r.crate_id
+          ORDER BY
+             c.name, r.version;
+        "#
+    )
+    .fetch(&mut *conn);
+
+    while let Some(row) = result.try_next().await? {
+        info!("checking {} {}", row.name, row.version);
+
+        check_archive(storage, rustdoc_archive_path(&row.name, &row.version)).await?;
+        check_archive(storage, source_archive_path(&row.name, &row.version)).await?;
+
+        clean_prefix(
+            storage,
+            format!("rustdoc/{}/{}/", row.name, row.version),
+            dry_run,
+        )
+        .await?;
+        clean_prefix(
+            storage,
+            format!("sources/{}/{}/", row.name, row.version),
+            dry_run,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::TestEnvironment;
+    use docs_rs_types::testing::KRATE;
+    use pretty_assertions::assert_eq;
+
+    async fn list(storage: &AsyncStorage) -> Result<Vec<String>> {
+        let mut result: Vec<_> = storage.list_prefix("").await.try_collect().await?;
+
+        result.sort_unstable();
+
+        Ok(result)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_no_releases_leaves_files() -> Result<()> {
+        let env = TestEnvironment::new().await?;
+        let storage = env.storage()?;
+
+        storage.store_one("something.html", "content").await?;
+
+        cleanup_s3_bucket(&mut *env.async_conn().await?, storage, false).await?;
+
+        assert_eq!(list(storage).await?, vec!["something.html"]);
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_with_releases_nothing_to_delete() -> Result<()> {
+        let env = TestEnvironment::new().await?;
+        env.fake_release().await.name(&KRATE).create().await?;
+
+        let storage = env.storage()?;
+        storage.store_one("something.html", "content").await?;
+
+        let expected_files = vec![
+            "build-logs/10000/x86_64-unknown-linux-gnu.txt",
+            "rustdoc-json/krate/1.0.0/x86_64-unknown-linux-gnu/krate_1.0.0_x86_64-unknown-linux-gnu_42.json.gz",
+            "rustdoc-json/krate/1.0.0/x86_64-unknown-linux-gnu/krate_1.0.0_x86_64-unknown-linux-gnu_42.json.zst",
+            "rustdoc-json/krate/1.0.0/x86_64-unknown-linux-gnu/krate_1.0.0_x86_64-unknown-linux-gnu_latest.json.gz",
+            "rustdoc-json/krate/1.0.0/x86_64-unknown-linux-gnu/krate_1.0.0_x86_64-unknown-linux-gnu_latest.json.zst",
+            "rustdoc/krate/1.0.0.zip",
+            "rustdoc/krate/1.0.0.zip.index",
+            "something.html",
+            "sources/krate/1.0.0.zip",
+            "sources/krate/1.0.0.zip.index",
+        ];
+
+        assert_eq!(list(storage).await?, expected_files);
+
+        cleanup_s3_bucket(&mut *env.async_conn().await?, storage, false).await?;
+
+        assert_eq!(list(storage).await?, expected_files);
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_with_releases_and_legacy_files() -> Result<()> {
+        let env = TestEnvironment::new().await?;
+        env.fake_release().await.name(&KRATE).create().await?;
+
+        let storage = env.storage()?;
+        storage.store_one("something.html", "content").await?;
+        storage
+            .store_one("rustdoc/krate/1.0.0/legacy/1.html", "content")
+            .await?;
+        storage
+            .store_one("rustdoc/krate/1.0.0/2.html", "content")
+            .await?;
+        storage
+            .store_one("rustdoc/krate/left_alone.html", "content")
+            .await?;
+        storage
+            .store_one("sources/krate/left_alone.html", "content")
+            .await?;
+        storage
+            .store_one("sources/krate/1.0.0/legacy/1.rs", "content")
+            .await?;
+        storage
+            .store_one("sources/krate/1.0.0/2.rs", "content")
+            .await?;
+
+        let old_count = list(storage).await?.len();
+
+        // dry-run does nothing
+        cleanup_s3_bucket(&mut *env.async_conn().await?, storage, true).await?;
+        assert_eq!(list(storage).await?.len(), old_count);
+
+        // real clean does clean
+        cleanup_s3_bucket(&mut *env.async_conn().await?, storage, false).await?;
+
+        assert_eq!(
+            list(storage).await?,
+            vec![
+                "build-logs/10000/x86_64-unknown-linux-gnu.txt",
+                "rustdoc-json/krate/1.0.0/x86_64-unknown-linux-gnu/krate_1.0.0_x86_64-unknown-linux-gnu_42.json.gz",
+                "rustdoc-json/krate/1.0.0/x86_64-unknown-linux-gnu/krate_1.0.0_x86_64-unknown-linux-gnu_42.json.zst",
+                "rustdoc-json/krate/1.0.0/x86_64-unknown-linux-gnu/krate_1.0.0_x86_64-unknown-linux-gnu_latest.json.gz",
+                "rustdoc-json/krate/1.0.0/x86_64-unknown-linux-gnu/krate_1.0.0_x86_64-unknown-linux-gnu_latest.json.zst",
+                "rustdoc/krate/1.0.0.zip",
+                "rustdoc/krate/1.0.0.zip.index",
+                "rustdoc/krate/left_alone.html",
+                "something.html",
+                "sources/krate/1.0.0.zip",
+                "sources/krate/1.0.0.zip.index",
+                "sources/krate/left_alone.html",
+            ]
+        );
+
+        Ok(())
+    }
+}

--- a/crates/bin/docs_rs_admin/src/main.rs
+++ b/crates/bin/docs_rs_admin/src/main.rs
@@ -1,3 +1,4 @@
+mod cleanup_s3;
 mod rebuilds;
 #[cfg(test)]
 pub(crate) mod testing;
@@ -371,6 +372,12 @@ enum DatabaseSubcommand {
     /// Updates GitHub/GitLab stats for crates.
     UpdateRepositoryFields,
 
+    /// Clean up the s3 bucket from non-archive storage files.
+    CleanS3Bucket {
+        #[arg(long)]
+        dry_run: bool,
+    },
+
     /// Backfill GitHub/GitLab stats for crates.
     BackfillRepositoryStats,
 
@@ -432,6 +439,14 @@ impl DatabaseSubcommand {
 
                 println!("update repository stats where outdated...");
                 ctx.repository_stats()?.update_all_crates().await?;
+            }
+
+            Self::CleanS3Bucket { dry_run } => {
+                println!("clean up s3 bucket...");
+                let mut conn = ctx.pool()?.get_async().await?;
+                let storage = ctx.storage()?;
+
+                cleanup_s3::cleanup_s3_bucket(&mut conn, storage, dry_run).await?;
             }
 
             Self::BackfillRepositoryStats => {

--- a/crates/lib/docs_rs_storage/src/backends/s3.rs
+++ b/crates/lib/docs_rs_storage/src/backends/s3.rs
@@ -35,8 +35,9 @@ use tracing::{error, warn};
 // (200), so the SDK's retry layer never sees these — we have to retry them
 // ourselves. See:
 // https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
-static RETRYABLE_DELETE_OBJECT_ERROR_CODES: [&str; 4] = [
+static RETRYABLE_DELETE_OBJECT_ERROR_CODES: [&str; 5] = [
     "InternalError",
+    "OperationAborted",
     "RequestTimeout",
     "ServiceUnavailable",
     "SlowDown",
@@ -563,30 +564,17 @@ impl S3Backend {
     async fn delete_batch_with_retry(&self, keys: Vec<String>) -> Result<(), Error> {
         let mut remaining = keys;
         for attempt in 1.. {
-            let resp = match self
+            // Request-level failures are retried by the AWS SDK. We only retry
+            // per-object failures returned in a successful `DeleteObjects`
+            // response below, since the SDK cannot see those as errors.
+            let resp = self
                 .client
                 .delete_objects()
                 .bucket(&self.bucket)
                 .delete(Self::delete_request(&remaining)?)
                 .send()
                 .await
-            {
-                Ok(resp) => resp,
-                Err(err)
-                    if attempt <= self.max_retries && Self::is_retryable_delete_error(&err) =>
-                {
-                    let backoff = retry_backoff(attempt);
-                    warn!(
-                        attempt,
-                        ?backoff,
-                        ?err,
-                        "retrying s3 delete_objects request after transient error",
-                    );
-                    time::sleep(backoff).await;
-                    continue;
-                }
-                Err(err) => return Err(err.into()),
-            };
+                .with_context(|| format!("failed to delete files from s3: {remaining:?}"))?;
 
             let Some(errs) = resp.errors.filter(|e| !e.is_empty()) else {
                 return Ok(());
@@ -635,25 +623,6 @@ impl S3Backend {
         }
 
         unreachable!("unbounded retry loop should return or fail internally")
-    }
-
-    fn is_retryable_delete_error<E>(err: &SdkError<E>) -> bool
-    where
-        E: ProvideErrorMetadata + std::error::Error + Send + Sync + 'static,
-    {
-        if let Some(err_code) = err.code()
-            && RETRYABLE_DELETE_OBJECT_ERROR_CODES.contains(&err_code)
-        {
-            return true;
-        }
-
-        if let SdkError::ServiceError(err) = err
-            && err.raw().status().is_server_error()
-        {
-            return true;
-        }
-
-        false
     }
 
     fn delete_request(keys: &[String]) -> Result<Delete, Error> {


### PR DESCRIPTION
When running the `repackage` command (that converted legacy single-file to archive-storage) I had regular errors in the cleanup phase. Since [that was was only tried _after_ everything else is finished, that wasn't an issue for the conversion itself](https://github.com/syphar/docs.rs/blob/eaa7f6af7403a361377c58f82237c2961aec3be4/crates/bin/docs_rs_admin/src/repackage.rs#L113-L115). 

The error I was was from the AWS SDK, and about a mismatchin the XML schema when running `delete_prefix`. Currently I don't know why that error happened. 

But: I checked an bucket-inventory (= file-list for the whole bucket), and there are plenty of remaining rustdoc or source files. 

This command tries to clean these up. Likely I'll run into the same XML encoding errors, but no I'll print the file-list / error list to be able to debug these better. 

Before actually running the delete, I'll `--dry-run` the command, and inspect the resulting file-list. 