### PR TITLE
drop pre-sqlx schemamama compat migration layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,7 +2161,6 @@ dependencies = [
  "docs_rs_uri",
  "docs_rs_utils",
  "futures-util",
- "hex",
  "hostname",
  "opentelemetry",
  "rand 0.10.2",

--- a/crates/lib/docs_rs_database/Cargo.toml
+++ b/crates/lib/docs_rs_database/Cargo.toml
@@ -20,7 +20,6 @@ docs_rs_types = { path = "../docs_rs_types" }
 docs_rs_uri = { path = "../docs_rs_uri" }
 docs_rs_utils = { path = "../docs_rs_utils" }
 futures-util = { workspace = true }
-hex = "0.4.3"
 hostname = "0.4.0"
 opentelemetry = { workspace = true }
 rand = { workspace = true, optional = true }

--- a/crates/lib/docs_rs_database/src/migrations.rs
+++ b/crates/lib/docs_rs_database/src/migrations.rs
@@ -6,50 +6,6 @@ pub static MIGRATOR: Migrator = sqlx::migrate!(); // defaults to "./migrations"
 pub async fn migrate(conn: &mut sqlx::PgConnection, target: Option<i64>) -> Result<()> {
     conn.ensure_migrations_table(&MIGRATOR.table_name).await?;
 
-    // `database_versions` is the table that tracked the old `schemamama` migrations.
-    // If we find the table, and it contains records, we insert a fake record
-    // into the `_sqlx_migrations` table so the big initial migration isn't executed.
-    if sqlx::query(
-        "SELECT table_name
-         FROM information_schema.tables
-         WHERE table_schema = 'public' AND table_name = 'database_versions'",
-    )
-    .fetch_optional(&mut *conn)
-    .await?
-    .is_some()
-    {
-        let max_version: Option<i64> =
-            sqlx::query_scalar("SELECT max(version) FROM database_versions")
-                .fetch_one(&mut *conn)
-                .await?;
-
-        if max_version != Some(39) {
-            anyhow::bail!(
-                "database_versions table has unexpected version: {:?}",
-                max_version
-            );
-        }
-
-        sqlx::query(
-            "INSERT INTO _sqlx_migrations ( version, description, success, checksum, execution_time )
-             VALUES ( $1, $2, TRUE, $3, -1 )",
-        )
-        // the next two parameters relate to the filename of the initial migration file
-        .bind(20231021111635i64)
-        .bind("initial")
-        // this is the hash of the initial migration file, as sqlx requires it.
-        // if the initial migration file changes, this has to be updated with the new value,
-        // easiest to get from the `_sqlx_migrations` table when the migration was normally
-        // executed.
-        .bind(hex::decode("df802e0ec416063caadd1c06b13348cd885583c44962998886b929d5fe6ef3b70575d5101c5eb31daa989721df08d806").unwrap())
-        .execute(&mut *conn)
-        .await?;
-
-        sqlx::query("DROP TABLE database_versions")
-            .execute(&mut *conn)
-            .await?;
-    }
-
     // when we find records
     if let Some(target) = target {
         MIGRATOR.undo(conn, target).await?;


### PR DESCRIPTION
- we only care about our deployment, no self-deployment
- the migration sqlx is already a couple of years in the past. 