### PR TITLE
builder: report error when we can't fetch owner data from crates.io

### DIFF
--- a/crates/bin/docs_rs_builder/src/docbuilder/rustwide_builder.rs
+++ b/crates/bin/docs_rs_builder/src/docbuilder/rustwide_builder.rs
@@ -876,7 +876,9 @@ impl RustwideBuilder {
                             name,
                             &crate_data,
                         ))?,
-                        Err(err) => warn!("{:#?}", err),
+                        Err(err) => {
+                            error!(%name, %version, ?err, "could not fetch crate & owner data");
+                        },
                     }
                 }
 


### PR DESCRIPTION
let's upgrade this to an error, I think we should get a sentry report when this happens, it's not normal, and should be fixed. 