### PR TITLE
watcher: Start recording metrics for git index change handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,10 +1259,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -2144,6 +2142,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "test-case",
 ]
 
 [[package]]
@@ -2494,6 +2493,7 @@ dependencies = [
  "docs_rs_build_queue",
  "docs_rs_config",
  "docs_rs_context",
+ "docs_rs_crates_io",
  "docs_rs_database",
  "docs_rs_env_vars",
  "docs_rs_fastly",

--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ $ just lint
 ```
 
 Linting GitHub Actions workflows requires
-[`actionlint`](https://github.com/rhysd/actionlint/blob/main/docs/install.md). If
-it is not installed, that check is skipped with a warning.
+[`actionlint`](https://github.com/rhysd/actionlint/blob/main/docs/install.md).
+If it is not installed, that check is skipped with a warning.
 
 Run all formatters with:
 

--- a/crates/bin/docs_rs_watcher/Cargo.toml
+++ b/crates/bin/docs_rs_watcher/Cargo.toml
@@ -16,6 +16,7 @@ crates-index-diff = { version = "31.0.0", default-features = false, features = [
 docs_rs_build_queue = { path = "../../lib/docs_rs_build_queue" }
 docs_rs_config = { path = "../../lib/docs_rs_config" }
 docs_rs_context = { path = "../../lib/docs_rs_context" }
+docs_rs_crates_io = { path = "../../lib/docs_rs_crates_io" }
 docs_rs_database = { path = "../../lib/docs_rs_database" }
 docs_rs_env_vars = { path = "../../lib/docs_rs_env_vars" }
 docs_rs_fastly = { path = "../../lib/docs_rs_fastly" }

--- a/crates/bin/docs_rs_watcher/src/db/delete.rs
+++ b/crates/bin/docs_rs_watcher/src/db/delete.rs
@@ -5,12 +5,14 @@ use docs_rs_storage::{AsyncStorage, rustdoc_archive_path, source_archive_path};
 use docs_rs_types::{CrateId, KrateName, Version};
 use sqlx::Connection;
 use tokio::fs;
+use tracing::instrument;
 
 /// List of directories in docs.rs's underlying storage (either the database or S3) containing a
 /// subdirectory named after the crate. Those subdirectories will be deleted.
 static LIBRARY_STORAGE_PATHS_TO_DELETE: &[&str] = &["rustdoc", "rustdoc-json", "sources"];
 static OTHER_STORAGE_PATHS_TO_DELETE: &[&str] = &["sources"];
 
+#[instrument(skip_all, fields(name=%name))]
 pub async fn delete_crate(
     conn: &mut sqlx::PgConnection,
     storage: &AsyncStorage,
@@ -56,6 +58,7 @@ pub async fn delete_crate(
     Ok(())
 }
 
+#[instrument(skip_all, fields(name=%name, version=%version))]
 pub async fn delete_version(
     conn: &mut sqlx::PgConnection,
     storage: &AsyncStorage,

--- a/crates/bin/docs_rs_watcher/src/index_watcher.rs
+++ b/crates/bin/docs_rs_watcher/src/index_watcher.rs
@@ -2,18 +2,57 @@ use crate::{
     Config,
     db::{delete_crate, delete_version},
     index::Index,
+    metrics::{EventSource, WatcherMetrics},
 };
 use anyhow::{Context as _, Result};
 use crates_index_diff::Change;
 use docs_rs_build_queue::PRIORITY_MANUAL_FROM_CRATES_IO;
 use docs_rs_context::Context;
+use docs_rs_crates_io::events::ChangeKind;
 use docs_rs_database::{
     crate_details::update_latest_version_id,
     service_config::{ConfigName, get_config, set_config},
 };
 use docs_rs_fastly::{Cdn, CdnBehaviour as _};
 use docs_rs_types::{CrateId, KrateName, Version};
-use tracing::{debug, error, info, warn};
+use std::time::Instant;
+use tracing::{debug, error, info, instrument, warn};
+
+trait ChangeExt {
+    fn name(&self) -> &str;
+    fn version(&self) -> Option<&str>;
+    fn kind(&self) -> ChangeKind;
+    fn first_crate_version(&self) -> &crates_index_diff::CrateVersion;
+}
+
+impl ChangeExt for Change {
+    fn first_crate_version(&self) -> &crates_index_diff::CrateVersion {
+        self.versions().first().expect("always exists")
+    }
+
+    fn name(&self) -> &str {
+        self.first_crate_version().name.as_str()
+    }
+
+    fn version(&self) -> Option<&str> {
+        if let Change::CrateDeleted { .. } = self {
+            None
+        } else {
+            Some(self.first_crate_version().version.as_str())
+        }
+    }
+
+    fn kind(&self) -> ChangeKind {
+        match *self {
+            Change::Added(_) => ChangeKind::Added,
+            Change::Yanked(_) => ChangeKind::Yanked,
+            Change::CrateDeleted { .. } => ChangeKind::CrateDeleted,
+            Change::VersionDeleted(_) => ChangeKind::VersionDeleted,
+            Change::Unyanked(_) => ChangeKind::Unyanked,
+            Change::AddedAndYanked(_) => ChangeKind::AddedAndYanked,
+        }
+    }
+}
 
 #[derive(Debug)]
 pub(crate) struct CrateVersion {
@@ -94,6 +133,7 @@ pub(crate) async fn get_new_crates(
     context: &Context,
     index: &Index,
     config: &Config,
+    metrics: &WatcherMetrics,
 ) -> Result<usize> {
     let mut conn = context.pool()?.get_async().await?;
 
@@ -115,7 +155,10 @@ pub(crate) async fn get_new_crates(
 
     debug!(last_seen_reference=%last_seen_reference, new_reference=%new_reference, "queueing changes");
 
-    let crates_added = process_changes(context, &changes, config).await;
+    metrics.record_events_received(EventSource::Git, changes.len());
+    // NOTE: `Box::pin` to type-erase this future, otherwise we'll run into `recursion_limit`
+    // errors.
+    let crates_added = Box::pin(process_changes(context, &changes, config, metrics)).await;
 
     if let Err(err) = context.build_queue()?.reevaluate_priorities().await {
         error!(?err, "error reevaluating queued release priorities");
@@ -129,32 +172,66 @@ pub(crate) async fn get_new_crates(
     Ok(crates_added)
 }
 
-async fn process_changes(context: &Context, changes: &Vec<Change>, config: &Config) -> usize {
+async fn process_changes(
+    context: &Context,
+    changes: &Vec<Change>,
+    config: &Config,
+    metrics: &WatcherMetrics,
+) -> usize {
     let mut crates_added = 0;
 
     for change in changes {
-        match process_change(context, change, config).await {
+        let start = Instant::now();
+        let crate_name = change.name();
+        let crate_version = change.version();
+        let change_type = change.kind();
+
+        // Start temporarily loging all changes, as preparation for the SQS event migration.
+        debug!(
+            target: "docs_rs_watcher::index_event",
+            source = %EventSource::Git,
+            %change_type,
+            crate_name,
+            crate_version,
+            "crates.io index event"
+        );
+
+        let success = match process_change(context, change, config).await {
             Ok(added) => {
+                metrics.record_change_applied(EventSource::Git, change_type);
                 if added {
                     crates_added += 1;
                 }
+                true
             }
             Err(err) => {
                 error!(?change, ?err, "failed to process change");
+                false
             }
-        }
+        };
+        metrics.record_event_processing_time(
+            EventSource::Git,
+            Some(change_type),
+            success,
+            start.elapsed(),
+        );
     }
     crates_added
 }
 
 /// Process a crate change, returning whether the change was a crate addition or not.
+#[instrument(skip_all, fields(name, version))]
 async fn process_change(context: &Context, change: &Change, config: &Config) -> Result<bool> {
-    let crate_version: CrateVersion = change
-        .versions()
-        .first()
-        .expect("always exists")
-        .clone()
-        .try_into()?;
+    // 1: use the `CrateVersion` from `crates-index-diff`.
+    let crate_version = change.first_crate_version();
+
+    // record name & version on the tracing span for performance instrumentation.
+    tracing::Span::current()
+        .record("name", crate_version.name.as_str())
+        .record("version", crate_version.version.as_str());
+
+    // 2: now, convert to our own internal `CrateVersion.`
+    let crate_version: CrateVersion = crate_version.clone().try_into()?;
 
     match change {
         Change::Added(_release) => process_version_added(context, &crate_version).await?,
@@ -177,6 +254,7 @@ async fn process_change(context: &Context, change: &Change, config: &Config) -> 
 }
 
 /// Processes crate changes, whether they got yanked or unyanked.
+#[instrument(skip_all)]
 async fn process_version_yank_status(context: &Context, release: &CrateVersion) -> Result<()> {
     // FIXME: delay yanks of crates that have not yet finished building
     // https://github.com/rust-lang/docs.rs/issues/1934
@@ -185,6 +263,7 @@ async fn process_version_yank_status(context: &Context, release: &CrateVersion) 
     Ok(())
 }
 
+#[instrument(skip_all)]
 async fn process_version_added(context: &Context, release: &CrateVersion) -> Result<()> {
     let build_queue = context.build_queue()?;
 
@@ -217,6 +296,7 @@ async fn process_version_added(context: &Context, release: &CrateVersion) -> Res
     Ok(())
 }
 
+#[instrument(skip_all)]
 async fn process_version_deleted(
     context: &Context,
     config: &Config,
@@ -251,6 +331,7 @@ async fn process_version_deleted(
     Ok(())
 }
 
+#[instrument(skip_all)]
 async fn process_crate_deleted(
     context: &Context,
     config: &Config,
@@ -270,6 +351,7 @@ async fn process_crate_deleted(
     context.build_queue()?.remove_crate_from_queue(krate).await
 }
 
+#[instrument(skip_all, fields(name=%name, version=%version, yanked=%yanked))]
 pub(crate) async fn set_yanked(
     context: &Context,
     name: &KrateName,
@@ -518,6 +600,7 @@ mod tests {
             version: V2,
             ..Default::default()
         };
+        let metrics = WatcherMetrics::new(&env.context().meter_provider);
         let added = process_changes(
             &env,
             &vec![
@@ -531,6 +614,7 @@ mod tests {
                 Change::VersionDeleted(non_existing_version.into()),
             ],
             env.config(),
+            &metrics,
         )
         .await;
 

--- a/crates/bin/docs_rs_watcher/src/lib.rs
+++ b/crates/bin/docs_rs_watcher/src/lib.rs
@@ -3,6 +3,7 @@ pub mod consistency;
 mod db;
 mod index;
 pub mod index_watcher;
+mod metrics;
 mod rebuilds;
 mod service_metrics;
 #[cfg(test)]
@@ -13,7 +14,11 @@ pub use db::{delete_crate, delete_version};
 pub use index::Index;
 pub use rebuilds::queue_rebuilds;
 
-use crate::{index_watcher::get_new_crates, service_metrics::OtelServiceMetrics};
+use crate::{
+    index_watcher::get_new_crates,
+    metrics::{EventSource, WatcherMetrics},
+    service_metrics::OtelServiceMetrics,
+};
 use anyhow::Result;
 use docs_rs_context::Context;
 use docs_rs_utils::start_async_cron;
@@ -28,6 +33,7 @@ pub async fn watch_registry(config: &Config, context: &Context) -> Result<()> {
     let mut last_gc = Instant::now();
 
     let queue = context.build_queue()?;
+    let metrics = WatcherMetrics::new(context.meter_provider());
 
     loop {
         if queue.is_locked().await? {
@@ -36,9 +42,10 @@ pub async fn watch_registry(config: &Config, context: &Context) -> Result<()> {
             debug!("Checking new crates");
             let index = Index::from_config(config).await?;
 
-            match get_new_crates(context, &index, config).await {
+            match get_new_crates(context, &index, config, &metrics).await {
                 Ok(n) => debug!("{} crates added to queue", n),
                 Err(e) => {
+                    metrics.record_poll_error(EventSource::Git);
                     error!(?e, "Failed to get new crates");
                 }
             }

--- a/crates/bin/docs_rs_watcher/src/metrics.rs
+++ b/crates/bin/docs_rs_watcher/src/metrics.rs
@@ -1,0 +1,110 @@
+use docs_rs_crates_io::events::ChangeKind;
+use docs_rs_opentelemetry::AnyMeterProvider;
+use opentelemetry::{
+    KeyValue,
+    metrics::{Counter, Histogram},
+};
+use std::{fmt, time::Duration};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum EventSource {
+    Git,
+    // NOTE: Sqs will be added later
+}
+
+impl EventSource {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Git => "git",
+        }
+    }
+}
+
+impl fmt::Display for EventSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct WatcherMetrics {
+    /// received event count, by source
+    events_received_total: Counter<u64>,
+    /// poll errors, by source
+    poll_errors_total: Counter<u64>,
+    /// changes applied, by source and change-kind
+    changes_applied_total: Counter<u64>,
+    /// event processing time, by source and change-kind
+    event_processing_time: Histogram<f64>,
+}
+
+impl WatcherMetrics {
+    pub(crate) fn new(meter_provider: &AnyMeterProvider) -> Self {
+        let meter = meter_provider.meter("watcher");
+        const PREFIX: &str = "docsrs.watcher";
+        Self {
+            events_received_total: meter
+                .u64_counter(format!("{PREFIX}.events_received_total"))
+                .with_unit("1")
+                .build(),
+            poll_errors_total: meter
+                .u64_counter(format!("{PREFIX}.poll_errors_total"))
+                .with_unit("1")
+                .build(),
+            changes_applied_total: meter
+                .u64_counter(format!("{PREFIX}.changes_applied_total"))
+                .with_unit("1")
+                .build(),
+            event_processing_time: meter
+                .f64_histogram(format!("{PREFIX}.event_processing_time"))
+                // Boundaries for the histogram, should be min/max for the processing time
+                .with_boundaries(vec![
+                    // that's what we expect in processing time, between <1s, and 5 minutes.
+                    0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0,
+                    45.0, 55.0, 60.0, 65.0, 90.0, 120.0, 180.0, 300.0,
+                    // these are just for outliers, so we see them
+                    600.0, 900.0, 1800.0, 3600.0,
+                ])
+                .with_unit("s")
+                .build(),
+        }
+    }
+
+    pub(crate) fn record_change_applied(&self, source: EventSource, kind: ChangeKind) {
+        self.changes_applied_total.add(
+            1,
+            &[
+                KeyValue::new("source", source.as_str()),
+                KeyValue::new("type", kind.as_str()),
+            ],
+        );
+    }
+
+    pub(crate) fn record_event_processing_time(
+        &self,
+        source: EventSource,
+        kind: Option<ChangeKind>,
+        success: bool,
+        duration: Duration,
+    ) {
+        let result = if success { "ok" } else { "err" };
+        self.event_processing_time.record(
+            duration.as_secs_f64(),
+            &[
+                KeyValue::new("source", source.as_str()),
+                KeyValue::new("type", kind.map(ChangeKind::as_str).unwrap_or("unknown")),
+                KeyValue::new("result", result),
+            ],
+        );
+    }
+
+    pub(crate) fn record_events_received(&self, source: EventSource, count: usize) {
+        self.events_received_total
+            .add(count as u64, &[KeyValue::new("source", source.as_str())]);
+    }
+
+    pub(crate) fn record_poll_error(&self, source: EventSource) {
+        self.poll_errors_total
+            .add(1, &[KeyValue::new("source", source.as_str())]);
+    }
+}

--- a/crates/lib/docs_rs_crates_io/Cargo.toml
+++ b/crates/lib/docs_rs_crates_io/Cargo.toml
@@ -9,11 +9,12 @@ repository.workspace = true
 edition.workspace = true
 
 [dependencies]
-chrono = { version = "0.4", features = ["serde"] }
-serde = { version = "1", features = ["derive"] }
+chrono = { workspace = true }
+serde = { workspace = true }
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json = { workspace = true }
+test-case = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/lib/docs_rs_crates_io/src/events.rs
+++ b/crates/lib/docs_rs_crates_io/src/events.rs
@@ -1,6 +1,35 @@
 use chrono::{DateTime, Utc};
 use std::fmt;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChangeKind {
+    Added,
+    AddedAndYanked,
+    Unyanked,
+    Yanked,
+    CrateDeleted,
+    VersionDeleted,
+}
+
+impl ChangeKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Added => "added",
+            Self::AddedAndYanked => "added_and_yanked",
+            Self::Unyanked => "unyanked",
+            Self::Yanked => "yanked",
+            Self::CrateDeleted => "crate_deleted",
+            Self::VersionDeleted => "version_deleted",
+        }
+    }
+}
+
+impl fmt::Display for ChangeKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// A change that can happen to a crate on our index.
 #[derive(Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, Debug)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
@@ -21,7 +50,7 @@ impl IndexChangeV1 {
     /// Return the added crate, if this is this kind of change.
     pub fn added(&self) -> Option<&CrateVersion> {
         match self {
-            IndexChangeV1::Added(v) => Some(v),
+            Self::Added(version) => Some(version),
             _ => None,
         }
     }
@@ -29,7 +58,7 @@ impl IndexChangeV1 {
     /// Return the yanked crate, if this is this kind of change.
     pub fn yanked(&self) -> Option<&CrateVersion> {
         match self {
-            IndexChangeV1::Yanked(v) => Some(v),
+            Self::Yanked(version) => Some(version),
             _ => None,
         }
     }
@@ -37,7 +66,7 @@ impl IndexChangeV1 {
     /// Return the unyanked crate, if this is this kind of change.
     pub fn unyanked(&self) -> Option<&CrateVersion> {
         match self {
-            IndexChangeV1::Unyanked(v) => Some(v),
+            Self::Unyanked(version) => Some(version),
             _ => None,
         }
     }
@@ -45,7 +74,7 @@ impl IndexChangeV1 {
     /// Return the deleted crate, if this is this kind of change.
     pub fn crate_deleted(&self) -> Option<&str> {
         match self {
-            IndexChangeV1::CrateDeleted { name } => Some(name.as_str()),
+            Self::CrateDeleted { name } => Some(name),
             _ => None,
         }
     }
@@ -53,21 +82,45 @@ impl IndexChangeV1 {
     /// Return the deleted version crate, if this is this kind of change.
     pub fn version_deleted(&self) -> Option<&CrateVersion> {
         match self {
-            IndexChangeV1::VersionDeleted(v) => Some(v),
+            Self::VersionDeleted(version) => Some(version),
             _ => None,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Added(crate_version)
+            | Self::Unyanked(crate_version)
+            | Self::Yanked(crate_version)
+            | Self::VersionDeleted(crate_version) => &crate_version.name,
+            Self::CrateDeleted { name } => name,
+        }
+    }
+
+    pub fn version(&self) -> Option<&str> {
+        match self {
+            Self::Added(crate_version)
+            | Self::Unyanked(crate_version)
+            | Self::Yanked(crate_version)
+            | Self::VersionDeleted(crate_version) => Some(&crate_version.version),
+            Self::CrateDeleted { .. } => None,
+        }
+    }
+
+    pub fn kind(&self) -> ChangeKind {
+        match self {
+            Self::Added(_) => ChangeKind::Added,
+            Self::Unyanked(_) => ChangeKind::Unyanked,
+            Self::Yanked(_) => ChangeKind::Yanked,
+            Self::CrateDeleted { .. } => ChangeKind::CrateDeleted,
+            Self::VersionDeleted(_) => ChangeKind::VersionDeleted,
         }
     }
 }
 
 impl fmt::Display for IndexChangeV1 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match *self {
-            IndexChangeV1::Added(_) => "added",
-            IndexChangeV1::Yanked(_) => "yanked",
-            IndexChangeV1::CrateDeleted { .. } => "crate deleted",
-            IndexChangeV1::VersionDeleted(_) => "version deleted",
-            IndexChangeV1::Unyanked(_) => "unyanked",
-        })
+        self.kind().fmt(f)
     }
 }
 
@@ -76,7 +129,7 @@ impl fmt::Display for IndexChangeV1 {
 pub struct Event<T> {
     /// Unique event identifier for deduplication and tracing.
     pub id: String,
-    /// Timestamp when the event occured
+    /// Timestamp when the event occurred.
     pub occurred_at: DateTime<Utc>,
     /// The typed payload.
     #[serde(flatten)]
@@ -100,6 +153,7 @@ pub struct CrateVersion {
 mod tests {
     use super::*;
     use serde_json::json;
+    use test_case::test_case;
 
     fn crate_version() -> CrateVersion {
         CrateVersion {
@@ -131,67 +185,81 @@ mod tests {
         );
     }
 
+    #[test_case(ChangeKind::Added, "added"; "added")]
+    #[test_case(ChangeKind::AddedAndYanked, "added_and_yanked"; "added and yanked")]
+    #[test_case(ChangeKind::Unyanked, "unyanked"; "unyanked")]
+    #[test_case(ChangeKind::Yanked, "yanked"; "yanked")]
+    #[test_case(ChangeKind::CrateDeleted, "crate_deleted"; "crate deleted")]
+    #[test_case(ChangeKind::VersionDeleted, "version_deleted"; "version deleted")]
+    fn change_kind_formats_as_expected(kind: ChangeKind, expected: &str) {
+        assert_eq!(kind.as_str(), expected);
+        assert_eq!(kind.to_string(), expected);
+    }
+
+    #[test_case(IndexChangeV1::Added(crate_version()), "added", json!({ "name": "clap", "vers": "4.5.0" }); "added")]
+    #[test_case(IndexChangeV1::Unyanked(crate_version()), "unyanked", json!({ "name": "clap", "vers": "4.5.0" }); "unyanked")]
+    #[test_case(IndexChangeV1::Yanked(crate_version()), "yanked", json!({ "name": "clap", "vers": "4.5.0" }); "yanked")]
+    #[test_case(IndexChangeV1::CrateDeleted { name: "old-crate".into() }, "crate_deleted", json!({ "name": "old-crate" }); "crate deleted")]
+    #[test_case(IndexChangeV1::VersionDeleted(crate_version()), "version_deleted", json!({ "name": "clap", "vers": "4.5.0" }); "version deleted")]
+    fn change_serializes_with_expected_variant_shape(
+        change: IndexChangeV1,
+        change_type: &str,
+        payload: serde_json::Value,
+    ) {
+        assert_eq!(
+            serde_json::to_value(change).unwrap(),
+            json!({
+                "type": change_type,
+                "payload": payload,
+            })
+        );
+    }
+
+    #[test_case(IndexChangeV1::Added(crate_version()), ChangeKind::Added, "clap", Some("4.5.0"); "added")]
+    #[test_case(IndexChangeV1::Unyanked(crate_version()), ChangeKind::Unyanked, "clap", Some("4.5.0"); "unyanked")]
+    #[test_case(IndexChangeV1::Yanked(crate_version()), ChangeKind::Yanked, "clap", Some("4.5.0"); "yanked")]
+    #[test_case(IndexChangeV1::CrateDeleted { name: "old-crate".into() }, ChangeKind::CrateDeleted, "old-crate", None; "crate deleted")]
+    #[test_case(IndexChangeV1::VersionDeleted(crate_version()), ChangeKind::VersionDeleted, "clap", Some("4.5.0"); "version deleted")]
+    fn change_metadata_matches_variant(
+        change: IndexChangeV1,
+        kind: ChangeKind,
+        name: &str,
+        version: Option<&str>,
+    ) {
+        assert_eq!(change.name(), name);
+        assert_eq!(change.version(), version);
+        assert_eq!(change.kind(), kind);
+        assert_eq!(change.to_string(), kind.as_str());
+    }
+
     #[test]
-    fn change_serializes_with_expected_variant_shapes() {
-        let crate_version = crate_version();
+    fn variant_accessors_only_match_their_variant() {
+        let added = IndexChangeV1::Added(crate_version());
+        assert_eq!(added.added(), Some(&crate_version()));
+        assert_eq!(added.yanked(), None);
+        assert_eq!(added.unyanked(), None);
+        assert_eq!(added.crate_deleted(), None);
+        assert_eq!(added.version_deleted(), None);
 
-        let cases = [
-            (
-                IndexChangeV1::Added(crate_version.clone()),
-                json!({
-                    "type": "added",
-                    "payload": {
-                        "name": "clap",
-                        "vers": "4.5.0",
-                    }
-                }),
-            ),
-            (
-                IndexChangeV1::Unyanked(crate_version.clone()),
-                json!({
-                    "type": "unyanked",
-                    "payload": {
-                        "name": "clap",
-                        "vers": "4.5.0",
-                    }
-                }),
-            ),
-            (
-                IndexChangeV1::Yanked(crate_version.clone()),
-                json!({
-                    "type": "yanked",
-                    "payload": {
-                        "name": "clap",
-                        "vers": "4.5.0",
-                    }
-                }),
-            ),
-            (
-                IndexChangeV1::CrateDeleted {
-                    name: "old-crate".into(),
-                },
-                json!({
-                    "type": "crate_deleted",
-                    "payload": {
-                        "name": "old-crate"
-                    }
-                }),
-            ),
-            (
-                IndexChangeV1::VersionDeleted(crate_version),
-                json!({
-                    "type": "version_deleted",
-                    "payload": {
-                        "name": "clap",
-                        "vers": "4.5.0",
-                    }
-                }),
-            ),
-        ];
-
-        for (event, expected) in cases {
-            assert_eq!(serde_json::to_value(&event).unwrap(), expected);
-        }
+        assert_eq!(
+            IndexChangeV1::Yanked(crate_version()).yanked(),
+            Some(&crate_version())
+        );
+        assert_eq!(
+            IndexChangeV1::Unyanked(crate_version()).unyanked(),
+            Some(&crate_version())
+        );
+        assert_eq!(
+            IndexChangeV1::CrateDeleted {
+                name: "old-crate".into(),
+            }
+            .crate_deleted(),
+            Some("old-crate")
+        );
+        assert_eq!(
+            IndexChangeV1::VersionDeleted(crate_version()).version_deleted(),
+            Some(&crate_version())
+        );
     }
 
     #[test]


### PR DESCRIPTION
preparation for https://github.com/rust-lang/docs.rs/pull/3349. 

For SQS I'm missing one piece of information: **How long does it take to handle one change, depending on the type?** 
Some of the architecture decisions and settings in the sqs subscriber depend on that, at least the visibility timeout, perhaps how many events we can fetch in a batch. Or if we need to `tokio::spawn` the event-handling? not sure. In any case, the data will help. 

Mainly for the new SQS logic I added some metrics in #3349, so I thought we could also just merge and track these just for the git index. With that data I'll be able to estimate much better. 

While we touch it, i also added some `tracing::instrument` markers so we have sampled detailed performance traces in sentry. 

