### PR TITLE
deploy dev-guide to gh pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,19 +101,6 @@ jobs:
         if: ${{ always() }}
         run: just compose-down-and-wipe
 
-  dev-guide:
-    name: dev-guide mdbook
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: just,mdbook,mdbook-linkcheck2
-
-      - run: just book-test
-
   lint-format:
     name: linters & formatters
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-guide.yml
+++ b/.github/workflows/dev-guide.yml
@@ -1,0 +1,47 @@
+name: Dev-Guide mdBook
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        run: rustup update stable && rustup default stable
+
+      - name: Install mdbook
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just,mdbook,mdbook-linkcheck2
+
+      - run:
+          just book-test  # also runs the build
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/book/html
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'rust-lang'
+
+  # Deploy is run as a separate job as it needs elevated permissions
+  deploy:
+    name: deploy
+    needs: test  # the `test` job uploads the pages artifact
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'rust-lang'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
+        id: deployment

--- a/.github/workflows/dev-guide.yml
+++ b/.github/workflows/dev-guide.yml
@@ -1,14 +1,16 @@
 name: Dev-Guide mdBook
 
 on:
-  push:
+  pull_request:
+  pull_request_target:
     branches:
       - main
-  pull_request:
+    types: [closed]
 
 jobs:
   test:
     name: build and test
+    if: ${{ github.event_name == 'pull_request' || github.event.pull_request.merged }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -27,13 +29,12 @@ jobs:
       - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/book/html
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'rust-lang'
 
   # Deploy is run as a separate job as it needs elevated permissions
   deploy:
     name: deploy
     needs: test  # the `test` job uploads the pages artifact
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'rust-lang'
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.merged && github.repository_owner == 'rust-lang'
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
working example from `async-book`: 
- https://github.com/rust-lang/async-book/blob/master/.github/workflows/ci.yml
- https://github.com/rust-lang/team/blob/main/repos/rust-lang/async-book.toml

docs.rs repo permissions: https://github.com/rust-lang/team/pull/2692