### PR TITLE
fix source-browser with filenames that have literal `%` in their name

### DIFF
--- a/crates/bin/docs_rs_web/src/handlers/source.rs
+++ b/crates/bin/docs_rs_web/src/handlers/source.rs
@@ -276,11 +276,11 @@ mod tests {
     use docs_rs_headers::IfNoneMatch;
     use docs_rs_storage::StorageKind;
     use docs_rs_types::KrateName;
-    use docs_rs_uri::encode_url_path;
     use kuchikiki::traits::TendrilSink;
     use mime::APPLICATION_PDF;
     use reqwest::StatusCode;
     use std::str::FromStr as _;
+    use test_case::test_case;
 
     fn get_file_list_links(body: &str) -> Vec<String> {
         let dom = kuchikiki::parse_html().one(body);
@@ -294,11 +294,14 @@ mod tests {
             .collect()
     }
 
-    #[test]
-    fn fetch_source_file_utf8_path() {
+    #[test_case("序.pdf", "%E5%BA%8F.pdf"; "utf8 path")]
+    #[test_case(
+        "templates/_base_/src-tauri/capabilities/%(v2)%default.json.lte",
+        "templates/_base_/src-tauri/capabilities/%25(v2)%25default.json.lte";
+        "literal percent signs"
+    )]
+    fn fetch_source_file_utf8_path(filename: &str, encoded_filename: &str) {
         async_wrapper(|env| async move {
-            let filename = "序.pdf";
-
             env.fake_release()
                 .await
                 .name("fake")
@@ -309,15 +312,15 @@ mod tests {
 
             let web = env.web_app().await;
             let response = web
-                .get(&format!(
-                    "/crate/fake/0.1.0/source/{}",
-                    encode_url_path(filename)
-                ))
+                .get(&format!("/crate/fake/0.1.0/source/{encoded_filename}"))
                 .await?;
             assert!(response.status().is_success());
+            let canonical_url = format!(
+                "<https://docs.rs/crate/fake/latest/source/{encoded_filename}>; rel=\"canonical\"",
+            );
             assert_eq!(
                 response.headers().get("link").unwrap(),
-                "<https://docs.rs/crate/fake/latest/source/%E5%BA%8F.pdf>; rel=\"canonical\"",
+                canonical_url.as_str(),
             );
             assert!(response.text().await?.contains("some_random_content"));
             Ok(())

--- a/crates/lib/docs_rs_uri/src/encode.rs
+++ b/crates/lib/docs_rs_uri/src/encode.rs
@@ -5,10 +5,14 @@ use std::borrow::Cow;
 // from https://github.com/servo/rust-url/blob/master/url/src/parser.rs
 // and https://github.com/tokio-rs/axum/blob/main/axum-extra/src/lib.rs
 const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`');
-const PATH: &AsciiSet = &FRAGMENT.add(b'#').add(b'?').add(b'{').add(b'}');
+const PATH: &AsciiSet = &FRAGMENT.add(b'#').add(b'%').add(b'?').add(b'{').add(b'}');
 
 pub fn encode_url_path(path: &str) -> String {
     utf8_percent_encode(path, PATH).to_string()
+}
+
+pub(crate) fn encode_url_fragment(fragment: &str) -> String {
+    utf8_percent_encode(fragment, FRAGMENT).to_string()
 }
 
 pub fn url_decode<'a>(input: &'a str) -> Result<Cow<'a, str>> {
@@ -22,7 +26,7 @@ mod test {
 
     #[test_case("/something/", "/something/")] // already valid path
     #[test_case("/something>", "/something%3E")] // something to encode
-    #[test_case("/something%3E", "/something%3E")] // re-running doesn't change anything
+    #[test_case("/something%3E", "/something%253E")] // literal percent sign
     fn test_encode_url_path(input: &str, expected: &str) {
         assert_eq!(encode_url_path(input), expected);
     }

--- a/crates/lib/docs_rs_uri/src/escaped_uri.rs
+++ b/crates/lib/docs_rs_uri/src/escaped_uri.rs
@@ -1,6 +1,6 @@
 use crate::{
     UriError,
-    encode::{encode_url_path, url_decode},
+    encode::{encode_url_fragment, encode_url_path, url_decode},
     errors::Result,
 };
 use askama::filters::HtmlSafe;
@@ -189,7 +189,7 @@ impl EscapedURI {
     }
 
     pub fn with_fragment(mut self, fragment: impl AsRef<str>) -> Self {
-        self.fragment = Some(encode_url_path(fragment.as_ref()));
+        self.fragment = Some(encode_url_fragment(fragment.as_ref()));
         self
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 #
 # runs & configures by default:
 # * `db` -> postgres db
-# * `s3` -> minio
+# * `s3` -> rustfs
 #
 # optional profile: `web`:
 # * `web` -> webserver
@@ -26,6 +26,7 @@
 # optional profile: `full`: all of the above.
 #
 # Services purely for manual usage with `docker compose run` are:
+# * `s3-init`: provisions the configured S3 bucket after RustFS is ready
 # * `cli`: to run simple CLI commands that only need the database & S3
 # * `builder-cli`: to run CLI commands that need the build environment.
 # * `registry-watcher-cli`: to run CLI commands that need the crates.io index.
@@ -106,8 +107,10 @@ x-builder: &builder
     # this.
     platform: "linux/amd64"
     depends_on:
-        - db
-        - s3
+        db:
+            condition: service_started
+        s3:
+            condition: service_healthy
     environment:
         <<: *builder-environment
     env_file:
@@ -118,8 +121,10 @@ x-registry-watcher: &registry-watcher
         <<: *build
         target: registry-watcher
     depends_on:
-        - db
-        - s3
+        db:
+            condition: service_started
+        s3:
+            condition: service_healthy
     volumes:
         - "./ignored/docker-registry-watcher/prefix:/opt/docsrs/prefix"
         - crates-io-index:/opt/docsrs/crates.io-index
@@ -141,8 +146,10 @@ services:
             <<: *build
             target: web-server
         depends_on:
-            - db
-            - s3
+            db:
+                condition: service_started
+            s3:
+                condition: service_healthy
         ports:
             - "3000:3000"
         environment:
@@ -213,8 +220,10 @@ services:
             # only for clarification.
             # When using "docker compose run", these dependencies are ignored,
             # we handle this in our `just` commands.
-            - db
-            - s3
+            db:
+                condition: service_started
+            s3:
+                condition: service_healthy
         environment: *environment
         volumes:
             - "./ignored/docker-cli/prefix:/opt/docsrs/prefix"
@@ -240,23 +249,45 @@ services:
             test: pg_isready --username cratesfyi
 
     s3:
-        image: minio/minio
-        entrypoint: >
-            /bin/sh -c "
-                mkdir -p /data/rust-docs-rs;
-                minio server /data --console-address ":9001";
-            "
+        image: rustfs/rustfs:latest
+        command: /data
         ports:
             - "127.0.0.1:9000:9000"
             - "127.0.0.1:9001:9001"
         volumes:
-            - minio-data:/data
+            - rustfs-data:/data
         environment:
-            MINIO_ROOT_USER: cratesfyi
-            MINIO_ROOT_PASSWORD: secret_key
+            RUSTFS_ACCESS_KEY: cratesfyi
+            RUSTFS_SECRET_KEY: secret_key
+            RUSTFS_ADDRESS: :9000
+            RUSTFS_CONSOLE_ADDRESS: :9001
+            RUSTFS_CONSOLE_ENABLE: true
+            RUSTFS_OBS_LOGGER_LEVEL: error
         healthcheck:
             <<: *healthcheck-interval
-            test: mc ready local
+            test: curl --fail http://localhost:9000/health
+
+    # RustFS starts with no buckets. Provision the application bucket before
+    # starting services that write to object storage.
+    s3-init:
+        image: amazon/aws-cli:latest
+        depends_on:
+            s3:
+                condition: service_healthy
+        environment:
+            AWS_ACCESS_KEY_ID: cratesfyi
+            AWS_SECRET_ACCESS_KEY: secret_key
+            AWS_DEFAULT_REGION: us-east-1
+            AWS_EC2_METADATA_DISABLED: true
+            S3_BUCKET: ${DOCSRS_S3_BUCKET:-rust-docs-rs}
+        entrypoint: /bin/sh
+        command:
+            - -c
+            - >-
+                aws --endpoint-url http://s3:9000 s3api head-bucket --bucket "$$S3_BUCKET"
+                || aws --endpoint-url http://s3:9000 s3api create-bucket --bucket "$$S3_BUCKET"
+        profiles:
+            - manual
 
     opentelemetry:
         build:
@@ -277,7 +308,7 @@ services:
 
 volumes:
     postgres-data: {}
-    minio-data: {}
+    rustfs-data: {}
     crates-io-index: {}
     rustwide-builder-a: {}
     rustwide-builder-b: {}

--- a/justfiles/services.just
+++ b/justfiles/services.just
@@ -1,8 +1,11 @@
 # Start the PostgreSQL and S3 resources used by local development.
 [group('compose')]
 compose-up-resources: _touch-docker-env
-    # this just start up the "default" resources from `docker-compose.yml`
-    docker compose up --detach --wait --remove-orphans
+    # Keep the persistent resources as the default Compose services. The
+    # bucket provisioner is a one-shot command, which `--wait` would otherwise
+    # treat as a failed (exited) service.
+    docker compose up --detach --wait --remove-orphans db s3
+    docker compose run --rm --no-deps s3-init
 
 # Apply migrations, then start the requested Compose profiles.
 [group('compose')]


### PR DESCRIPTION
minio fix from https://github.com/rust-lang/docs.rs/pull/3515 only that the tests pass. 

- [sentry error](https://rust-lang.sentry.io/issues/7726770013/events/14a3d97c2887440aa0a17257c95f28a5/?query=is%3Aunresolved&referrer=previous-event) 
- [source folder with the file](https://docs.rs/crate/create-tauri-app/4.6.0/source/templates/_base_/src-tauri/capabilities/)