### PR TITLE
refactor `just lint` and `just format`, make GH actions use them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,42 +112,20 @@ jobs:
         with:
           tool: just,fd-find,cargo-machete,cargo-udeps,cargo-sort@2.1.3
 
+      - name: Install actionlint
+        run: |
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.12 "$RUNNER_TEMP"
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+
       - uses: denoland/setup-deno@v2
+        with:
+          deno-version: 2.9.5
 
       - name: restore build & cargo cache
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: linters-${{ env.RUST_CACHE_KEY }}
 
-      - run: |
-          just lint
-          just lint-dependencies-udeps
-
-  lint-js:
-    name: js linters
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: denoland/setup-deno@v2
-        with:
-          deno-version: 2.9.5
-
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: just
-
-      - run: just lint-js
-
-  lint-actions:
-    name: gh actions linters
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      # We check that all github actions workflows have valid syntax
-      - name: Validate YAML file
-        uses: raven-actions/actionlint@v2
-        with:
-          files: .github/workflow/*
-          flags: "-ignore SC2086"  # ignore some shellcheck errors
+      - run: just format
+      - run: just lint
+      - run: just lint-dependencies-udeps

--- a/README.md
+++ b/README.md
@@ -165,6 +165,19 @@ Run the complete lint suite with:
 $ just lint
 ```
 
+Linting GitHub Actions workflows requires
+[`actionlint`](https://github.com/rhysd/actionlint/blob/main/docs/install.md). If
+it is not installed, that check is skipped with a warning.
+
+Run all formatters with:
+
+```console
+$ just format
+```
+
+If files are not formatted correctly, this command rewrites them and exits with
+an error so that you can review the changes.
+
 Run browser-based GUI tests with:
 
 ```console

--- a/justfiles/testing.just
+++ b/justfiles/testing.just
@@ -68,7 +68,9 @@ _format_markdown mdfile:
       exit 1
     fi
 
-_format_rust:
+# format rust code
+[group('testing')]
+format-rust:
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -80,9 +82,7 @@ _format_rust:
       exit 1
     fi
 
-# Format the code using `cargo fmt` and `just --fmt`.
-#
-# Will continue with other formatters when some fail.
+# run all formatters, continue after error
 [group('testing')]
 format:
     #!/usr/bin/env bash
@@ -90,15 +90,25 @@ format:
 
     exit_code=0
 
-    just _format_rust || exit_code=1
+    just format-rust || exit_code=1
+    just format-just || exit_code=1
+    just format-markdown || exit_code=1
+    just format-cargo-toml || exit_code=1
 
+    exit "$exit_code"
+
+# format all justfiles
+[group('testing')]
+format-just:
     fd \
       --type file \
       --threads 1 \
       '^(Justfile|.+\.just)$' . \
       --exec just _format_justfile {} || exit_code=1
 
-    echo "formatting markdown files"
+# format all markdown files we maintain
+[group('testing')]
+format-markdown:
     fd \
       --type file \
       --threads 1 \
@@ -107,8 +117,6 @@ format:
       --exclude 'crates/bin/docs_rs_web/assets/syntaxes/' \
       --exclude 'crates/bin/docs_rs_web/static/' \
       --exec just _format_markdown {} || exit_code=1
-
-    exit "$exit_code"
 
 # run clippy, in our config
 [group('testing')]
@@ -127,22 +135,29 @@ clippy *args:
 clippy-fix:
     just clippy --fix --allow-dirty --allow-staged
 
-# run all linters, for local development & CI
 [group('testing')]
-lint: format lint-dependencies-machete
+lint-rust:
     #!/usr/bin/env bash
     set -euo pipefail
 
     if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
-      just sort-cargo-toml --check
       just clippy
     else
-      just sort-cargo-toml
       just clippy-fix
     fi
 
+# run all linters, for local development & CI
 [group('testing')]
-sort-cargo-toml *args:
+lint: lint-rust lint-actions lint-js lint-dependencies-machete
+
+# validate GitHub Actions workflows
+[group('testing')]
+lint-actions:
+    @command -v actionlint >/dev/null || { echo "warning: actionlint not installed, skipping"; exit 0; }
+    actionlint -ignore SC2086
+
+[group('testing')]
+format-cargo-toml *args:
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -151,7 +166,12 @@ sort-cargo-toml *args:
       exit 1;
     fi
 
-    cargo sort --workspace {{ args }}
+    # like this we get both the non-zero exit code, and the local code is
+    # formatted.
+    if ! cargo sort --workspace --check {{ args }} >/dev/null; then
+      cargo sort --workspace {{ args }}
+      exit 1
+    fi
 
 [group('testing')]
 lint-dependencies-machete:


### PR DESCRIPTION
move all linting and formatting logic into the corresponding just recipes, also use these in CI. 