### PR TITLE
switch from minio to RustFS for local & CI testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ x-environment: &environment
     DOCSRS_MIN_POOL_SIZE: 2
     DOCSRS_MAX_POOL_SIZE: 10
     DOCSRS_STORAGE_BACKEND: s3
+    DOCSRS_S3_BUCKET: ${DOCSRS_S3_BUCKET:-rust-docs-rs}
     S3_ENDPOINT: http://s3:9000
     AWS_ACCESS_KEY_ID: cratesfyi
     AWS_SECRET_ACCESS_KEY: secret_key
@@ -279,13 +280,13 @@ services:
             AWS_SECRET_ACCESS_KEY: secret_key
             AWS_DEFAULT_REGION: us-east-1
             AWS_EC2_METADATA_DISABLED: true
-            S3_BUCKET: ${DOCSRS_S3_BUCKET:-rust-docs-rs}
+            DOCSRS_S3_BUCKET: ${DOCSRS_S3_BUCKET:-rust-docs-rs}
         entrypoint: /bin/sh
         command:
             - -c
             - >-
-                aws --endpoint-url http://s3:9000 s3api head-bucket --bucket "$$S3_BUCKET"
-                || aws --endpoint-url http://s3:9000 s3api create-bucket --bucket "$$S3_BUCKET"
+                aws --endpoint-url http://s3:9000 s3api head-bucket --bucket "$$DOCSRS_S3_BUCKET"
+                || aws --endpoint-url http://s3:9000 s3api create-bucket --bucket "$$DOCSRS_S3_BUCKET"
         profiles:
             - manual
 

--- a/justfiles/services.just
+++ b/justfiles/services.just
@@ -4,13 +4,13 @@ compose-up-resources: _touch-docker-env
     # Keep the persistent resources as the default Compose services. The
     # bucket provisioner is a one-shot command, which `--wait` would otherwise
     # treat as a failed (exited) service.
-    docker compose up --detach --wait --remove-orphans db s3
-    docker compose run --rm --no-deps s3-init
+    docker compose --env-file .docker.env up --detach --wait --remove-orphans db s3
+    docker compose --env-file .docker.env run --rm --no-deps s3-init
 
 # Apply migrations, then start the requested Compose profiles.
 [group('compose')]
 compose-up *profiles: _touch-docker-env _ensure_db_migrated
-    docker compose {{ prepend("--profile ", profiles) }} up --build -d --wait --remove-orphans
+    docker compose --env-file .docker.env {{ prepend("--profile ", profiles) }} up --build -d --wait --remove-orphans
 
 # Start the web-server Compose profile.
 [group('compose')]
@@ -36,7 +36,7 @@ compose-up-full: (compose-up "full")
 # Stop Compose services while retaining local images and volumes.
 [group('compose')]
 compose-down:
-    docker compose --profile full --profile manual down --remove-orphans
+    docker compose --env-file .docker.env --profile full --profile manual down --remove-orphans
 
 # Remove Compose services, images, volumes, and generated local artifacts.
 [group('compose')]
@@ -44,7 +44,7 @@ compose-down-and-wipe:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    docker compose --profile full --profile manual down --volumes --remove-orphans --rmi local
+    docker compose --env-file .docker.env --profile full --profile manual down --volumes --remove-orphans --rmi local
 
     # When testing this in CI, I had permission issues when trying to remove this folder.
     # Likely it's related to the docker container runnning as a different (root?) user, so
@@ -64,7 +64,7 @@ compose-down-and-wipe:
 # Follow logs from all Compose services or the specified services.
 [group('compose')]
 compose-logs *services:
-    docker compose --profile full logs -f {{ services }}
+    docker compose --env-file .docker.env --profile full logs -f {{ services }}
 
 # Run a command in a one-off Compose service container.
 [group('cli')]
@@ -72,4 +72,4 @@ compose-logs *services:
 docker-run service_name *args: compose-up-resources
     # `docker compose run` ignores service dependencies, so the recipe starts
     # the database and object storage explicitly before reaching this point.
-    docker compose run --build --rm {{ service_name }} {{ args }}
+    docker compose --env-file .docker.env run --build --rm {{ service_name }} {{ args }}


### PR DESCRIPTION
This fixes CI on `main`, and in other PRs. 

Minio seem to have become commercial: 
- https://www.min.io/ 
- https://github.com/minio/minio
( also, their docker image is gone). 

The new thing (_AIStor_, who comes up with these names?) needs a license key to run. 

[`rustfs`](https://github.com/rustfs/rustfs) seems to be [S3 compatible](https://docs.rustfs.com/en/reference/s3-compatibility), big enough in usage, apache2 licensed, and works. 

