### PR TITLE
fix: Fix pluralization in rebuild queue message

### DIFF
--- a/crates/bin/docs_rs_web/templates/releases/build_queue.html
+++ b/crates/bin/docs_rs_web/templates/releases/build_queue.html
@@ -106,7 +106,7 @@ centered
                 </p>
                 {%- if !expand_rebuild_queue -%}
                     {% let rebuild_queue_len = rebuild_queue.len() %}
-                    <p>There are currently {{ rebuild_queue_len }} crate{{ rebuild_queue_len|pluralize }} in the rebuild queue.</p>
+                    <p>There are currently {{ rebuild_queue_len | pluralize("is", "are") }} crate{{ rebuild_queue_len|pluralize }} in the rebuild queue.</p>
                     <p><a href="?expand=1">Show</a></p>
                 {%- endif -%}
             </div>


### PR DESCRIPTION
Not really tested, but should be good to go