### PR TITLE
cratesfyi legacy binary: increase recursion limit

### DIFF
--- a/crates/bin/cratesfyi/src/lib.rs
+++ b/crates/bin/cratesfyi/src/lib.rs
@@ -1,1 +1,3 @@
+#![recursion_limit = "256"]
+
 pub mod daemon;


### PR DESCRIPTION
error, only on the server deploy

```
error: queries overflow the depth limit!
  |
  = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`cratesfyi`)
  = note: query depth increased by 130 when computing layout of `{async fn body of docs_rs_watcher::index_watcher::process_changes()}`

error: could not compile `cratesfyi` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

can't reproduce locally. 

Perhaps just increase it here for the legacy binary? 