### PR TITLE
s3 cleanup: continue without deleting if no archive found

### DIFF
--- a/crates/bin/docs_rs_admin/src/cleanup_s3.rs
+++ b/crates/bin/docs_rs_admin/src/cleanup_s3.rs
@@ -1,21 +1,25 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use docs_rs_storage::{AsyncStorage, rustdoc_archive_path, source_archive_path};
 use docs_rs_types::{KrateName, Version};
 use futures_util::TryStreamExt as _;
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
-async fn check_archive(storage: &AsyncStorage, path: impl AsRef<str>) -> Result<()> {
+async fn check_archive(storage: &AsyncStorage, path: impl AsRef<str>) -> Result<bool> {
     let path = path.as_ref();
-    if !storage.exists(path).await? {
-        bail!("archive {} missing", path);
-    }
-
     let index_path = format!("{path}.index");
-    if !storage.exists(&index_path).await? {
-        bail!("archive index {} missing", index_path);
-    }
 
-    Ok(())
+    let has_archive = storage.exists(path).await?;
+    let has_index = storage.exists(&index_path).await?;
+
+    if has_archive && has_index {
+        Ok(true)
+    } else {
+        warn!(
+            has_archive,
+            has_index, path, index_path, "missing archive or index"
+        );
+        Ok(false)
+    }
 }
 
 async fn clean_prefix(
@@ -61,8 +65,9 @@ pub(crate) async fn cleanup_s3_bucket(
     while let Some(row) = result.try_next().await? {
         info!("checking {} {}", row.name, row.version);
 
-        if row.rustdoc_status.is_some_and(|st| st) {
-            check_archive(storage, rustdoc_archive_path(&row.name, &row.version)).await?;
+        if row.rustdoc_status.is_some_and(|st| st)
+            && check_archive(storage, rustdoc_archive_path(&row.name, &row.version)).await?
+        {
             clean_prefix(
                 storage,
                 format!("rustdoc/{}/{}/", row.name, row.version),
@@ -71,14 +76,14 @@ pub(crate) async fn cleanup_s3_bucket(
             .await?;
         }
 
-        check_archive(storage, source_archive_path(&row.name, &row.version)).await?;
-
-        clean_prefix(
-            storage,
-            format!("sources/{}/{}/", row.name, row.version),
-            dry_run,
-        )
-        .await?;
+        if check_archive(storage, source_archive_path(&row.name, &row.version)).await? {
+            clean_prefix(
+                storage,
+                format!("sources/{}/{}/", row.name, row.version),
+                dry_run,
+            )
+            .await?;
+        }
     }
 
     Ok(())
@@ -275,10 +280,14 @@ mod tests {
         // real clean does clean
         cleanup_s3_bucket(&mut *env.async_conn().await?, storage, false).await?;
 
+        let mut contents = list(storage).await?;
+
+        let build_log = contents.remove(0);
+        build_log.starts_with("builds-logs/");
+
         assert_eq!(
-            list(storage).await?,
+            contents,
             vec![
-                "build-logs/10000/x86_64-unknown-linux-gnu.txt",
                 "something.html",
                 "sources/krate/1.0.0.zip",
                 "sources/krate/1.0.0.zip.index",


### PR DESCRIPTION
first dry-run stopped when one source archive was missing. 