### PR TITLE
refactor dockerfile & docker build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 /.docker.env
+/.env
 /.env.*
 /.envrc
 /.rustwide

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,15 +10,7 @@ on:
 
 jobs:
   docker:
-    strategy:
-      matrix:
-        target: [
-          "web-server",
-          "build-server",
-          "registry-watcher",
-          "cli"
-        ]
-    name: Test docker image builds
+    name: Test Docker images
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -26,22 +18,30 @@ jobs:
       - name: setup docker buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: build docker image
-        uses: docker/build-push-action@v7
+      - name: build docker images
+        uses: docker/bake-action@v7
         with:
-          context: .
-          file: "./dockerfiles/Dockerfile"
-          platforms: linux/amd64
-          target: ${{ matrix.target }}
-          build-args: |
-            GIT_SHA=${{ github.sha }}
-            PROFILE=release
-            PROFILE_DIR=release
-          load: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: false
+          source: .
+          files: docker-bake.hcl
+          # All targets share a cache scope so their common Dockerfile stages
+          # can be reused across images and CI runs.
+          set: |
+            *.args.GIT_SHA=${{ github.sha }}
+            *.cache-from=type=gha,scope=docs-rs-images
+            *.cache-to=type=gha,mode=max,scope=docs-rs-images
 
-          # TODO: later we would set `push: true` and also provide nice tags
-          # for the images.
-          # Unclear is how the deploy would work then.
+      - name: smoke test packaged binaries
+        run: |
+          set -euo pipefail
+
+          docker buildx bake --file docker-bake.hcl --print |
+            jq -r '
+              . as $bake
+              | $bake.group.default.targets[] as $target
+              | $bake.target[$target].tags[0]
+                // error("Bake target \($target) has no image tag")
+            ' |
+            while IFS= read -r image; do
+              echo "testing $image..."
+              docker run --rm "$image" --help
+            done

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,44 @@
+variable "GIT_SHA" {
+  default = "dev"
+}
+
+group "default" {
+  targets = ["web-server", "build-server", "registry-watcher", "cli"]
+}
+
+target "common" {
+  context    = "."
+  dockerfile = "dockerfiles/Dockerfile"
+  platforms  = ["linux/amd64"]
+  # Load images into the local Docker daemon so CI can smoke-test them.
+  output     = ["type=docker"]
+  args = {
+    GIT_SHA    = GIT_SHA
+    PROFILE    = "release"
+    PROFILE_DIR = "release"
+  }
+}
+
+target "web-server" {
+  inherits = ["common"]
+  target   = "web-server"
+  tags     = ["docs-rs-web-server:ci"]
+}
+
+target "build-server" {
+  inherits = ["common"]
+  target   = "build-server"
+  tags     = ["docs-rs-build-server:ci"]
+}
+
+target "registry-watcher" {
+  inherits = ["common"]
+  target   = "registry-watcher"
+  tags     = ["docs-rs-registry-watcher:ci"]
+}
+
+target "cli" {
+  inherits = ["common"]
+  target   = "cli"
+  tags     = ["docs-rs-cli:ci"]
+}

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -2,9 +2,9 @@
 
 FROM rust:1.98-slim-trixie AS chef
 
-# We only pay the installation cost once, 
+# We only pay the installation cost once,
 # it will be cached from the second build onwards
-RUN cargo install cargo-chef 
+RUN cargo install --locked --version 0.1.78 cargo-chef
 WORKDIR /build
 
 #################
@@ -26,21 +26,20 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install packaged dependencies
 # hadolint ignore=DL3008
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    build-essential \
-    git \
-    curl \
-    cmake \
-    gcc \
-    g++ \
-    pkg-config \
-    libmagic-dev \
-    libssl-dev \
-    zlib1g-dev \
-    ca-certificates \
-    mold \
-    clang
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        cmake \
+        pkg-config \
+        libmagic-dev \
+        libssl-dev \
+        zlib1g-dev \
+        ca-certificates \
+        mold \
+        clang \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 
@@ -53,35 +52,69 @@ ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS=-Clink-arg=-fuse-ld=mold
 
 
 ARG PROFILE=release
-
-# Build dependencies - this is the caching Docker layer!
-RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry,sharing=locked \
-    --mount=type=cache,target=/build/target,id=cargo-target,sharing=locked \
-    cargo chef cook --profile=$PROFILE --recipe-path /build/recipe.json
-
-ENV PATH=/root/.cargo/bin:$PATH
-
-# get the git SHA from the build args, for our generated version numbers
-ARG GIT_SHA=dev
-ENV GIT_SHA=$GIT_SHA
+ARG PROFILE_DIR=release
 
 ENV SQLX_OFFLINE=true
 
-# Build application
+##########################
+#  Cached dependencies   #
+##########################
+
+FROM build AS dependencies
+
+# Do not use a cache mount here: keep cargo-chef's /build/target output in an
+# ordinary image layer so remote cache exporters retain it. Each binary build
+# below uses this directory as the initial contents of its mutable target cache.
+RUN cargo chef cook --profile=$PROFILE --recipe-path /build/recipe.json
+
+##########################
+#  Application binaries  #
+##########################
+
+FROM dependencies AS application-build
+
+# Get the git SHA from the build args for our generated version numbers. Keep
+# it after the dependency layer so each commit only invalidates application builds.
+ARG GIT_SHA=dev
+ENV GIT_SHA=$GIT_SHA
+
+FROM application-build AS build-web-server
 COPY . .
-ARG PROFILE_DIR=release
-RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry,sharing=locked \
-    --mount=type=cache,target=/build/target,id=cargo-target,sharing=locked \
+# Seed the target cache from cargo-chef's dependency layer. BuildKit keeps later
+# changes to this cache for fast incremental rebuilds on a persistent local
+# builder. Ephemeral CI builders generally do not retain the cache mount between
+# runs, but still receive the cargo-chef dependency baseline from the image layer.
+RUN --mount=type=cache,target=/build/target,id=docs-rs-cargo-target,from=dependencies,source=/build/target,sharing=locked \
     mkdir /artifacts && \
-    cargo build --profile=$PROFILE --workspace && \
-    cp /build/target/$PROFILE_DIR/cratesfyi /artifacts/ && \
-    cp /build/target/$PROFILE_DIR/docs_rs_* /artifacts/
+    cargo build --profile=$PROFILE --package docs_rs_web && \
+    cp /build/target/$PROFILE_DIR/docs_rs_web /artifacts/
 
-######################
-#  Web server stage  #
-######################
+FROM application-build AS build-build-server
+COPY . .
+RUN --mount=type=cache,target=/build/target,id=docs-rs-cargo-target,from=dependencies,source=/build/target,sharing=locked \
+    mkdir /artifacts && \
+    cargo build --profile=$PROFILE --package docs_rs_builder && \
+    cp /build/target/$PROFILE_DIR/docs_rs_builder /artifacts/
 
-FROM debian:trixie-slim AS web-server
+FROM application-build AS build-registry-watcher
+COPY . .
+RUN --mount=type=cache,target=/build/target,id=docs-rs-cargo-target,from=dependencies,source=/build/target,sharing=locked \
+    mkdir /artifacts && \
+    cargo build --profile=$PROFILE --package docs_rs_watcher && \
+    cp /build/target/$PROFILE_DIR/docs_rs_watcher /artifacts/
+
+FROM application-build AS build-cli
+COPY . .
+RUN --mount=type=cache,target=/build/target,id=docs-rs-cargo-target,from=dependencies,source=/build/target,sharing=locked \
+    mkdir /artifacts && \
+    cargo build --profile=$PROFILE --package docs_rs_admin && \
+    cp /build/target/$PROFILE_DIR/docs_rs_admin /artifacts/
+
+########################
+#  Runtime base stage  #
+########################
+
+FROM debian:trixie-slim AS runtime-base
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -90,47 +123,53 @@ RUN apt-get update \
     && apt-get install -y \
         --no-install-recommends \
         ca-certificates \
-        curl \
+        libssl3t64 \
         tini \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+######################
+#  Web server stage  #
+######################
+
+FROM runtime-base AS web-server
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get install -y \
+        --no-install-recommends \
+        curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /srv/docsrs
 
 # copy the new binary, will also be used as default entrypoint.
-COPY --from=build /artifacts/docs_rs_web /usr/local/bin/
-
-# also copy the old legacy binary, so we can fall back to using it 
-# by just overwriting the entrypoint & CMD when running this container.
-COPY --from=build /artifacts/cratesfyi /usr/local/bin/
+COPY --from=build-web-server /artifacts/docs_rs_web /usr/local/bin/
 
 # copy necessary assets
 COPY crates/bin/docs_rs_web/static /srv/docsrs/static
 COPY crates/bin/docs_rs_web/vendor /srv/docsrs/vendor
 
-ENTRYPOINT ["/usr/bin/tini"]
-CMD ["/usr/local/bin/docs_rs_web", "--", "0.0.0.0:3000"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docs_rs_web"]
+CMD ["0.0.0.0:3000"]
 
 
 ########################
 #  Build server stage  #
 ########################
-# * includes docker-cli, but expects the docker engine to be mapped into 
-#   the container from the outside, e.g. via 
+# * includes docker-cli, but expects the docker engine to be mapped into
+#   the container from the outside, e.g. via
 #
 #     volumes:
 #       - "/var/run/docker.sock:/var/run/docker.sock"
 
-FROM debian:trixie-slim AS build-server
-
-ENV DEBIAN_FRONTEND=noninteractive
+FROM runtime-base AS build-server
 
 # hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get install -y \
         --no-install-recommends \
-        ca-certificates \
-        tini \
         curl \
         docker-cli \
         build-essential \
@@ -141,13 +180,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # copy the new binary, will also be used as default entrypoint.
-COPY --from=build /artifacts/docs_rs_builder /usr/local/bin/
+COPY --from=build-build-server /artifacts/docs_rs_builder /usr/local/bin/
 
-# also copy the old legacy binary, so we can fall back to using it 
-# by just overwriting the entrypoint & CMD when running this container.
-COPY --from=build /artifacts/cratesfyi /usr/local/bin/
-
-ENTRYPOINT ["/usr/bin/tini", "/usr/local/bin/docs_rs_builder", "--"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docs_rs_builder"]
 CMD ["start"]
 
 
@@ -155,58 +190,37 @@ CMD ["start"]
 #  Registry watcher stage  #
 ############################
 
-FROM debian:trixie-slim AS registry-watcher
-
-ENV DEBIAN_FRONTEND=noninteractive
+FROM runtime-base AS registry-watcher
 
 # hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get install -y \
         --no-install-recommends \
-        ca-certificates \
-        tini \
-        curl \
         git \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # copy the new binary, will also be used as default entrypoint.
-COPY --from=build /artifacts/docs_rs_watcher /usr/local/bin/
+COPY --from=build-registry-watcher /artifacts/docs_rs_watcher /usr/local/bin/
 
-# also copy the old legacy binary, so we can fall back to using it 
-# by just overwriting the entrypoint & CMD when running this container.
-COPY --from=build /artifacts/cratesfyi /usr/local/bin/
-
-ENTRYPOINT ["/usr/bin/tini", "/usr/local/bin/docs_rs_watcher", "--"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docs_rs_watcher"]
 CMD ["start", "--repository-stats-updater", "--queue-rebuilds"]
 
 ###############
 #  CLI stage  #
 ###############
 # This stage is used to run one-off commands like database migrations.
-# not suited for commands that need: 
+# not suited for commands that need:
 # * the crates.io index, or
 # * need to run builds.
 # for these, use the build-server stage, or registry-watcher stage instead.
 
-FROM debian:trixie-slim AS cli
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-# hadolint ignore=DL3008
-RUN apt-get update \
-    && apt-get install -y \
-        --no-install-recommends \
-        ca-certificates \
-        tini \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+FROM runtime-base AS cli
 
 WORKDIR /srv/docsrs
 
 COPY crates/bin/docs_rs_admin/bin/docs_rs_release.sh /usr/local/bin/
 
-COPY --from=build /artifacts/docs_rs_admin /usr/local/bin/
-COPY --from=build /artifacts/cratesfyi /usr/local/bin
+COPY --from=build-cli /artifacts/docs_rs_admin /usr/local/bin/
 
-ENTRYPOINT ["/usr/bin/tini", "/usr/local/bin/docs_rs_admin", "--"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docs_rs_admin"]

--- a/docs/src/development/docker-commands.md
+++ b/docs/src/development/docker-commands.md
@@ -3,15 +3,40 @@
 The local services are defined in the repository's `docker-compose.yml`. The
 `just` recipes wrap common Compose operations, run database migrations when
 needed, and rebuild application images automatically when their inputs change.
-Containerized application builds have less effective incremental caching than
-host builds, so changes to `Cargo.lock` can require a lengthy dependency
-rebuild.
 
 List all available recipes with:
 
 ```console
 $ just --list
 ```
+
+## Build images directly
+
+Docker images are defined in `docker-bake.hcl`. Build one image with its Bake
+target:
+
+```console
+$ docker buildx bake build-server
+```
+
+Build all application images with:
+
+```console
+$ docker buildx bake
+```
+
+The images are loaded into the local Docker daemon. For example, smoke-test the
+build-server image with:
+
+```console
+$ docker run --rm docs-rs-build-server:ci --help
+```
+
+The Docker build stores cargo-chef's compiled dependency baseline in an image
+layer that can be reused by remote builders. Application builds additionally
+share a Cargo target cache local to the Buildx builder, which enables
+incremental rebuilds after source changes. A new Buildx builder starts without
+that local incremental cache.
 
 ## Start services
 


### PR DESCRIPTION
- Build all Docker images together using Buildx Bake.
- Improve dependency and incremental build caching across CI runs and for local development
- Share common Dockerfile stages between image targets.
- only `apt install` what is actually needed by each stage. 
- Build only the binary required by each image.
- Smoke-test every packaged binary in CI.
- don't build/copy the legacy `cratesfyi` binary any more, we'll definitely not use it in the new infra. 
- move `GIT_SHA` docker arg into the binary build stages, so the `chef` dependency layer isn't invalidated for each new commit. 


I think this is now a good balance between CI docker build time, and local incremental docker build time. I imagine having had this on my old mac would have made my life much easier. 