### PR TITLE
build_limits: Default::default for defaults, rename `new` to `from_config`

### DIFF
--- a/crates/bin/docs_rs_web/src/handlers/about.rs
+++ b/crates/bin/docs_rs_web/src/handlers/about.rs
@@ -37,7 +37,7 @@ pub(crate) async fn about_builds_handler(
 ) -> AxumResult<impl IntoResponse> {
     Ok(AboutBuilds {
         rustc_version: get_config::<String>(&mut conn, ConfigName::RustcVersion).await?,
-        limits: Limits::new(context.config().build_limits()?),
+        limits: Limits::from_config(context.config().build_limits()?),
         active_tab: "builds",
     })
 }

--- a/crates/lib/docs_rs_build_limits/src/limits.rs
+++ b/crates/lib/docs_rs_build_limits/src/limits.rs
@@ -15,16 +15,28 @@ pub struct Limits {
     pub max_log_size: usize,
 }
 
-impl Limits {
-    pub fn new(config: &Config) -> Self {
+impl Default for Limits {
+    fn default() -> Self {
         Self {
             // 3 GB default default
-            memory: config.build_default_memory_limit.unwrap_or(3 * GB),
+            memory: 3 * GB,
             timeout: Duration::from_secs(15 * 60), // 15 minutes
             targets: crate::DEFAULT_MAX_TARGETS,
             networking: false,
             max_log_size: 100 * 1024, // 100 KB
         }
+    }
+}
+
+impl Limits {
+    pub fn from_config(config: &Config) -> Self {
+        let mut limits = Limits::default();
+
+        if let Some(memory_limit) = config.build_default_memory_limit {
+            limits.memory = memory_limit;
+        }
+
+        limits
     }
 
     pub async fn for_crate(
@@ -32,7 +44,7 @@ impl Limits {
         conn: &mut sqlx::PgConnection,
         name: &KrateName,
     ) -> Result<Self> {
-        let default = Self::new(config);
+        let default = Self::from_config(config);
         let overrides = Overrides::for_crate(conn, name).await?.unwrap_or_default();
         Ok(Self {
             memory: overrides
@@ -94,7 +106,7 @@ mod test {
 
         let cfg = Config::default();
 
-        let defaults = Limits::new(&cfg);
+        let defaults = Limits::from_config(&cfg);
 
         let krate = KrateName::from_static("hexponent");
         // limits work if no crate has limits set
@@ -186,7 +198,7 @@ mod test {
 
         let cfg = Config::default();
 
-        let defaults = Limits::new(&cfg);
+        let defaults = Limits::from_config(&cfg);
 
         Overrides::save(
             &mut conn,

--- a/mise.lock
+++ b/mise.lock
@@ -157,6 +157,11 @@ checksum = "sha256:b67e1836c468e42e411984b56e52fa7abec08c2bd22c867398e7cc134aac5
 url = "https://github.com/sharkdp/fd/releases/download/v10.5.0/fd-v10.5.0-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/sharkdp/fd/releases/assets/530481346"
 
+[tools.fd."platforms.macos-x64"]
+checksum = "sha256:7e31028c62c6955877735d0406807aa484c2a5e6f86235a59e26c29c301da590"
+url = "https://github.com/sharkdp/fd/releases/download/v10.5.0/fd-v10.5.0-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/sharkdp/fd/releases/assets/530484719"
+
 [tools.fd."platforms.windows-x64"]
 checksum = "sha256:a227701b8551c35a9931d9f6da75503cf86d88e182d71fb849a70864c5d57cd7"
 url = "https://github.com/sharkdp/fd/releases/download/v10.5.0/fd-v10.5.0-x86_64-pc-windows-msvc.zip"


### PR DESCRIPTION
starting to pull out things from https://github.com/rust-lang/docs.rs/pull/3480 

- use `Default::default` for the default values 
- rename `::new` to `::from_config` to make it more explicit