### PR TITLE
update tracing log format, remove unnessary rustwide log fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,7 +2115,6 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
- "tracing-log",
 ]
 
 [[package]]
@@ -8359,17 +8358,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8395,7 +8383,6 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
  "tracing-serde",
 ]
 

--- a/crates/bin/docs_rs_builder/Cargo.toml
+++ b/crates/bin/docs_rs_builder/Cargo.toml
@@ -41,7 +41,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
-tracing-log = "0.2.0"
 
 [dev-dependencies]
 docs_rs_build_queue = { path = "../../lib/docs_rs_build_queue", features = ["testing"] }

--- a/crates/bin/docs_rs_builder/src/logging.rs
+++ b/crates/bin/docs_rs_builder/src/logging.rs
@@ -1,10 +1,65 @@
 use docs_rs_logging::Config;
-use tracing_log::LogTracer;
+use log::{Level, Log, Metadata, Record};
 
 pub fn init(config: &Config) {
     if config.log_build_logs {
-        rustwide::logging::init_with(LogTracer::new());
+        rustwide::logging::init_with(RustwideLogTracer);
     } else {
         rustwide::logging::init();
     }
+}
+
+/// Forwards Rustwide's `log` records as tracing events containing their level,
+/// formatted message, and original log target.
+///
+/// Unlike `tracing_log::LogTracer`, this deliberately omits origin fields
+/// such as `log.module_path`, `log.file`, and `log.line`. Events retain the
+/// currently entered tracing span context, use `rustwide` as their tracing target,
+/// and preserve the original target in the `log.target` field.
+///
+/// Later we'll migrate rustwide to directly emitting tracing-events.
+#[derive(Debug, Default)]
+struct RustwideLogTracer;
+
+impl Log for RustwideLogTracer {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        match metadata.level() {
+            Level::Error => tracing::enabled!(target: "rustwide", tracing::Level::ERROR),
+            Level::Warn => tracing::enabled!(target: "rustwide", tracing::Level::WARN),
+            Level::Info => tracing::enabled!(target: "rustwide", tracing::Level::INFO),
+            Level::Debug => tracing::enabled!(target: "rustwide", tracing::Level::DEBUG),
+            Level::Trace => tracing::enabled!(target: "rustwide", tracing::Level::TRACE),
+        }
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        match record.level() {
+            Level::Error => tracing::event!(
+                target: "rustwide", tracing::Level::ERROR,
+                { "log.target" = record.target(), message = format_args!("{}", record.args()) }
+            ),
+            Level::Warn => tracing::event!(
+                target: "rustwide", tracing::Level::WARN,
+                { "log.target" = record.target(), message = format_args!("{}", record.args()) }
+            ),
+            Level::Info => tracing::event!(
+                target: "rustwide", tracing::Level::INFO,
+                { "log.target" = record.target(), message = format_args!("{}", record.args()) }
+            ),
+            Level::Debug => tracing::event!(
+                target: "rustwide", tracing::Level::DEBUG,
+                { "log.target" = record.target(), message = format_args!("{}", record.args()) }
+            ),
+            Level::Trace => tracing::event!(
+                target: "rustwide", tracing::Level::TRACE,
+                { "log.target" = record.target(), message = format_args!("{}", record.args()) }
+            ),
+        }
+    }
+
+    fn flush(&self) {}
 }

--- a/crates/lib/docs_rs_logging/Cargo.toml
+++ b/crates/lib/docs_rs_logging/Cargo.toml
@@ -14,7 +14,7 @@ docs_rs_env_vars = { path = "../docs_rs_env_vars" }
 docs_rs_utils = { path = "../docs_rs_utils" }
 sentry = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.20", default-features = false, features = ["ansi", "env-filter", "fmt", "json", "tracing-log"] }
+tracing-subscriber = { version = "0.3.20", default-features = false, features = ["ansi", "env-filter", "fmt", "json"] }
 
 [dev-dependencies]
 docs_rs_config = { path = "../docs_rs_config", features = ["testing"] }

--- a/crates/lib/docs_rs_logging/src/lib.rs
+++ b/crates/lib/docs_rs_logging/src/lib.rs
@@ -33,8 +33,10 @@ pub fn init_from_environment() -> anyhow::Result<Guard> {
 
 pub fn init_with_config(config: &Config) -> anyhow::Result<Guard> {
     let log_formatter = match config.format {
+        LogFormat::Full => tracing_subscriber::fmt::layer().boxed(),
+        LogFormat::Compact => tracing_subscriber::fmt::layer().compact().boxed(),
+        LogFormat::Pretty => tracing_subscriber::fmt::layer().pretty().boxed(),
         LogFormat::Json => tracing_subscriber::fmt::layer().json().boxed(),
-        LogFormat::Pretty => tracing_subscriber::fmt::layer().boxed(),
     };
 
     let tracing_registry = tracing_subscriber::registry()

--- a/crates/lib/docs_rs_logging/src/log_format.rs
+++ b/crates/lib/docs_rs_logging/src/log_format.rs
@@ -1,10 +1,25 @@
-use std::{fmt, str::FromStr};
+use std::{
+    fmt,
+    io::{self, IsTerminal as _},
+    str::FromStr,
+};
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Copy)]
 pub enum LogFormat {
-    Json,
-    #[default]
+    Full,
+    Compact,
     Pretty,
+    Json,
+}
+
+impl Default for LogFormat {
+    fn default() -> Self {
+        if io::stdout().is_terminal() {
+            LogFormat::Compact
+        } else {
+            LogFormat::Json
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -22,10 +37,16 @@ impl FromStr for LogFormat {
     type Err = InvalidLogFormat;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "json" => Ok(Self::Json),
-            "pretty" => Ok(Self::Pretty),
-            _ => Err(InvalidLogFormat(s.to_string())),
+        if s.eq_ignore_ascii_case("full") {
+            Ok(Self::Full)
+        } else if s.eq_ignore_ascii_case("compact") {
+            Ok(Self::Compact)
+        } else if s.eq_ignore_ascii_case("pretty") {
+            Ok(Self::Pretty)
+        } else if s.eq_ignore_ascii_case("json") {
+            Ok(Self::Json)
+        } else {
+            Err(InvalidLogFormat(s.to_string()))
         }
     }
 }

--- a/crates/lib/docs_rs_logging/src/testing.rs
+++ b/crates/lib/docs_rs_logging/src/testing.rs
@@ -1,8 +1,9 @@
 use std::str::FromStr as _;
-use tracing_subscriber::{EnvFilter, filter::Directive};
+use tracing_subscriber::{EnvFilter, filter::Directive, fmt};
 
 pub fn init() {
     let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .event_format(fmt::format().compact())
         .with_env_filter(
             EnvFilter::builder()
                 .with_default_directive(Directive::from_str("docs_rs=info").unwrap())


### PR DESCRIPTION
- our internal `Pretty` format used the tracing-subscriber `Full` format, which is quite noisy. 
- I now added support for all log-formats that `tracing-subscriber` supports by default. 
- for local cli usage, `compact` will be the default, which puts the msg/span fields at the end 
- the default for the log-format is now determined by `is_terminal` or not. So we can drop the explicit setting on our server, and will have nicers logs in `docs_rs_admin`, or other CLI calls. 
- `rustwide` build logs came via `tracing_log::LogTracer`, which appended 4 additional fields to each line. We don't need most of these, so I added  a custom adapter that will just emit the log-message and target to tracing, and drop the rest. This only affects tests, local CLI / dev usage, etc. On our production build-servers, the log-tracer was disabled anyways, since we don't emit the build logs, just capture and upload them. But: this will be much more interesting when the build-cli for CI makes progress, so the output is actually usable. 

### next steps after this 
- reduce the level from `INFO` to `DEBUG` for some spans (for example internal function calls in rustwide) 
- remove _all_ fields from spans (via `instrument(skip_all)`), only add back what we really want to see in the logs, and _never use the debug representation of structs in logs_. 
- move some fields from spans to events, so they get logged once, and not again in all child-method-calls. 

### tracing log format 
 With an active `build{crate=example}` span, the previous full formatter
 repeated the span fields before each bridged message:

 ```text
 2026-09-03T12:00:00Z  INFO build{crate=example}: log: Compiling example
 ```

 The compact formatter keeps the span name before the message and appends
 the span fields after it:

 ```text
 2026-09-03T12:00:00Z  INFO build: log: Compiling example crate=example
 ```
