### PR TITLE
drop unused fuzzystrmatch postgres extension

### DIFF
--- a/crates/lib/docs_rs_database/migrations/20231021111635_initial.up.sql
+++ b/crates/lib/docs_rs_database/migrations/20231021111635_initial.up.sql
@@ -1,15 +1,11 @@
--- generated via: 
+-- generated via:
 -- `pg_dump --schema-only --no-owner cratesfyi`
 --
--- and then manually removing 
+-- and then manually removing
 -- * the `public.` schema references from this file, so it also works for the test setup
 -- * the `SET` settings
 
 CREATE SCHEMA IF NOT EXISTS public;
-
-CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
-COMMENT ON EXTENSION fuzzystrmatch IS 'determine similarities and distance between strings';
-
 
 
 CREATE TYPE feature AS (

--- a/crates/lib/docs_rs_database/migrations/20260826120000_drop-fuzzystrmatch.down.sql
+++ b/crates/lib/docs_rs_database/migrations/20260826120000_drop-fuzzystrmatch.down.sql
@@ -1,0 +1,1 @@
+-- do nothing, we don't have that extension available in the postgres container any more

--- a/crates/lib/docs_rs_database/migrations/20260826120000_drop-fuzzystrmatch.up.sql
+++ b/crates/lib/docs_rs_database/migrations/20260826120000_drop-fuzzystrmatch.up.sql
@@ -1,0 +1,1 @@
+DROP EXTENSION IF EXISTS fuzzystrmatch;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,10 +225,7 @@ services:
             - manual
 
     db:
-        build:
-            context: ./dockerfiles
-            dockerfile: ./Dockerfile-postgres
-            <<: *docker-cache
+        image: postgres:18-alpine
         volumes:
             - postgres-data:/var/lib/postgresql
         environment:

--- a/dockerfiles/Dockerfile-postgres
+++ b/dockerfiles/Dockerfile-postgres
@@ -1,4 +1,0 @@
-FROM postgres:18-alpine
-EXPOSE 5432
-
-COPY ./install_extensions.sql /docker-entrypoint-initdb.d/

--- a/dockerfiles/install_extensions.sql
+++ b/dockerfiles/install_extensions.sql
@@ -1,1 +1,0 @@
-CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;


### PR DESCRIPTION
we don't use that since we migrated to using the crates.io search api a couple of years ago. 

This also means we don't need the custom `Dockerfile-postgres`. 

I adapted the initial migration, and made the reverse migration a noop, 
because otherwise our testing would fail creating the extension in the new docker postgres image, since we don't create that with `install_extensions.sql` any more. 